### PR TITLE
feat(media): bulk delete, album cover picker, upload-to-album fix

### DIFF
--- a/src/app/api/media/albums/[albumId]/route.ts
+++ b/src/app/api/media/albums/[albumId]/route.ts
@@ -6,6 +6,7 @@ import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limi
 import { getOrgMembership } from "@/lib/auth/api-helpers";
 import { validateJson, ValidationError, validationErrorResponse, baseSchemas, safeString } from "@/lib/security/validation";
 import { batchGetMediaUrls } from "@/lib/media/urls";
+import { getAlbumCoverValidationError } from "@/lib/media/albums";
 import { decodeCursor } from "@/lib/pagination/cursor";
 import { z } from "zod";
 
@@ -216,7 +217,31 @@ export async function PATCH(request: NextRequest, { params }: Params) {
 
     const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
     if (name !== undefined) updates.name = name;
-    if (cover_media_id !== undefined) updates.cover_media_id = cover_media_id;
+    if (cover_media_id !== undefined) {
+      if (cover_media_id === null) {
+        updates.cover_media_id = null;
+      } else {
+        const { data: coverCandidate, error: coverError } = await serviceClient
+          .from("media_album_items")
+          .select("media_items!inner(media_type, status)")
+          .eq("album_id", albumId)
+          .eq("media_item_id", cover_media_id)
+          .maybeSingle();
+
+        if (coverError) {
+          console.error("[media/albums/[albumId]] Cover validation failed:", coverError);
+          return NextResponse.json({ error: "Failed to validate album cover" }, { status: 500 });
+        }
+
+        const media = coverCandidate?.media_items as { media_type: string | null; status: string | null } | undefined;
+        const coverValidationError = getAlbumCoverValidationError(media ?? null);
+        if (coverValidationError) {
+          return NextResponse.json({ error: coverValidationError }, { status: 400 });
+        }
+
+        updates.cover_media_id = cover_media_id;
+      }
+    }
 
     const { data: updated, error: updateError } = await (serviceClient as any)
       .from("media_albums")

--- a/src/app/api/media/albums/route.ts
+++ b/src/app/api/media/albums/route.ts
@@ -7,6 +7,7 @@ import { getOrgMembership } from "@/lib/auth/api-helpers";
 import { validateJson, ValidationError, validationErrorResponse, baseSchemas } from "@/lib/security/validation";
 import { createAlbumSchema } from "@/lib/schemas/media";
 import { batchGetMediaUrls } from "@/lib/media/urls";
+import { shouldExposeAlbumCover } from "@/lib/media/albums";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
@@ -86,7 +87,7 @@ export async function GET(request: NextRequest) {
     if (coversToFetch.length > 0) {
       const { data: coverItems } = await serviceClient
         .from("media_items")
-        .select("id, storage_path, mime_type")
+        .select("id, storage_path, mime_type, status")
         .in("id", coversToFetch)
         .is("deleted_at", null);
 
@@ -94,6 +95,7 @@ export async function GET(request: NextRequest) {
         const urlMap = await batchGetMediaUrls(
           serviceClient,
           coverItems
+            .filter((ci) => shouldExposeAlbumCover(ci))
             .filter((ci) => ci.storage_path)
             .map((ci) => ({
               id: ci.id,

--- a/src/app/api/media/bulk-delete/route.ts
+++ b/src/app/api/media/bulk-delete/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { validateJson, ValidationError, validationErrorResponse, baseSchemas } from "@/lib/security/validation";
+import { checkOrgReadOnly, readOnlyResponse } from "@/lib/subscription/read-only-guard";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+import { getOrgMembership } from "@/lib/auth/api-helpers";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const bulkDeleteSchema = z.object({
+  orgId: baseSchemas.uuid,
+  mediaIds: z.array(baseSchemas.uuid).min(1).max(100),
+});
+
+/**
+ * POST /api/media/bulk-delete
+ * Soft-delete multiple media items. Auth: admin or uploader of ALL items.
+ */
+export async function POST(req: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const rateLimit = checkRateLimit(req, {
+    limitPerIp: 20,
+    limitPerUser: 10,
+    userId: user?.id ?? null,
+    feature: "media-bulk-delete",
+  });
+  if (!rateLimit.ok) return buildRateLimitResponse(rateLimit);
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: rateLimit.headers });
+  }
+
+  let body: z.infer<typeof bulkDeleteSchema>;
+  try {
+    body = await validateJson(req, bulkDeleteSchema);
+  } catch (error) {
+    if (error instanceof ValidationError) return validationErrorResponse(error);
+    return NextResponse.json({ error: "Invalid request" }, { status: 400, headers: rateLimit.headers });
+  }
+
+  const { orgId, mediaIds } = body;
+
+  // Check org membership
+  const membership = await getOrgMembership(supabase, user.id, orgId);
+  if (!membership) {
+    return NextResponse.json(
+      { error: "Not a member of this organization" },
+      { status: 403, headers: rateLimit.headers },
+    );
+  }
+
+  const isAdmin = membership.role === "admin";
+
+  // Read-only check
+  const { isReadOnly } = await checkOrgReadOnly(orgId);
+  if (isReadOnly) {
+    return NextResponse.json(readOnlyResponse(), { status: 403, headers: rateLimit.headers });
+  }
+
+  const serviceClient = createServiceClient();
+
+  // If not admin, verify user uploaded ALL requested items
+  if (!isAdmin) {
+    const { data: items, error: fetchError } = await serviceClient
+      .from("media_items")
+      .select("id, uploaded_by")
+      .in("id", mediaIds)
+      .eq("organization_id", orgId)
+      .is("deleted_at", null);
+
+    if (fetchError) {
+      return NextResponse.json({ error: "Failed to verify ownership" }, { status: 500, headers: rateLimit.headers });
+    }
+
+    const allOwned = (items || []).length === mediaIds.length &&
+      (items || []).every((item) => item.uploaded_by === user.id);
+
+    if (!allOwned) {
+      return NextResponse.json(
+        { error: "You can only bulk-delete your own media" },
+        { status: 403, headers: rateLimit.headers },
+      );
+    }
+  }
+
+  // Soft delete
+  const { data, error: deleteError } = await serviceClient
+    .from("media_items")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("organization_id", orgId)
+    .in("id", mediaIds)
+    .is("deleted_at", null)
+    .select("id");
+
+  if (deleteError) {
+    console.error("[media/bulk-delete] Soft delete failed:", deleteError);
+    return NextResponse.json(
+      { error: "Failed to delete media items" },
+      { status: 500, headers: rateLimit.headers },
+    );
+  }
+
+  const deletedIds = (data ?? []).map((r) => r.id as string);
+
+  return NextResponse.json({ deleted: deletedIds.length, deletedIds }, { headers: rateLimit.headers });
+}

--- a/src/app/api/media/bulk-delete/route.ts
+++ b/src/app/api/media/bulk-delete/route.ts
@@ -65,6 +65,7 @@ export async function POST(req: Request) {
   }
 
   const serviceClient = createServiceClient();
+  const now = new Date().toISOString();
 
   // If not admin, verify user uploaded ALL requested items
   if (!isAdmin) {
@@ -90,10 +91,25 @@ export async function POST(req: Request) {
     }
   }
 
+  const { error: clearCoverError } = await serviceClient
+    .from("media_albums")
+    .update({ cover_media_id: null, updated_at: now })
+    .eq("organization_id", orgId)
+    .in("cover_media_id", mediaIds)
+    .is("deleted_at", null);
+
+  if (clearCoverError) {
+    console.error("[media/bulk-delete] Failed to clear album covers:", clearCoverError);
+    return NextResponse.json(
+      { error: "Failed to clear album covers" },
+      { status: 500, headers: rateLimit.headers },
+    );
+  }
+
   // Soft delete
   const { data, error: deleteError } = await serviceClient
     .from("media_items")
-    .update({ deleted_at: new Date().toISOString() })
+    .update({ deleted_at: now })
     .eq("organization_id", orgId)
     .in("id", mediaIds)
     .is("deleted_at", null)

--- a/src/components/media/AlbumView.tsx
+++ b/src/components/media/AlbumView.tsx
@@ -9,6 +9,13 @@ import { MediaUploadPanel } from "./MediaUploadPanel";
 import { CoverPickerModal } from "./CoverPickerModal";
 import type { MediaAlbum } from "./AlbumCard";
 import type { UploadFileEntry } from "@/hooks/useGalleryUpload";
+import {
+  canDeleteMediaFromAlbumView,
+  canUploadDirectlyToAlbum,
+  getAlbumBulkDeleteEligibleIds,
+  getAlbumCoverPickerItems,
+  getAlbumUpdatesAfterMediaDelete,
+} from "@/lib/media/albums";
 
 interface AlbumViewProps {
   album: MediaAlbum;
@@ -40,6 +47,10 @@ export function AlbumView({
   const [selectedItem, setSelectedItem] = useState<MediaItem | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false);
 
   // Upload to album
   const [showUpload, setShowUpload] = useState(false);
@@ -56,6 +67,10 @@ export function AlbumView({
   const nameErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const canEdit = isAdmin || album.created_by === currentUserId;
+  const canDirectUpload = canUploadDirectlyToAlbum(canUpload, canEdit);
+  const deleteActor = { isAdmin, currentUserId };
+  const eligibleDeleteIds = getAlbumBulkDeleteEligibleIds(items, deleteActor);
+  const coverPickerItems = getAlbumCoverPickerItems(items, isAdmin);
 
   const fetchItems = useCallback(
     async (cursor?: string) => {
@@ -93,6 +108,21 @@ export function AlbumView({
     return () => { cancelled = true; };
   }, [fetchItems]);
 
+  useEffect(() => {
+    setBulkDeleteConfirm(false);
+  }, [selectedIds]);
+
+  useEffect(() => {
+    if (!selectMode) return;
+
+    const eligibleSet = new Set(eligibleDeleteIds);
+    setSelectedIds((prev) => {
+      const next = new Set(Array.from(prev).filter((id) => eligibleSet.has(id)));
+      if (next.size === prev.size) return prev;
+      return next;
+    });
+  }, [eligibleDeleteIds, selectMode]);
+
   const loadMore = async () => {
     if (!nextCursor || loadingMore) return;
     setLoadingMore(true);
@@ -108,6 +138,24 @@ export function AlbumView({
     }
   };
 
+  const toggleItem = useCallback((mediaId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(mediaId)) {
+        next.delete(mediaId);
+      } else {
+        next.add(mediaId);
+      }
+      return next;
+    });
+  }, []);
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+    setBulkDeleteConfirm(false);
+  }, []);
+
   const handleRemoveFromAlbum = async (mediaId: string) => {
     try {
       const res = await fetch(
@@ -122,6 +170,51 @@ export function AlbumView({
       setSelectedItem(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Remove failed");
+    }
+  };
+
+  const handleBulkDelete = async () => {
+    if (selectedIds.size === 0) return;
+    if (!bulkDeleteConfirm) {
+      setBulkDeleteConfirm(true);
+      return;
+    }
+
+    setBulkDeleting(true);
+    try {
+      const res = await fetch("/api/media/bulk-delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orgId, mediaIds: Array.from(selectedIds) }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error || "Failed to delete");
+      }
+
+      const { deletedIds } = await res.json();
+      const deletedSet = new Set((deletedIds as string[]) || []);
+      setItems((prev) => prev.filter((item) => !deletedSet.has(item.id)));
+      if (selectedItem && deletedSet.has(selectedItem.id)) {
+        setSelectedItem(null);
+      }
+
+      const albumUpdates = getAlbumUpdatesAfterMediaDelete(album, deletedSet, deletedSet.size);
+      if (Object.keys(albumUpdates).length > 0) {
+        onAlbumUpdated?.(albumUpdates);
+      }
+
+      exitSelectMode();
+      showFeedback(
+        `Deleted ${deletedSet.size} item${deletedSet.size === 1 ? "" : "s"}`,
+        "success",
+        { duration: 3000 },
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Bulk delete failed");
+    } finally {
+      setBulkDeleting(false);
+      setBulkDeleteConfirm(false);
     }
   };
 
@@ -355,7 +448,42 @@ export function AlbumView({
                 Set cover
               </Button>
             )}
-            {canUpload && (
+            {items.length > 0 && eligibleDeleteIds.length > 0 && (
+              <Button
+                variant={selectMode ? "secondary" : "ghost"}
+                size="sm"
+                onClick={() => {
+                  if (selectMode) {
+                    exitSelectMode();
+                  } else {
+                    setSelectMode(true);
+                  }
+                }}
+              >
+                {selectMode ? "Done" : "Select"}
+              </Button>
+            )}
+            {selectMode && (
+              <>
+                <button
+                  onClick={() => setSelectedIds(new Set(eligibleDeleteIds))}
+                  className="px-2.5 py-1 text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] rounded-lg hover:bg-[var(--muted)] transition-colors"
+                >
+                  All
+                </button>
+                {selectedIds.size > 0 && (
+                  <Button
+                    variant={bulkDeleteConfirm ? "danger" : "ghost"}
+                    size="sm"
+                    isLoading={bulkDeleting}
+                    onClick={handleBulkDelete}
+                  >
+                    {bulkDeleteConfirm ? "Confirm delete" : `Delete ${selectedIds.size}`}
+                  </Button>
+                )}
+              </>
+            )}
+            {canDirectUpload && (
               <Button size="sm" onClick={() => setShowUpload(true)}>
                 Upload
               </Button>
@@ -389,6 +517,12 @@ export function AlbumView({
         </div>
       )}
 
+      {selectMode && !isAdmin && eligibleDeleteIds.length < items.length && (
+        <div className="mb-4 text-xs text-muted-foreground">
+          Only your uploads can be selected for delete.
+        </div>
+      )}
+
       {loading ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
           {Array.from({ length: 6 }).map((_, i) => (
@@ -408,9 +542,9 @@ export function AlbumView({
             </svg>
           }
           title="No photos in this album"
-          description={canUpload ? "Upload photos directly to this album." : "Add photos to this album from the All Photos view."}
+          description={canDirectUpload ? "Upload photos directly to this album." : "Add photos to this album from the All Photos view."}
           action={
-            canUpload ? (
+            canDirectUpload ? (
               <Button onClick={() => setShowUpload(true)}>Upload Photos</Button>
             ) : undefined
           }
@@ -423,6 +557,13 @@ export function AlbumView({
                 key={item.id}
                 item={item}
                 onClick={() => setSelectedItem(item)}
+                selectable={selectMode}
+                selected={selectedIds.has(item.id)}
+                selectionDisabled={selectMode && !canDeleteMediaFromAlbumView(item, deleteActor)}
+                onToggle={() => {
+                  if (!canDeleteMediaFromAlbumView(item, deleteActor)) return;
+                  toggleItem(item.id);
+                }}
               />
             ))}
           </div>
@@ -436,7 +577,7 @@ export function AlbumView({
         </>
       )}
 
-      {selectedItem && (
+      {selectedItem && !selectMode && (
         <MediaDetailModal
           item={selectedItem}
           isAdmin={isAdmin}
@@ -462,7 +603,7 @@ export function AlbumView({
       {/* Cover picker modal */}
       {showCoverPicker && (
         <CoverPickerModal
-          items={items.filter((i) => i.media_type === "image")}
+          items={coverPickerItems}
           currentCoverId={album.cover_media_id ?? null}
           onSelect={handleSetCover}
           onClose={() => setShowCoverPicker(false)}

--- a/src/components/media/AlbumView.tsx
+++ b/src/components/media/AlbumView.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { showFeedback } from "@/lib/feedback/show-feedback";
 import { Button, EmptyState } from "@/components/ui";
 import { MediaCard, type MediaItem } from "./MediaCard";
 import { MediaDetailModal } from "./MediaDetailModal";
+import { MediaUploadPanel } from "./MediaUploadPanel";
+import { CoverPickerModal } from "./CoverPickerModal";
 import type { MediaAlbum } from "./AlbumCard";
+import type { UploadFileEntry } from "@/hooks/useGalleryUpload";
 
 interface AlbumViewProps {
   album: MediaAlbum;
@@ -21,6 +25,7 @@ export function AlbumView({
   album,
   orgId,
   isAdmin,
+  canUpload,
   currentUserId,
   onBack,
   onAlbumDeleted,
@@ -35,6 +40,13 @@ export function AlbumView({
   const [selectedItem, setSelectedItem] = useState<MediaItem | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+
+  // Upload to album
+  const [showUpload, setShowUpload] = useState(false);
+
+  // Cover picker
+  const [showCoverPicker, setShowCoverPicker] = useState(false);
+  const [coverSaving, setCoverSaving] = useState(false);
 
   // Inline name editing
   const [editingName, setEditingName] = useState(false);
@@ -197,6 +209,60 @@ export function AlbumView({
     setNameValue(album.name);
   };
 
+  // Handle upload completion — add to album item list optimistically
+  const handleFileComplete = useCallback(
+    (entry: UploadFileEntry, mediaId: string) => {
+      const isVideo = entry.mimeType.startsWith("video/");
+      const optimisticItem: MediaItem = {
+        id: mediaId,
+        title: entry.title || entry.fileName,
+        description: entry.description || null,
+        media_type: isVideo ? "video" : "image",
+        url: entry.previewUrl,
+        thumbnail_url: isVideo ? null : entry.previewUrl,
+        tags: entry.tags,
+        taken_at: entry.takenAt ? new Date(entry.takenAt).toISOString() : null,
+        created_at: new Date().toISOString(),
+        uploaded_by: currentUserId || "",
+        status: isAdmin ? "approved" : "pending",
+      };
+      setItems((prev) => [optimisticItem, ...prev]);
+
+      // Fetch real data
+      fetch(`/api/media/${mediaId}`)
+        .then((res) => (res.ok ? res.json() : null))
+        .then((real: MediaItem | null) => {
+          if (!real) return;
+          setItems((prev) => prev.map((i) => (i.id === mediaId ? { ...i, ...real } : i)));
+        })
+        .catch(() => {});
+    },
+    [currentUserId, isAdmin],
+  );
+
+  // Set album cover
+  const handleSetCover = async (mediaId: string, coverUrl: string) => {
+    setCoverSaving(true);
+    try {
+      const res = await fetch(`/api/media/albums/${album.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orgId, cover_media_id: mediaId }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error || "Failed to set cover");
+      }
+      onAlbumUpdated?.({ cover_media_id: mediaId, cover_url: coverUrl });
+      setShowCoverPicker(false);
+      showFeedback("Album cover updated", "success", { duration: 3000 });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to set cover");
+    } finally {
+      setCoverSaving(false);
+    }
+  };
+
   return (
     <div>
       {/* Header */}
@@ -281,18 +347,30 @@ export function AlbumView({
           <h2 className="text-base font-semibold text-foreground truncate">{nameValue}</h2>
         )}
 
-        {/* Admin/creator actions */}
-        {canEdit && !editingName && (
+        {/* Actions */}
+        {!editingName && (
           <div className="ml-auto flex items-center gap-2 shrink-0">
-            <Button
-              variant={confirmDelete ? "danger" : "ghost"}
-              size="sm"
-              isLoading={deleting}
-              onClick={handleDeleteAlbum}
-              onBlur={() => setConfirmDelete(false)}
-            >
-              {confirmDelete ? "Confirm delete" : "Delete album"}
-            </Button>
+            {canEdit && items.length > 0 && (
+              <Button variant="ghost" size="sm" onClick={() => setShowCoverPicker(true)}>
+                Set cover
+              </Button>
+            )}
+            {canUpload && (
+              <Button size="sm" onClick={() => setShowUpload(true)}>
+                Upload
+              </Button>
+            )}
+            {canEdit && (
+              <Button
+                variant={confirmDelete ? "danger" : "ghost"}
+                size="sm"
+                isLoading={deleting}
+                onClick={handleDeleteAlbum}
+                onBlur={() => setConfirmDelete(false)}
+              >
+                {confirmDelete ? "Confirm delete" : "Delete album"}
+              </Button>
+            )}
           </div>
         )}
       </div>
@@ -330,7 +408,12 @@ export function AlbumView({
             </svg>
           }
           title="No photos in this album"
-          description="Add photos to this album from the All Photos view."
+          description={canUpload ? "Upload photos directly to this album." : "Add photos to this album from the All Photos view."}
+          action={
+            canUpload ? (
+              <Button onClick={() => setShowUpload(true)}>Upload Photos</Button>
+            ) : undefined
+          }
         />
       ) : (
         <>
@@ -362,6 +445,28 @@ export function AlbumView({
           onClose={() => setSelectedItem(null)}
           onDelete={handleRemoveFromAlbum}
           onUpdate={handleUpdate}
+        />
+      )}
+
+      {/* Upload panel — uploads directly into this album */}
+      <MediaUploadPanel
+        orgId={orgId}
+        open={showUpload}
+        onClose={() => setShowUpload(false)}
+        availableTags={[]}
+        targetAlbumId={album.id}
+        targetAlbumName={album.name}
+        onFileComplete={handleFileComplete}
+      />
+
+      {/* Cover picker modal */}
+      {showCoverPicker && (
+        <CoverPickerModal
+          items={items.filter((i) => i.media_type === "image")}
+          currentCoverId={album.cover_media_id ?? null}
+          onSelect={handleSetCover}
+          onClose={() => setShowCoverPicker(false)}
+          saving={coverSaving}
         />
       )}
     </div>

--- a/src/components/media/CoverPickerModal.tsx
+++ b/src/components/media/CoverPickerModal.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { Button } from "@/components/ui";
+import type { MediaItem } from "./MediaCard";
+
+interface CoverPickerModalProps {
+  items: MediaItem[];
+  currentCoverId: string | null;
+  onSelect: (mediaId: string, coverUrl: string) => void;
+  onClose: () => void;
+  saving: boolean;
+}
+
+export function CoverPickerModal({
+  items,
+  currentCoverId,
+  onSelect,
+  onClose,
+  saving,
+}: CoverPickerModalProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(currentCoverId);
+
+  const selectedItem = items.find((i) => i.id === selectedId);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-[2px]"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative bg-[var(--card)] border border-[var(--border)] rounded-2xl shadow-2xl w-full max-w-lg max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--border)] shrink-0">
+          <h3 className="text-base font-semibold text-[var(--foreground)]">
+            Set album cover
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-8 h-8 rounded-full hover:bg-[var(--muted)] flex items-center justify-center transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-4 h-4 text-[var(--foreground)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Grid */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {items.length === 0 ? (
+            <p className="text-sm text-[var(--muted-foreground)] text-center py-8">
+              No images in this album to use as a cover.
+            </p>
+          ) : (
+            <div className="grid grid-cols-3 gap-2">
+              {items.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => setSelectedId(item.id)}
+                  className={`relative aspect-square rounded-lg overflow-hidden border-2 transition-all ${
+                    selectedId === item.id
+                      ? "border-[var(--color-org-secondary)] ring-2 ring-[var(--color-org-secondary)]/30"
+                      : "border-transparent hover:border-[var(--border)]"
+                  }`}
+                >
+                  {item.thumbnail_url || item.url ? (
+                    <Image
+                      src={item.thumbnail_url || item.url!}
+                      alt={item.title}
+                      fill
+                      className="object-cover"
+                      sizes="120px"
+                    />
+                  ) : (
+                    <div className="w-full h-full bg-[var(--muted)]" />
+                  )}
+                  {selectedId === item.id && (
+                    <div className="absolute inset-0 bg-[var(--color-org-secondary)]/20 flex items-center justify-center">
+                      <svg className="w-6 h-6 text-white drop-shadow" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                      </svg>
+                    </div>
+                  )}
+                  {currentCoverId === item.id && selectedId !== item.id && (
+                    <div className="absolute top-1 left-1">
+                      <span className="text-[10px] font-medium bg-black/60 text-white px-1.5 py-0.5 rounded">
+                        Current
+                      </span>
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        {items.length > 0 && (
+          <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-[var(--border)] shrink-0">
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              isLoading={saving}
+              disabled={!selectedId || selectedId === currentCoverId}
+              onClick={() => {
+                if (selectedId && selectedItem) {
+                  onSelect(selectedId, selectedItem.url || selectedItem.thumbnail_url || "");
+                }
+              }}
+            >
+              Set as cover
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/media/MediaCard.tsx
+++ b/src/components/media/MediaCard.tsx
@@ -28,9 +28,17 @@ interface MediaCardProps {
   selectable?: boolean;
   selected?: boolean;
   onToggle?: () => void;
+  selectionDisabled?: boolean;
 }
 
-export function MediaCard({ item, onClick, selectable, selected, onToggle }: MediaCardProps) {
+export function MediaCard({
+  item,
+  onClick,
+  selectable,
+  selected,
+  onToggle,
+  selectionDisabled = false,
+}: MediaCardProps) {
   const displayUrl = getCardDisplayUrl(item);
   const uploaderName = item.users?.name || "Unknown";
   const displayDate = item.taken_at
@@ -39,6 +47,7 @@ export function MediaCard({ item, onClick, selectable, selected, onToggle }: Med
 
   const handleClick = () => {
     if (selectable) {
+      if (selectionDisabled) return;
       onToggle?.();
     } else {
       onClick();
@@ -52,7 +61,9 @@ export function MediaCard({ item, onClick, selectable, selected, onToggle }: Med
       className={`group overflow-hidden transition-all duration-150 ${
         selected
           ? "ring-2 ring-[var(--color-org-secondary)] ring-offset-1 scale-[0.97]"
-          : ""
+          : selectionDisabled
+            ? "opacity-60"
+            : ""
       }`}
       onClick={handleClick}
     >
@@ -82,10 +93,13 @@ export function MediaCard({ item, onClick, selectable, selected, onToggle }: Med
             className={`absolute top-2 left-2 z-10 w-5 h-5 rounded-full border-2 flex items-center justify-center transition-all ${
               selected
                 ? "bg-[var(--color-org-secondary)] border-[var(--color-org-secondary)]"
+                : selectionDisabled
+                  ? "bg-white/60 border-[var(--border)] opacity-100"
                 : "bg-white/80 border-[var(--border)] backdrop-blur-sm opacity-0 group-hover:opacity-100"
             }`}
             onClick={(e) => {
               e.stopPropagation();
+              if (selectionDisabled) return;
               onToggle?.();
             }}
           >

--- a/src/components/media/MediaGallery.tsx
+++ b/src/components/media/MediaGallery.tsx
@@ -54,6 +54,10 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [showAlbumPicker, setShowAlbumPicker] = useState(false);
 
+  // Bulk delete
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false);
+
   const fetchMedia = useCallback(
     async (cursor?: string) => {
       const params = new URLSearchParams({ orgId, limit: "24" });
@@ -147,6 +151,40 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
       setError(err instanceof Error ? err.message : "Delete failed");
     }
   };
+
+  const handleBulkDelete = async () => {
+    if (!bulkDeleteConfirm) {
+      setBulkDeleteConfirm(true);
+      return;
+    }
+    setBulkDeleting(true);
+    try {
+      const res = await fetch("/api/media/bulk-delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orgId, mediaIds: Array.from(selectedIds) }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error || "Failed to delete");
+      }
+      const { deletedIds } = await res.json();
+      const deletedSet = new Set(deletedIds as string[]);
+      setItems((prev) => prev.filter((i) => !deletedSet.has(i.id)));
+      exitSelectMode();
+      showFeedback(`Deleted ${deletedIds.length} item${deletedIds.length === 1 ? "" : "s"}`, "success", { duration: 3000 });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Bulk delete failed");
+    } finally {
+      setBulkDeleting(false);
+      setBulkDeleteConfirm(false);
+    }
+  };
+
+  // Reset bulk delete confirm when selection changes
+  useEffect(() => {
+    setBulkDeleteConfirm(false);
+  }, [selectedIds]);
 
   const handleUpdate = async (mediaId: string, data: { description?: string; tags?: string[] }) => {
     try {
@@ -498,6 +536,17 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
               <Button size="sm" onClick={() => setShowAlbumPicker(true)}>
                 Add to album
               </Button>
+              {/* Bulk delete: show if admin or uploader of all selected */}
+              {(isAdmin || (currentUserId && items.filter((i) => selectedIds.has(i.id)).every((i) => i.uploaded_by === currentUserId))) && (
+                <Button
+                  size="sm"
+                  variant={bulkDeleteConfirm ? "danger" : "secondary"}
+                  isLoading={bulkDeleting}
+                  onClick={handleBulkDelete}
+                >
+                  {bulkDeleteConfirm ? `Confirm delete (${selectedIds.size})` : "Delete"}
+                </Button>
+              )}
               <button
                 onClick={exitSelectMode}
                 className="w-7 h-7 rounded-full hover:bg-[var(--muted)] flex items-center justify-center transition-colors text-[var(--muted-foreground)] hover:text-[var(--foreground)]"

--- a/src/components/media/MediaUploadPanel.tsx
+++ b/src/components/media/MediaUploadPanel.tsx
@@ -13,6 +13,8 @@ interface MediaUploadPanelProps {
   open: boolean;
   onClose: () => void;
   availableTags: string[];
+  targetAlbumId?: string;
+  targetAlbumName?: string;
   onFileComplete?: (entry: UploadFileEntry, mediaId: string) => void;
   onAlbumCreated?: (album: MediaAlbum) => void;
 }
@@ -22,6 +24,8 @@ export function MediaUploadPanel({
   open,
   onClose,
   availableTags,
+  targetAlbumId,
+  targetAlbumName,
   onFileComplete,
   onAlbumCreated,
 }: MediaUploadPanelProps) {
@@ -44,15 +48,17 @@ export function MediaUploadPanel({
     updateTags,
     setPendingAlbumName,
     clearPendingAlbum,
-  } = useGalleryUpload({ orgId, onFileComplete });
+  } = useGalleryUpload({ orgId, targetAlbumId, onFileComplete });
 
   // Combine gallery tags + tags from the current batch for suggestions
   const batchTags = files.flatMap((f) => f.tags);
   const allSuggestions = [...new Set([...availableTags, ...batchTags])].sort();
 
   // Auto-create album when all files are done and we have a pending album name
+  // Skip when uploading directly to a target album
   useEffect(() => {
     if (
+      targetAlbumId ||
       !stats.allDone ||
       !pendingAlbumName ||
       completedMediaIds.length === 0 ||
@@ -101,6 +107,7 @@ export function MediaUploadPanel({
 
     createAlbum();
   }, [
+    targetAlbumId,
     stats.allDone,
     pendingAlbumName,
     completedMediaIds,
@@ -120,14 +127,16 @@ export function MediaUploadPanel({
     }
   }, [open]);
 
-  // Handle folder upload: add files + set pending album name
+  // Handle folder upload: add files + set pending album name (unless targeting an album)
   const handleFolder = useCallback(
     (folderFiles: File[], folderName: string) => {
       addFiles(folderFiles);
-      setPendingAlbumName(folderName);
-      setAlbumCreated(false);
+      if (!targetAlbumId) {
+        setPendingAlbumName(folderName);
+        setAlbumCreated(false);
+      }
     },
-    [addFiles, setPendingAlbumName],
+    [addFiles, setPendingAlbumName, targetAlbumId],
   );
 
   // Escape to close (only when not uploading)
@@ -183,9 +192,13 @@ export function MediaUploadPanel({
         <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--border)] shrink-0">
           <div>
             <h2 className="text-base font-semibold text-[var(--foreground)]">
-              {pendingAlbumName !== null && !albumCreated ? "New Album" : "Upload Media"}
+              {targetAlbumName ? "Upload to Album" : pendingAlbumName !== null && !albumCreated ? "New Album" : "Upload Media"}
             </h2>
-            {pendingAlbumName !== null && !albumCreated ? (
+            {targetAlbumName ? (
+              <p className="text-xs text-[var(--color-org-secondary)] mt-0.5 font-medium truncate max-w-[260px]">
+                {targetAlbumName}
+              </p>
+            ) : pendingAlbumName !== null && !albumCreated ? (
               <p className="text-xs text-[var(--color-org-secondary)] mt-0.5 font-medium truncate max-w-[260px]">
                 {pendingAlbumName}
               </p>

--- a/src/components/media/UploadFileCard.tsx
+++ b/src/components/media/UploadFileCard.tsx
@@ -25,6 +25,7 @@ const statusConfig: Record<FileUploadStatus, { dot: string; label: string }> = {
   requesting: { dot: "bg-blue-500 animate-pulse", label: "Preparing..." },
   uploading: { dot: "bg-[var(--color-org-secondary)] animate-pulse", label: "Uploading" },
   finalizing: { dot: "bg-[var(--color-org-secondary)] animate-pulse", label: "Finalizing..." },
+  associating: { dot: "bg-[var(--color-org-secondary)] animate-pulse", label: "Adding to album..." },
   done: { dot: "bg-emerald-500", label: "Done" },
   error: { dot: "bg-red-500", label: "Failed" },
 };
@@ -83,6 +84,9 @@ export function UploadFileCard({
               {entry.fileName}{" "}
               <span className="font-mono text-[10px]">{formatFileSize(entry.fileSize)}</span>
             </p>
+            {entry.status !== "done" && entry.status !== "error" && (
+              <p className="text-[11px] text-[var(--muted-foreground)]">{config.label}</p>
+            )}
           </div>
           <div className="flex items-center gap-1 shrink-0">
             {entry.status === "error" && entry.retryCount < 3 && (

--- a/src/hooks/useGalleryUpload.ts
+++ b/src/hooks/useGalleryUpload.ts
@@ -156,10 +156,11 @@ const MAX_RETRIES = 3;
 
 interface UseGalleryUploadOptions {
   orgId: string;
+  targetAlbumId?: string;
   onFileComplete?: (entry: UploadFileEntry, mediaId: string) => void;
 }
 
-export function useGalleryUpload({ orgId, onFileComplete }: UseGalleryUploadOptions) {
+export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGalleryUploadOptions) {
   const [state, dispatch] = useReducer(reducer, {
     files: [],
     completedMediaIds: [],
@@ -326,6 +327,15 @@ export function useGalleryUpload({ orgId, onFileComplete }: UseGalleryUploadOpti
 
         dispatch({ type: "MARK_DONE", id: entry.id, mediaId });
         onFileCompleteRef.current?.(entry, mediaId);
+
+        // Auto-add to target album if uploading from album view
+        if (targetAlbumId) {
+          fetch(`/api/media/albums/${targetAlbumId}/items`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ orgId, mediaIds: [mediaId] }),
+          }).catch(() => {});
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : "Upload failed";
         if (message === "Upload cancelled") {
@@ -341,7 +351,7 @@ export function useGalleryUpload({ orgId, onFileComplete }: UseGalleryUploadOpti
         processingRef.current.delete(entry.id);
       }
     },
-    [orgId],
+    [orgId, targetAlbumId],
   );
 
   // ------- Concurrency dispatcher -------

--- a/src/hooks/useGalleryUpload.ts
+++ b/src/hooks/useGalleryUpload.ts
@@ -8,6 +8,10 @@ import {
   resolveGalleryMimeType,
   checkBatchLimit,
 } from "@/lib/media/gallery-validation";
+import {
+  getGalleryRetryProgress,
+  getGalleryUploadMode,
+} from "@/lib/media/gallery-upload-flow";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,6 +22,7 @@ export type FileUploadStatus =
   | "requesting"
   | "uploading"
   | "finalizing"
+  | "associating"
   | "done"
   | "error";
 
@@ -37,6 +42,7 @@ export interface UploadFileEntry {
   error: string | null;
   retryCount: number;
   mediaId: string | null; // from upload intent response
+  uploadFinalized: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -50,6 +56,7 @@ type Action =
   | { type: "SET_STATUS"; id: string; status: FileUploadStatus; error?: string }
   | { type: "SET_PROGRESS"; id: string; progress: number }
   | { type: "SET_MEDIA_ID"; id: string; mediaId: string }
+  | { type: "MARK_FINALIZED"; id: string }
   | { type: "MARK_DONE"; id: string; mediaId: string }
   | { type: "REMOVE_FILE"; id: string }
   | { type: "CLEAR_ALL" }
@@ -114,12 +121,27 @@ function reducer(state: State, action: Action): State {
         ),
       };
 
+    case "MARK_FINALIZED":
+      return {
+        ...state,
+        files: state.files.map((f) =>
+          f.id === action.id ? { ...f, uploadFinalized: true } : f,
+        ),
+      };
+
     case "MARK_DONE":
       return {
         ...state,
         files: state.files.map((f) =>
           f.id === action.id
-            ? { ...f, status: "done", progress: 100, file: null, error: null }
+            ? {
+                ...f,
+                status: "done",
+                progress: 100,
+                file: null,
+                error: null,
+                uploadFinalized: true,
+              }
             : f,
         ),
         completedMediaIds: [...state.completedMediaIds, action.mediaId],
@@ -219,6 +241,7 @@ export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGa
           error: null,
           retryCount: 0,
           mediaId: null,
+          uploadFinalized: false,
         };
 
         entries.push(entry);
@@ -246,7 +269,49 @@ export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGa
   // ------- Process a single file -------
   const processFile = useCallback(
     async (entry: UploadFileEntry) => {
-      if (!entry.file) return;
+      const mode = getGalleryUploadMode({
+        mediaId: entry.mediaId,
+        targetAlbumId,
+        uploadFinalized: entry.uploadFinalized,
+      });
+
+      if (mode === "upload" && !entry.file) return;
+
+      const associateWithAlbum = async (mediaId: string) => {
+        if (!targetAlbumId) return;
+
+        dispatch({ type: "SET_STATUS", id: entry.id, status: "associating" });
+
+        const albumRes = await fetch(`/api/media/albums/${targetAlbumId}/items`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ orgId, mediaIds: [mediaId] }),
+        });
+
+        if (!albumRes.ok) {
+          const data = await albumRes.json().catch(() => null);
+          throw new Error(data?.error || "Failed to add upload to album");
+        }
+      };
+
+      if (mode === "associate-only" && entry.mediaId) {
+        try {
+          await associateWithAlbum(entry.mediaId);
+          dispatch({ type: "MARK_DONE", id: entry.id, mediaId: entry.mediaId });
+          onFileCompleteRef.current?.(entry, entry.mediaId);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Upload failed";
+          dispatch({
+            type: "SET_STATUS",
+            id: entry.id,
+            status: "error",
+            error: message,
+          });
+        } finally {
+          processingRef.current.delete(entry.id);
+        }
+        return;
+      }
 
       dispatch({ type: "SET_STATUS", id: entry.id, status: "requesting" });
 
@@ -325,17 +390,14 @@ export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGa
           throw new Error(data?.error || "Failed to finalize upload");
         }
 
+        dispatch({ type: "MARK_FINALIZED", id: entry.id });
+
+        if (targetAlbumId) {
+          await associateWithAlbum(mediaId);
+        }
+
         dispatch({ type: "MARK_DONE", id: entry.id, mediaId });
         onFileCompleteRef.current?.(entry, mediaId);
-
-        // Auto-add to target album if uploading from album view
-        if (targetAlbumId) {
-          fetch(`/api/media/albums/${targetAlbumId}/items`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ orgId, mediaIds: [mediaId] }),
-          }).catch(() => {});
-        }
       } catch (err) {
         const message = err instanceof Error ? err.message : "Upload failed";
         if (message === "Upload cancelled") {
@@ -357,7 +419,11 @@ export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGa
   // ------- Concurrency dispatcher -------
   useEffect(() => {
     const activeCount = state.files.filter(
-      (f) => f.status === "requesting" || f.status === "uploading" || f.status === "finalizing",
+      (f) =>
+        f.status === "requesting" ||
+        f.status === "uploading" ||
+        f.status === "finalizing" ||
+        f.status === "associating",
     ).length;
 
     if (activeCount >= MAX_CONCURRENT) return;
@@ -398,7 +464,7 @@ export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGa
       dispatch({
         type: "SET_PROGRESS",
         id,
-        progress: 0,
+        progress: getGalleryRetryProgress(entry.uploadFinalized),
       });
     },
     [state.files],
@@ -452,7 +518,11 @@ export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGa
   // ------- beforeunload -------
   useEffect(() => {
     const hasActive = state.files.some(
-      (f) => f.status === "requesting" || f.status === "uploading" || f.status === "finalizing",
+      (f) =>
+        f.status === "requesting" ||
+        f.status === "uploading" ||
+        f.status === "finalizing" ||
+        f.status === "associating",
     );
 
     if (!hasActive) return;
@@ -483,7 +553,11 @@ export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGa
     total: state.files.length,
     queued: state.files.filter((f) => f.status === "queued").length,
     active: state.files.filter(
-      (f) => f.status === "requesting" || f.status === "uploading" || f.status === "finalizing",
+      (f) =>
+        f.status === "requesting" ||
+        f.status === "uploading" ||
+        f.status === "finalizing" ||
+        f.status === "associating",
     ).length,
     done: state.files.filter((f) => f.status === "done").length,
     errored: state.files.filter((f) => f.status === "error").length,
@@ -494,7 +568,11 @@ export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGa
           )
         : 0,
     isUploading: state.files.some(
-      (f) => f.status === "requesting" || f.status === "uploading" || f.status === "finalizing",
+      (f) =>
+        f.status === "requesting" ||
+        f.status === "uploading" ||
+        f.status === "finalizing" ||
+        f.status === "associating",
     ),
     allDone:
       state.files.length > 0 &&

--- a/src/lib/media/albums.ts
+++ b/src/lib/media/albums.ts
@@ -1,0 +1,90 @@
+interface AlbumCoverCandidate {
+  media_type: string | null;
+  status: string | null;
+}
+
+interface AlbumDeleteActor {
+  isAdmin: boolean;
+  currentUserId?: string;
+}
+
+interface AlbumItemLike {
+  id: string;
+  media_type: string;
+  status: string;
+  uploaded_by: string;
+}
+
+interface AlbumLike {
+  cover_media_id?: string | null;
+  cover_url?: string | null;
+  item_count?: number;
+}
+
+export function canUploadDirectlyToAlbum(canUpload: boolean, canEdit: boolean): boolean {
+  return canUpload && canEdit;
+}
+
+export function getAlbumCoverPickerItems<T extends Pick<AlbumItemLike, "media_type" | "status">>(
+  items: T[],
+  isAdmin: boolean,
+): T[] {
+  return items.filter(
+    (item) => item.media_type === "image" && (isAdmin || item.status === "approved"),
+  );
+}
+
+export function canDeleteMediaFromAlbumView(
+  item: Pick<AlbumItemLike, "uploaded_by">,
+  actor: AlbumDeleteActor,
+): boolean {
+  return actor.isAdmin || Boolean(actor.currentUserId && item.uploaded_by === actor.currentUserId);
+}
+
+export function getAlbumBulkDeleteEligibleIds<T extends Pick<AlbumItemLike, "id" | "uploaded_by">>(
+  items: T[],
+  actor: AlbumDeleteActor,
+): string[] {
+  return items
+    .filter((item) => canDeleteMediaFromAlbumView(item, actor))
+    .map((item) => item.id);
+}
+
+export function getAlbumCoverValidationError(candidate: AlbumCoverCandidate | null): string | null {
+  if (!candidate) {
+    return "Selected cover must belong to this album";
+  }
+  if (candidate.media_type !== "image") {
+    return "Album cover must be an image";
+  }
+  if (candidate.status !== "approved") {
+    return "Album cover must be approved before it can be used";
+  }
+  return null;
+}
+
+export function shouldExposeAlbumCover(
+  item: Pick<AlbumCoverCandidate, "status"> | null | undefined,
+): boolean {
+  return item?.status === "approved";
+}
+
+export function getAlbumUpdatesAfterMediaDelete(
+  album: AlbumLike,
+  deletedIds: Iterable<string>,
+  deletedCount: number,
+): Partial<AlbumLike> {
+  const deletedSet = new Set(deletedIds);
+  const updates: Partial<AlbumLike> = {};
+
+  if (album.cover_media_id && deletedSet.has(album.cover_media_id)) {
+    updates.cover_media_id = null;
+    updates.cover_url = null;
+  }
+
+  if (typeof album.item_count === "number") {
+    updates.item_count = Math.max(0, album.item_count - deletedCount);
+  }
+
+  return updates;
+}

--- a/src/lib/media/gallery-upload-flow.ts
+++ b/src/lib/media/gallery-upload-flow.ts
@@ -1,0 +1,18 @@
+interface UploadProcessingState {
+  mediaId: string | null;
+  targetAlbumId?: string;
+  uploadFinalized: boolean;
+}
+
+export function getGalleryUploadMode(
+  state: UploadProcessingState,
+): "upload" | "associate-only" {
+  if (state.targetAlbumId && state.mediaId && state.uploadFinalized) {
+    return "associate-only";
+  }
+  return "upload";
+}
+
+export function getGalleryRetryProgress(uploadFinalized: boolean): number {
+  return uploadFinalized ? 100 : 0;
+}

--- a/tests/gallery-upload-flow.test.ts
+++ b/tests/gallery-upload-flow.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  getGalleryRetryProgress,
+  getGalleryUploadMode,
+} from "@/lib/media/gallery-upload-flow";
+
+test("retry resumes album association without re-uploading once media finalization already succeeded", () => {
+  assert.equal(
+    getGalleryUploadMode({
+      mediaId: "media-1",
+      targetAlbumId: "album-1",
+      uploadFinalized: true,
+    }),
+    "associate-only",
+  );
+});
+
+test("upload flow performs a full upload when media has not finished finalizing", () => {
+  assert.equal(
+    getGalleryUploadMode({
+      mediaId: "media-1",
+      targetAlbumId: "album-1",
+      uploadFinalized: false,
+    }),
+    "upload",
+  );
+});
+
+test("retry progress stays at 100 percent when only album association remains", () => {
+  assert.equal(getGalleryRetryProgress(true), 100);
+  assert.equal(getGalleryRetryProgress(false), 0);
+});

--- a/tests/media-albums.test.ts
+++ b/tests/media-albums.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  canDeleteMediaFromAlbumView,
+  canUploadDirectlyToAlbum,
+  getAlbumBulkDeleteEligibleIds,
+  getAlbumCoverPickerItems,
+  getAlbumCoverValidationError,
+  getAlbumUpdatesAfterMediaDelete,
+  shouldExposeAlbumCover,
+} from "@/lib/media/albums";
+
+test("album direct upload requires both upload permission and album edit permission", () => {
+  assert.equal(canUploadDirectlyToAlbum(true, true), true);
+  assert.equal(canUploadDirectlyToAlbum(true, false), false);
+  assert.equal(canUploadDirectlyToAlbum(false, true), false);
+});
+
+test("non-admin cover picker only includes approved images", () => {
+  const items = [
+    { id: "approved-image", media_type: "image", status: "approved" },
+    { id: "pending-image", media_type: "image", status: "pending" },
+    { id: "rejected-image", media_type: "image", status: "rejected" },
+    { id: "approved-video", media_type: "video", status: "approved" },
+  ];
+
+  assert.deepEqual(
+    getAlbumCoverPickerItems(items, false).map((item) => item.id),
+    ["approved-image"],
+  );
+});
+
+test("admin cover picker can use any image regardless of moderation status", () => {
+  const items = [
+    { id: "approved-image", media_type: "image", status: "approved" },
+    { id: "pending-image", media_type: "image", status: "pending" },
+    { id: "rejected-image", media_type: "image", status: "rejected" },
+    { id: "approved-video", media_type: "video", status: "approved" },
+  ];
+
+  assert.deepEqual(
+    getAlbumCoverPickerItems(items, true).map((item) => item.id),
+    ["approved-image", "pending-image", "rejected-image"],
+  );
+});
+
+test("album cover validation rejects missing, non-image, and unapproved candidates", () => {
+  assert.equal(getAlbumCoverValidationError(null), "Selected cover must belong to this album");
+  assert.equal(
+    getAlbumCoverValidationError({ media_type: "video", status: "approved" }),
+    "Album cover must be an image",
+  );
+  assert.equal(
+    getAlbumCoverValidationError({ media_type: "image", status: "pending" }),
+    "Album cover must be approved before it can be used",
+  );
+  assert.equal(getAlbumCoverValidationError({ media_type: "image", status: "approved" }), null);
+});
+
+test("album list only exposes approved covers", () => {
+  assert.equal(shouldExposeAlbumCover({ status: "approved" }), true);
+  assert.equal(shouldExposeAlbumCover({ status: "pending" }), false);
+  assert.equal(shouldExposeAlbumCover({ status: "rejected" }), false);
+  assert.equal(shouldExposeAlbumCover(null), false);
+});
+
+test("album bulk delete permissions allow admins and item owners only", () => {
+  const item = { uploaded_by: "owner-1" };
+
+  assert.equal(canDeleteMediaFromAlbumView(item, { isAdmin: true }), true);
+  assert.equal(
+    canDeleteMediaFromAlbumView(item, { isAdmin: false, currentUserId: "owner-1" }),
+    true,
+  );
+  assert.equal(
+    canDeleteMediaFromAlbumView(item, { isAdmin: false, currentUserId: "other-user" }),
+    false,
+  );
+});
+
+test("album bulk delete eligible ids only includes items the actor can delete", () => {
+  const items = [
+    { id: "item-1", uploaded_by: "owner-1" },
+    { id: "item-2", uploaded_by: "owner-2" },
+  ];
+
+  assert.deepEqual(
+    getAlbumBulkDeleteEligibleIds(items, { isAdmin: false, currentUserId: "owner-1" }),
+    ["item-1"],
+  );
+  assert.deepEqual(
+    getAlbumBulkDeleteEligibleIds(items, { isAdmin: true }),
+    ["item-1", "item-2"],
+  );
+});
+
+test("album state clears deleted cover media and decrements item count", () => {
+  assert.deepEqual(
+    getAlbumUpdatesAfterMediaDelete(
+      { cover_media_id: "cover-1", cover_url: "https://example.com/cover.jpg", item_count: 4 },
+      ["cover-1", "other-2"],
+      2,
+    ),
+    {
+      cover_media_id: null,
+      cover_url: null,
+      item_count: 2,
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- **Bulk delete**: Select photos in the media tab → floating action bar now shows a "Delete" button with two-click confirmation. New `POST /api/media/bulk-delete` endpoint handles batch soft-deletion (admin or uploader of all items, max 100).
- **Album cover**: "Set cover" button in AlbumView opens a `CoverPickerModal` to pick from existing album images. Uses the existing PATCH endpoint.
- **Upload-to-album fix**: Uploading from within an album now adds photos directly to that album instead of the general pool. `MediaUploadPanel` accepts `targetAlbumId` and the upload hook auto-adds each completed file.

## Changes
| File | What changed |
|------|-------------|
| `src/app/api/media/bulk-delete/route.ts` | New bulk delete API route |
| `src/components/media/CoverPickerModal.tsx` | New cover picker modal component |
| `src/components/media/MediaGallery.tsx` | Bulk delete handler + confirm UI in floating bar |
| `src/components/media/MediaUploadPanel.tsx` | `targetAlbumId`/`targetAlbumName` props, header update |
| `src/hooks/useGalleryUpload.ts` | Auto-add to album after each upload completes |
| `src/components/media/AlbumView.tsx` | Upload button, cover picker, file complete handler |

## Test plan
- [ ] Select 5+ photos → click Delete → confirm → verify removed from grid
- [ ] As non-admin, select mix of own + others' photos → verify Delete button hidden
- [ ] Open album → click Upload → upload 3 photos → verify they appear in album view
- [ ] Folder upload from album view → verify files go to existing album (no new album created)
- [ ] Open album → Set cover → pick photo → go back to Albums grid → verify cover shows
- [ ] Verify type check (`npx tsc --noEmit`) and lint (`npm run lint`) pass

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: client-side UI features with existing API patterns. The bulk-delete endpoint follows the same soft-delete pattern as alumni bulk-delete.