### PR TITLE
feat: Blackbaud Raiser's Edge integration (Phase 1)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -51,6 +51,13 @@ const linkedInEnv = [
   "LINKEDIN_TOKEN_ENCRYPTION_KEY",
 ];
 
+const blackbaudEnv = [
+  "BLACKBAUD_CLIENT_ID",
+  "BLACKBAUD_CLIENT_SECRET",
+  "BLACKBAUD_TOKEN_ENCRYPTION_KEY",
+  "BLACKBAUD_SUBSCRIPTION_KEY",
+];
+
 function assertEnv(name, required = true) {
   const value = process.env[name];
   if (required && (!value || value.trim() === "")) {
@@ -108,6 +115,12 @@ function validateBuildEnv() {
   const missingLinkedInVars = linkedInEnv.filter((key) => !process.env[key] || process.env[key].trim() === "");
   if (missingLinkedInVars.length > 0 && missingLinkedInVars.length < linkedInEnv.length) {
     console.warn(`⚠️  Partial LinkedIn config: missing ${missingLinkedInVars.join(", ")}. LinkedIn integration will not work.`);
+  }
+
+  // Optional: warn if Blackbaud env vars are partially configured
+  const missingBlackbaudVars = blackbaudEnv.filter((key) => !process.env[key] || process.env[key].trim() === "");
+  if (missingBlackbaudVars.length > 0 && missingBlackbaudVars.length < blackbaudEnv.length) {
+    console.warn(`⚠️  Partial Blackbaud config: missing ${missingBlackbaudVars.join(", ")}. Blackbaud integration will not work.`);
   }
 
   // Optional: Proxycurl enrichment (enriches member profiles from LinkedIn)

--- a/src/app/api/blackbaud/auth/route.ts
+++ b/src/app/api/blackbaud/auth/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { getOrgContext } from "@/lib/auth/roles";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+import { getAuthorizationUrl } from "@/lib/blackbaud/oauth";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  const rateLimit = checkRateLimit(req, {
+    userId: user?.id ?? null,
+    feature: "blackbaud-auth",
+    limitPerIp: 10,
+    limitPerUser: 5,
+  });
+  if (!rateLimit.ok) return buildRateLimitResponse(rateLimit);
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: rateLimit.headers });
+  }
+
+  const url = new URL(req.url);
+  const orgSlug = url.searchParams.get("orgSlug");
+  if (!orgSlug) {
+    return NextResponse.json({ error: "Missing orgSlug" }, { status: 400, headers: rateLimit.headers });
+  }
+
+  const orgContext = await getOrgContext(orgSlug);
+  if (!orgContext || !orgContext.isAdmin || !orgContext.organization) {
+    return NextResponse.json({ error: "Not an admin of this organization" }, { status: 403, headers: rateLimit.headers });
+  }
+
+  const serviceSupabase = createServiceClient();
+  const { data: oauthState, error: insertError } = await (serviceSupabase as any)
+    .from("org_integration_oauth_state")
+    .insert({
+      organization_id: orgContext.organization.id,
+      provider: "blackbaud",
+      user_id: user.id,
+      redirect_path: `/${orgSlug}/settings/integrations`,
+    })
+    .select("id")
+    .single() as { data: { id: string } | null; error: any };
+
+  if (insertError || !oauthState) {
+    console.error("[blackbaud-auth] Failed to create OAuth state:", insertError);
+    return NextResponse.json({ error: "Failed to initiate connection" }, { status: 500, headers: rateLimit.headers });
+  }
+
+  const authUrl = getAuthorizationUrl(oauthState.id);
+  return NextResponse.redirect(authUrl);
+}

--- a/src/app/api/blackbaud/callback/route.ts
+++ b/src/app/api/blackbaud/callback/route.ts
@@ -4,6 +4,7 @@ import { createServiceClient } from "@/lib/supabase/service";
 import { exchangeCodeForTokens, encryptToken, makeSyncError, getBlackbaudSubscriptionKey } from "@/lib/blackbaud/oauth";
 import { createBlackbaudClient } from "@/lib/blackbaud/client";
 import { getAppUrl } from "@/lib/url";
+import { debugLog } from "@/lib/debug";
 import type { BlackbaudConstituent } from "@/lib/blackbaud/types";
 
 export const dynamic = "force-dynamic";
@@ -118,7 +119,7 @@ export async function GET(req: Request) {
     const redirectPath = oauthState.redirect_path || "/app";
     return NextResponse.redirect(`${appUrl}${redirectPath}?success=blackbaud_connected`);
   } catch (err) {
-    console.error("[blackbaud-callback] Token exchange failed:", err);
+    debugLog("blackbaud-callback", "token exchange failed", { error: err instanceof Error ? err.message : String(err) });
 
     const syncError = makeSyncError(
       "code_exchange",

--- a/src/app/api/blackbaud/callback/route.ts
+++ b/src/app/api/blackbaud/callback/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { exchangeCodeForTokens, encryptToken, makeSyncError, getBlackbaudSubscriptionKey } from "@/lib/blackbaud/oauth";
+import { createBlackbaudClient } from "@/lib/blackbaud/client";
+import { getAppUrl } from "@/lib/url";
+import type { BlackbaudConstituent } from "@/lib/blackbaud/types";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const STATE_EXPIRY_MS = 15 * 60 * 1000;
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const error = url.searchParams.get("error");
+  const appUrl = getAppUrl();
+
+  if (error) {
+    return NextResponse.redirect(`${appUrl}/app?error=blackbaud_oauth_denied`);
+  }
+
+  if (!code || !state) {
+    return NextResponse.redirect(`${appUrl}/app?error=blackbaud_invalid_callback`);
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.redirect(`${appUrl}/auth/login?error=session_expired`);
+  }
+
+  const serviceSupabase = createServiceClient();
+  const { data: oauthState, error: lookupError } = await (serviceSupabase as any)
+    .from("org_integration_oauth_state")
+    .select("id, organization_id, provider, user_id, redirect_path, initiated_at, used")
+    .eq("id", state)
+    .eq("provider", "blackbaud")
+    .maybeSingle() as { data: any | null; error: any };
+
+  if (lookupError || !oauthState) {
+    return NextResponse.redirect(`${appUrl}/app?error=blackbaud_invalid_state`);
+  }
+
+  if (oauthState.used) {
+    return NextResponse.redirect(`${appUrl}/app?error=blackbaud_state_reused`);
+  }
+
+  if (oauthState.user_id !== user.id) {
+    return NextResponse.redirect(`${appUrl}/app?error=blackbaud_user_mismatch`);
+  }
+
+  const initiatedAt = new Date(oauthState.initiated_at);
+  if (Date.now() - initiatedAt.getTime() > STATE_EXPIRY_MS) {
+    return NextResponse.redirect(`${appUrl}/app?error=blackbaud_state_expired`);
+  }
+
+  // Mark state as used (prevent replay)
+  await (serviceSupabase as any)
+    .from("org_integration_oauth_state")
+    .update({ used: true })
+    .eq("id", oauthState.id);
+
+  try {
+    const tokens = await exchangeCodeForTokens(code);
+    const tokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000);
+
+    // Post-callback verification: test API call
+    const client = createBlackbaudClient({
+      accessToken: tokens.access_token,
+      subscriptionKey: getBlackbaudSubscriptionKey(),
+    });
+
+    try {
+      await client.getList<BlackbaudConstituent>("/constituent/v1/constituents", { limit: "1" });
+    } catch (verifyError) {
+      const syncError = makeSyncError(
+        "api_verify",
+        "VERIFY_FAILED",
+        verifyError instanceof Error ? verifyError.message : "API verification failed"
+      );
+
+      await (serviceSupabase as any)
+        .from("org_integrations")
+        .upsert({
+          organization_id: oauthState.organization_id,
+          provider: "blackbaud",
+          status: "error",
+          access_token_enc: encryptToken(tokens.access_token),
+          refresh_token_enc: encryptToken(tokens.refresh_token),
+          token_expires_at: tokenExpiresAt.toISOString(),
+          connected_by: user.id,
+          last_sync_error: syncError,
+          updated_at: new Date().toISOString(),
+        }, { onConflict: "organization_id,provider" });
+
+      const redirectPath = oauthState.redirect_path || "/app";
+      return NextResponse.redirect(`${appUrl}${redirectPath}?error=blackbaud_verify_failed`);
+    }
+
+    // Success: upsert integration row as active
+    await (serviceSupabase as any)
+      .from("org_integrations")
+      .upsert({
+        organization_id: oauthState.organization_id,
+        provider: "blackbaud",
+        status: "active",
+        access_token_enc: encryptToken(tokens.access_token),
+        refresh_token_enc: encryptToken(tokens.refresh_token),
+        token_expires_at: tokenExpiresAt.toISOString(),
+        connected_by: user.id,
+        last_sync_error: null,
+        updated_at: new Date().toISOString(),
+      }, { onConflict: "organization_id,provider" });
+
+    const redirectPath = oauthState.redirect_path || "/app";
+    return NextResponse.redirect(`${appUrl}${redirectPath}?success=blackbaud_connected`);
+  } catch (err) {
+    console.error("[blackbaud-callback] Token exchange failed:", err);
+
+    const syncError = makeSyncError(
+      "code_exchange",
+      "EXCHANGE_FAILED",
+      err instanceof Error ? err.message : "Token exchange failed"
+    );
+
+    await (serviceSupabase as any)
+      .from("org_integrations")
+      .update({
+        last_sync_error: syncError,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("organization_id", oauthState.organization_id)
+      .eq("provider", "blackbaud");
+
+    const redirectPath = oauthState.redirect_path || "/app";
+    return NextResponse.redirect(`${appUrl}${redirectPath}?error=blackbaud_exchange_failed`);
+  }
+}

--- a/src/app/api/blackbaud/disconnect/route.ts
+++ b/src/app/api/blackbaud/disconnect/route.ts
@@ -35,7 +35,7 @@ export async function POST(req: Request) {
   }
 
   const serviceSupabase = createServiceClient();
-  const { error } = await (serviceSupabase as any)
+  const { error, count } = (await (serviceSupabase as any)
     .from("org_integrations")
     .update({
       status: "disconnected",
@@ -46,10 +46,15 @@ export async function POST(req: Request) {
       updated_at: new Date().toISOString(),
     })
     .eq("organization_id", orgContext.organization.id)
-    .eq("provider", "blackbaud");
+    .eq("provider", "blackbaud")
+    .select("id", { count: "exact", head: true })) as { error: any; count: number };
 
   if (error) {
     return NextResponse.json({ error: "Failed to disconnect" }, { status: 500, headers: rateLimit.headers });
+  }
+
+  if (count === 0) {
+    return NextResponse.json({ error: "No Blackbaud connection found" }, { status: 404, headers: rateLimit.headers });
   }
 
   return NextResponse.json({ success: true }, { headers: rateLimit.headers });

--- a/src/app/api/blackbaud/disconnect/route.ts
+++ b/src/app/api/blackbaud/disconnect/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { getOrgContext } from "@/lib/auth/roles";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  const rateLimit = checkRateLimit(req, {
+    userId: user?.id ?? null,
+    feature: "blackbaud-disconnect",
+    limitPerIp: 10,
+    limitPerUser: 5,
+  });
+  if (!rateLimit.ok) return buildRateLimitResponse(rateLimit);
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: rateLimit.headers });
+  }
+
+  const url = new URL(req.url);
+  const orgSlug = url.searchParams.get("orgSlug");
+  if (!orgSlug) {
+    return NextResponse.json({ error: "Missing orgSlug" }, { status: 400, headers: rateLimit.headers });
+  }
+
+  const orgContext = await getOrgContext(orgSlug);
+  if (!orgContext || !orgContext.isAdmin || !orgContext.organization) {
+    return NextResponse.json({ error: "Not an admin" }, { status: 403, headers: rateLimit.headers });
+  }
+
+  const serviceSupabase = createServiceClient();
+  const { error } = await (serviceSupabase as any)
+    .from("org_integrations")
+    .update({
+      status: "disconnected",
+      access_token_enc: null,
+      refresh_token_enc: null,
+      token_expires_at: null,
+      last_sync_error: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("organization_id", orgContext.organization.id)
+    .eq("provider", "blackbaud");
+
+  if (error) {
+    return NextResponse.json({ error: "Failed to disconnect" }, { status: 500, headers: rateLimit.headers });
+  }
+
+  return NextResponse.json({ success: true }, { headers: rateLimit.headers });
+}

--- a/src/app/api/cron/integrations-sync/route.ts
+++ b/src/app/api/cron/integrations-sync/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: Request) {
   };
 
   if (error) {
-    console.error("[integrations-cron] Failed to load integrations:", error);
+    debugLog("integrations-cron", "failed to load integrations", { error });
     return NextResponse.json({ error: "Database error" }, { status: 500 });
   }
 
@@ -64,7 +64,7 @@ export async function GET(request: Request) {
             const refreshToken = decryptToken(integration.refresh_token_enc);
             const newTokens = await refreshAccessToken(refreshToken);
 
-            await (supabase as any)
+            const { count } = (await (supabase as any)
               .from("org_integrations")
               .update({
                 access_token_enc: encryptToken(newTokens.access_token),
@@ -75,9 +75,22 @@ export async function GET(request: Request) {
                 updated_at: new Date().toISOString(),
               })
               .eq("id", integration.id)
-              .eq("token_expires_at", integration.token_expires_at);
+              .eq("token_expires_at", integration.token_expires_at)
+              .select("id", { count: "exact", head: true })) as {
+              count: number;
+            };
 
-            accessToken = newTokens.access_token;
+            if (count === 0) {
+              // Another process refreshed — re-read the current token
+              const { data: refreshed } = (await (supabase as any)
+                .from("org_integrations")
+                .select("access_token_enc")
+                .eq("id", integration.id)
+                .single()) as { data: { access_token_enc: string } };
+              accessToken = decryptToken(refreshed.access_token_enc);
+            } else {
+              accessToken = newTokens.access_token;
+            }
           } else {
             accessToken = decryptToken(integration.access_token_enc);
           }

--- a/src/app/api/cron/integrations-sync/route.ts
+++ b/src/app/api/cron/integrations-sync/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { validateCronAuth } from "@/lib/security/cron-auth";
+import {
+  decryptToken,
+  isTokenExpired,
+  refreshAccessToken,
+  encryptToken,
+  getBlackbaudSubscriptionKey,
+} from "@/lib/blackbaud/oauth";
+import { createBlackbaudClient } from "@/lib/blackbaud/client";
+import { runSync } from "@/lib/blackbaud/sync";
+import { getAlumniCapacitySnapshot } from "@/lib/alumni/capacity";
+import { debugLog } from "@/lib/debug";
+
+export const dynamic = "force-dynamic";
+
+const MAX_CONCURRENCY = 3;
+
+export async function GET(request: Request) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const supabase = createServiceClient();
+
+  // Find all active Blackbaud integrations due for sync (not synced in last 24h)
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const { data: integrations, error } = (await (supabase as any)
+    .from("org_integrations")
+    .select(
+      "id, organization_id, access_token_enc, refresh_token_enc, token_expires_at, last_synced_at"
+    )
+    .eq("provider", "blackbaud")
+    .eq("status", "active")
+    .or(`last_synced_at.is.null,last_synced_at.lt.${cutoff}`)) as {
+    data: any[] | null;
+    error: any;
+  };
+
+  if (error) {
+    console.error("[integrations-cron] Failed to load integrations:", error);
+    return NextResponse.json({ error: "Database error" }, { status: 500 });
+  }
+
+  const typedIntegrations = integrations ?? [];
+  const results: {
+    id: string;
+    orgId: string;
+    status: string;
+    created?: number;
+    updated?: number;
+    error?: string;
+  }[] = [];
+
+  for (let i = 0; i < typedIntegrations.length; i += MAX_CONCURRENCY) {
+    const batch = typedIntegrations.slice(i, i + MAX_CONCURRENCY);
+    const batchResults = await Promise.all(
+      batch.map(async (integration: any) => {
+        try {
+          let accessToken: string;
+          const tokenExpiresAt = new Date(integration.token_expires_at);
+
+          if (isTokenExpired(tokenExpiresAt)) {
+            const refreshToken = decryptToken(integration.refresh_token_enc);
+            const newTokens = await refreshAccessToken(refreshToken);
+
+            await (supabase as any)
+              .from("org_integrations")
+              .update({
+                access_token_enc: encryptToken(newTokens.access_token),
+                refresh_token_enc: encryptToken(newTokens.refresh_token),
+                token_expires_at: new Date(
+                  Date.now() + newTokens.expires_in * 1000
+                ).toISOString(),
+                updated_at: new Date().toISOString(),
+              })
+              .eq("id", integration.id)
+              .eq("token_expires_at", integration.token_expires_at);
+
+            accessToken = newTokens.access_token;
+          } else {
+            accessToken = decryptToken(integration.access_token_enc);
+          }
+
+          const capacity = await getAlumniCapacitySnapshot(
+            integration.organization_id,
+            supabase
+          );
+          const client = createBlackbaudClient({
+            accessToken,
+            subscriptionKey: getBlackbaudSubscriptionKey(),
+          });
+
+          const result = await runSync({
+            client,
+            supabase,
+            integrationId: integration.id,
+            organizationId: integration.organization_id,
+            alumniLimit: capacity.alumniLimit,
+            currentAlumniCount: capacity.currentAlumniCount,
+            syncType: "incremental",
+            lastSyncedAt: integration.last_synced_at,
+          });
+
+          return {
+            id: integration.id,
+            orgId: integration.organization_id,
+            status: result.ok ? "ok" : "error",
+            created: result.created,
+            updated: result.updated,
+            error: result.error,
+          };
+        } catch (err) {
+          debugLog("integrations-cron", "sync error", {
+            integrationId: integration.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return {
+            id: integration.id,
+            orgId: integration.organization_id,
+            status: "error",
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      })
+    );
+    results.push(...batchResults);
+  }
+
+  return NextResponse.json({
+    processed: typedIntegrations.length,
+    results,
+  });
+}

--- a/src/app/api/organizations/[organizationId]/integrations/blackbaud/sync/route.ts
+++ b/src/app/api/organizations/[organizationId]/integrations/blackbaud/sync/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { requireOrgRole } from "@/lib/auth/roles";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+import {
+  decryptToken,
+  isTokenExpired,
+  refreshAccessToken,
+  encryptToken,
+  getBlackbaudSubscriptionKey,
+} from "@/lib/blackbaud/oauth";
+import { createBlackbaudClient } from "@/lib/blackbaud/client";
+import { runSync } from "@/lib/blackbaud/sync";
+import { getAlumniCapacitySnapshot } from "@/lib/alumni/capacity";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ organizationId: string }> }
+) {
+  const { organizationId } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const rateLimit = checkRateLimit(req, {
+    userId: user?.id ?? null,
+    feature: "blackbaud-sync",
+    limitPerIp: 5,
+    limitPerUser: 3,
+  });
+  if (!rateLimit.ok) return buildRateLimitResponse(rateLimit);
+
+  if (!user) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401, headers: rateLimit.headers }
+    );
+  }
+
+  // Verify org admin explicitly (uses orgId, not orgSlug)
+  try {
+    await requireOrgRole({ orgId: organizationId, allowedRoles: ["admin"] });
+  } catch {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403, headers: rateLimit.headers }
+    );
+  }
+
+  const serviceSupabase = createServiceClient();
+  const { data: integration } = (await (serviceSupabase as any)
+    .from("org_integrations")
+    .select(
+      "id, status, access_token_enc, refresh_token_enc, token_expires_at, last_synced_at"
+    )
+    .eq("organization_id", organizationId)
+    .eq("provider", "blackbaud")
+    .eq("status", "active")
+    .maybeSingle()) as { data: any | null };
+
+  if (!integration) {
+    return NextResponse.json(
+      { error: "No active Blackbaud connection for this organization" },
+      { status: 404, headers: rateLimit.headers }
+    );
+  }
+
+  // Get valid access token (refresh if needed)
+  let accessToken: string;
+  try {
+    const tokenExpiresAt = new Date(integration.token_expires_at);
+    if (isTokenExpired(tokenExpiresAt)) {
+      const refreshToken = decryptToken(integration.refresh_token_enc);
+      const newTokens = await refreshAccessToken(refreshToken);
+
+      // Optimistic concurrency: only update if token_expires_at hasn't changed
+      const { count } = (await (serviceSupabase as any)
+        .from("org_integrations")
+        .update({
+          access_token_enc: encryptToken(newTokens.access_token),
+          refresh_token_enc: encryptToken(newTokens.refresh_token),
+          token_expires_at: new Date(
+            Date.now() + newTokens.expires_in * 1000
+          ).toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", integration.id)
+        .eq("token_expires_at", integration.token_expires_at)
+        .select("id", { count: "exact", head: true })) as { count: number };
+
+      if (count === 0) {
+        // Another process refreshed — re-read
+        const { data: refreshed } = (await (serviceSupabase as any)
+          .from("org_integrations")
+          .select("access_token_enc")
+          .eq("id", integration.id)
+          .single()) as { data: { access_token_enc: string } };
+        accessToken = decryptToken(refreshed.access_token_enc);
+      } else {
+        accessToken = newTokens.access_token;
+      }
+    } else {
+      accessToken = decryptToken(integration.access_token_enc);
+    }
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to refresh Blackbaud access token" },
+      { status: 502, headers: rateLimit.headers }
+    );
+  }
+
+  const capacity = await getAlumniCapacitySnapshot(
+    organizationId,
+    serviceSupabase
+  );
+
+  const client = createBlackbaudClient({
+    accessToken,
+    subscriptionKey: getBlackbaudSubscriptionKey(),
+  });
+
+  const result = await runSync({
+    client,
+    supabase: serviceSupabase,
+    integrationId: integration.id,
+    organizationId,
+    alumniLimit: capacity.alumniLimit,
+    currentAlumniCount: capacity.currentAlumniCount,
+    syncType: "manual",
+    lastSyncedAt: integration.last_synced_at,
+  });
+
+  return NextResponse.json(
+    { result },
+    { status: result.ok ? 200 : 500, headers: rateLimit.headers }
+  );
+}

--- a/src/lib/blackbaud/client.ts
+++ b/src/lib/blackbaud/client.ts
@@ -1,0 +1,54 @@
+import type { BlackbaudListResponse } from "./types";
+
+const SKY_API_BASE = "https://api.sky.blackbaud.com";
+
+export interface BlackbaudClientConfig {
+  accessToken: string;
+  subscriptionKey: string;
+  fetchFn?: typeof fetch;
+}
+
+export interface BlackbaudClient {
+  get: <T = unknown>(path: string, params?: Record<string, string>) => Promise<T>;
+  getList: <T>(path: string, params?: Record<string, string>) => Promise<BlackbaudListResponse<T>>;
+}
+
+export function createBlackbaudClient(config: BlackbaudClientConfig): BlackbaudClient {
+  const fetchFn = config.fetchFn ?? fetch;
+
+  async function request<T>(path: string, params?: Record<string, string>): Promise<T> {
+    const url = new URL(path, SKY_API_BASE);
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        url.searchParams.set(key, value);
+      }
+    }
+
+    const response = await fetchFn(url.toString(), {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${config.accessToken}`,
+        "Bb-Api-Subscription-Key": config.subscriptionKey,
+        Accept: "application/json",
+      },
+    });
+
+    if (response.status === 429) {
+      throw new Error(`Blackbaud rate limit hit (429) on ${path}`);
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Blackbaud API error (${response.status}) on ${path}: ${text}`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  return {
+    get: <T = unknown>(path: string, params?: Record<string, string>) =>
+      request<T>(path, params),
+    getList: <T>(path: string, params?: Record<string, string>) =>
+      request<BlackbaudListResponse<T>>(path, params),
+  };
+}

--- a/src/lib/blackbaud/normalize.ts
+++ b/src/lib/blackbaud/normalize.ts
@@ -1,0 +1,49 @@
+import type {
+  BlackbaudConstituent,
+  BlackbaudEmail,
+  BlackbaudPhone,
+  BlackbaudAddress,
+  NormalizedConstituent,
+} from "./types";
+
+function findPrimary<T extends { primary?: boolean; inactive?: boolean }>(items: T[]): T | undefined {
+  const active = items.filter((item) => !item.inactive);
+  return active.find((item) => item.primary) ?? active[0];
+}
+
+function formatAddress(address: BlackbaudAddress): string | null {
+  const cityState = [address.city, address.state].filter(Boolean).join(", ");
+  const cityStateZip = [cityState, address.postal_code].filter(Boolean).join(" ");
+  const parts = [address.address_lines, cityStateZip].filter(Boolean).join(", ");
+
+  return parts || null;
+}
+
+function parseClassYear(classOf: string | undefined): number | null {
+  if (!classOf) return null;
+  const year = parseInt(classOf, 10);
+  if (isNaN(year) || year < 1900 || year > 2100) return null;
+  return year;
+}
+
+export function normalizeConstituent(
+  constituent: BlackbaudConstituent,
+  emails: BlackbaudEmail[],
+  phones: BlackbaudPhone[],
+  addresses: BlackbaudAddress[]
+): NormalizedConstituent {
+  const primaryEmail = findPrimary(emails);
+  const primaryPhone = findPrimary(phones);
+  const primaryAddress = findPrimary(addresses);
+
+  return {
+    external_id: constituent.id,
+    first_name: constituent.first ?? "",
+    last_name: constituent.last ?? "",
+    email: primaryEmail?.address ?? null,
+    phone_number: primaryPhone?.number ?? null,
+    address_summary: primaryAddress ? formatAddress(primaryAddress) : null,
+    graduation_year: parseClassYear(constituent.class_of),
+    source: "integration_sync",
+  };
+}

--- a/src/lib/blackbaud/oauth.ts
+++ b/src/lib/blackbaud/oauth.ts
@@ -1,0 +1,140 @@
+import {
+  encryptToken as sharedEncrypt,
+  decryptToken as sharedDecrypt,
+} from "@/lib/crypto/token-encryption";
+import { getAppUrl } from "@/lib/url";
+import type { BlackbaudTokenResponse, SyncError } from "./types";
+
+// ── Environment helpers ──────────────────────────────────────
+
+function getBlackbaudClientId(): string {
+  const val = process.env.BLACKBAUD_CLIENT_ID;
+  if (!val || val.trim() === "") {
+    throw new Error("Missing required environment variable: BLACKBAUD_CLIENT_ID");
+  }
+  return val;
+}
+
+function getBlackbaudClientSecret(): string {
+  const val = process.env.BLACKBAUD_CLIENT_SECRET;
+  if (!val || val.trim() === "") {
+    throw new Error("Missing required environment variable: BLACKBAUD_CLIENT_SECRET");
+  }
+  return val;
+}
+
+function getBlackbaudEncryptionKey(): string {
+  const val = process.env.BLACKBAUD_TOKEN_ENCRYPTION_KEY;
+  if (!val || val.trim() === "") {
+    throw new Error("Missing required environment variable: BLACKBAUD_TOKEN_ENCRYPTION_KEY");
+  }
+  return val;
+}
+
+export function getBlackbaudSubscriptionKey(): string {
+  const val = process.env.BLACKBAUD_SUBSCRIPTION_KEY;
+  if (!val || val.trim() === "") {
+    throw new Error("Missing required environment variable: BLACKBAUD_SUBSCRIPTION_KEY");
+  }
+  return val;
+}
+
+function getRedirectUri(): string {
+  return `${getAppUrl()}/api/blackbaud/callback`;
+}
+
+// ── Token encryption (delegates to shared crypto module) ─────
+
+export function encryptToken(token: string): string {
+  return sharedEncrypt(token, getBlackbaudEncryptionKey());
+}
+
+export function decryptToken(encryptedToken: string): string {
+  return sharedDecrypt(encryptedToken, getBlackbaudEncryptionKey());
+}
+
+// ── OAuth flow ───────────────────────────────────────────────
+
+const BLACKBAUD_AUTH_URL = "https://oauth2.sky.blackbaud.com/authorization";
+const BLACKBAUD_TOKEN_URL = "https://oauth2.sky.blackbaud.com/token";
+
+/**
+ * Generates the Blackbaud OAuth authorization URL.
+ * @param state - The UUID of the pending oauth_state row (server-stored state)
+ */
+export function getAuthorizationUrl(state: string): string {
+  const params = new URLSearchParams({
+    client_id: getBlackbaudClientId(),
+    response_type: "code",
+    redirect_uri: getRedirectUri(),
+    state,
+  });
+
+  return `${BLACKBAUD_AUTH_URL}?${params.toString()}`;
+}
+
+/**
+ * Exchanges an authorization code for access and refresh tokens.
+ */
+export async function exchangeCodeForTokens(code: string): Promise<BlackbaudTokenResponse> {
+  const response = await fetch(BLACKBAUD_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: getRedirectUri(),
+      client_id: getBlackbaudClientId(),
+      client_secret: getBlackbaudClientSecret(),
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Blackbaud token exchange failed (${response.status}): ${text}`);
+  }
+
+  return response.json() as Promise<BlackbaudTokenResponse>;
+}
+
+/**
+ * Refreshes an expired access token.
+ */
+export async function refreshAccessToken(refreshToken: string): Promise<BlackbaudTokenResponse> {
+  const response = await fetch(BLACKBAUD_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: getBlackbaudClientId(),
+      client_secret: getBlackbaudClientSecret(),
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Blackbaud token refresh failed (${response.status}): ${text}`);
+  }
+
+  return response.json() as Promise<BlackbaudTokenResponse>;
+}
+
+/**
+ * Checks if an access token is expired or about to expire.
+ */
+export function isTokenExpired(expiresAt: Date, bufferSeconds: number = 300): boolean {
+  const bufferMs = bufferSeconds * 1000;
+  return Date.now() >= expiresAt.getTime() - bufferMs;
+}
+
+/**
+ * Creates a structured sync error for storage in org_integrations.last_sync_error
+ */
+export function makeSyncError(
+  phase: SyncError["phase"],
+  code: string,
+  message: string
+): SyncError {
+  return { phase, code, message, at: new Date().toISOString() };
+}

--- a/src/lib/blackbaud/storage.ts
+++ b/src/lib/blackbaud/storage.ts
@@ -62,7 +62,7 @@ export async function upsertConstituents(
           const alumniUpdatedAt = currentAlumni.updated_at ? new Date(currentAlumni.updated_at) : null;
           const userHasEdited = lastSync && alumniUpdatedAt && alumniUpdatedAt > lastSync;
 
-          const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+          const updates: Record<string, unknown> = {};
 
           if (!userHasEdited) {
             // No user edits since last sync — safe to overwrite all fields
@@ -79,6 +79,11 @@ export async function upsertConstituents(
             if (!currentAlumni.address_summary && record.address_summary) updates.address_summary = record.address_summary;
             if (!currentAlumni.graduation_year && record.graduation_year) updates.graduation_year = record.graduation_year;
           }
+
+          // Only bump updated_at when actual fields change (prevents sticky provenance)
+          const hasFieldChanges = Object.keys(updates).length > 0;
+          if (!hasFieldChanges) { unchanged += 1; continue; }
+          updates.updated_at = new Date().toISOString();
 
           const { error: updateError } = await supabase
             .from("alumni")
@@ -131,14 +136,24 @@ export async function upsertConstituents(
           continue;
         }
 
-        // Create external ID mapping
-        await supabase.from("alumni_external_ids").insert({
+        // Create external ID mapping — rollback alumni if this fails
+        const { error: mappingError } = await supabase.from("alumni_external_ids").insert({
           alumni_id: newAlumni.id,
           integration_id: integrationId,
           external_id: record.external_id,
           external_data: record as unknown,
           last_synced_at: new Date().toISOString(),
         });
+
+        if (mappingError) {
+          debugLog("blackbaud-storage", "mapping insert failed, rolling back alumni", {
+            alumniId: newAlumni.id,
+            error: mappingError.message,
+          });
+          await supabase.from("alumni").delete().eq("id", newAlumni.id);
+          skipped += 1;
+          continue;
+        }
 
         created += 1;
         runningCount += 1;

--- a/src/lib/blackbaud/storage.ts
+++ b/src/lib/blackbaud/storage.ts
@@ -1,0 +1,156 @@
+import type { NormalizedConstituent, SyncResult } from "./types";
+import { debugLog } from "@/lib/debug";
+
+export function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+interface UpsertDeps {
+  supabase: any;
+  integrationId: string;
+  organizationId: string;
+  alumniLimit: number | null;
+  currentAlumniCount: number;
+}
+
+/**
+ * Upserts normalized constituents into the alumni table + alumni_external_ids.
+ *
+ * Conflict resolution:
+ * - If external_id already mapped → update alumni record (preserve user-edited fields)
+ * - Otherwise → create new alumni record (respecting quota)
+ * - No email auto-merge in Phase 1 (deferred to Phase 2 claim flow)
+ */
+export async function upsertConstituents(
+  deps: UpsertDeps,
+  constituents: NormalizedConstituent[]
+): Promise<SyncResult> {
+  const { supabase, integrationId, organizationId, alumniLimit, currentAlumniCount } = deps;
+  let created = 0;
+  let updated = 0;
+  let unchanged = 0;
+  let skipped = 0;
+  let runningCount = currentAlumniCount;
+
+  for (const chunk of chunkArray(constituents, 50)) {
+    for (const record of chunk) {
+      try {
+        // Step 1: Check if external ID already mapped
+        const { data: existingMapping } = await supabase
+          .from("alumni_external_ids")
+          .select("id, alumni_id, last_synced_at")
+          .eq("integration_id", integrationId)
+          .eq("external_id", record.external_id)
+          .maybeSingle();
+
+        if (existingMapping) {
+          // Update existing linked alumni — PRESERVE USER-EDITED FIELDS
+          const { data: currentAlumni } = await supabase
+            .from("alumni")
+            .select("id, first_name, last_name, email, phone_number, address_summary, graduation_year, updated_at")
+            .eq("id", existingMapping.alumni_id)
+            .is("deleted_at", null)
+            .single();
+
+          if (!currentAlumni) { unchanged += 1; continue; }
+
+          const lastSync = existingMapping.last_synced_at ? new Date(existingMapping.last_synced_at) : null;
+          const alumniUpdatedAt = currentAlumni.updated_at ? new Date(currentAlumni.updated_at) : null;
+          const userHasEdited = lastSync && alumniUpdatedAt && alumniUpdatedAt > lastSync;
+
+          const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+
+          if (!userHasEdited) {
+            // No user edits since last sync — safe to overwrite all fields
+            updates.first_name = record.first_name;
+            updates.last_name = record.last_name;
+            updates.email = record.email;
+            updates.phone_number = record.phone_number;
+            updates.address_summary = record.address_summary;
+            updates.graduation_year = record.graduation_year;
+          } else {
+            // User edited since last sync — only fill blank fields
+            if (!currentAlumni.email && record.email) updates.email = record.email;
+            if (!currentAlumni.phone_number && record.phone_number) updates.phone_number = record.phone_number;
+            if (!currentAlumni.address_summary && record.address_summary) updates.address_summary = record.address_summary;
+            if (!currentAlumni.graduation_year && record.graduation_year) updates.graduation_year = record.graduation_year;
+          }
+
+          const { error: updateError } = await supabase
+            .from("alumni")
+            .update(updates)
+            .eq("id", existingMapping.alumni_id);
+
+          if (updateError) {
+            debugLog("blackbaud-storage", "update error", { alumniId: existingMapping.alumni_id, error: updateError.message });
+            skipped += 1;
+            continue;
+          }
+
+          // Refresh external_data and last_synced_at
+          await supabase
+            .from("alumni_external_ids")
+            .update({
+              external_data: record as unknown,
+              last_synced_at: new Date().toISOString(),
+            })
+            .eq("id", existingMapping.id);
+
+          updated += 1;
+          continue;
+        }
+
+        // Step 2: Create new alumni record (check quota first)
+        if (alumniLimit !== null && runningCount >= alumniLimit) {
+          skipped += 1;
+          continue;
+        }
+
+        const { data: newAlumni, error: insertError } = await supabase
+          .from("alumni")
+          .insert({
+            organization_id: organizationId,
+            first_name: record.first_name,
+            last_name: record.last_name,
+            email: record.email,
+            phone_number: record.phone_number,
+            address_summary: record.address_summary,
+            graduation_year: record.graduation_year,
+            source: "integration_sync",
+          })
+          .select("id")
+          .single();
+
+        if (insertError) {
+          debugLog("blackbaud-storage", "insert error", { record: record.external_id, error: insertError.message });
+          skipped += 1;
+          continue;
+        }
+
+        // Create external ID mapping
+        await supabase.from("alumni_external_ids").insert({
+          alumni_id: newAlumni.id,
+          integration_id: integrationId,
+          external_id: record.external_id,
+          external_data: record as unknown,
+          last_synced_at: new Date().toISOString(),
+        });
+
+        created += 1;
+        runningCount += 1;
+      } catch (err) {
+        debugLog("blackbaud-storage", "record error", {
+          external_id: record.external_id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        skipped += 1;
+      }
+    }
+  }
+
+  return { ok: true, created, updated, unchanged, skipped };
+}

--- a/src/lib/blackbaud/sync.ts
+++ b/src/lib/blackbaud/sync.ts
@@ -1,0 +1,207 @@
+import type {
+  BlackbaudConstituent,
+  BlackbaudEmail,
+  SyncResult,
+  NormalizedConstituent,
+} from "./types";
+import type { BlackbaudClient } from "./client";
+import { normalizeConstituent } from "./normalize";
+import { upsertConstituents } from "./storage";
+import { makeSyncError } from "./oauth";
+import { debugLog } from "@/lib/debug";
+
+export interface SyncDeps {
+  client: BlackbaudClient;
+  supabase: any;
+  integrationId: string;
+  organizationId: string;
+  alumniLimit: number | null;
+  currentAlumniCount: number;
+  syncType: "full" | "incremental" | "manual";
+  lastSyncedAt: string | null;
+}
+
+/**
+ * Runs a full sync cycle: paginated fetch → normalize → upsert.
+ * Creates a sync log entry and updates integration state.
+ */
+export async function runSync(deps: SyncDeps): Promise<SyncResult> {
+  const { client, supabase, integrationId, syncType, lastSyncedAt } = deps;
+
+  // ── Concurrency guard ──
+  const { data: runningSyncs } = await supabase
+    .from("integration_sync_log")
+    .select("id, started_at")
+    .eq("integration_id", integrationId)
+    .eq("status", "running")
+    .limit(1);
+
+  if (runningSyncs && runningSyncs.length > 0) {
+    const runningSync = runningSyncs[0];
+    const startedAt = new Date(runningSync.started_at);
+    const STALE_THRESHOLD_MS = 30 * 60 * 1000;
+
+    if (Date.now() - startedAt.getTime() < STALE_THRESHOLD_MS) {
+      return { ok: false, created: 0, updated: 0, unchanged: 0, skipped: 0, error: "Sync already in progress" };
+    }
+
+    // Stale lock — mark as failed and proceed
+    await supabase
+      .from("integration_sync_log")
+      .update({ status: "failed", error_message: "Stale lock released", completed_at: new Date().toISOString() })
+      .eq("id", runningSync.id);
+  }
+
+  // Create sync log entry (concurrency lock)
+  const { data: syncLog, error: logError } = await supabase
+    .from("integration_sync_log")
+    .insert({
+      integration_id: integrationId,
+      sync_type: syncType,
+      status: "running",
+    })
+    .select("id")
+    .single();
+
+  if (logError) {
+    debugLog("blackbaud-sync", "failed to create sync log", { error: logError.message });
+  }
+
+  const totals: SyncResult = { ok: true, created: 0, updated: 0, unchanged: 0, skipped: 0 };
+
+  try {
+    let offset = 0;
+    const limit = 500;
+    let hasMore = true;
+
+    while (hasMore) {
+      const params: Record<string, string> = {
+        limit: String(limit),
+        offset: String(offset),
+      };
+
+      if (syncType === "incremental" && lastSyncedAt) {
+        params.date_modified = `>${lastSyncedAt}`;
+      }
+
+      const response = await client.getList<BlackbaudConstituent>(
+        "/constituent/v1/constituents",
+        params
+      );
+
+      const constituents = response.value;
+      debugLog("blackbaud-sync", "fetched page", {
+        offset,
+        count: constituents.length,
+        total: response.count,
+      });
+
+      if (constituents.length === 0) {
+        break;
+      }
+
+      // Phase 1: fetch email sub-resource only
+      const normalized: NormalizedConstituent[] = [];
+      for (const constituent of constituents) {
+        try {
+          let emails: BlackbaudEmail[] = [];
+          try {
+            const emailsRes = await client.getList<BlackbaudEmail>(
+              `/constituent/v1/constituents/${constituent.id}/emailaddresses`
+            );
+            emails = emailsRes.value;
+            await new Promise((resolve) => setTimeout(resolve, 50));
+          } catch (err) {
+            debugLog("blackbaud-sync", "email fetch error", {
+              constituentId: constituent.id,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+
+          normalized.push(normalizeConstituent(constituent, emails, [], []));
+        } catch (err) {
+          debugLog("blackbaud-sync", "normalize error", {
+            constituentId: constituent.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          normalized.push(normalizeConstituent(constituent, [], [], []));
+        }
+      }
+
+      const batchResult = await upsertConstituents(
+        {
+          supabase: deps.supabase,
+          integrationId: deps.integrationId,
+          organizationId: deps.organizationId,
+          alumniLimit: deps.alumniLimit,
+          currentAlumniCount: deps.currentAlumniCount + totals.created,
+        },
+        normalized
+      );
+
+      totals.created += batchResult.created;
+      totals.updated += batchResult.updated;
+      totals.unchanged += batchResult.unchanged;
+      totals.skipped += batchResult.skipped;
+
+      offset += limit;
+      hasMore = constituents.length === limit;
+    }
+
+    // Update sync log as completed
+    if (syncLog?.id) {
+      await supabase
+        .from("integration_sync_log")
+        .update({
+          status: "completed",
+          records_created: totals.created,
+          records_updated: totals.updated,
+          records_unchanged: totals.unchanged,
+          records_skipped: totals.skipped,
+          completed_at: new Date().toISOString(),
+        })
+        .eq("id", syncLog.id);
+    }
+
+    // Update integration state
+    await supabase
+      .from("org_integrations")
+      .update({
+        last_synced_at: new Date().toISOString(),
+        last_sync_count: totals.created + totals.updated,
+        last_sync_error: null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", integrationId);
+
+    return totals;
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    const syncError = makeSyncError("api_fetch", "SYNC_FAILED", errorMessage);
+
+    if (syncLog?.id) {
+      await supabase
+        .from("integration_sync_log")
+        .update({
+          status: "failed",
+          records_created: totals.created,
+          records_updated: totals.updated,
+          records_unchanged: totals.unchanged,
+          records_skipped: totals.skipped,
+          error_message: errorMessage,
+          completed_at: new Date().toISOString(),
+        })
+        .eq("id", syncLog.id);
+    }
+
+    await supabase
+      .from("org_integrations")
+      .update({
+        last_sync_error: syncError,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", integrationId);
+
+    return { ...totals, ok: false, error: errorMessage };
+  }
+}

--- a/src/lib/blackbaud/types.ts
+++ b/src/lib/blackbaud/types.ts
@@ -1,0 +1,98 @@
+/** Raw constituent from SKY API GET /constituent/v1/constituents */
+export interface BlackbaudConstituent {
+  id: string;
+  type: string;
+  lookup_id?: string;
+  first?: string;
+  last?: string;
+  preferred_name?: string;
+  former_name?: string;
+  suffix?: string;
+  title?: string;
+  gender?: string;
+  birthdate?: { y: number; m: number; d: number };
+  age?: number;
+  deceased?: boolean;
+  date_added?: string;
+  date_modified?: string;
+  gives_anonymously?: boolean;
+  class_of?: string;
+}
+
+/** Raw email address from SKY API */
+export interface BlackbaudEmail {
+  id: string;
+  address: string;
+  type: string;
+  primary?: boolean;
+  inactive?: boolean;
+  do_not_email?: boolean;
+}
+
+/** Raw phone from SKY API */
+export interface BlackbaudPhone {
+  id: string;
+  number: string;
+  type: string;
+  primary?: boolean;
+  inactive?: boolean;
+  do_not_call?: boolean;
+}
+
+/** Raw address from SKY API */
+export interface BlackbaudAddress {
+  id: string;
+  address_lines?: string;
+  city?: string;
+  state?: string;
+  postal_code?: string;
+  country?: string;
+  type: string;
+  primary?: boolean;
+  inactive?: boolean;
+}
+
+/** Paginated list response from SKY API */
+export interface BlackbaudListResponse<T> {
+  count: number;
+  next_link?: string;
+  value: T[];
+}
+
+/** Normalized alumni record ready for upsert */
+export interface NormalizedConstituent {
+  external_id: string;
+  first_name: string;
+  last_name: string;
+  email: string | null;
+  phone_number: string | null;
+  address_summary: string | null;
+  graduation_year: number | null;
+  source: "integration_sync";
+}
+
+/** OAuth token pair from Blackbaud */
+export interface BlackbaudTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+/** Structured sync error stored in org_integrations.last_sync_error */
+export interface SyncError {
+  phase: "token_refresh" | "code_exchange" | "state_validation" | "api_verify" | "api_fetch" | "upsert";
+  code: string;
+  message: string;
+  at: string;
+}
+
+/** Sync result returned by the sync engine */
+export interface SyncResult {
+  ok: boolean;
+  created: number;
+  updated: number;
+  unchanged: number;
+  skipped: number;
+  error?: string;
+}

--- a/src/lib/schemas/blackbaud.ts
+++ b/src/lib/schemas/blackbaud.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { safeString, baseSchemas } from "./common";
+
+// OAuth initiation — admin provides orgSlug, we redirect to Blackbaud
+export const blackbaudAuthSchema = z
+  .object({
+    orgSlug: safeString(100),
+  })
+  .strict();
+export type BlackbaudAuthRequest = z.infer<typeof blackbaudAuthSchema>;
+
+// OAuth callback — Blackbaud redirects with code + state
+export const blackbaudCallbackSchema = z
+  .object({
+    code: safeString(2048),
+    state: baseSchemas.uuid,
+  })
+  .strict();
+export type BlackbaudCallbackRequest = z.infer<typeof blackbaudCallbackSchema>;
+
+// Manual sync trigger
+export const blackbaudSyncSchema = z
+  .object({
+    syncType: z.enum(["full", "incremental"]).default("incremental"),
+  })
+  .strict();
+export type BlackbaudSyncRequest = z.infer<typeof blackbaudSyncSchema>;
+
+// Disconnect request
+export const blackbaudDisconnectSchema = z
+  .object({
+    orgSlug: safeString(100),
+  })
+  .strict();
+export type BlackbaudDisconnectRequest = z.infer<typeof blackbaudDisconnectSchema>;

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -67,3 +67,6 @@ export * from "./media";
 
 // Enterprise schemas
 export * from "./enterprise";
+
+// Blackbaud integration schemas
+export * from "./blackbaud";

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -83,8 +83,160 @@ export type Database = {
           },
         ]
       }
+      ai_audit_log: {
+        Row: {
+          created_at: string
+          error: string | null
+          expires_at: string
+          id: string
+          input_tokens: number | null
+          intent: string | null
+          latency_ms: number | null
+          message_id: string | null
+          model: string | null
+          org_id: string
+          output_tokens: number | null
+          thread_id: string | null
+          tool_calls: Json | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          error?: string | null
+          expires_at?: string
+          id?: string
+          input_tokens?: number | null
+          intent?: string | null
+          latency_ms?: number | null
+          message_id?: string | null
+          model?: string | null
+          org_id: string
+          output_tokens?: number | null
+          thread_id?: string | null
+          tool_calls?: Json | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          error?: string | null
+          expires_at?: string
+          id?: string
+          input_tokens?: number | null
+          intent?: string | null
+          latency_ms?: number | null
+          message_id?: string | null
+          model?: string | null
+          org_id?: string
+          output_tokens?: number | null
+          thread_id?: string | null
+          tool_calls?: Json | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "ai_audit_log_message_id_fkey"
+            columns: ["message_id"]
+            isOneToOne: false
+            referencedRelation: "ai_messages"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "ai_audit_log_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: false
+            referencedRelation: "ai_threads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      ai_messages: {
+        Row: {
+          content: string | null
+          created_at: string
+          id: string
+          idempotency_key: string | null
+          intent: string | null
+          role: string
+          status: string
+          thread_id: string
+          tool_calls: Json | null
+        }
+        Insert: {
+          content?: string | null
+          created_at?: string
+          id?: string
+          idempotency_key?: string | null
+          intent?: string | null
+          role: string
+          status?: string
+          thread_id: string
+          tool_calls?: Json | null
+        }
+        Update: {
+          content?: string | null
+          created_at?: string
+          id?: string
+          idempotency_key?: string | null
+          intent?: string | null
+          role?: string
+          status?: string
+          thread_id?: string
+          tool_calls?: Json | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "ai_messages_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: false
+            referencedRelation: "ai_threads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      ai_threads: {
+        Row: {
+          created_at: string
+          deleted_at: string | null
+          id: string
+          org_id: string
+          surface: string
+          title: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          org_id: string
+          surface?: string
+          title?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          org_id?: string
+          surface?: string
+          title?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "ai_threads_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       alumni: {
         Row: {
+          address_summary: string | null
           created_at: string | null
           current_city: string | null
           current_company: string | null
@@ -103,10 +255,12 @@ export type Database = {
           phone_number: string | null
           photo_url: string | null
           position_title: string | null
+          source: string
           updated_at: string | null
           user_id: string | null
         }
         Insert: {
+          address_summary?: string | null
           created_at?: string | null
           current_city?: string | null
           current_company?: string | null
@@ -125,10 +279,12 @@ export type Database = {
           phone_number?: string | null
           photo_url?: string | null
           position_title?: string | null
+          source?: string
           updated_at?: string | null
           user_id?: string | null
         }
         Update: {
+          address_summary?: string | null
           created_at?: string | null
           current_city?: string | null
           current_company?: string | null
@@ -147,6 +303,7 @@ export type Database = {
           phone_number?: string | null
           photo_url?: string | null
           position_title?: string | null
+          source?: string
           updated_at?: string | null
           user_id?: string | null
         }
@@ -156,6 +313,58 @@ export type Database = {
             columns: ["organization_id"]
             isOneToOne: false
             referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      alumni_external_ids: {
+        Row: {
+          alumni_id: string
+          created_at: string
+          external_data: Json | null
+          external_id: string
+          id: string
+          integration_id: string
+          last_synced_at: string | null
+        }
+        Insert: {
+          alumni_id: string
+          created_at?: string
+          external_data?: Json | null
+          external_id: string
+          id?: string
+          integration_id: string
+          last_synced_at?: string | null
+        }
+        Update: {
+          alumni_id?: string
+          created_at?: string
+          external_data?: Json | null
+          external_id?: string
+          id?: string
+          integration_id?: string
+          last_synced_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "alumni_external_ids_alumni_id_fkey"
+            columns: ["alumni_id"]
+            isOneToOne: false
+            referencedRelation: "alumni"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "alumni_external_ids_alumni_id_fkey"
+            columns: ["alumni_id"]
+            isOneToOne: false
+            referencedRelation: "enterprise_alumni_directory"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "alumni_external_ids_integration_id_fkey"
+            columns: ["integration_id"]
+            isOneToOne: false
+            referencedRelation: "org_integrations"
             referencedColumns: ["id"]
           },
         ]
@@ -1264,6 +1473,57 @@ export type Database = {
           },
         ]
       }
+      enterprise_audit_logs: {
+        Row: {
+          action: string
+          actor_email_redacted: string
+          actor_user_id: string
+          created_at: string
+          enterprise_id: string
+          id: string
+          ip_address: string | null
+          metadata: Json | null
+          organization_id: string | null
+          request_method: string | null
+          request_path: string | null
+          target_id: string | null
+          target_type: string | null
+          user_agent: string | null
+        }
+        Insert: {
+          action: string
+          actor_email_redacted: string
+          actor_user_id: string
+          created_at?: string
+          enterprise_id: string
+          id?: string
+          ip_address?: string | null
+          metadata?: Json | null
+          organization_id?: string | null
+          request_method?: string | null
+          request_path?: string | null
+          target_id?: string | null
+          target_type?: string | null
+          user_agent?: string | null
+        }
+        Update: {
+          action?: string
+          actor_email_redacted?: string
+          actor_user_id?: string
+          created_at?: string
+          enterprise_id?: string
+          id?: string
+          ip_address?: string | null
+          metadata?: Json | null
+          organization_id?: string | null
+          request_method?: string | null
+          request_path?: string | null
+          target_id?: string | null
+          target_type?: string | null
+          user_agent?: string | null
+        }
+        Relationships: []
+      }
       enterprise_invites: {
         Row: {
           code: string
@@ -1331,17 +1591,12 @@ export type Database = {
       enterprise_subscriptions: {
         Row: {
           alumni_bucket_quantity: number
-          alumni_tier: string
           billing_interval: string
           created_at: string
           current_period_end: string | null
-          custom_price_cents: number | null
           enterprise_id: string
           grace_period_ends_at: string | null
           id: string
-          pooled_alumni_limit: number | null
-          price_per_sub_org_cents: number | null
-          pricing_model: string | null
           status: string
           stripe_customer_id: string | null
           stripe_subscription_id: string | null
@@ -1350,17 +1605,12 @@ export type Database = {
         }
         Insert: {
           alumni_bucket_quantity?: number
-          alumni_tier?: string
           billing_interval: string
           created_at?: string
           current_period_end?: string | null
-          custom_price_cents?: number | null
           enterprise_id: string
           grace_period_ends_at?: string | null
           id?: string
-          pooled_alumni_limit?: number | null
-          price_per_sub_org_cents?: number | null
-          pricing_model?: string | null
           status?: string
           stripe_customer_id?: string | null
           stripe_subscription_id?: string | null
@@ -1369,17 +1619,12 @@ export type Database = {
         }
         Update: {
           alumni_bucket_quantity?: number
-          alumni_tier?: string
           billing_interval?: string
           created_at?: string
           current_period_end?: string | null
-          custom_price_cents?: number | null
           enterprise_id?: string
           grace_period_ends_at?: string | null
           id?: string
-          pooled_alumni_limit?: number | null
-          price_per_sub_org_cents?: number | null
-          pricing_model?: string | null
           status?: string
           stripe_customer_id?: string | null
           stripe_subscription_id?: string | null
@@ -1897,6 +2142,51 @@ export type Database = {
           },
         ]
       }
+      feed_poll_votes: {
+        Row: {
+          created_at: string | null
+          id: string
+          option_index: number
+          organization_id: string
+          post_id: string
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          option_index: number
+          organization_id: string
+          post_id: string
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          option_index?: number
+          organization_id?: string
+          post_id?: string
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "feed_poll_votes_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "feed_poll_votes_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "feed_posts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       feed_posts: {
         Row: {
           author_id: string
@@ -1906,7 +2196,9 @@ export type Database = {
           deleted_at: string | null
           id: string
           like_count: number
+          metadata: Json | null
           organization_id: string
+          post_type: string
           updated_at: string
         }
         Insert: {
@@ -1917,7 +2209,9 @@ export type Database = {
           deleted_at?: string | null
           id?: string
           like_count?: number
+          metadata?: Json | null
           organization_id: string
+          post_type?: string
           updated_at?: string
         }
         Update: {
@@ -1928,7 +2222,9 @@ export type Database = {
           deleted_at?: string | null
           id?: string
           like_count?: number
+          metadata?: Json | null
           organization_id?: string
+          post_type?: string
           updated_at?: string
         }
         Relationships: [
@@ -2168,6 +2464,56 @@ export type Database = {
             columns: ["organization_id"]
             isOneToOne: false
             referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      integration_sync_log: {
+        Row: {
+          completed_at: string | null
+          error_message: string | null
+          id: string
+          integration_id: string
+          records_created: number
+          records_skipped: number
+          records_unchanged: number
+          records_updated: number
+          started_at: string
+          status: string
+          sync_type: string
+        }
+        Insert: {
+          completed_at?: string | null
+          error_message?: string | null
+          id?: string
+          integration_id: string
+          records_created?: number
+          records_skipped?: number
+          records_unchanged?: number
+          records_updated?: number
+          started_at?: string
+          status?: string
+          sync_type: string
+        }
+        Update: {
+          completed_at?: string | null
+          error_message?: string | null
+          id?: string
+          integration_id?: string
+          records_created?: number
+          records_skipped?: number
+          records_unchanged?: number
+          records_updated?: number
+          started_at?: string
+          status?: string
+          sync_type?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "integration_sync_log_integration_id_fkey"
+            columns: ["integration_id"]
+            isOneToOne: false
+            referencedRelation: "org_integrations"
             referencedColumns: ["id"]
           },
         ]
@@ -2550,6 +2896,7 @@ export type Database = {
       members: {
         Row: {
           created_at: string | null
+          current_company: string | null
           deleted_at: string | null
           email: string | null
           expected_graduation_date: string | null
@@ -2563,12 +2910,14 @@ export type Database = {
           organization_id: string
           photo_url: string | null
           role: string | null
+          school: string | null
           status: Database["public"]["Enums"]["member_status"] | null
           updated_at: string | null
           user_id: string | null
         }
         Insert: {
           created_at?: string | null
+          current_company?: string | null
           deleted_at?: string | null
           email?: string | null
           expected_graduation_date?: string | null
@@ -2582,12 +2931,14 @@ export type Database = {
           organization_id: string
           photo_url?: string | null
           role?: string | null
+          school?: string | null
           status?: Database["public"]["Enums"]["member_status"] | null
           updated_at?: string | null
           user_id?: string | null
         }
         Update: {
           created_at?: string | null
+          current_company?: string | null
           deleted_at?: string | null
           email?: string | null
           expected_graduation_date?: string | null
@@ -2601,6 +2952,7 @@ export type Database = {
           organization_id?: string
           photo_url?: string | null
           role?: string | null
+          school?: string | null
           status?: Database["public"]["Enums"]["member_status"] | null
           updated_at?: string | null
           user_id?: string | null
@@ -2970,6 +3322,103 @@ export type Database = {
           },
         ]
       }
+      org_integration_oauth_state: {
+        Row: {
+          id: string
+          initiated_at: string
+          organization_id: string
+          provider: string
+          redirect_path: string | null
+          used: boolean
+          user_id: string
+        }
+        Insert: {
+          id?: string
+          initiated_at?: string
+          organization_id: string
+          provider: string
+          redirect_path?: string | null
+          used?: boolean
+          user_id: string
+        }
+        Update: {
+          id?: string
+          initiated_at?: string
+          organization_id?: string
+          provider?: string
+          redirect_path?: string | null
+          used?: boolean
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "org_integration_oauth_state_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      org_integrations: {
+        Row: {
+          access_token_enc: string | null
+          connected_by: string | null
+          created_at: string
+          id: string
+          last_sync_count: number | null
+          last_sync_error: Json | null
+          last_synced_at: string | null
+          organization_id: string
+          provider: string
+          provider_config: Json
+          refresh_token_enc: string | null
+          status: string
+          token_expires_at: string | null
+          updated_at: string
+        }
+        Insert: {
+          access_token_enc?: string | null
+          connected_by?: string | null
+          created_at?: string
+          id?: string
+          last_sync_count?: number | null
+          last_sync_error?: Json | null
+          last_synced_at?: string | null
+          organization_id: string
+          provider: string
+          provider_config?: Json
+          refresh_token_enc?: string | null
+          status?: string
+          token_expires_at?: string | null
+          updated_at?: string
+        }
+        Update: {
+          access_token_enc?: string | null
+          connected_by?: string | null
+          created_at?: string
+          id?: string
+          last_sync_count?: number | null
+          last_sync_error?: Json | null
+          last_synced_at?: string | null
+          organization_id?: string
+          provider?: string
+          provider_config?: Json
+          refresh_token_enc?: string | null
+          status?: string
+          token_expires_at?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "org_integrations_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       org_philanthropy_embeds: {
         Row: {
           created_at: string
@@ -3046,6 +3495,7 @@ export type Database = {
       organization_donations: {
         Row: {
           amount_cents: number
+          anonymous: boolean
           created_at: string
           currency: string
           donor_email: string | null
@@ -3062,6 +3512,7 @@ export type Database = {
         }
         Insert: {
           amount_cents: number
+          anonymous?: boolean
           created_at?: string
           currency?: string
           donor_email?: string | null
@@ -3078,6 +3529,7 @@ export type Database = {
         }
         Update: {
           amount_cents?: number
+          anonymous?: boolean
           created_at?: string
           currency?: string
           donor_email?: string | null
@@ -4570,6 +5022,12 @@ export type Database = {
       get_dropdown_options: { Args: { p_org_id: string }; Returns: Json }
       get_media_storage_stats: { Args: { p_org_id: string }; Returns: Json }
       get_org_context_by_slug: { Args: { p_slug: string }; Returns: Json }
+      get_parents_relationship_options: {
+        Args: { p_org_id: string }
+        Returns: {
+          relationship: string
+        }[]
+      }
       get_subscription_status: {
         Args: { p_org_id: string }
         Returns: {
@@ -4648,6 +5106,7 @@ export type Database = {
       parents_bucket_limit: { Args: { p_bucket: string }; Returns: number }
       purge_analytics_events: { Args: never; Returns: Json }
       purge_expired_usage_events: { Args: never; Returns: Json }
+      purge_old_enterprise_audit_logs: { Args: never; Returns: number }
       purge_ops_events: { Args: never; Returns: Json }
       redeem_enterprise_invite: {
         Args: { p_code_or_token: string }
@@ -4663,9 +5122,35 @@ export type Database = {
           quota_limit: number
         }[]
       }
+      save_user_linkedin_url: {
+        Args: { p_linkedin_url: string; p_user_id: string }
+        Returns: Json
+      }
       sync_enterprise_nav_to_org: {
         Args: { p_enterprise_id: string; p_organization_id: string }
         Returns: boolean
+      }
+      sync_user_linkedin_enrichment: {
+        Args: {
+          p_current_city?: string
+          p_current_company?: string
+          p_enrichment_json?: Json
+          p_job_title?: string
+          p_major?: string
+          p_position_title?: string
+          p_school?: string
+          p_user_id: string
+        }
+        Returns: Json
+      }
+      sync_user_linkedin_profile_fields: {
+        Args: {
+          p_first_name: string
+          p_last_name: string
+          p_photo_url: string
+          p_user_id: string
+        }
+        Returns: Json
       }
       update_error_baselines: { Args: never; Returns: undefined }
       upsert_error_group: {

--- a/supabase/migrations/20260320120000_blackbaud_integration_tables.sql
+++ b/supabase/migrations/20260320120000_blackbaud_integration_tables.sql
@@ -1,0 +1,151 @@
+-- =============================================================
+-- Blackbaud / CRM Integration Tables
+-- =============================================================
+
+-- 1. org_integrations: stores OAuth connections per org per provider
+CREATE TABLE IF NOT EXISTS public.org_integrations (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  provider        text NOT NULL,
+  status          text NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending','active','error','disconnected')),
+  access_token_enc  text,
+  refresh_token_enc text,
+  token_expires_at  timestamptz,
+  provider_config   jsonb NOT NULL DEFAULT '{}',
+  connected_by      uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  last_synced_at    timestamptz,
+  last_sync_error   jsonb,
+  last_sync_count   integer,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(organization_id, provider)
+);
+
+-- 2. alumni_external_ids: provider-agnostic external ID mapping
+CREATE TABLE IF NOT EXISTS public.alumni_external_ids (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  alumni_id       uuid NOT NULL REFERENCES public.alumni(id) ON DELETE CASCADE,
+  integration_id  uuid NOT NULL REFERENCES public.org_integrations(id) ON DELETE CASCADE,
+  external_id     text NOT NULL,
+  external_data   jsonb,
+  last_synced_at  timestamptz,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(integration_id, external_id)
+);
+CREATE INDEX IF NOT EXISTS idx_alumni_external_ids_alumni
+  ON public.alumni_external_ids(alumni_id);
+
+-- 3. integration_sync_log: audit trail for sync operations
+CREATE TABLE IF NOT EXISTS public.integration_sync_log (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  integration_id    uuid NOT NULL REFERENCES public.org_integrations(id) ON DELETE CASCADE,
+  sync_type         text NOT NULL CHECK (sync_type IN ('full','incremental','manual')),
+  status            text NOT NULL DEFAULT 'running'
+                    CHECK (status IN ('running','completed','failed')),
+  records_created   integer NOT NULL DEFAULT 0,
+  records_updated   integer NOT NULL DEFAULT 0,
+  records_unchanged integer NOT NULL DEFAULT 0,
+  records_skipped   integer NOT NULL DEFAULT 0,
+  error_message     text,
+  started_at        timestamptz NOT NULL DEFAULT now(),
+  completed_at      timestamptz
+);
+
+-- 4. OAuth state table (separate from live integration to avoid disrupting active connections)
+CREATE TABLE IF NOT EXISTS public.org_integration_oauth_state (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  provider        text NOT NULL,
+  user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  redirect_path   text,
+  initiated_at    timestamptz NOT NULL DEFAULT now(),
+  used            boolean NOT NULL DEFAULT false
+);
+CREATE INDEX IF NOT EXISTS idx_oauth_state_cleanup
+  ON public.org_integration_oauth_state(initiated_at);
+
+-- RLS for oauth_state (service role only — no client access needed)
+ALTER TABLE public.org_integration_oauth_state ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "oauth_state_service_role"
+  ON public.org_integration_oauth_state FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- 5. Add provider-agnostic columns to alumni
+ALTER TABLE public.alumni
+  ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'manual',
+  ADD COLUMN IF NOT EXISTS address_summary text;
+
+-- 6. RLS policies for org_integrations
+ALTER TABLE public.org_integrations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "org_integrations_select_org_member"
+  ON public.org_integrations FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_organization_roles r
+      WHERE r.organization_id = org_integrations.organization_id
+        AND r.user_id = auth.uid()
+        AND r.status = 'active'
+    )
+  );
+
+CREATE POLICY "org_integrations_insert_org_admin"
+  ON public.org_integrations FOR INSERT
+  WITH CHECK (
+    is_org_admin(organization_id)
+  );
+
+CREATE POLICY "org_integrations_update_org_admin"
+  ON public.org_integrations FOR UPDATE
+  USING (
+    is_org_admin(organization_id)
+  );
+
+CREATE POLICY "org_integrations_delete_org_admin"
+  ON public.org_integrations FOR DELETE
+  USING (
+    is_org_admin(organization_id)
+  );
+
+-- Service role bypass for cron/sync operations
+CREATE POLICY "org_integrations_service_role"
+  ON public.org_integrations FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- 7. RLS policies for alumni_external_ids
+ALTER TABLE public.alumni_external_ids ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "alumni_external_ids_select_org_member"
+  ON public.alumni_external_ids FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.org_integrations i
+      JOIN public.user_organization_roles r
+        ON r.organization_id = i.organization_id
+      WHERE i.id = alumni_external_ids.integration_id
+        AND r.user_id = auth.uid()
+        AND r.status = 'active'
+    )
+  );
+
+CREATE POLICY "alumni_external_ids_service_role"
+  ON public.alumni_external_ids FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- 8. RLS policies for integration_sync_log
+ALTER TABLE public.integration_sync_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "integration_sync_log_select_org_admin"
+  ON public.integration_sync_log FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.org_integrations i
+      WHERE i.id = integration_sync_log.integration_id
+        AND is_org_admin(i.organization_id)
+    )
+  );
+
+CREATE POLICY "integration_sync_log_service_role"
+  ON public.integration_sync_log FOR ALL
+  USING (auth.role() = 'service_role');

--- a/tests/blackbaud-client.test.ts
+++ b/tests/blackbaud-client.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+describe("BlackbaudClient", () => {
+  it("builds correct URL with subscription key header", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    const mockFetch = mock.fn(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({ count: 0, value: [] }), { status: 200 });
+    });
+
+    const { createBlackbaudClient } = await import("../src/lib/blackbaud/client");
+    const client = createBlackbaudClient({
+      accessToken: "test-token",
+      subscriptionKey: "test-sub-key",
+      fetchFn: mockFetch as unknown as typeof fetch,
+    });
+
+    await client.get("/constituent/v1/constituents", { limit: "10" });
+
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].url.includes("/constituent/v1/constituents"));
+    assert.ok(calls[0].url.includes("limit=10"));
+
+    const headers = calls[0].init.headers as Record<string, string>;
+    assert.equal(headers["Authorization"], "Bearer test-token");
+    assert.equal(headers["Bb-Api-Subscription-Key"], "test-sub-key");
+  });
+
+  it("throws on non-200 responses", async () => {
+    const mockFetch = mock.fn(async () => {
+      return new Response("Forbidden", { status: 403 });
+    });
+
+    const { createBlackbaudClient } = await import("../src/lib/blackbaud/client");
+    const client = createBlackbaudClient({
+      accessToken: "test-token",
+      subscriptionKey: "test-sub-key",
+      fetchFn: mockFetch as unknown as typeof fetch,
+    });
+
+    await assert.rejects(
+      () => client.get("/constituent/v1/constituents"),
+      (err: Error) => err.message.includes("403")
+    );
+  });
+
+  it("throws specific error on rate limit (429)", async () => {
+    const mockFetch = mock.fn(async () => {
+      return new Response("Rate limited", { status: 429 });
+    });
+
+    const { createBlackbaudClient } = await import("../src/lib/blackbaud/client");
+    const client = createBlackbaudClient({
+      accessToken: "test-token",
+      subscriptionKey: "test-sub-key",
+      fetchFn: mockFetch as unknown as typeof fetch,
+    });
+
+    await assert.rejects(
+      () => client.get("/constituent/v1/constituents"),
+      (err: Error) => err.message.includes("rate limit")
+    );
+  });
+});

--- a/tests/blackbaud-normalize.test.ts
+++ b/tests/blackbaud-normalize.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+describe("normalizeConstituent", () => {
+  it("maps a full constituent record", async () => {
+    const { normalizeConstituent } = await import("../src/lib/blackbaud/normalize");
+    const result = normalizeConstituent(
+      {
+        id: "abc-123",
+        type: "Individual",
+        first: "Jane",
+        last: "Doe",
+        class_of: "2015",
+      },
+      [{ id: "e1", address: "jane@example.com", type: "Email", primary: true }],
+      [{ id: "p1", number: "555-1234", type: "Mobile", primary: true }],
+      [{
+        id: "a1",
+        address_lines: "123 Main St",
+        city: "Springfield",
+        state: "IL",
+        postal_code: "62701",
+        country: "US",
+        type: "Home",
+        primary: true,
+      }]
+    );
+
+    assert.equal(result.external_id, "abc-123");
+    assert.equal(result.first_name, "Jane");
+    assert.equal(result.last_name, "Doe");
+    assert.equal(result.email, "jane@example.com");
+    assert.equal(result.phone_number, "555-1234");
+    assert.equal(result.address_summary, "123 Main St, Springfield, IL 62701");
+    assert.equal(result.graduation_year, 2015);
+    assert.equal(result.source, "integration_sync");
+  });
+
+  it("handles missing sub-resources gracefully", async () => {
+    const { normalizeConstituent } = await import("../src/lib/blackbaud/normalize");
+    const result = normalizeConstituent(
+      { id: "xyz-789", type: "Individual", first: "John", last: "Smith" },
+      [],
+      [],
+      []
+    );
+
+    assert.equal(result.external_id, "xyz-789");
+    assert.equal(result.first_name, "John");
+    assert.equal(result.last_name, "Smith");
+    assert.equal(result.email, null);
+    assert.equal(result.phone_number, null);
+    assert.equal(result.address_summary, null);
+    assert.equal(result.graduation_year, null);
+  });
+
+  it("selects primary email over non-primary", async () => {
+    const { normalizeConstituent } = await import("../src/lib/blackbaud/normalize");
+    const result = normalizeConstituent(
+      { id: "test", type: "Individual", first: "A", last: "B" },
+      [
+        { id: "e1", address: "secondary@example.com", type: "Email", primary: false },
+        { id: "e2", address: "primary@example.com", type: "Email", primary: true },
+      ],
+      [],
+      []
+    );
+
+    assert.equal(result.email, "primary@example.com");
+  });
+
+  it("skips inactive items", async () => {
+    const { normalizeConstituent } = await import("../src/lib/blackbaud/normalize");
+    const result = normalizeConstituent(
+      { id: "test2", type: "Individual", first: "C", last: "D" },
+      [
+        { id: "e1", address: "inactive@example.com", type: "Email", primary: true, inactive: true },
+        { id: "e2", address: "active@example.com", type: "Email", primary: false },
+      ],
+      [],
+      []
+    );
+
+    assert.equal(result.email, "active@example.com");
+  });
+
+  it("returns null graduation_year for invalid class_of", async () => {
+    const { normalizeConstituent } = await import("../src/lib/blackbaud/normalize");
+    const result = normalizeConstituent(
+      { id: "test3", type: "Individual", first: "E", last: "F", class_of: "notayear" },
+      [], [], []
+    );
+
+    assert.equal(result.graduation_year, null);
+  });
+});

--- a/tests/blackbaud-oauth.test.ts
+++ b/tests/blackbaud-oauth.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// Set env vars before importing the module so env helpers resolve correctly
+process.env.BLACKBAUD_CLIENT_ID = process.env.BLACKBAUD_CLIENT_ID || "test-client-id";
+process.env.NEXT_PUBLIC_SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://www.myteamnetwork.com";
+
+const { isTokenExpired, getAuthorizationUrl, makeSyncError } = await import(
+  "@/lib/blackbaud/oauth"
+);
+
+describe("Blackbaud OAuth", () => {
+  it("isTokenExpired returns true for expired tokens", () => {
+    const pastDate = new Date(Date.now() - 60_000);
+    assert.equal(isTokenExpired(pastDate), true);
+  });
+
+  it("isTokenExpired returns false for fresh tokens", () => {
+    const futureDate = new Date(Date.now() + 600_000);
+    assert.equal(isTokenExpired(futureDate), false);
+  });
+
+  it("isTokenExpired returns true within buffer window", () => {
+    // Token expires in 2 minutes, but buffer is 5 minutes
+    const nearFuture = new Date(Date.now() + 120_000);
+    assert.equal(isTokenExpired(nearFuture, 300), true);
+  });
+
+  it("getAuthorizationUrl returns a valid URL", () => {
+    const url = getAuthorizationUrl("test-state-uuid");
+    const parsed = new URL(url);
+
+    assert.equal(parsed.hostname, "oauth2.sky.blackbaud.com");
+    assert.equal(parsed.pathname, "/authorization");
+    assert.equal(parsed.searchParams.get("client_id"), "test-client-id");
+    assert.equal(parsed.searchParams.get("state"), "test-state-uuid");
+    assert.ok(parsed.searchParams.get("redirect_uri")?.includes("/api/blackbaud/callback"));
+  });
+
+  it("makeSyncError creates structured error", () => {
+    const error = makeSyncError("api_fetch", "RATE_LIMITED", "Too many requests");
+
+    assert.equal(error.phase, "api_fetch");
+    assert.equal(error.code, "RATE_LIMITED");
+    assert.equal(error.message, "Too many requests");
+    assert.ok(error.at); // ISO timestamp
+  });
+});

--- a/tests/blackbaud-storage.test.ts
+++ b/tests/blackbaud-storage.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+describe("chunkArray", () => {
+  it("splits into correct chunks", async () => {
+    const { chunkArray } = await import("../src/lib/blackbaud/storage");
+    const items = [1, 2, 3, 4, 5];
+    const chunks = chunkArray(items, 2);
+    assert.deepEqual(chunks, [[1, 2], [3, 4], [5]]);
+  });
+
+  it("handles empty array", async () => {
+    const { chunkArray } = await import("../src/lib/blackbaud/storage");
+    assert.deepEqual(chunkArray([], 10), []);
+  });
+
+  it("handles chunk size larger than array", async () => {
+    const { chunkArray } = await import("../src/lib/blackbaud/storage");
+    assert.deepEqual(chunkArray([1, 2], 10), [[1, 2]]);
+  });
+
+  it("handles chunk size of 1", async () => {
+    const { chunkArray } = await import("../src/lib/blackbaud/storage");
+    assert.deepEqual(chunkArray([1, 2, 3], 1), [[1], [2], [3]]);
+  });
+});


### PR DESCRIPTION
## Summary

- Enables organizations to connect their Blackbaud Raiser's Edge environment via OAuth 2.0
- Syncs constituent data into the alumni directory (manual trigger + nightly cron)
- Provider-agnostic architecture: `org_integrations` table supports future CRM providers

## What's included

### Database (4 new tables + alumni columns)
- `org_integrations` — OAuth connections per org/provider with encrypted tokens
- `alumni_external_ids` — Provider-agnostic external ID mapping
- `integration_sync_log` — Sync audit trail with concurrency guard
- `org_integration_oauth_state` — Separate OAuth state (doesn't disrupt active connections)
- Added `source` and `address_summary` columns to `alumni` table

### OAuth Flow
- `GET /api/blackbaud/auth?orgSlug=X` — Initiates OAuth, admin-only
- `GET /api/blackbaud/callback` — Handles callback with state validation, replay prevention, 15-min expiry
- `POST /api/blackbaud/disconnect?orgSlug=X` — Disconnects, preserves alumni mappings

### Sync Engine
- `POST /api/organizations/:id/integrations/blackbaud/sync` — Manual sync (admin-only)
- `GET /api/cron/integrations-sync` — Nightly cron with 3-org concurrency
- Paginated constituent fetch with email sub-resource enrichment
- Field provenance: user-edited fields preserved on subsequent syncs
- Alumni quota enforcement during sync
- Concurrency guard with 30-min stale lock timeout
- Optimistic token refresh with re-read fallback

### Security
- Rate limiting on all user-facing routes
- Admin auth via `requireOrgRole` (not RLS inference)
- AES-256-GCM token encryption (shared crypto module)
- RLS policies: members can SELECT, admins can mutate, service role bypasses for sync

## Adversarial review findings addressed
1. Auth: explicit admin check on sync route
2. Field provenance: `updated_at` only bumped when fields actually change
3. Concurrency guard: sync log check with stale lock timeout
4. Re-auth safety: separate OAuth state table
5. Callback: requires valid session (no middleware bypass)
6. Orphan prevention: alumni rollback if mapping insert fails

## Test plan
- [x] 17 unit tests passing (oauth, client, normalizer, storage)
- [x] Type check clean on all new files
- [x] Existing test suite passes (1 pre-existing failure in schedule-source-sync.test.ts)
- [x] Migration applied to Supabase, types regenerated
- [ ] Manual: set BLACKBAUD_* env vars, complete OAuth flow
- [ ] Manual: trigger sync, verify alumni appear in directory
- [ ] Manual: verify quota enforcement with low limit
- [ ] Manual: disconnect and verify tokens cleared