### PR TITLE
feat: per-org invite approval gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,3 +171,7 @@ Work is NOT complete until `git push` succeeds. Mandatory:
 4. Hand off context for next session
 
 NEVER stop before pushing. NEVER say "ready to push when you are" — YOU must push.
+
+## TODO
+
+- [ ] Invite expiration uses UTC midnight instead of user's local timezone end-of-day — an invite set to expire "March 27" actually expires at 7pm ET on March 26. Fix: append `T23:59:59` in the user's local timezone before converting to ISO string.

--- a/src/app/[orgSlug]/layout.tsx
+++ b/src/app/[orgSlug]/layout.tsx
@@ -66,6 +66,19 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
     );
   }
 
+  if (orgContext.status === "pending" && !isDevAdmin) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background px-6">
+        <div className="max-w-lg text-center space-y-4">
+          <h1 className="text-2xl font-bold text-foreground">Pending admin approval</h1>
+          <p className="text-muted-foreground">
+            Your request to join this organization is awaiting admin approval. You&apos;ll gain access once an admin approves your membership.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   if (!orgContext.role && !isDevAdmin) {
     return (
       <JoinOrgGate

--- a/src/app/[orgSlug]/settings/approvals/page.tsx
+++ b/src/app/[orgSlug]/settings/approvals/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { PageHeader } from "@/components/layout";
-import { Button, Card, Badge, Select, Input } from "@/components/ui";
-import { ToggleSwitch } from "@/components/ui/ToggleSwitch";
-import { QRCodeDisplay } from "@/components/invites";
-import { getRoleBadgeVariant, getRoleLabel } from "@/lib/auth/role-display";
+import { Button, Card, Badge } from "@/components/ui";
+import { getRoleLabel } from "@/lib/auth/role-display";
 import { formatShortDate } from "@/lib/utils/dates";
 
 interface PendingMember {
@@ -18,78 +17,31 @@ interface PendingMember {
   users?: { name: string | null; email: string | null };
 }
 
-interface Invite {
-  id: string;
-  code: string;
-  token: string | null;
-  role: string;
-  uses_remaining: number | null;
-  expires_at: string | null;
-  revoked_at: string | null;
-  created_at: string;
-}
-
-function generateCode(): string {
-  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-  let code = "";
-  for (let i = 0; i < 8; i++) {
-    code += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return code;
-}
-
-function generateToken(): string {
-  const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  let token = "";
-  for (let i = 0; i < 32; i++) {
-    token += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return token;
-}
-
 export default function ApprovalsPage() {
   const params = useParams();
   const orgSlug = params.orgSlug as string;
 
   const [pendingMembers, setPendingMembers] = useState<PendingMember[]>([]);
   const [pendingAlumni, setPendingAlumni] = useState<PendingMember[]>([]);
-  const [invites, setInvites] = useState<Invite[]>([]);
   const [orgId, setOrgId] = useState<string | null>(null);
-  const [requireApproval, setRequireApproval] = useState(false);
-  const [isSavingToggle, setIsSavingToggle] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState<string | null>(null);
 
-  // New invite form state
-  const [showInviteForm, setShowInviteForm] = useState(false);
-  const [newRole, setNewRole] = useState<"active_member" | "admin" | "alumni">("active_member");
-  const [newUses, setNewUses] = useState<string>("");
-  const [newExpires, setNewExpires] = useState<string>("");
-  const [isCreating, setIsCreating] = useState(false);
-  const [showQR, setShowQR] = useState<string | null>(null);
-
-  // Fetch pending members and invites
   useEffect(() => {
     const fetchData = async () => {
       const supabase = createClient();
 
-      // Get org
-      // Cast needed: require_invite_approval exists in DB but not yet in generated types
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: orgs, error: orgError } = await (supabase as any)
+      const { data: orgs, error: orgError } = await supabase
         .from("organizations")
-        .select("id, require_invite_approval")
+        .select("id")
         .eq("slug", orgSlug)
         .limit(1);
 
-      const org = orgs?.[0] as { id: string; require_invite_approval?: boolean } | undefined;
+      const org = orgs?.[0];
 
       if (org && !orgError) {
         setOrgId(org.id);
-        setRequireApproval(org.require_invite_approval ?? false);
 
-        // Get pending memberships
         const { data: memberships } = await supabase
           .from("user_organization_roles")
           .select("user_id, role, status, created_at, users(name, email)")
@@ -112,19 +64,8 @@ export default function ApprovalsPage() {
             };
           }) || [];
 
-        // Separate members and alumni
         setPendingMembers(normalizedMemberships.filter(m => m.role === "active_member" || m.role === "admin"));
         setPendingAlumni(normalizedMemberships.filter(m => m.role === "alumni"));
-
-        // Get active invites
-        const { data: inviteData } = await supabase
-          .from("organization_invites")
-          .select("*")
-          .eq("organization_id", org.id)
-          .is("revoked_at", null)
-          .order("created_at", { ascending: false });
-
-        setInvites(inviteData || []);
       }
 
       setIsLoading(false);
@@ -149,7 +90,6 @@ export default function ApprovalsPage() {
       return;
     }
 
-    // Remove from pending lists
     setPendingMembers((prev) => prev.filter((m) => m.user_id !== userId));
     setPendingAlumni((prev) => prev.filter((m) => m.user_id !== userId));
   };
@@ -172,114 +112,14 @@ export default function ApprovalsPage() {
       return;
     }
 
-    // Remove from pending lists
     setPendingMembers((prev) => prev.filter((m) => m.user_id !== userId));
     setPendingAlumni((prev) => prev.filter((m) => m.user_id !== userId));
-  };
-
-  const handleCreateInvite = async () => {
-    if (!orgId) return;
-    setIsCreating(true);
-    setError(null);
-
-    const supabase = createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-
-    const code = generateCode();
-    const token = generateToken();
-    const usesRemaining = newUses ? parseInt(newUses) : null;
-    const expiresAt = newExpires ? new Date(newExpires).toISOString() : null;
-
-    const { data, error: insertError } = await supabase
-      .from("organization_invites")
-      .insert({
-        organization_id: orgId,
-        code,
-        token,
-        role: newRole,
-        uses_remaining: usesRemaining,
-        expires_at: expiresAt,
-        created_by_user_id: user?.id,
-      })
-      .select()
-      .single();
-
-    if (insertError) {
-      setError(insertError.message);
-    } else if (data) {
-      setInvites([data, ...invites]);
-      setShowInviteForm(false);
-      setNewRole("active_member");
-      setNewUses("");
-      setNewExpires("");
-    }
-
-    setIsCreating(false);
-  };
-
-  const handleRevokeInvite = async (inviteId: string) => {
-    const supabase = createClient();
-    await supabase
-      .from("organization_invites")
-      .update({ revoked_at: new Date().toISOString() })
-      .eq("id", inviteId);
-
-    setInvites(invites.filter((i) => i.id !== inviteId));
-  };
-
-  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
-    };
-  }, []);
-
-  const copyToClipboard = (text: string, key: string) => {
-    navigator.clipboard.writeText(text);
-    setCopied(key);
-    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
-    copyTimerRef.current = setTimeout(() => setCopied(null), 2000);
-  };
-
-  const handleToggleApproval = async (checked: boolean) => {
-    if (!orgId) return;
-    setIsSavingToggle(true);
-    setError(null);
-
-    try {
-      const res = await fetch(`/api/organizations/${orgId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ require_invite_approval: checked }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        setError(data.error || "Failed to update approval setting");
-        return;
-      }
-
-      setRequireApproval(checked);
-    } catch {
-      setError("Failed to update approval setting");
-    } finally {
-      setIsSavingToggle(false);
-    }
-  };
-
-  const getInviteLink = (invite: Invite) => {
-    const base = typeof window !== "undefined" ? window.location.origin : "";
-    if (invite.token) {
-      return `${base}/app/join?token=${invite.token}`;
-    }
-    return `${base}/app/join?code=${invite.code}`;
   };
 
   if (isLoading) {
     return (
       <div>
-        <PageHeader title="Member Approvals" description="Loading..." />
+        <PageHeader title="Pending Approvals" description="Loading..." />
         <div className="animate-pulse space-y-4">
           <div className="h-32 bg-muted rounded-xl" />
         </div>
@@ -292,9 +132,9 @@ export default function ApprovalsPage() {
   return (
     <div>
       <PageHeader
-        title="Member Approvals"
+        title="Pending Approvals"
         description="Review and approve pending membership requests"
-        backHref={`/${orgSlug}`}
+        backHref={`/${orgSlug}/settings/invites`}
       />
 
       {error && (
@@ -302,144 +142,6 @@ export default function ApprovalsPage() {
           {error}
         </div>
       )}
-
-      {/* Approval Toggle */}
-      <Card className="p-6 mb-8">
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="font-semibold text-foreground">Require Approval for New Members</h3>
-            <p className="text-sm text-muted-foreground mt-1">
-              When enabled, users who join via invite must be approved before gaining access.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={requireApproval}
-            onChange={handleToggleApproval}
-            disabled={isSavingToggle}
-            label="Require invite approval"
-          />
-        </div>
-        {!requireApproval && totalPending > 0 && (
-          <div className="mt-4 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 text-sm">
-            Approval is off, but {totalPending} request{totalPending !== 1 ? "s" : ""} still require{totalPending === 1 ? "s" : ""} manual review.
-          </div>
-        )}
-      </Card>
-
-      {/* Invite Link Section */}
-      <Card className="p-6 mb-8">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h3 className="font-semibold text-foreground">Invite Links</h3>
-            <p className="text-sm text-muted-foreground">Generate invite links for new members</p>
-          </div>
-          {!showInviteForm && (
-            <Button onClick={() => setShowInviteForm(true)} size="sm">
-              <svg className="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-              </svg>
-              Create Invite
-            </Button>
-          )}
-        </div>
-
-        {showInviteForm && (
-          <div className="p-4 rounded-xl bg-muted/50 mb-4">
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4">
-              <Select
-                label="Role"
-                value={newRole}
-                onChange={(e) => setNewRole(e.target.value as "active_member" | "admin" | "alumni")}
-                options={[
-                  { value: "active_member", label: "Active Member" },
-                  { value: "admin", label: "Admin" },
-                  { value: "alumni", label: "Alumni" },
-                ]}
-              />
-              <Input
-                label="Max Uses"
-                type="number"
-                value={newUses}
-                onChange={(e) => setNewUses(e.target.value)}
-                placeholder="Unlimited"
-                min={1}
-              />
-              <Input
-                label="Expires On"
-                type="date"
-                value={newExpires}
-                onChange={(e) => setNewExpires(e.target.value)}
-              />
-            </div>
-            <div className="flex gap-3">
-              <Button onClick={handleCreateInvite} isLoading={isCreating}>
-                Generate Link
-              </Button>
-              <Button variant="secondary" onClick={() => setShowInviteForm(false)}>
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {invites.length > 0 ? (
-          <div className="space-y-3">
-            {invites.slice(0, 3).map((invite) => {
-              const inviteLink = getInviteLink(invite);
-              const isExpired = invite.expires_at && new Date(invite.expires_at) < new Date();
-              const isExhausted = invite.uses_remaining !== null && invite.uses_remaining <= 0;
-
-              return (
-                <div key={invite.id} className={`p-4 rounded-xl border border-border ${isExpired || isExhausted ? "opacity-60" : ""}`}>
-                  <div className="flex items-center justify-between flex-wrap gap-3">
-                    <div className="flex items-center gap-3">
-                      <code className="font-mono text-lg font-bold">{invite.code}</code>
-                      <Badge variant={getRoleBadgeVariant(invite.role)}>
-                        {getRoleLabel(invite.role)}
-                      </Badge>
-                      {isExpired && <Badge variant="error">Expired</Badge>}
-                      {isExhausted && <Badge variant="error">No uses left</Badge>}
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => copyToClipboard(inviteLink, `link-${invite.id}`)}
-                      >
-                        {copied === `link-${invite.id}` ? "Copied!" : "Copy Link"}
-                      </Button>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => setShowQR(showQR === invite.id ? null : invite.id)}
-                      >
-                        QR
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="text-red-500"
-                        onClick={() => handleRevokeInvite(invite.id)}
-                      >
-                        Revoke
-                      </Button>
-                    </div>
-                  </div>
-                  {showQR === invite.id && (
-                    <div className="mt-4 pt-4 border-t border-border flex justify-center">
-                      <QRCodeDisplay url={inviteLink} size={180} />
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        ) : (
-          <p className="text-sm text-muted-foreground text-center py-4">
-            No active invites. Create one to let people join.
-          </p>
-        )}
-      </Card>
 
       {/* Pending Members Section */}
       <h2 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
@@ -549,6 +251,12 @@ export default function ApprovalsPage() {
             </svg>
           </div>
           <p className="text-muted-foreground">All caught up! No pending approvals.</p>
+          <Link
+            href={`/${orgSlug}/settings/invites`}
+            className="text-sm text-muted-foreground hover:underline mt-2 inline-block"
+          >
+            Back to Settings
+          </Link>
         </div>
       )}
     </div>

--- a/src/app/[orgSlug]/settings/approvals/page.tsx
+++ b/src/app/[orgSlug]/settings/approvals/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { PageHeader } from "@/components/layout";
 import { Button, Card, Badge, Select, Input } from "@/components/ui";
+import { ToggleSwitch } from "@/components/ui/ToggleSwitch";
 import { QRCodeDisplay } from "@/components/invites";
 import { getRoleBadgeVariant, getRoleLabel } from "@/lib/auth/role-display";
 import { formatShortDate } from "@/lib/utils/dates";
@@ -54,6 +55,8 @@ export default function ApprovalsPage() {
   const [pendingAlumni, setPendingAlumni] = useState<PendingMember[]>([]);
   const [invites, setInvites] = useState<Invite[]>([]);
   const [orgId, setOrgId] = useState<string | null>(null);
+  const [requireApproval, setRequireApproval] = useState(false);
+  const [isSavingToggle, setIsSavingToggle] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
@@ -72,16 +75,19 @@ export default function ApprovalsPage() {
       const supabase = createClient();
 
       // Get org
-      const { data: orgs, error: orgError } = await supabase
+      // Cast needed: require_invite_approval exists in DB but not yet in generated types
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: orgs, error: orgError } = await (supabase as any)
         .from("organizations")
-        .select("id")
+        .select("id, require_invite_approval")
         .eq("slug", orgSlug)
         .limit(1);
 
-      const org = orgs?.[0];
+      const org = orgs?.[0] as { id: string; require_invite_approval?: boolean } | undefined;
 
       if (org && !orgError) {
         setOrgId(org.id);
+        setRequireApproval(org.require_invite_approval ?? false);
 
         // Get pending memberships
         const { data: memberships } = await supabase
@@ -135,7 +141,8 @@ export default function ApprovalsPage() {
       .from("user_organization_roles")
       .update({ status: "active" })
       .eq("organization_id", orgId)
-      .eq("user_id", userId);
+      .eq("user_id", userId)
+      .eq("status", "pending");
 
     if (updateError) {
       setError(updateError.message);
@@ -157,7 +164,8 @@ export default function ApprovalsPage() {
       .from("user_organization_roles")
       .delete()
       .eq("organization_id", orgId)
-      .eq("user_id", userId);
+      .eq("user_id", userId)
+      .eq("status", "pending");
 
     if (deleteError) {
       setError(deleteError.message);
@@ -234,6 +242,32 @@ export default function ApprovalsPage() {
     copyTimerRef.current = setTimeout(() => setCopied(null), 2000);
   };
 
+  const handleToggleApproval = async (checked: boolean) => {
+    if (!orgId) return;
+    setIsSavingToggle(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/organizations/${orgId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ require_invite_approval: checked }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to update approval setting");
+        return;
+      }
+
+      setRequireApproval(checked);
+    } catch {
+      setError("Failed to update approval setting");
+    } finally {
+      setIsSavingToggle(false);
+    }
+  };
+
   const getInviteLink = (invite: Invite) => {
     const base = typeof window !== "undefined" ? window.location.origin : "";
     if (invite.token) {
@@ -268,6 +302,29 @@ export default function ApprovalsPage() {
           {error}
         </div>
       )}
+
+      {/* Approval Toggle */}
+      <Card className="p-6 mb-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="font-semibold text-foreground">Require Approval for New Members</h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              When enabled, users who join via invite must be approved before gaining access.
+            </p>
+          </div>
+          <ToggleSwitch
+            checked={requireApproval}
+            onChange={handleToggleApproval}
+            disabled={isSavingToggle}
+            label="Require invite approval"
+          />
+        </div>
+        {!requireApproval && totalPending > 0 && (
+          <div className="mt-4 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 text-sm">
+            Approval is off, but {totalPending} request{totalPending !== 1 ? "s" : ""} still require{totalPending === 1 ? "s" : ""} manual review.
+          </div>
+        )}
+      </Card>
 
       {/* Invite Link Section */}
       <Card className="p-6 mb-8">

--- a/src/app/[orgSlug]/settings/invites/page.tsx
+++ b/src/app/[orgSlug]/settings/invites/page.tsx
@@ -2,9 +2,11 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { PageHeader } from "@/components/layout";
-import { Button } from "@/components/ui";
+import { Button, Card } from "@/components/ui";
+import { ToggleSwitch } from "@/components/ui/ToggleSwitch";
 import type { SubscriptionInfo } from "@/types/subscription";
 import { OrgInvitePanel } from "@/components/settings/OrgInvitePanel";
 import { MembershipPanel } from "@/components/settings/MembershipPanel";
@@ -21,6 +23,10 @@ export default function InvitesPage() {
   const [quota, setQuota] = useState<SubscriptionInfo | null>(null);
   const [isLoadingQuota, setIsLoadingQuota] = useState(true);
   const [showInviteForm, setShowInviteForm] = useState(false);
+  const [requireApproval, setRequireApproval] = useState(false);
+  const [isSavingToggle, setIsSavingToggle] = useState(false);
+  const [pendingCount, setPendingCount] = useState(0);
+  const [approvalError, setApprovalError] = useState<string | null>(null);
 
   const loadQuota = useCallback(async (organizationId: string) => {
     setIsLoadingQuota(true);
@@ -43,17 +49,28 @@ export default function InvitesPage() {
   useEffect(() => {
     const fetchData = async () => {
       const supabase = createClient();
-      const { data: orgs, error: orgError } = await supabase
+      // Cast needed: require_invite_approval exists in DB but not yet in generated types
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: orgs, error: orgError } = await (supabase as any)
         .from("organizations")
-        .select("id, name")
+        .select("id, name, require_invite_approval")
         .eq("slug", orgSlug)
         .limit(1);
 
-      const org = orgs?.[0];
+      const org = orgs?.[0] as { id: string; name: string; require_invite_approval?: boolean } | undefined;
       if (org && !orgError) {
         setOrgId(org.id);
         setOrgName(org.name);
+        setRequireApproval(org.require_invite_approval ?? false);
         void loadQuota(org.id);
+
+        // Fetch pending member count
+        const { count } = await supabase
+          .from("user_organization_roles")
+          .select("*", { count: "exact", head: true })
+          .eq("organization_id", org.id)
+          .eq("status", "pending");
+        setPendingCount(count ?? 0);
       }
 
       setIsLoading(false);
@@ -76,6 +93,32 @@ export default function InvitesPage() {
       </div>
     );
   }
+
+  const handleToggleApproval = async (checked: boolean) => {
+    if (!orgId) return;
+    setIsSavingToggle(true);
+    setApprovalError(null);
+
+    try {
+      const res = await fetch(`/api/organizations/${orgId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ require_invite_approval: checked }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setApprovalError(data.error || "Failed to update approval setting");
+        return;
+      }
+
+      setRequireApproval(checked);
+    } catch {
+      setApprovalError("Failed to update approval setting");
+    } finally {
+      setIsSavingToggle(false);
+    }
+  };
 
   if (!orgId) return null;
 
@@ -103,6 +146,43 @@ export default function InvitesPage() {
         isLoadingQuota={isLoadingQuota}
         onQuotaRefresh={handleQuotaRefresh}
       />
+
+      {/* Invite Approval Settings */}
+      <Card className="p-6 mb-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="font-semibold text-foreground">Require Approval for New Members</h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              When enabled, users who join via invite must be approved before gaining access.
+              You can also override this per invite.
+            </p>
+          </div>
+          <ToggleSwitch
+            checked={requireApproval}
+            onChange={handleToggleApproval}
+            disabled={isSavingToggle}
+            label="Require invite approval"
+          />
+        </div>
+        {approvalError && (
+          <div className="mt-3 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 text-sm">
+            {approvalError}
+          </div>
+        )}
+        {pendingCount > 0 && (
+          <div className="mt-4 flex items-center justify-between p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20">
+            <span className="text-sm text-amber-700 dark:text-amber-400">
+              {pendingCount} pending approval{pendingCount !== 1 ? "s" : ""}
+            </span>
+            <Link
+              href={`/${orgSlug}/settings/approvals`}
+              className="text-sm font-medium text-amber-700 dark:text-amber-400 hover:underline"
+            >
+              Review pending members
+            </Link>
+          </div>
+        )}
+      </Card>
 
       <OrgInvitePanel
         orgId={orgId}

--- a/src/app/[orgSlug]/settings/invites/page.tsx
+++ b/src/app/[orgSlug]/settings/invites/page.tsx
@@ -191,6 +191,7 @@ export default function InvitesPage() {
         showForm={showInviteForm}
         onShowFormChange={setShowInviteForm}
         onAlumniInviteCreated={handleQuotaRefresh}
+        orgRequireApproval={requireApproval}
       />
 
       <MembershipPanel

--- a/src/app/[orgSlug]/settings/invites/page.tsx
+++ b/src/app/[orgSlug]/settings/invites/page.tsx
@@ -169,19 +169,19 @@ export default function InvitesPage() {
             {approvalError}
           </div>
         )}
-        {pendingCount > 0 && (
-          <div className="mt-4 flex items-center justify-between p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20">
-            <span className="text-sm text-amber-700 dark:text-amber-400">
-              {pendingCount} pending approval{pendingCount !== 1 ? "s" : ""}
-            </span>
-            <Link
-              href={`/${orgSlug}/settings/approvals`}
-              className="text-sm font-medium text-amber-700 dark:text-amber-400 hover:underline"
-            >
-              Review pending members
-            </Link>
-          </div>
-        )}
+        <div className={`mt-4 flex items-center justify-between p-3 rounded-lg ${pendingCount > 0 ? "bg-amber-50 dark:bg-amber-900/20" : "bg-muted/50"}`}>
+          <span className={`text-sm ${pendingCount > 0 ? "text-amber-700 dark:text-amber-400" : "text-muted-foreground"}`}>
+            {pendingCount > 0
+              ? `${pendingCount} pending approval${pendingCount !== 1 ? "s" : ""}`
+              : "No pending approvals"}
+          </span>
+          <Link
+            href={`/${orgSlug}/settings/approvals`}
+            className={`text-sm font-medium hover:underline ${pendingCount > 0 ? "text-amber-700 dark:text-amber-400" : "text-muted-foreground"}`}
+          >
+            {pendingCount > 0 ? "Review pending members" : "View approvals"}
+          </Link>
+        </div>
       </Card>
 
       <OrgInvitePanel

--- a/src/app/api/organizations/[organizationId]/invites/route.ts
+++ b/src/app/api/organizations/[organizationId]/invites/route.ts
@@ -10,6 +10,7 @@ const createInviteSchema = z.object({
   role: z.enum(["admin", "active_member", "alumni", "parent"]),
   uses: z.number().int().positive().optional().nullable(),
   expiresAt: z.string().datetime().optional().nullable(),
+  requireApproval: z.boolean().optional().nullable(),
 });
 
 export const dynamic = "force-dynamic";
@@ -83,6 +84,7 @@ export async function POST(req: Request, { params }: RouteParams) {
     p_role: body.role,
     p_uses: body.uses ?? null,
     p_expires_at: body.expiresAt ?? null,
+    p_require_approval: body.requireApproval ?? null,
   });
 
   if (rpcError || !invite) {

--- a/src/app/api/organizations/[organizationId]/route.ts
+++ b/src/app/api/organizations/[organizationId]/route.ts
@@ -50,6 +50,7 @@ const patchSchema = z
     discussion_post_roles: z.array(z.enum(ALLOWED_ROLES)).min(1).optional(),
     media_upload_roles: z.array(z.enum(ALLOWED_ROLES)).min(1).optional(),
     linkedin_resync_enabled: z.boolean().optional(),
+    require_invite_approval: z.boolean().optional(),
   })
   .strict();
 const ALLOWED_NAV_PATHS = new Set([...ORG_NAV_ITEMS.map((item) => item.href), "dashboard"]);
@@ -165,7 +166,7 @@ export async function PATCH(req: Request, { params }: RouteParams) {
     const serviceSupabase = createServiceClient();
 
     // Build update payload - only include fields that were provided
-    const updatePayload: { nav_config?: NavConfig; name?: string; feed_post_roles?: string[]; job_post_roles?: string[]; discussion_post_roles?: string[]; media_upload_roles?: string[]; linkedin_resync_enabled?: boolean } = {};
+    const updatePayload: { nav_config?: NavConfig; name?: string; feed_post_roles?: string[]; job_post_roles?: string[]; discussion_post_roles?: string[]; media_upload_roles?: string[]; linkedin_resync_enabled?: boolean; require_invite_approval?: boolean } = {};
 
     // Only update nav_config if navConfig or nav_config was provided in the request
     if (parsedBody.navConfig !== undefined || parsedBody.nav_config !== undefined) {
@@ -205,6 +206,10 @@ export async function PATCH(req: Request, { params }: RouteParams) {
       updatePayload.linkedin_resync_enabled = parsedBody.linkedin_resync_enabled;
     }
 
+    if (parsedBody.require_invite_approval !== undefined) {
+      updatePayload.require_invite_approval = parsedBody.require_invite_approval;
+    }
+
     // If nothing to update, return early
     if (Object.keys(updatePayload).length === 0) {
       return respond({ error: "No valid fields to update" }, 400);
@@ -216,7 +221,7 @@ export async function PATCH(req: Request, { params }: RouteParams) {
       .from("organizations")
       .update(updatePayload)
       .eq("id", organizationId)
-      .select("id, name, nav_config, feed_post_roles, job_post_roles, discussion_post_roles, media_upload_roles, linkedin_resync_enabled")
+      .select("id, name, nav_config, feed_post_roles, job_post_roles, discussion_post_roles, media_upload_roles, linkedin_resync_enabled, require_invite_approval")
       .maybeSingle();
 
     if (updateError) {
@@ -228,7 +233,7 @@ export async function PATCH(req: Request, { params }: RouteParams) {
     }
 
     // Return response with updated fields
-    const response: { navConfig?: NavConfig; name?: string; feed_post_roles?: string[]; job_post_roles?: string[]; discussion_post_roles?: string[]; media_upload_roles?: string[]; linkedin_resync_enabled?: boolean } = {};
+    const response: { navConfig?: NavConfig; name?: string; feed_post_roles?: string[]; job_post_roles?: string[]; discussion_post_roles?: string[]; media_upload_roles?: string[]; linkedin_resync_enabled?: boolean; require_invite_approval?: boolean } = {};
     if (updatePayload.nav_config !== undefined) {
       response.navConfig = navConfig;
     }
@@ -249,6 +254,9 @@ export async function PATCH(req: Request, { params }: RouteParams) {
     }
     if (updatePayload.linkedin_resync_enabled !== undefined) {
       response.linkedin_resync_enabled = updatedOrg.linkedin_resync_enabled as boolean;
+    }
+    if (updatePayload.require_invite_approval !== undefined) {
+      response.require_invite_approval = updatedOrg.require_invite_approval as boolean;
     }
 
     return respond(response);

--- a/src/app/api/organizations/[organizationId]/route.ts
+++ b/src/app/api/organizations/[organizationId]/route.ts
@@ -145,15 +145,15 @@ export async function PATCH(req: Request, { params }: RouteParams) {
       return respond({ error: "Unauthorized" }, 401);
     }
 
-    // Require admin role in the organization
+    // Require admin role with active status in the organization
     const { data: role } = await supabase
       .from("user_organization_roles")
-      .select("role")
+      .select("role, status")
       .eq("user_id", user.id)
       .eq("organization_id", organizationId)
       .maybeSingle();
 
-    if (role?.role !== "admin") {
+    if (role?.role !== "admin" || role?.status !== "active") {
       return respond({ error: "Forbidden" }, 403);
     }
 

--- a/src/components/settings/OrgInvitePanel.tsx
+++ b/src/components/settings/OrgInvitePanel.tsx
@@ -52,6 +52,7 @@ interface OrgInvitePanelProps {
   showForm: boolean;
   onShowFormChange: (show: boolean) => void;
   onAlumniInviteCreated: () => void;
+  orgRequireApproval: boolean;
 }
 
 export function OrgInvitePanel({
@@ -61,6 +62,7 @@ export function OrgInvitePanel({
   showForm,
   onShowFormChange,
   onAlumniInviteCreated,
+  orgRequireApproval,
 }: OrgInvitePanelProps) {
   const supabase = useMemo(() => createClient(), []);
   const [orgInvites, setOrgInvites] = useState<Invite[]>([]);
@@ -308,34 +310,21 @@ export function OrgInvitePanel({
               onChange={(e) => setNewExpires(e.target.value)}
             />
           </div>
-          <div className="mb-4">
-            <label className="flex items-center gap-3 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={newRequireApproval === true}
-                ref={(el) => {
-                  if (el) el.indeterminate = newRequireApproval === null;
-                }}
-                onChange={() => {
-                  // Cycle: null (inherit) -> true (require) -> false (skip) -> null
-                  if (newRequireApproval === null) setNewRequireApproval(true);
-                  else if (newRequireApproval === true) setNewRequireApproval(false);
-                  else setNewRequireApproval(null);
-                }}
-                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-              />
-              <span className="text-sm text-foreground">
-                Require approval
-                <span className="text-muted-foreground ml-1">
-                  {newRequireApproval === null
-                    ? "(use org default)"
-                    : newRequireApproval
-                      ? "(always require)"
-                      : "(never require)"}
+          {!orgRequireApproval && (
+            <div className="mb-4">
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={newRequireApproval === true}
+                  onChange={(e) => setNewRequireApproval(e.target.checked ? true : null)}
+                  className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                />
+                <span className="text-sm text-foreground">
+                  Require approval for this invite
                 </span>
-              </span>
-            </label>
-          </div>
+              </label>
+            </div>
+          )}
           {newRole === "alumni" && atAlumniLimit && (
             <p className="text-xs text-amber-600">
               Alumni limit reached for your plan. Upgrade above to add more alumni invites.

--- a/src/components/settings/OrgInvitePanel.tsx
+++ b/src/components/settings/OrgInvitePanel.tsx
@@ -310,7 +310,11 @@ export function OrgInvitePanel({
               onChange={(e) => setNewExpires(e.target.value)}
             />
           </div>
-          {!orgRequireApproval && (
+          {orgRequireApproval ? (
+            <div className="mb-4 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 text-sm">
+              Approval is required — new members who use this invite will need admin approval before gaining access.
+            </div>
+          ) : (
             <div className="mb-4">
               <label className="flex items-center gap-3 cursor-pointer">
                 <input

--- a/src/components/settings/OrgInvitePanel.tsx
+++ b/src/components/settings/OrgInvitePanel.tsx
@@ -17,6 +17,7 @@ interface Invite {
   expires_at: string | null;
   revoked_at: string | null;
   created_at: string;
+  require_approval: boolean | null;
 }
 
 interface ParentInvite {
@@ -41,6 +42,7 @@ interface InviteItem {
   revoked_at?: string | null;
   status?: "pending" | "accepted" | "revoked";
   email?: string;
+  require_approval?: boolean | null;
 }
 
 interface OrgInvitePanelProps {
@@ -80,6 +82,7 @@ export function OrgInvitePanel({
   const [newRole, setNewRole] = useState<"active_member" | "admin" | "alumni" | "parent">("active_member");
   const [newUses, setNewUses] = useState("");
   const [newExpires, setNewExpires] = useState("");
+  const [newRequireApproval, setNewRequireApproval] = useState<boolean | null>(null);
 
   // Fetch invites
   useEffect(() => {
@@ -129,6 +132,7 @@ export function OrgInvitePanel({
           role: newRole,
           uses: usesRemaining,
           expiresAt,
+          requireApproval: newRequireApproval,
         }),
       });
 
@@ -146,6 +150,7 @@ export function OrgInvitePanel({
       setNewRole("active_member");
       setNewUses("");
       setNewExpires("");
+      setNewRequireApproval(null);
       succeeded = true;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to create invite");
@@ -249,6 +254,7 @@ export function OrgInvitePanel({
       role: invite.role,
       uses_remaining: invite.uses_remaining,
       revoked_at: invite.revoked_at,
+      require_approval: invite.require_approval,
     })),
     ...parentInvites.map((invite) => ({
       source: "legacy_parent_invite" as const,
@@ -301,6 +307,34 @@ export function OrgInvitePanel({
               value={newExpires}
               onChange={(e) => setNewExpires(e.target.value)}
             />
+          </div>
+          <div className="mb-4">
+            <label className="flex items-center gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={newRequireApproval === true}
+                ref={(el) => {
+                  if (el) el.indeterminate = newRequireApproval === null;
+                }}
+                onChange={() => {
+                  // Cycle: null (inherit) -> true (require) -> false (skip) -> null
+                  if (newRequireApproval === null) setNewRequireApproval(true);
+                  else if (newRequireApproval === true) setNewRequireApproval(false);
+                  else setNewRequireApproval(null);
+                }}
+                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+              />
+              <span className="text-sm text-foreground">
+                Require approval
+                <span className="text-muted-foreground ml-1">
+                  {newRequireApproval === null
+                    ? "(use org default)"
+                    : newRequireApproval
+                      ? "(always require)"
+                      : "(never require)"}
+                </span>
+              </span>
+            </label>
           </div>
           {newRole === "alumni" && atAlumniLimit && (
             <p className="text-xs text-amber-600">
@@ -358,6 +392,12 @@ export function OrgInvitePanel({
                         <Badge variant={getRoleBadgeVariant(role)}>
                           {getRoleLabel(role)}
                         </Badge>
+                        {invite.require_approval === true && (
+                          <Badge variant="warning">Approval required</Badge>
+                        )}
+                        {invite.require_approval === false && (
+                          <Badge variant="success">Auto-approve</Badge>
+                        )}
                         {expired && <Badge variant="error">Expired</Badge>}
                         {exhausted && <Badge variant="error">No uses left</Badge>}
                         {revoked && <Badge variant="error">Revoked</Badge>}

--- a/src/lib/auth/roles.ts
+++ b/src/lib/auth/roles.ts
@@ -33,7 +33,7 @@ function normalizeMembershipRow(data: { role?: unknown; status?: unknown } | nul
 } {
   return {
     role: normalizeRole((data?.role as UserRole | null) ?? null),
-    status: (data?.status as MembershipStatus | null) ?? "active",
+    status: (data?.status as MembershipStatus | null) ?? null,
   };
 }
 
@@ -76,7 +76,7 @@ export async function requireOrgRole(params: {
 }): Promise<OrgRoleResult> {
   const membership = await getOrgRole({ orgId: params.orgId, userId: undefined });
   const allowed =
-    membership.role && membership.status !== "revoked" && params.allowedRoles.includes(membership.role);
+    membership.role && membership.status === "active" && params.allowedRoles.includes(membership.role);
 
   if (!allowed) {
     if (params.redirectTo) {
@@ -160,7 +160,7 @@ export const getOrgContext = cache(async (orgSlug: string): Promise<OrgContextRe
   const gracePeriod = getGracePeriodInfo(subscription);
 
   const { role, status: memberStatus } = normalizeMembershipRow(membershipData?.data);
-  const flags = memberStatus === "revoked" ? roleFlags(null) : roleFlags(role);
+  const flags = memberStatus === "active" ? roleFlags(role) : roleFlags(null);
 
   return {
     organization: org as Organization,

--- a/supabase/migrations/20260326000000_require_invite_approval.sql
+++ b/supabase/migrations/20260326000000_require_invite_approval.sql
@@ -1,0 +1,4 @@
+-- Add per-org toggle to gate invite redemptions behind admin approval.
+-- DEFAULT false preserves current auto-approve behavior for all existing orgs.
+ALTER TABLE public.organizations
+  ADD COLUMN IF NOT EXISTS require_invite_approval boolean NOT NULL DEFAULT false;

--- a/supabase/migrations/20260326000001_redeem_org_invite_approval_gate.sql
+++ b/supabase/migrations/20260326000001_redeem_org_invite_approval_gate.sql
@@ -1,0 +1,116 @@
+-- Update redeem_org_invite to respect per-org require_invite_approval flag.
+-- When enabled, new members land in 'pending' status instead of 'active'.
+-- Also adds FOR UPDATE on invite SELECT to prevent concurrent over-redemption.
+CREATE OR REPLACE FUNCTION public.redeem_org_invite(p_code text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, auth
+AS $$
+DECLARE
+  v_invite public.organization_invites;
+  v_org public.organizations;
+  v_existing public.user_organization_roles;
+  v_user_id uuid;
+  v_new_status text;
+BEGIN
+  v_user_id := auth.uid();
+
+  -- Must be authenticated
+  IF v_user_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'You must be logged in to redeem an invite');
+  END IF;
+
+  -- Find invite by code OR token (lock row to prevent concurrent over-redemption)
+  SELECT * INTO v_invite
+  FROM public.organization_invites
+  WHERE (upper(code) = upper(trim(p_code)) OR token = trim(p_code))
+    AND revoked_at IS NULL
+  FOR UPDATE;
+
+  IF v_invite IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Invalid invite code (not found)');
+  END IF;
+
+  -- Check if invite has expired
+  IF v_invite.expires_at IS NOT NULL AND v_invite.expires_at < now() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'This invite has expired');
+  END IF;
+
+  -- Check if invite has uses remaining
+  IF v_invite.uses_remaining IS NOT NULL AND v_invite.uses_remaining <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'This invite has no uses remaining');
+  END IF;
+
+  -- Fetch org (needed for approval flag and response fields)
+  SELECT * INTO v_org FROM public.organizations WHERE id = v_invite.organization_id;
+
+  -- Determine new status based on org approval setting
+  v_new_status := CASE
+    WHEN COALESCE(v_org.require_invite_approval, false) THEN 'pending'
+    ELSE 'active'
+  END;
+
+  -- Check if user already has a membership in this org
+  SELECT * INTO v_existing
+  FROM public.user_organization_roles
+  WHERE user_id = v_user_id
+    AND organization_id = v_invite.organization_id;
+
+  IF v_existing IS NOT NULL THEN
+    IF v_existing.status = 'revoked' THEN
+      -- Revoked user rejoining: respect the approval flag
+      UPDATE public.user_organization_roles
+      SET status = v_new_status::public.membership_status,
+          role = v_invite.role::public.user_role
+      WHERE user_id = v_user_id
+        AND organization_id = v_invite.organization_id;
+
+      -- Decrement uses_remaining if set
+      IF v_invite.uses_remaining IS NOT NULL THEN
+        UPDATE public.organization_invites
+        SET uses_remaining = uses_remaining - 1
+        WHERE id = v_invite.id;
+      END IF;
+
+      RETURN jsonb_build_object(
+        'success', true,
+        'organization_id', v_invite.organization_id,
+        'slug', v_org.slug,
+        'name', v_org.name,
+        'role', v_invite.role,
+        'pending_approval', v_org.require_invite_approval
+      );
+    END IF;
+
+    RETURN jsonb_build_object(
+      'success', true,
+      'organization_id', v_invite.organization_id,
+      'slug', v_org.slug,
+      'name', v_org.name,
+      'already_member', true,
+      'status', v_existing.status
+    );
+  END IF;
+
+  -- Insert new membership with status based on approval flag
+  INSERT INTO public.user_organization_roles (user_id, organization_id, role, status)
+  VALUES (v_user_id, v_invite.organization_id, v_invite.role::public.user_role, v_new_status::public.membership_status);
+
+  -- Decrement uses_remaining if it's set
+  IF v_invite.uses_remaining IS NOT NULL THEN
+    UPDATE public.organization_invites
+    SET uses_remaining = uses_remaining - 1
+    WHERE id = v_invite.id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'organization_id', v_invite.organization_id,
+    'slug', v_org.slug,
+    'name', v_org.name,
+    'role', v_invite.role,
+    'pending_approval', COALESCE(v_org.require_invite_approval, false)
+  );
+END;
+$$;

--- a/supabase/migrations/20260326000002_sync_trigger_skip_pending.sql
+++ b/supabase/migrations/20260326000002_sync_trigger_skip_pending.sql
@@ -1,0 +1,235 @@
+-- Update handle_org_member_sync to skip member directory sync for pending users.
+-- Pending users should not appear in member directories until approved.
+-- The normal approval path (pending -> active UPDATE) is NOT caught,
+-- so it correctly syncs to members when an admin approves.
+CREATE OR REPLACE FUNCTION public.handle_org_member_sync()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_email text;
+  v_first_name text;
+  v_last_name text;
+  v_full_name text;
+  v_display_name text;
+  v_avatar_url text;
+  v_member_id uuid;
+  v_alumni_id uuid;
+  v_parent_id uuid;
+BEGIN
+  IF NEW.status = 'revoked' THEN
+    IF NEW.role = 'alumni' AND NEW.user_id IS NOT NULL THEN
+      UPDATE public.alumni
+      SET deleted_at = now(), updated_at = now()
+      WHERE organization_id = NEW.organization_id
+        AND user_id = NEW.user_id
+        AND deleted_at IS NULL;
+    END IF;
+
+    IF NEW.user_id IS NOT NULL THEN
+      UPDATE public.members
+      SET deleted_at = now(), updated_at = now()
+      WHERE organization_id = NEW.organization_id
+        AND user_id = NEW.user_id
+        AND deleted_at IS NULL;
+    END IF;
+
+    IF NEW.role = 'parent' AND NEW.user_id IS NOT NULL THEN
+      UPDATE public.parents
+      SET deleted_at = now(), updated_at = now()
+      WHERE organization_id = NEW.organization_id
+        AND user_id = NEW.user_id
+        AND deleted_at IS NULL;
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  -- Pending users should not appear in member directories until approved.
+  -- Covers both: new INSERT with pending, AND revoked->pending UPDATE path.
+  IF NEW.status = 'pending' AND (
+    TG_OP = 'INSERT'
+    OR (TG_OP = 'UPDATE' AND OLD.status = 'revoked')
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT
+    email,
+    NULLIF(btrim(raw_user_meta_data->>'first_name'), ''),
+    NULLIF(btrim(raw_user_meta_data->>'last_name'), ''),
+    NULLIF(btrim(raw_user_meta_data->>'full_name'), ''),
+    NULLIF(btrim(raw_user_meta_data->>'name'), ''),
+    raw_user_meta_data->>'avatar_url'
+  INTO v_user_email, v_first_name, v_last_name, v_full_name, v_display_name, v_avatar_url
+  FROM auth.users
+  WHERE id = NEW.user_id;
+
+  IF COALESCE(v_first_name, '') = '' AND COALESCE(v_last_name, '') = '' THEN
+    v_full_name := COALESCE(v_full_name, v_display_name);
+
+    IF COALESCE(v_full_name, '') <> '' THEN
+      v_first_name := split_part(v_full_name, ' ', 1);
+      v_last_name := COALESCE(
+        NULLIF(btrim(substr(v_full_name, length(split_part(v_full_name, ' ', 1)) + 1)), ''),
+        ''
+      );
+    END IF;
+  END IF;
+
+  v_first_name := COALESCE(v_first_name, 'Member');
+  v_last_name := COALESCE(v_last_name, '');
+
+  SELECT id INTO v_member_id
+  FROM public.members
+  WHERE organization_id = NEW.organization_id
+    AND (user_id = NEW.user_id OR (email IS NOT NULL AND email = v_user_email))
+  LIMIT 1;
+
+  IF v_member_id IS NOT NULL THEN
+    UPDATE public.members
+    SET
+      user_id = NEW.user_id,
+      first_name = CASE
+        WHEN (
+          COALESCE(btrim(first_name), '') = '' AND COALESCE(btrim(last_name), '') = ''
+        ) OR (
+          COALESCE(btrim(first_name), '') = 'Member' AND COALESCE(btrim(last_name), '') = ''
+        )
+        THEN v_first_name
+        ELSE first_name
+      END,
+      last_name = CASE
+        WHEN (
+          COALESCE(btrim(first_name), '') = '' AND COALESCE(btrim(last_name), '') = ''
+        ) OR (
+          COALESCE(btrim(first_name), '') = 'Member' AND COALESCE(btrim(last_name), '') = ''
+        )
+        THEN v_last_name
+        ELSE last_name
+      END,
+      role = NEW.role,
+      status = NEW.status::text::public.member_status,
+      updated_at = now()
+    WHERE id = v_member_id;
+  ELSE
+    INSERT INTO public.members (
+      organization_id,
+      user_id,
+      first_name,
+      last_name,
+      email,
+      photo_url,
+      role,
+      status
+    )
+    VALUES (
+      NEW.organization_id,
+      NEW.user_id,
+      v_first_name,
+      v_last_name,
+      v_user_email,
+      v_avatar_url,
+      NEW.role,
+      NEW.status::text::public.member_status
+    );
+  END IF;
+
+  IF NEW.role = 'alumni' THEN
+    SELECT id INTO v_alumni_id
+    FROM public.alumni
+    WHERE organization_id = NEW.organization_id
+      AND (user_id = NEW.user_id OR (email IS NOT NULL AND email = v_user_email))
+    LIMIT 1;
+
+    IF v_alumni_id IS NOT NULL THEN
+      UPDATE public.alumni
+      SET
+        user_id = NEW.user_id,
+        updated_at = now()
+      WHERE id = v_alumni_id;
+    ELSE
+      PERFORM public.assert_alumni_quota(NEW.organization_id);
+
+      INSERT INTO public.alumni (
+        organization_id,
+        user_id,
+        first_name,
+        last_name,
+        email,
+        photo_url
+      )
+      VALUES (
+        NEW.organization_id,
+        NEW.user_id,
+        v_first_name,
+        v_last_name,
+        v_user_email,
+        v_avatar_url
+      );
+    END IF;
+  END IF;
+
+  IF NEW.role = 'parent' THEN
+    SELECT id INTO v_parent_id
+    FROM public.parents
+    WHERE organization_id = NEW.organization_id
+      AND deleted_at IS NULL
+      AND (
+        user_id = NEW.user_id OR (
+          v_user_email IS NOT NULL
+          AND email IS NOT NULL
+          AND lower(email) = lower(v_user_email)
+        )
+      )
+    LIMIT 1;
+
+    IF v_parent_id IS NOT NULL THEN
+      UPDATE public.parents
+      SET
+        user_id = NEW.user_id,
+        email = COALESCE(email, v_user_email),
+        photo_url = COALESCE(photo_url, v_avatar_url),
+        updated_at = now()
+      WHERE id = v_parent_id;
+    ELSE
+      INSERT INTO public.parents (
+        organization_id,
+        user_id,
+        first_name,
+        last_name,
+        email,
+        photo_url
+      )
+      VALUES (
+        NEW.organization_id,
+        NEW.user_id,
+        v_first_name,
+        v_last_name,
+        v_user_email,
+        v_avatar_url
+      );
+    END IF;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.role = 'alumni' AND NEW.role != 'alumni' THEN
+    UPDATE public.alumni
+    SET deleted_at = now(), updated_at = now()
+    WHERE organization_id = NEW.organization_id
+      AND user_id = NEW.user_id
+      AND deleted_at IS NULL;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.role = 'parent' AND NEW.role != 'parent' THEN
+    UPDATE public.parents
+    SET deleted_at = now(), updated_at = now()
+    WHERE organization_id = NEW.organization_id
+      AND user_id = NEW.user_id
+      AND deleted_at IS NULL;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;

--- a/supabase/migrations/20260803000000_sync_trigger_skip_pending.sql
+++ b/supabase/migrations/20260803000000_sync_trigger_skip_pending.sql
@@ -1,6 +1,9 @@
 -- Update handle_org_member_sync to skip member directory sync for pending users.
+-- This must come AFTER 20260714000000_member_identity_hardening.sql which is
+-- the latest migration that redefines this function.
+--
 -- Pending users should not appear in member directories until approved.
--- The normal approval path (pending -> active UPDATE) is NOT caught,
+-- The normal approval path (pending -> active UPDATE) is NOT caught by the guard,
 -- so it correctly syncs to members when an admin approves.
 CREATE OR REPLACE FUNCTION public.handle_org_member_sync()
 RETURNS trigger
@@ -49,6 +52,8 @@ BEGIN
 
   -- Pending users should not appear in member directories until approved.
   -- Covers both: new INSERT with pending, AND revoked->pending UPDATE path.
+  -- The normal approval UPDATE (pending -> active) is NOT caught here,
+  -- so it correctly syncs to members/alumni/parents when an admin approves.
   IF NEW.status = 'pending' AND (
     TG_OP = 'INSERT'
     OR (TG_OP = 'UPDATE' AND OLD.status = 'revoked')

--- a/supabase/migrations/20260803100000_per_invite_require_approval.sql
+++ b/supabase/migrations/20260803100000_per_invite_require_approval.sql
@@ -1,0 +1,184 @@
+-- Add per-invite approval override.
+-- NULL = inherit from org setting, true = always require, false = never require.
+ALTER TABLE public.organization_invites
+  ADD COLUMN IF NOT EXISTS require_approval boolean DEFAULT NULL;
+
+-- Update create_org_invite to accept the new parameter
+CREATE OR REPLACE FUNCTION public.create_org_invite(
+  p_organization_id uuid,
+  p_role            text DEFAULT 'active_member',
+  p_uses            int  DEFAULT NULL,
+  p_expires_at      timestamptz DEFAULT NULL,
+  p_require_approval boolean DEFAULT NULL
+)
+RETURNS public.organization_invites
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_code   text;
+  v_token  text;
+  v_result public.organization_invites;
+BEGIN
+  -- Verify caller is admin of the organization
+  IF NOT public.is_org_admin(p_organization_id) THEN
+    RAISE EXCEPTION 'Only organization admins can create invites';
+  END IF;
+
+  -- Validate role
+  IF p_role NOT IN ('admin', 'active_member', 'alumni', 'parent') THEN
+    RAISE EXCEPTION 'Invalid role. Must be admin, active_member, alumni, or parent';
+  END IF;
+
+  -- Respect alumni quota for alumni invites
+  IF p_role = 'alumni' THEN
+    PERFORM public.assert_alumni_quota(p_organization_id);
+  END IF;
+
+  -- Generate secure random code (8 chars, alphanumeric)
+  v_code := upper(substr(
+    replace(replace(replace(
+      encode(gen_random_bytes(6), 'base64'),
+      '/', ''), '+', ''), '=', ''),
+    1, 8
+  ));
+
+  -- Generate secure token (URL-safe base64, 32 chars)
+  v_token := replace(replace(replace(
+    encode(gen_random_bytes(24), 'base64'),
+    '/', '_'), '+', '-'), '=', '');
+
+  INSERT INTO public.organization_invites (
+    organization_id,
+    code,
+    token,
+    role,
+    uses_remaining,
+    expires_at,
+    created_by_user_id,
+    require_approval
+  ) VALUES (
+    p_organization_id,
+    v_code,
+    v_token,
+    p_role,
+    p_uses,
+    p_expires_at,
+    auth.uid(),
+    p_require_approval
+  )
+  RETURNING * INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+-- Update redeem_org_invite to check invite-level override first, then org-level
+CREATE OR REPLACE FUNCTION public.redeem_org_invite(p_code text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, auth
+AS $$
+DECLARE
+  v_invite public.organization_invites;
+  v_org public.organizations;
+  v_existing public.user_organization_roles;
+  v_user_id uuid;
+  v_new_status text;
+  v_requires_approval boolean;
+BEGIN
+  v_user_id := auth.uid();
+
+  IF v_user_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'You must be logged in to redeem an invite');
+  END IF;
+
+  -- Find invite by code OR token (lock row to prevent concurrent over-redemption)
+  SELECT * INTO v_invite
+  FROM public.organization_invites
+  WHERE (upper(code) = upper(trim(p_code)) OR token = trim(p_code))
+    AND revoked_at IS NULL
+  FOR UPDATE;
+
+  IF v_invite IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Invalid invite code (not found)');
+  END IF;
+
+  IF v_invite.expires_at IS NOT NULL AND v_invite.expires_at < now() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'This invite has expired');
+  END IF;
+
+  IF v_invite.uses_remaining IS NOT NULL AND v_invite.uses_remaining <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'This invite has no uses remaining');
+  END IF;
+
+  -- Fetch org (needed for approval flag and response fields)
+  SELECT * INTO v_org FROM public.organizations WHERE id = v_invite.organization_id;
+
+  -- Per-invite override takes precedence, then org-level setting
+  v_requires_approval := COALESCE(v_invite.require_approval, v_org.require_invite_approval, false);
+
+  v_new_status := CASE WHEN v_requires_approval THEN 'pending' ELSE 'active' END;
+
+  -- Check if user already has a membership in this org
+  SELECT * INTO v_existing
+  FROM public.user_organization_roles
+  WHERE user_id = v_user_id
+    AND organization_id = v_invite.organization_id;
+
+  IF v_existing IS NOT NULL THEN
+    IF v_existing.status = 'revoked' THEN
+      -- Revoked user rejoining: respect the approval setting
+      UPDATE public.user_organization_roles
+      SET status = v_new_status::public.membership_status,
+          role = v_invite.role::public.user_role
+      WHERE user_id = v_user_id
+        AND organization_id = v_invite.organization_id;
+
+      IF v_invite.uses_remaining IS NOT NULL THEN
+        UPDATE public.organization_invites
+        SET uses_remaining = uses_remaining - 1
+        WHERE id = v_invite.id;
+      END IF;
+
+      RETURN jsonb_build_object(
+        'success', true,
+        'organization_id', v_invite.organization_id,
+        'slug', v_org.slug,
+        'name', v_org.name,
+        'role', v_invite.role,
+        'pending_approval', v_requires_approval
+      );
+    END IF;
+
+    RETURN jsonb_build_object(
+      'success', true,
+      'organization_id', v_invite.organization_id,
+      'slug', v_org.slug,
+      'name', v_org.name,
+      'already_member', true,
+      'status', v_existing.status
+    );
+  END IF;
+
+  -- Insert new membership
+  INSERT INTO public.user_organization_roles (user_id, organization_id, role, status)
+  VALUES (v_user_id, v_invite.organization_id, v_invite.role::public.user_role, v_new_status::public.membership_status);
+
+  IF v_invite.uses_remaining IS NOT NULL THEN
+    UPDATE public.organization_invites
+    SET uses_remaining = uses_remaining - 1
+    WHERE id = v_invite.id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'organization_id', v_invite.organization_id,
+    'slug', v_org.slug,
+    'name', v_org.name,
+    'role', v_invite.role,
+    'pending_approval', v_requires_approval
+  );
+END;
+$$;

--- a/supabase/migrations/20260803100000_per_invite_require_approval.sql
+++ b/supabase/migrations/20260803100000_per_invite_require_approval.sql
@@ -76,8 +76,13 @@ BEGIN
 END;
 $$;
 
--- Update redeem_org_invite to check invite-level override first, then org-level
-CREATE OR REPLACE FUNCTION public.redeem_org_invite(p_code text)
+-- Drop and recreate redeem_org_invite (not CREATE OR REPLACE) to force
+-- PostgreSQL to recompile the row type for organization_invites, which now
+-- includes the require_approval column. CREATE OR REPLACE reuses the cached
+-- composite type and v_invite.require_approval silently resolves to NULL.
+DROP FUNCTION IF EXISTS public.redeem_org_invite(text);
+
+CREATE FUNCTION public.redeem_org_invite(p_code text)
 RETURNS jsonb
 LANGUAGE plpgsql
 SECURITY DEFINER

--- a/supabase/migrations/20260803100000_per_invite_require_approval.sql
+++ b/supabase/migrations/20260803100000_per_invite_require_approval.sql
@@ -3,7 +3,10 @@
 ALTER TABLE public.organization_invites
   ADD COLUMN IF NOT EXISTS require_approval boolean DEFAULT NULL;
 
--- Update create_org_invite to accept the new parameter
+-- Drop old 4-param overload to prevent PostgreSQL function ambiguity
+DROP FUNCTION IF EXISTS public.create_org_invite(uuid, text, int, timestamptz);
+
+-- Recreate with 5 params (the only version)
 CREATE OR REPLACE FUNCTION public.create_org_invite(
   p_organization_id uuid,
   p_role            text DEFAULT 'active_member',


### PR DESCRIPTION
## Summary
- Per-org toggle (`require_invite_approval`) gates invite redemptions behind admin approval
- Per-invite override allows individual invites to require/skip approval regardless of org setting
- Auth security fixes: `getOrgContext`, `requireOrgRole`, and org PATCH handler now whitelist `status=active` (fail-closed)
- Defense-in-depth pending gate in org layout catches middleware bypass edge cases
- Sync trigger skips member directory for pending users until approved

## Key Changes
- **3 migrations**: add column, update `redeem_org_invite` RPC (with `FOR UPDATE` locking), update `handle_org_member_sync` trigger, add per-invite `require_approval` column
- **Settings/invites page**: org-level approval toggle, per-invite checkbox, pending count with link to approvals
- **Approvals page**: stripped to pending queue only (approve/reject)
- **Auth hardening**: `requireOrgRole` blocks pending users from API routes, PATCH handler requires `status=active`

## Test plan
- [x] Org toggle ON: invite redemption → pending → admin approve → access granted
- [x] Org toggle ON: invite redemption → pending → admin reject → user removed
- [x] Org toggle OFF: invite redemption → auto-approve (existing behavior)
- [x] Revoked user rejoin with approval ON → pending (not auto-active)
- [x] Per-invite "never require" overrides org toggle → auto-approve
- [x] Existing active members unaffected (verified via DB health check)
- [x] Pending user cannot access org API routes (requireOrgRole blocks)
- [x] Build, lint, tests pass