### PR TITLE
fix: mark Approvals nav item as non-configurable

### DIFF
--- a/src/lib/navigation/nav-items.tsx
+++ b/src/lib/navigation/nav-items.tsx
@@ -87,7 +87,7 @@ export const ORG_NAV_ITEMS: OrgNavItem[] = [
   { href: "/forms", label: "Forms", icon: ClipboardIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community" },
   { href: "/media", label: "Media", icon: GridIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community" },
   { href: "/customization", label: "Customization", icon: SettingsIcon, roles: ["admin", "active_member", "alumni", "parent"], configurable: false, group: "admin" },
-  { href: "/settings/approvals", label: "Approvals", icon: ShieldCheckIcon, roles: ["admin"], group: "admin" },
+  { href: "/settings/approvals", label: "Approvals", icon: ShieldCheckIcon, roles: ["admin"], configurable: false, group: "admin" },
   { href: "/settings/invites", label: "Settings", icon: InviteIcon, roles: ["admin"], group: "admin" },
   { href: "/settings/navigation", label: "Navigation", icon: SettingsIcon, roles: ["admin"], configurable: false, group: "admin" },
 ];


### PR DESCRIPTION
## Summary
- Adds `configurable: false` to the Approvals nav item, preventing admins from accidentally hiding it via the Navigation customization page
- Matches the pattern used by Customization and Navigation admin nav items
- Forces Vercel cache bust on merge to fix the missing sidebar link in production

## Test plan
- [ ] After force redeploy, hard-refresh the site (Cmd+Shift+R)
- [ ] Desktop (≥1024px): Approvals appears in ADMIN sidebar section
- [ ] Mobile: hamburger menu → ADMIN → Approvals appears
- [ ] Click Approvals → navigates to `/settings/approvals`