### PR TITLE
Fix: make folder uploads create albums reliably on media page

### DIFF
--- a/src/app/[orgSlug]/layout.tsx
+++ b/src/app/[orgSlug]/layout.tsx
@@ -17,6 +17,7 @@ import { LinkedInUrlPrompt } from "@/components/linkedin/LinkedInUrlPrompt";
 import { AnalyticsProvider } from "@/components/analytics/AnalyticsProvider";
 import { AIPanelProvider } from "@/components/ai-assistant";
 import { JoinOrgGate } from "@/components/join/JoinOrgGate";
+import { MediaUploadManagerProvider } from "@/components/media/MediaUploadManagerContext";
 import dynamic from "next/dynamic";
 const AIPanel = dynamic(
   () => import("@/components/ai-assistant/AIPanel").then((m) => m.AIPanel),
@@ -262,9 +263,11 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
       {!isDevAdmin && <ConsentModal />}
       {!isDevAdmin && <LinkedInUrlPrompt />}
 
-      <OrgMainContent hasTopBanner={orgContext.gracePeriod.isInGracePeriod || orgContext.gracePeriod.isCanceling}>
-        {children}
-      </OrgMainContent>
+      <MediaUploadManagerProvider orgId={organization.id}>
+        <OrgMainContent hasTopBanner={orgContext.gracePeriod.isInGracePeriod || orgContext.gracePeriod.isCanceling}>
+          {children}
+        </OrgMainContent>
+      </MediaUploadManagerProvider>
 
       {isDevAdmin && (
         <DevPanel

--- a/src/app/api/cron/media-cleanup/route.ts
+++ b/src/app/api/cron/media-cleanup/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { isStaleEmptyUploadDraftAlbum } from "@/lib/media/gallery-upload-server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { validateCronAuth } from "@/lib/security/cron-auth";
 
@@ -35,15 +36,12 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: "Failed to query stale uploads" }, { status: 500 });
     }
 
-    if (!staleUploads || staleUploads.length === 0) {
-      return NextResponse.json({ success: true, cleanedUp: 0 });
-    }
+    let cleanedUpUploads = 0;
 
-    let cleanedUp = 0;
-
-    for (const upload of staleUploads) {
-      // Delete file from storage (ignore errors for missing files)
-      await supabase.storage.from(BUCKET).remove([upload.storage_path]);
+    for (const upload of staleUploads || []) {
+      if (upload.storage_path) {
+        await supabase.storage.from(BUCKET).remove([upload.storage_path]);
+      }
 
       // Mark as orphaned
       const { error: updateError } = await supabase
@@ -55,13 +53,51 @@ export async function GET(request: Request) {
         .eq("id", upload.id);
 
       if (!updateError) {
-        cleanedUp++;
+        cleanedUpUploads++;
       } else {
         console.error(`[cron/media-cleanup] Failed to mark ${upload.id} as orphaned:`, updateError);
       }
     }
 
-    return NextResponse.json({ success: true, cleanedUp });
+    const { data: candidateDraftAlbums, error: draftQueryError } = await supabase
+      .from("media_albums")
+      .select("id, is_upload_draft, item_count, created_at, deleted_at")
+      .eq("is_upload_draft", true)
+      .eq("item_count", 0)
+      .is("deleted_at", null)
+      .lt("created_at", cutoff)
+      .limit(BATCH_SIZE);
+
+    if (draftQueryError) {
+      console.error("[cron/media-cleanup] Draft album query error:", draftQueryError);
+      return NextResponse.json({ error: "Failed to query stale draft albums" }, { status: 500 });
+    }
+
+    let cleanedUpDraftAlbums = 0;
+
+    for (const album of candidateDraftAlbums || []) {
+      if (!isStaleEmptyUploadDraftAlbum(album, cutoff)) continue;
+
+      const { error: deleteDraftError } = await supabase
+        .from("media_albums")
+        .update({
+          deleted_at: new Date().toISOString(),
+        })
+        .eq("id", album.id);
+
+      if (!deleteDraftError) {
+        cleanedUpDraftAlbums++;
+      } else {
+        console.error(`[cron/media-cleanup] Failed to delete draft album ${album.id}:`, deleteDraftError);
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      cleanedUp: cleanedUpUploads + cleanedUpDraftAlbums,
+      cleanedUpUploads,
+      cleanedUpDraftAlbums,
+    });
   } catch (err) {
     console.error("[cron/media-cleanup] Error:", err);
     return NextResponse.json({ error: "Failed to clean up media" }, { status: 500 });

--- a/src/app/api/cron/media-cleanup/route.ts
+++ b/src/app/api/cron/media-cleanup/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
-import { isStaleEmptyUploadDraftAlbum } from "@/lib/media/gallery-upload-server";
+import {
+  isMissingMediaAlbumsDraftColumnError,
+  isStaleEmptyUploadDraftAlbum,
+} from "@/lib/media/gallery-upload-server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { validateCronAuth } from "@/lib/security/cron-auth";
 
@@ -69,6 +72,14 @@ export async function GET(request: Request) {
       .limit(BATCH_SIZE);
 
     if (draftQueryError) {
+      if (isMissingMediaAlbumsDraftColumnError(draftQueryError)) {
+        return NextResponse.json({
+          success: true,
+          cleanedUp: cleanedUpUploads,
+          cleanedUpUploads,
+          cleanedUpDraftAlbums: 0,
+        });
+      }
       console.error("[cron/media-cleanup] Draft album query error:", draftQueryError);
       return NextResponse.json({ error: "Failed to query stale draft albums" }, { status: 500 });
     }

--- a/src/app/api/media/[mediaId]/finalize/route.ts
+++ b/src/app/api/media/[mediaId]/finalize/route.ts
@@ -5,6 +5,7 @@ import { createServiceClient } from "@/lib/supabase/service";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { baseSchemas } from "@/lib/security/validation";
 import { getOrgMembership } from "@/lib/auth/api-helpers";
+import { GALLERY_ALBUM_BATCH_RATE_LIMIT } from "@/lib/media/gallery-upload-server";
 import { validateMagicBytes } from "@/lib/media/validation";
 
 export const dynamic = "force-dynamic";
@@ -37,8 +38,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const rateLimit = checkRateLimit(request, {
       userId: user.id,
       feature: "media finalize",
-      limitPerIp: 20,
-      limitPerUser: 10,
+      ...GALLERY_ALBUM_BATCH_RATE_LIMIT,
     });
     if (!rateLimit.ok) {
       return buildRateLimitResponse(rateLimit);

--- a/src/app/api/media/albums/[albumId]/items/route.ts
+++ b/src/app/api/media/albums/[albumId]/items/route.ts
@@ -4,7 +4,11 @@ import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { getOrgMembership } from "@/lib/auth/api-helpers";
-import { GALLERY_ALBUM_BATCH_RATE_LIMIT } from "@/lib/media/gallery-upload-server";
+import {
+  GALLERY_ALBUM_BATCH_RATE_LIMIT,
+  isMissingMediaAlbumsDraftColumnError,
+  withMediaAlbumsDraftColumnFallback,
+} from "@/lib/media/gallery-upload-server";
 import { validateJson, ValidationError, validationErrorResponse } from "@/lib/security/validation";
 import { z } from "zod";
 import { baseSchemas } from "@/lib/security/validation";
@@ -18,6 +22,12 @@ const addItemsSchema = z.object({
 });
 
 type Params = { params: { albumId: string } };
+type AlbumRow = {
+  id: string;
+  created_by: string;
+  organization_id: string;
+  is_upload_draft: boolean;
+};
 
 /**
  * POST /api/media/albums/[albumId]/items
@@ -47,15 +57,36 @@ export async function POST(request: NextRequest, { params }: Params) {
 
     const isAdmin = membership.role === "admin";
     const serviceClient = createServiceClient();
+    const selectWithDraftColumn = "id, created_by, organization_id, is_upload_draft";
+    const selectWithoutDraftColumn = "id, created_by, organization_id";
 
     // Verify album exists and user has permission
-    const { data: album, error: albumError } = await (serviceClient as any)
-      .from("media_albums")
-      .select("id, created_by, organization_id, is_upload_draft")
-      .eq("id", albumId)
-      .eq("organization_id", orgId)
-      .is("deleted_at", null)
-      .maybeSingle();
+    const { data: rawAlbum, error: albumError, usedDraftColumn } = await withMediaAlbumsDraftColumnFallback({
+      withDraftColumn: async () => await (serviceClient as any)
+        .from("media_albums")
+        .select(selectWithDraftColumn)
+        .eq("id", albumId)
+        .eq("organization_id", orgId)
+        .is("deleted_at", null)
+        .maybeSingle(),
+      withoutDraftColumn: async () => await (serviceClient as any)
+        .from("media_albums")
+        .select(selectWithoutDraftColumn)
+        .eq("id", albumId)
+        .eq("organization_id", orgId)
+        .is("deleted_at", null)
+        .maybeSingle(),
+    });
+
+    const rawAlbumRecord = rawAlbum as Record<string, unknown> | null;
+    const album: AlbumRow | null = rawAlbumRecord
+      ? {
+        id: String(rawAlbumRecord.id),
+        created_by: String(rawAlbumRecord.created_by),
+        organization_id: String(rawAlbumRecord.organization_id),
+        is_upload_draft: usedDraftColumn ? Boolean(rawAlbumRecord.is_upload_draft) : false,
+      }
+      : null;
 
     if (albumError || !album) {
       return NextResponse.json({ error: "Album not found" }, { status: 404 });
@@ -112,6 +143,9 @@ export async function POST(request: NextRequest, { params }: Params) {
         .eq("id", albumId);
 
       if (draftUpdateError) {
+        if (isMissingMediaAlbumsDraftColumnError(draftUpdateError)) {
+          return NextResponse.json({ success: true, added: mediaIds.length }, { headers: rateLimit.headers });
+        }
         console.error("[media/albums/items] Draft clear failed:", draftUpdateError);
         return NextResponse.json({ error: "Failed to finalize album upload" }, { status: 500 });
       }

--- a/src/app/api/media/albums/[albumId]/items/route.ts
+++ b/src/app/api/media/albums/[albumId]/items/route.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { getOrgMembership } from "@/lib/auth/api-helpers";
+import { GALLERY_ALBUM_BATCH_RATE_LIMIT } from "@/lib/media/gallery-upload-server";
 import { validateJson, ValidationError, validationErrorResponse } from "@/lib/security/validation";
 import { z } from "zod";
 import { baseSchemas } from "@/lib/security/validation";
@@ -28,8 +29,7 @@ export async function POST(request: NextRequest, { params }: Params) {
 
     const rateLimit = checkRateLimit(request, {
       feature: "media album add items",
-      limitPerIp: 30,
-      limitPerUser: 20,
+      ...GALLERY_ALBUM_BATCH_RATE_LIMIT,
     });
     if (!rateLimit.ok) return buildRateLimitResponse(rateLimit);
 
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest, { params }: Params) {
     // Verify album exists and user has permission
     const { data: album, error: albumError } = await (serviceClient as any)
       .from("media_albums")
-      .select("id, created_by, organization_id")
+      .select("id, created_by, organization_id, is_upload_draft")
       .eq("id", albumId)
       .eq("organization_id", orgId)
       .is("deleted_at", null)
@@ -100,6 +100,21 @@ export async function POST(request: NextRequest, { params }: Params) {
     if (insertError) {
       console.error("[media/albums/items] Insert failed:", insertError);
       return NextResponse.json({ error: "Failed to add items to album" }, { status: 500 });
+    }
+
+    if (album.is_upload_draft) {
+      const { error: draftUpdateError } = await serviceClient
+        .from("media_albums")
+        .update({
+          is_upload_draft: false,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", albumId);
+
+      if (draftUpdateError) {
+        console.error("[media/albums/items] Draft clear failed:", draftUpdateError);
+        return NextResponse.json({ error: "Failed to finalize album upload" }, { status: 500 });
+      }
     }
 
     return NextResponse.json({ success: true, added: mediaIds.length }, { headers: rateLimit.headers });

--- a/src/app/api/media/albums/[albumId]/route.ts
+++ b/src/app/api/media/albums/[albumId]/route.ts
@@ -6,7 +6,11 @@ import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limi
 import { getOrgMembership } from "@/lib/auth/api-helpers";
 import { validateJson, ValidationError, validationErrorResponse, baseSchemas, safeString } from "@/lib/security/validation";
 import { batchGetGridPreviewUrls } from "@/lib/media/urls";
-import { getAlbumCoverValidationError } from "@/lib/media/albums";
+import {
+  getAlbumCoverValidationError,
+  resolveAlbumDeleteMode,
+} from "@/lib/media/albums";
+import { softDeleteMediaItems } from "@/lib/media/delete-media";
 import { decodeCursor } from "@/lib/pagination/cursor";
 import { z } from "zod";
 
@@ -279,6 +283,7 @@ export async function DELETE(request: NextRequest, { params }: Params) {
     const { searchParams } = new URL(request.url);
     const orgId = searchParams.get("orgId");
     if (!orgId) return NextResponse.json({ error: "orgId required" }, { status: 400 });
+    const deleteMode = resolveAlbumDeleteMode(searchParams.get("mode"));
 
     const membership = await getOrgMembership(supabase, user.id, orgId);
     if (!membership) {
@@ -302,6 +307,31 @@ export async function DELETE(request: NextRequest, { params }: Params) {
 
     if (!isAdmin && album.created_by !== user.id) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    if (deleteMode === "album_and_media") {
+      const { data: albumItems, error: itemsError } = await serviceClient
+        .from("media_album_items")
+        .select("media_item_id")
+        .eq("album_id", albumId);
+
+      if (itemsError) {
+        console.error("[media/albums/[albumId]] Delete media lookup failed:", itemsError);
+        return NextResponse.json({ error: "Failed to load album media" }, { status: 500 });
+      }
+
+      const mediaIds = (albumItems ?? []).map((item) => item.media_item_id as string);
+      const deletion = await softDeleteMediaItems(serviceClient, {
+        orgId,
+        mediaIds,
+        actor: { isAdmin, userId: user.id },
+        forbiddenMessage:
+          "You can only delete all photos when you have permission to delete every upload in this album.",
+      });
+
+      if (!deletion.ok) {
+        return NextResponse.json({ error: deletion.error }, { status: deletion.status });
+      }
     }
 
     const { error: deleteError } = await (serviceClient as any)

--- a/src/app/api/media/albums/route.ts
+++ b/src/app/api/media/albums/route.ts
@@ -6,7 +6,10 @@ import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limi
 import { getOrgMembership } from "@/lib/auth/api-helpers";
 import { validateJson, ValidationError, validationErrorResponse, baseSchemas } from "@/lib/security/validation";
 import { createAlbumSchema } from "@/lib/schemas/media";
-import { shouldListMediaAlbum } from "@/lib/media/gallery-upload-server";
+import {
+  shouldListMediaAlbum,
+  withMediaAlbumsDraftColumnFallback,
+} from "@/lib/media/gallery-upload-server";
 import { batchGetGridPreviewUrls } from "@/lib/media/urls";
 import { shouldExposeAlbumCover } from "@/lib/media/albums";
 import { z } from "zod";
@@ -52,14 +55,18 @@ export async function GET(request: NextRequest) {
     }
 
     const serviceClient = createServiceClient();
+    const selectWithDraftColumn = "id, name, description, cover_media_id, item_count, sort_order, created_by, created_at, updated_at, is_upload_draft";
+    const selectWithoutDraftColumn = "id, name, description, cover_media_id, item_count, sort_order, created_by, created_at, updated_at";
 
-    let query = (serviceClient as any)
-      .from("media_albums")
-      .select("id, name, description, cover_media_id, item_count, sort_order, created_by, created_at, updated_at, is_upload_draft")
-      .eq("organization_id", orgId)
-      .is("deleted_at", null)
-      .order("sort_order", { ascending: true })
-      .order("created_at", { ascending: false });
+    const buildAlbumsQuery = (includeDraftColumn: boolean) => {
+      return (serviceClient as any)
+        .from("media_albums")
+        .select(includeDraftColumn ? selectWithDraftColumn : selectWithoutDraftColumn)
+        .eq("organization_id", orgId)
+        .is("deleted_at", null)
+        .order("sort_order", { ascending: true })
+        .order("created_at", { ascending: false });
+    };
 
     if (containsItemId) {
       // Filter to albums containing this media item
@@ -71,64 +78,47 @@ export async function GET(request: NextRequest) {
       if (albumIds.length === 0) {
         return NextResponse.json({ data: [] }, { headers: rateLimit.headers });
       }
-      query = query.in("id", albumIds);
+      // Reuse the same fallback path for both select shapes.
+      const { data: albums, error, usedDraftColumn } = await withMediaAlbumsDraftColumnFallback({
+        withDraftColumn: async () => buildAlbumsQuery(true).in("id", albumIds),
+        withoutDraftColumn: async () => buildAlbumsQuery(false).in("id", albumIds),
+      });
+
+      if (error) {
+        console.error("[media/albums] List failed:", error);
+        return NextResponse.json({ error: "Failed to fetch albums" }, { status: 500 });
+      }
+
+      const albumRows = normalizeAlbumRows(albums);
+      const visibleAlbums = usedDraftColumn
+        ? albumRows.filter((album) => shouldListMediaAlbum({
+          is_upload_draft: album.is_upload_draft as boolean | null | undefined,
+          item_count: album.item_count as number | null | undefined,
+        }))
+        : albumRows;
+
+      return enrichAlbumsWithCovers(serviceClient, visibleAlbums, rateLimit.headers);
     }
 
-    const { data: albums, error } = await query;
+    const { data: albums, error, usedDraftColumn } = await withMediaAlbumsDraftColumnFallback({
+      withDraftColumn: async () => buildAlbumsQuery(true),
+      withoutDraftColumn: async () => buildAlbumsQuery(false),
+    });
+
     if (error) {
       console.error("[media/albums] List failed:", error);
       return NextResponse.json({ error: "Failed to fetch albums" }, { status: 500 });
     }
 
-    const visibleAlbums = (albums || []).filter((album: Record<string, unknown>) => shouldListMediaAlbum({
-      is_upload_draft: album.is_upload_draft as boolean | null | undefined,
-      item_count: album.item_count as number | null | undefined,
-    }));
+    const albumRows = normalizeAlbumRows(albums);
+    const visibleAlbums = usedDraftColumn
+      ? albumRows.filter((album) => shouldListMediaAlbum({
+        is_upload_draft: album.is_upload_draft as boolean | null | undefined,
+        item_count: album.item_count as number | null | undefined,
+      }))
+      : albumRows;
 
-    // Attach cover image URLs for albums that have a cover_media_id
-    const coversToFetch = visibleAlbums
-      .filter((a: Record<string, unknown>) => a.cover_media_id)
-      .map((a: Record<string, unknown>) => a.cover_media_id as string);
-
-    const coverUrlMap = new Map<string, string>();
-    if (coversToFetch.length > 0) {
-      const { data: coverItems } = await serviceClient
-        .from("media_items")
-        .select("id, storage_path, mime_type, media_type, status")
-        .in("id", coversToFetch)
-        .is("deleted_at", null);
-
-      if (coverItems && coverItems.length > 0) {
-        const urlMap = await batchGetGridPreviewUrls(
-          serviceClient,
-          coverItems
-            .filter((ci) => shouldExposeAlbumCover(ci))
-            .filter((ci) => ci.storage_path)
-            .map((ci) => ({
-              id: ci.id,
-              storage_path: ci.storage_path as string,
-              mime_type: (ci.mime_type as string) || "application/octet-stream",
-              media_type: ci.media_type as "image" | "video",
-            })),
-        );
-        for (const [id, urls] of urlMap) {
-          if (urls.thumbnailUrl) {
-            coverUrlMap.set(id, urls.thumbnailUrl);
-          }
-        }
-      }
-    }
-
-    const enriched = visibleAlbums.map((a: Record<string, unknown>) => {
-      const album: Record<string, unknown> = {
-        ...a,
-        cover_url: a.cover_media_id ? (coverUrlMap.get(a.cover_media_id as string) || null) : null,
-      };
-      delete album.is_upload_draft;
-      return album;
-    });
-
-    return NextResponse.json({ data: enriched }, { headers: rateLimit.headers });
+    return enrichAlbumsWithCovers(serviceClient, visibleAlbums, rateLimit.headers);
   } catch (error) {
     if (error instanceof ValidationError) return validationErrorResponse(error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
@@ -186,29 +176,102 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Failed to create album" }, { status: 500 });
     }
 
-    const { data: album, error } = await (serviceClient as any)
-      .from("media_albums")
-      .insert({
-        organization_id: orgId,
-        name,
-        description: description || null,
-        created_by: user.id,
-        is_upload_draft: isUploadDraft ?? false,
-        sort_order: 0,
-      })
-      .select("id, name, description, cover_media_id, item_count, sort_order, created_by, created_at, updated_at, is_upload_draft")
-      .single();
+    const selectWithDraftColumn = "id, name, description, cover_media_id, item_count, sort_order, created_by, created_at, updated_at, is_upload_draft";
+    const selectWithoutDraftColumn = "id, name, description, cover_media_id, item_count, sort_order, created_by, created_at, updated_at";
+    const baseInsert = {
+      organization_id: orgId,
+      name,
+      description: description || null,
+      created_by: user.id,
+      sort_order: 0,
+    };
+
+    const { data: album, error } = await withMediaAlbumsDraftColumnFallback({
+      withDraftColumn: async () => await (serviceClient as any)
+        .from("media_albums")
+        .insert({
+          ...baseInsert,
+          is_upload_draft: isUploadDraft ?? false,
+        })
+        .select(selectWithDraftColumn)
+        .single(),
+      withoutDraftColumn: async () => await (serviceClient as any)
+        .from("media_albums")
+        .insert(baseInsert)
+        .select(selectWithoutDraftColumn)
+        .single(),
+    });
 
     if (error) {
       console.error("[media/albums] Create failed:", error);
       return NextResponse.json({ error: "Failed to create album" }, { status: 500 });
     }
 
-    const responseAlbum: Record<string, unknown> = { ...album };
+    const albumRecord = normalizeSingleAlbumRow(album);
+    const responseAlbum: Record<string, unknown> = { ...albumRecord };
     delete responseAlbum.is_upload_draft;
     return NextResponse.json({ ...responseAlbum, cover_url: null }, { status: 201, headers: rateLimit.headers });
   } catch (error) {
     if (error instanceof ValidationError) return validationErrorResponse(error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
+}
+
+function normalizeAlbumRows(data: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(data)) return [];
+  return data.filter((value): value is Record<string, unknown> => Boolean(value) && typeof value === "object");
+}
+
+function normalizeSingleAlbumRow(data: unknown): Record<string, unknown> {
+  return data && typeof data === "object" ? data as Record<string, unknown> : {};
+}
+
+async function enrichAlbumsWithCovers(
+  serviceClient: ReturnType<typeof createServiceClient>,
+  albums: Record<string, unknown>[],
+  headers: HeadersInit,
+) {
+  const coversToFetch = albums
+    .filter((album) => album.cover_media_id)
+    .map((album) => album.cover_media_id as string);
+
+  const coverUrlMap = new Map<string, string>();
+  if (coversToFetch.length > 0) {
+    const { data: coverItems } = await serviceClient
+      .from("media_items")
+      .select("id, storage_path, mime_type, media_type, status")
+      .in("id", coversToFetch)
+      .is("deleted_at", null);
+
+    if (coverItems && coverItems.length > 0) {
+      const urlMap = await batchGetGridPreviewUrls(
+        serviceClient,
+        coverItems
+          .filter((coverItem) => shouldExposeAlbumCover(coverItem))
+          .filter((coverItem) => coverItem.storage_path)
+          .map((coverItem) => ({
+            id: coverItem.id,
+            storage_path: coverItem.storage_path as string,
+            mime_type: (coverItem.mime_type as string) || "application/octet-stream",
+            media_type: coverItem.media_type as "image" | "video",
+          })),
+      );
+      for (const [id, urls] of urlMap) {
+        if (urls.thumbnailUrl) {
+          coverUrlMap.set(id, urls.thumbnailUrl);
+        }
+      }
+    }
+  }
+
+  const enriched = albums.map((album) => {
+    const responseAlbum: Record<string, unknown> = {
+      ...album,
+      cover_url: album.cover_media_id ? (coverUrlMap.get(album.cover_media_id as string) || null) : null,
+    };
+    delete responseAlbum.is_upload_draft;
+    return responseAlbum;
+  });
+
+  return NextResponse.json({ data: enriched }, { headers });
 }

--- a/src/app/api/media/albums/route.ts
+++ b/src/app/api/media/albums/route.ts
@@ -6,6 +6,7 @@ import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limi
 import { getOrgMembership } from "@/lib/auth/api-helpers";
 import { validateJson, ValidationError, validationErrorResponse, baseSchemas } from "@/lib/security/validation";
 import { createAlbumSchema } from "@/lib/schemas/media";
+import { shouldListMediaAlbum } from "@/lib/media/gallery-upload-server";
 import { batchGetGridPreviewUrls } from "@/lib/media/urls";
 import { shouldExposeAlbumCover } from "@/lib/media/albums";
 import { z } from "zod";
@@ -54,7 +55,7 @@ export async function GET(request: NextRequest) {
 
     let query = (serviceClient as any)
       .from("media_albums")
-      .select("id, name, description, cover_media_id, item_count, sort_order, created_by, created_at, updated_at")
+      .select("id, name, description, cover_media_id, item_count, sort_order, created_by, created_at, updated_at, is_upload_draft")
       .eq("organization_id", orgId)
       .is("deleted_at", null)
       .order("sort_order", { ascending: true })
@@ -79,8 +80,13 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Failed to fetch albums" }, { status: 500 });
     }
 
+    const visibleAlbums = (albums || []).filter((album: Record<string, unknown>) => shouldListMediaAlbum({
+      is_upload_draft: album.is_upload_draft as boolean | null | undefined,
+      item_count: album.item_count as number | null | undefined,
+    }));
+
     // Attach cover image URLs for albums that have a cover_media_id
-    const coversToFetch = (albums || [])
+    const coversToFetch = visibleAlbums
       .filter((a: Record<string, unknown>) => a.cover_media_id)
       .map((a: Record<string, unknown>) => a.cover_media_id as string);
 
@@ -113,10 +119,14 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    const enriched = (albums || []).map((a: Record<string, unknown>) => ({
-      ...a,
-      cover_url: a.cover_media_id ? (coverUrlMap.get(a.cover_media_id as string) || null) : null,
-    }));
+    const enriched = visibleAlbums.map((a: Record<string, unknown>) => {
+      const album: Record<string, unknown> = {
+        ...a,
+        cover_url: a.cover_media_id ? (coverUrlMap.get(a.cover_media_id as string) || null) : null,
+      };
+      delete album.is_upload_draft;
+      return album;
+    });
 
     return NextResponse.json({ data: enriched }, { headers: rateLimit.headers });
   } catch (error) {
@@ -147,7 +157,7 @@ export async function POST(request: NextRequest) {
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
     const body = await validateJson(request, createAlbumBodySchema);
-    const { orgId, name, description } = body;
+    const { orgId, name, description, isUploadDraft } = body;
 
     const membership = await getOrgMembership(supabase, user.id, orgId);
     if (!membership) {
@@ -183,9 +193,10 @@ export async function POST(request: NextRequest) {
         name,
         description: description || null,
         created_by: user.id,
+        is_upload_draft: isUploadDraft ?? false,
         sort_order: 0,
       })
-      .select("id, name, description, cover_media_id, item_count, sort_order, created_by, created_at, updated_at")
+      .select("id, name, description, cover_media_id, item_count, sort_order, created_by, created_at, updated_at, is_upload_draft")
       .single();
 
     if (error) {
@@ -193,7 +204,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Failed to create album" }, { status: 500 });
     }
 
-    return NextResponse.json({ ...album, cover_url: null }, { status: 201, headers: rateLimit.headers });
+    const responseAlbum: Record<string, unknown> = { ...album };
+    delete responseAlbum.is_upload_draft;
+    return NextResponse.json({ ...responseAlbum, cover_url: null }, { status: 201, headers: rateLimit.headers });
   } catch (error) {
     if (error instanceof ValidationError) return validationErrorResponse(error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/src/app/api/media/bulk-delete/route.ts
+++ b/src/app/api/media/bulk-delete/route.ts
@@ -6,6 +6,7 @@ import { validateJson, ValidationError, validationErrorResponse, baseSchemas } f
 import { checkOrgReadOnly, readOnlyResponse } from "@/lib/subscription/read-only-guard";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { getOrgMembership } from "@/lib/auth/api-helpers";
+import { softDeleteMediaItems } from "@/lib/media/delete-media";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -65,65 +66,22 @@ export async function POST(req: Request) {
   }
 
   const serviceClient = createServiceClient();
-  const now = new Date().toISOString();
+  const deletion = await softDeleteMediaItems(serviceClient, {
+    orgId,
+    mediaIds,
+    actor: { isAdmin, userId: user.id },
+    forbiddenMessage: "You can only bulk-delete your own media",
+  });
 
-  // If not admin, verify user uploaded ALL requested items
-  if (!isAdmin) {
-    const { data: items, error: fetchError } = await serviceClient
-      .from("media_items")
-      .select("id, uploaded_by")
-      .in("id", mediaIds)
-      .eq("organization_id", orgId)
-      .is("deleted_at", null);
-
-    if (fetchError) {
-      return NextResponse.json({ error: "Failed to verify ownership" }, { status: 500, headers: rateLimit.headers });
-    }
-
-    const allOwned = (items || []).length === mediaIds.length &&
-      (items || []).every((item) => item.uploaded_by === user.id);
-
-    if (!allOwned) {
-      return NextResponse.json(
-        { error: "You can only bulk-delete your own media" },
-        { status: 403, headers: rateLimit.headers },
-      );
-    }
-  }
-
-  const { error: clearCoverError } = await serviceClient
-    .from("media_albums")
-    .update({ cover_media_id: null, updated_at: now })
-    .eq("organization_id", orgId)
-    .in("cover_media_id", mediaIds)
-    .is("deleted_at", null);
-
-  if (clearCoverError) {
-    console.error("[media/bulk-delete] Failed to clear album covers:", clearCoverError);
+  if (!deletion.ok) {
     return NextResponse.json(
-      { error: "Failed to clear album covers" },
-      { status: 500, headers: rateLimit.headers },
+      { error: deletion.error },
+      { status: deletion.status, headers: rateLimit.headers },
     );
   }
 
-  // Soft delete
-  const { data, error: deleteError } = await serviceClient
-    .from("media_items")
-    .update({ deleted_at: now })
-    .eq("organization_id", orgId)
-    .in("id", mediaIds)
-    .is("deleted_at", null)
-    .select("id");
-
-  if (deleteError) {
-    console.error("[media/bulk-delete] Soft delete failed:", deleteError);
-    return NextResponse.json(
-      { error: "Failed to delete media items" },
-      { status: 500, headers: rateLimit.headers },
-    );
-  }
-
-  const deletedIds = (data ?? []).map((r) => r.id as string);
-
-  return NextResponse.json({ deleted: deletedIds.length, deletedIds }, { headers: rateLimit.headers });
+  return NextResponse.json(
+    { deleted: deletion.deletedIds.length, deletedIds: deletion.deletedIds },
+    { headers: rateLimit.headers },
+  );
 }

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -6,6 +6,7 @@ import { createServiceClient } from "@/lib/supabase/service";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { getOrgMembership } from "@/lib/auth/api-helpers";
 import { validateJson, ValidationError, validationErrorResponse } from "@/lib/security/validation";
+import { GALLERY_ALBUM_BATCH_RATE_LIMIT, getNextGallerySortOrder } from "@/lib/media/gallery-upload-server";
 import { checkOrgReadOnly, readOnlyResponse } from "@/lib/subscription/read-only-guard";
 import { galleryUploadIntentSchema, mediaListQuerySchema, GALLERY_ALLOWED_MIME_TYPES } from "@/lib/schemas/media";
 import {
@@ -178,8 +179,7 @@ export async function POST(request: NextRequest) {
     const rateLimit = checkRateLimit(request, {
       userId: user.id,
       feature: "media upload",
-      limitPerIp: 20,
-      limitPerUser: 10,
+      ...GALLERY_ALBUM_BATCH_RATE_LIMIT,
     });
     if (!rateLimit.ok) {
       return buildRateLimitResponse(rateLimit);
@@ -231,14 +231,21 @@ export async function POST(request: NextRequest) {
     // Start in "uploading" state — finalize endpoint transitions to final status
     const initialStatus = "uploading";
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- RPC not in generated client surface
-    const { error: shiftError } = await (serviceClient as any).rpc("shift_media_gallery_sort_orders", {
-      p_org_id: orgId,
-    });
-    if (shiftError) {
-      console.error("[media/gallery] shift gallery sort failed:", shiftError);
+    const { data: firstGalleryItem, error: sortOrderError } = await serviceClient
+      .from("media_items")
+      .select("gallery_sort_order")
+      .eq("organization_id", orgId)
+      .is("deleted_at", null)
+      .order("gallery_sort_order", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (sortOrderError) {
+      console.error("[media/gallery] next gallery sort lookup failed:", sortOrderError);
       return NextResponse.json({ error: "Failed to create media item" }, { status: 500 });
     }
+
+    const nextGallerySortOrder = getNextGallerySortOrder(firstGalleryItem?.gallery_sort_order ?? null);
 
     const { data: mediaItem, error: insertError } = await serviceClient
       .from("media_items")
@@ -255,7 +262,7 @@ export async function POST(request: NextRequest) {
         tags: tags || [],
         taken_at: takenAt || null,
         status: initialStatus,
-        gallery_sort_order: 0,
+        gallery_sort_order: nextGallerySortOrder,
       })
       .select("id")
       .single();

--- a/src/components/media/AlbumCard.tsx
+++ b/src/components/media/AlbumCard.tsx
@@ -16,6 +16,10 @@ export interface MediaAlbum {
   created_by: string;
   created_at: string;
   updated_at: string;
+  import_status?: "creating_album" | "waiting_for_uploads" | "adding_items" | "partial_success" | "success" | "failed";
+  import_expected_count?: number;
+  import_uploaded_count?: number;
+  import_failed_count?: number;
 }
 
 interface AlbumCardProps {
@@ -28,6 +32,8 @@ interface AlbumCardProps {
 }
 
 export function AlbumCard({ album, onClick, reorderMode = false, dragHandleProps, isDragging = false }: AlbumCardProps) {
+  const importLabel = getAlbumImportLabel(album);
+
   return (
     <Card
       interactive={!reorderMode}
@@ -60,6 +66,12 @@ export function AlbumCard({ album, onClick, reorderMode = false, dragHandleProps
           <AlbumPlaceholder />
         )}
 
+        {importLabel && !reorderMode && (
+          <div className="absolute right-2 top-2 z-10 rounded-full bg-background/90 px-2.5 py-1 text-[11px] font-medium text-foreground shadow-sm backdrop-blur-sm">
+            {importLabel}
+          </div>
+        )}
+
         {/* Overlay with name + count */}
         <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-3">
           <UserContent as="p" className="text-sm font-semibold text-white truncate">
@@ -72,6 +84,25 @@ export function AlbumCard({ album, onClick, reorderMode = false, dragHandleProps
       </div>
     </Card>
   );
+}
+
+function getAlbumImportLabel(album: MediaAlbum): string | null {
+  switch (album.import_status) {
+    case "creating_album":
+      return "Starting import";
+    case "waiting_for_uploads":
+    case "adding_items":
+      if (typeof album.import_expected_count === "number" && album.import_expected_count > 0) {
+        return `Importing ${album.import_uploaded_count ?? 0}/${album.import_expected_count}`;
+      }
+      return "Importing";
+    case "partial_success":
+      return "Partially imported";
+    case "failed":
+      return "Import failed";
+    default:
+      return null;
+  }
 }
 
 function AlbumPlaceholder() {

--- a/src/components/media/AlbumGrid.tsx
+++ b/src/components/media/AlbumGrid.tsx
@@ -21,8 +21,10 @@ import { CSS } from "@dnd-kit/utilities";
 import { useTranslations } from "next-intl";
 import { EmptyState } from "@/components/ui";
 import { showFeedback } from "@/lib/feedback/show-feedback";
+import { mergeFolderImportAlbum } from "@/lib/media/folder-import-session";
 import { AlbumCard, type MediaAlbum } from "./AlbumCard";
 import { CreateAlbumModal } from "./CreateAlbumModal";
+import { useMediaUploadManager } from "./MediaUploadManagerContext";
 
 interface AlbumGridProps {
   orgId: string;
@@ -86,6 +88,7 @@ function SortableAlbumRow({
 export function AlbumGrid({ orgId, canCreate, onSelectAlbum }: AlbumGridProps) {
   const tMedia = useTranslations("media");
   const tCommon = useTranslations("common");
+  const { importingAlbum } = useMediaUploadManager();
 
   const [albums, setAlbums] = useState<MediaAlbum[]>([]);
   const [loading, setLoading] = useState(true);
@@ -94,7 +97,11 @@ export function AlbumGrid({ orgId, canCreate, onSelectAlbum }: AlbumGridProps) {
   const [reorderMode, setReorderMode] = useState(false);
   const reducedMotion = usePrefersReducedMotion();
   const albumsRef = useRef<MediaAlbum[]>([]);
-  albumsRef.current = albums;
+  const visibleAlbums = useMemo(
+    () => mergeFolderImportAlbum(albums, importingAlbum),
+    [albums, importingAlbum],
+  );
+  albumsRef.current = visibleAlbums;
 
   const canReorder = canCreate;
 
@@ -120,7 +127,7 @@ export function AlbumGrid({ orgId, canCreate, onSelectAlbum }: AlbumGridProps) {
     fetchAlbums();
   }, [fetchAlbums]);
 
-  const albumIds = useMemo(() => albums.map((a) => a.id), [albums]);
+  const albumIds = useMemo(() => visibleAlbums.map((a) => a.id), [visibleAlbums]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -238,7 +245,7 @@ export function AlbumGrid({ orgId, canCreate, onSelectAlbum }: AlbumGridProps) {
               )}
 
               <SortableContext items={albumIds} strategy={rectSortingStrategy}>
-                {albums.map((album) => (
+                {visibleAlbums.map((album) => (
                   <SortableAlbumRow
                     key={album.id}
                     album={album}

--- a/src/components/media/AlbumView.tsx
+++ b/src/components/media/AlbumView.tsx
@@ -19,6 +19,7 @@ import {
   getAlbumUpdatesAfterMediaDelete,
 } from "@/lib/media/albums";
 import { buildOptimisticMediaItem } from "@/lib/media/gallery-upload-client";
+import { bulkDeleteSelectedMedia } from "@/lib/media/delete-media-client";
 
 interface AlbumViewProps {
   album: MediaAlbum;
@@ -186,18 +187,11 @@ export function AlbumView({
 
     setBulkDeleting(true);
     try {
-      const res = await fetch("/api/media/bulk-delete", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orgId, mediaIds: Array.from(selectedIds) }),
+      const { deletedIds } = await bulkDeleteSelectedMedia({
+        orgId,
+        mediaIds: Array.from(selectedIds),
       });
-      if (!res.ok) {
-        const data = await res.json().catch(() => null);
-        throw new Error(data?.error || "Failed to delete");
-      }
-
-      const { deletedIds } = await res.json();
-      const deletedSet = new Set((deletedIds as string[]) || []);
+      const deletedSet = new Set(deletedIds);
       setItems((prev) => prev.filter((item) => !deletedSet.has(item.id)));
       if (selectedItem && deletedSet.has(selectedItem.id)) {
         setSelectedItem(null);

--- a/src/components/media/AlbumView.tsx
+++ b/src/components/media/AlbumView.tsx
@@ -10,7 +10,9 @@ import { CoverPickerModal } from "./CoverPickerModal";
 import type { MediaAlbum } from "./AlbumCard";
 import type { UploadFileEntry } from "@/hooks/useGalleryUpload";
 import {
+  canDeleteAlbumAndMedia,
   canDeleteMediaFromAlbumView,
+  type AlbumDeleteMode,
   canUploadDirectlyToAlbum,
   getAlbumBulkDeleteEligibleIds,
   getAlbumCoverPickerItems,
@@ -46,8 +48,8 @@ export function AlbumView({
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [selectedItem, setSelectedItem] = useState<MediaItem | null>(null);
-  const [confirmDelete, setConfirmDelete] = useState(false);
-  const [deleting, setDeleting] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deletingMode, setDeletingMode] = useState<AlbumDeleteMode | null>(null);
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkDeleting, setBulkDeleting] = useState(false);
@@ -71,6 +73,7 @@ export function AlbumView({
   const canDirectUpload = canUploadDirectlyToAlbum(canUpload, canEdit);
   const deleteActor = { isAdmin, currentUserId };
   const eligibleDeleteIds = getAlbumBulkDeleteEligibleIds(items, deleteActor);
+  const canDeleteAlbumPhotos = canDeleteAlbumAndMedia(items, deleteActor);
   const coverPickerItems = getAlbumCoverPickerItems(items, isAdmin);
 
   const fetchItems = useCallback(
@@ -240,26 +243,23 @@ export function AlbumView({
     }
   };
 
-  const handleDeleteAlbum = async () => {
-    if (!confirmDelete) {
-      setConfirmDelete(true);
-      return;
-    }
-    setDeleting(true);
+  const handleDeleteAlbum = async (mode: AlbumDeleteMode) => {
+    setDeletingMode(mode);
     try {
+      const params = new URLSearchParams({ orgId, mode });
       const res = await fetch(
-        `/api/media/albums/${album.id}?orgId=${encodeURIComponent(orgId)}`,
+        `/api/media/albums/${album.id}?${params.toString()}`,
         { method: "DELETE" },
       );
       if (!res.ok) {
         const data = await res.json().catch(() => null);
         throw new Error(data?.error || "Failed to delete album");
       }
+      setShowDeleteModal(false);
       onAlbumDeleted();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Delete failed");
-      setDeleting(false);
-      setConfirmDelete(false);
+      setDeletingMode(null);
     }
   };
 
@@ -479,13 +479,11 @@ export function AlbumView({
             )}
             {canEdit && (
               <Button
-                variant={confirmDelete ? "danger" : "ghost"}
+                variant="ghost"
                 size="sm"
-                isLoading={deleting}
-                onClick={handleDeleteAlbum}
-                onBlur={() => setConfirmDelete(false)}
+                onClick={() => setShowDeleteModal(true)}
               >
-                {confirmDelete ? "Confirm delete" : "Delete album"}
+                Delete album
               </Button>
             )}
           </div>
@@ -598,6 +596,78 @@ export function AlbumView({
           onClose={() => setShowCoverPicker(false)}
           saving={coverSaving}
         />
+      )}
+
+      {showDeleteModal && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/30 backdrop-blur-[2px]"
+            onClick={() => {
+              if (!deletingMode) setShowDeleteModal(false);
+            }}
+          />
+          <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+            <div
+              role="dialog"
+              aria-label="Delete album options"
+              className="w-full max-w-md rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+            >
+              <div className="border-b border-[var(--border)] px-5 py-4">
+                <h3 className="text-base font-semibold text-[var(--foreground)]">Delete album</h3>
+                <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                  Choose whether to keep this album&apos;s photos in All Photos or remove them too.
+                </p>
+              </div>
+
+              <div className="space-y-3 px-5 py-4">
+                <button
+                  type="button"
+                  onClick={() => void handleDeleteAlbum("album_only")}
+                  disabled={deletingMode !== null}
+                  className="w-full rounded-xl border border-[var(--border)] px-4 py-3 text-left transition-colors hover:border-[var(--foreground)]/20 hover:bg-[var(--muted)] disabled:opacity-60"
+                >
+                  <p className="text-sm font-semibold text-[var(--foreground)]">Delete album only</p>
+                  <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+                    The album goes away, but all {items.length} photo{items.length === 1 ? "" : "s"} stay in All Photos.
+                  </p>
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => void handleDeleteAlbum("album_and_media")}
+                  disabled={deletingMode !== null || !canDeleteAlbumPhotos}
+                  className="w-full rounded-xl border border-red-200 bg-red-50/70 px-4 py-3 text-left transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-900 dark:bg-red-950/20"
+                >
+                  <p className="text-sm font-semibold text-red-700 dark:text-red-300">Delete album and all photos</p>
+                  <p className="mt-1 text-xs text-red-600/90 dark:text-red-300/80">
+                    This removes the album and deletes its {items.length} photo{items.length === 1 ? "" : "s"} from All Photos.
+                  </p>
+                </button>
+
+                {!canDeleteAlbumPhotos && (
+                  <p className="text-xs text-[var(--muted-foreground)]">
+                    Delete album and all photos is only available when you can delete every upload in this album.
+                  </p>
+                )}
+              </div>
+
+              <div className="flex justify-end gap-2 border-t border-[var(--border)] px-5 py-4">
+                <Button
+                  variant="secondary"
+                  onClick={() => setShowDeleteModal(false)}
+                  disabled={deletingMode !== null}
+                >
+                  Cancel
+                </Button>
+                {deletingMode && (
+                  <span className="self-center text-xs text-[var(--muted-foreground)]">
+                    Deleting...
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/components/media/AlbumView.tsx
+++ b/src/components/media/AlbumView.tsx
@@ -16,6 +16,7 @@ import {
   getAlbumCoverPickerItems,
   getAlbumUpdatesAfterMediaDelete,
 } from "@/lib/media/albums";
+import { buildOptimisticMediaItem } from "@/lib/media/gallery-upload-client";
 
 interface AlbumViewProps {
   album: MediaAlbum;
@@ -106,7 +107,7 @@ export function AlbumView({
       });
 
     return () => { cancelled = true; };
-  }, [fetchItems]);
+  }, [album.import_failed_count, album.import_uploaded_count, fetchItems]);
 
   useEffect(() => {
     setBulkDeleteConfirm(false);
@@ -305,30 +306,11 @@ export function AlbumView({
   // Handle upload completion — add to album item list optimistically
   const handleFileComplete = useCallback(
     (entry: UploadFileEntry, mediaId: string) => {
-      const isVideo = entry.mimeType.startsWith("video/");
-      const optimisticItem: MediaItem = {
-        id: mediaId,
-        title: entry.title || entry.fileName,
-        description: entry.description || null,
-        media_type: isVideo ? "video" : "image",
-        url: entry.previewUrl,
-        thumbnail_url: isVideo ? null : entry.previewUrl,
-        tags: entry.tags,
-        taken_at: entry.takenAt ? new Date(entry.takenAt).toISOString() : null,
-        created_at: new Date().toISOString(),
-        uploaded_by: currentUserId || "",
-        status: isAdmin ? "approved" : "pending",
-      };
+      const optimisticItem: MediaItem = buildOptimisticMediaItem(entry, mediaId, {
+        currentUserId,
+        isAdmin,
+      });
       setItems((prev) => [optimisticItem, ...prev]);
-
-      // Fetch real data
-      fetch(`/api/media/${mediaId}`)
-        .then((res) => (res.ok ? res.json() : null))
-        .then((real: MediaItem | null) => {
-          if (!real) return;
-          setItems((prev) => prev.map((i) => (i.id === mediaId ? { ...i, ...real } : i)));
-        })
-        .catch(() => {});
     },
     [currentUserId, isAdmin],
   );
@@ -358,6 +340,13 @@ export function AlbumView({
 
   return (
     <div>
+      {album.import_status && album.import_status !== "success" && (
+        <div className="mb-4 rounded-xl border border-[var(--color-org-secondary)]/20 bg-[var(--color-org-secondary)]/8 px-4 py-3">
+          <p className="text-sm font-medium text-[var(--foreground)]">{getAlbumImportHeadline(album)}</p>
+          <p className="mt-1 text-xs text-[var(--muted-foreground)]">{getAlbumImportDetail(album)}</p>
+        </div>
+      )}
+
       {/* Header */}
       <div className="flex items-center gap-3 mb-5 flex-wrap">
         <button
@@ -612,4 +601,35 @@ export function AlbumView({
       )}
     </div>
   );
+}
+
+function getAlbumImportHeadline(album: MediaAlbum): string {
+  switch (album.import_status) {
+    case "creating_album":
+      return "Creating album import";
+    case "partial_success":
+      return "Album import finished with some failures";
+    case "failed":
+      return "Album import failed";
+    default:
+      return "Album import in progress";
+  }
+}
+
+function getAlbumImportDetail(album: MediaAlbum): string {
+  const uploaded = album.import_uploaded_count ?? 0;
+  const expected = album.import_expected_count ?? 0;
+  const failed = album.import_failed_count ?? 0;
+
+  if (album.import_status === "failed") {
+    return failed > 0
+      ? `${failed} file${failed === 1 ? "" : "s"} failed before the album could finish importing.`
+      : "The album is waiting for another retry to complete.";
+  }
+
+  if (album.import_status === "partial_success") {
+    return `${uploaded} of ${expected} files finished importing. Retry the failed uploads to complete the album.`;
+  }
+
+  return `${uploaded} of ${expected} files imported so far. You can leave this page while the upload continues.`;
 }

--- a/src/components/media/DropZone.tsx
+++ b/src/components/media/DropZone.tsx
@@ -256,7 +256,7 @@ export function DropZone({ onFiles, onFolder, disabled = false }: DropZoneProps)
               )}
             </p>
             <p className="text-xs text-[var(--muted-foreground)]">
-              Images up to 10 MB, videos up to 100 MB. Max 20 files.
+              Images up to 10 MB, videos up to 100 MB. Max 100 files.
             </p>
           </>
         )}

--- a/src/components/media/MediaGallery.tsx
+++ b/src/components/media/MediaGallery.tsx
@@ -34,6 +34,12 @@ import {
   buildOptimisticMediaItem,
   mergeUploadTags,
 } from "@/lib/media/gallery-upload-client";
+import { bulkDeleteSelectedMedia } from "@/lib/media/delete-media-client";
+import {
+  canDeleteMediaItem,
+  filterBulkDeleteSelection,
+  getBulkDeleteEligibleIds,
+} from "@/lib/media/delete-selection";
 import { useMediaUploadManager } from "./MediaUploadManagerContext";
 
 interface MediaGalleryProps {
@@ -158,6 +164,14 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
 
   const galleryFiltersDefault =
     mediaType === "all" && !year && !tag && (!isAdmin || statusFilter === "all");
+  const deleteActor = useMemo(
+    () => ({ isAdmin, currentUserId }),
+    [isAdmin, currentUserId],
+  );
+  const eligibleDeleteIds = useMemo(
+    () => getBulkDeleteEligibleIds(items, deleteActor),
+    [items, deleteActor],
+  );
 
   /** Full-org order requires admin (non-admins only see approved items; RPC needs every row). */
   const canReorderPhotos = canUpload && isAdmin && galleryFiltersDefault;
@@ -253,6 +267,16 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
     }
   }, [photosReorderMode]);
 
+  useEffect(() => {
+    if (!selectMode) return;
+
+    setSelectedIds((prev) => {
+      const next = filterBulkDeleteSelection(items, prev, deleteActor);
+      if (next.length === prev.size) return prev;
+      return new Set(next);
+    });
+  }, [items, deleteActor, selectMode]);
+
   const loadMore = async () => {
     if (!nextCursor || loadingMore || photosReorderMode) return;
     setLoadingMore(true);
@@ -289,17 +313,11 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
     }
     setBulkDeleting(true);
     try {
-      const res = await fetch("/api/media/bulk-delete", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orgId, mediaIds: Array.from(selectedIds) }),
+      const { deletedIds } = await bulkDeleteSelectedMedia({
+        orgId,
+        mediaIds: Array.from(selectedIds),
       });
-      if (!res.ok) {
-        const data = await res.json().catch(() => null);
-        throw new Error(data?.error || "Failed to delete");
-      }
-      const { deletedIds } = await res.json();
-      const deletedSet = new Set(deletedIds as string[]);
+      const deletedSet = new Set(deletedIds);
       setItems((prev) => prev.filter((i) => !deletedSet.has(i.id)));
       exitSelectMode();
       showFeedback(`Deleted ${deletedIds.length} item${deletedIds.length === 1 ? "" : "s"}`, "success", { duration: 3000 });
@@ -582,7 +600,7 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
               {selectMode && items.length > 0 && (
                 <div className="flex items-center gap-1">
                   <button
-                    onClick={() => setSelectedIds(new Set(items.map((i) => i.id)))}
+                    onClick={() => setSelectedIds(new Set(eligibleDeleteIds))}
                     className="px-2.5 py-1 text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] rounded-lg hover:bg-[var(--muted)] transition-colors"
                   >
                     {tCommon("all")}
@@ -613,6 +631,12 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
         <div className="mb-4 text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950/20 rounded-lg p-3">
           {error}
           <button onClick={() => setError(null)} className="ml-2 underline">{tCommon("dismiss")}</button>
+        </div>
+      )}
+
+      {view === "photos" && selectMode && !isAdmin && eligibleDeleteIds.length < items.length && (
+        <div className="mb-4 text-xs text-muted-foreground">
+          Only your uploads can be selected for delete.
         </div>
       )}
 
@@ -753,7 +777,11 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
                       onClick={() => setSelectedItem(item)}
                       selectable={selectMode}
                       selected={selectedIds.has(item.id)}
-                      onToggle={() => toggleItem(item.id)}
+                      selectionDisabled={selectMode && !canDeleteMediaItem(item, deleteActor)}
+                      onToggle={() => {
+                        if (!canDeleteMediaItem(item, deleteActor)) return;
+                        toggleItem(item.id);
+                      }}
                     />
                   ))}
                 </div>
@@ -790,8 +818,7 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
               <Button size="sm" onClick={() => setShowAlbumPicker(true)}>
                 {tMedia("addToAlbum")}
               </Button>
-              {/* Bulk delete: show if admin or uploader of all selected */}
-              {(isAdmin || (currentUserId && items.filter((i) => selectedIds.has(i.id)).every((i) => i.uploaded_by === currentUserId))) && (
+              {selectedIds.size > 0 && (
                 <Button
                   size="sm"
                   variant={bulkDeleteConfirm ? "danger" : "secondary"}

--- a/src/components/media/MediaGallery.tsx
+++ b/src/components/media/MediaGallery.tsx
@@ -34,6 +34,7 @@ import {
   buildOptimisticMediaItem,
   mergeUploadTags,
 } from "@/lib/media/gallery-upload-client";
+import { useMediaUploadManager } from "./MediaUploadManagerContext";
 
 interface MediaGalleryProps {
   orgId: string;
@@ -109,6 +110,7 @@ function SortableMediaRow({
 export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: MediaGalleryProps) {
   const tMedia = useTranslations("media");
   const tCommon = useTranslations("common");
+  const { importingAlbum } = useMediaUploadManager();
 
   // View tab state
   const [view, setView] = useState<GalleryView>("albums");
@@ -149,6 +151,10 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
   const itemsRef = useRef<MediaItem[]>([]);
   itemsRef.current = items;
   const reducedMotion = usePrefersReducedMotion();
+  const displayedSelectedAlbum =
+    selectedAlbum && importingAlbum && importingAlbum.id === selectedAlbum.id
+      ? { ...selectedAlbum, ...importingAlbum }
+      : selectedAlbum;
 
   const galleryFiltersDefault =
     mediaType === "all" && !year && !tag && (!isAdmin || statusFilter === "all");
@@ -619,9 +625,9 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
         />
       )}
 
-      {view === "albums" && selectedAlbum && (
+      {view === "albums" && displayedSelectedAlbum && (
         <AlbumView
-          album={selectedAlbum}
+          album={displayedSelectedAlbum}
           orgId={orgId}
           isAdmin={isAdmin}
           canUpload={canUpload}

--- a/src/components/media/MediaGallery.tsx
+++ b/src/components/media/MediaGallery.tsx
@@ -30,6 +30,10 @@ import { AlbumView } from "./AlbumView";
 import { AlbumPickerModal } from "./AlbumPickerModal";
 import type { MediaAlbum } from "./AlbumCard";
 import type { UploadFileEntry } from "@/hooks/useGalleryUpload";
+import {
+  buildOptimisticMediaItem,
+  mergeUploadTags,
+} from "@/lib/media/gallery-upload-client";
 
 interface MediaGalleryProps {
   orgId: string;
@@ -352,20 +356,10 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
   // Optimistic insertion when a file finishes uploading
   const handleFileComplete = useCallback(
     (entry: UploadFileEntry, mediaId: string) => {
-      const isVideo = entry.mimeType.startsWith("video/");
-      const optimisticItem: MediaItem = {
-        id: mediaId,
-        title: entry.title || entry.fileName,
-        description: entry.description || null,
-        media_type: isVideo ? "video" : "image",
-        url: entry.previewUrl,
-        thumbnail_url: isVideo ? null : entry.previewUrl,
-        tags: entry.tags,
-        taken_at: entry.takenAt ? new Date(entry.takenAt).toISOString() : null,
-        created_at: new Date().toISOString(),
-        uploaded_by: currentUserId || "",
-        status: isAdmin ? "approved" : "pending",
-      };
+      const optimisticItem: MediaItem = buildOptimisticMediaItem(entry, mediaId, {
+        currentUserId,
+        isAdmin,
+      });
 
       // Only add to items list if we're on the photos tab
       if (view === "photos") {
@@ -373,22 +367,8 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
       }
 
       if (entry.tags.length > 0) {
-        setAvailableTags((prev) => {
-          const set = new Set(prev);
-          entry.tags.forEach((t) => set.add(t));
-          return Array.from(set).sort();
-        });
+        setAvailableTags((prev) => mergeUploadTags(prev, entry.tags));
       }
-
-      fetch(`/api/media/${mediaId}`)
-        .then((res) => (res.ok ? res.json() : null))
-        .then((real: MediaItem | null) => {
-          if (!real) return;
-          setItems((prev) =>
-            prev.map((i) => (i.id === mediaId ? { ...i, ...real } : i)),
-          );
-        })
-        .catch(() => {});
     },
     [currentUserId, isAdmin, view],
   );

--- a/src/components/media/MediaUploadManagerContext.tsx
+++ b/src/components/media/MediaUploadManagerContext.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useGalleryUpload, type UploadFileEntry } from "@/hooks/useGalleryUpload";
+import {
+  getFolderAlbumBatchStatus,
+  summarizeFolderAlbumBatch,
+  type FolderAlbumBatchStatus,
+} from "@/lib/media/gallery-upload-flow";
+import {
+  buildFolderImportAlbum,
+  isFolderImportSessionActive,
+} from "@/lib/media/folder-import-session";
+import type { MediaAlbum } from "./AlbumCard";
+
+interface FolderAlbumState {
+  status: FolderAlbumBatchStatus;
+  album: MediaAlbum | null;
+  attachedMediaIds: string[];
+  error: string | null;
+  requiresManualRetry: boolean;
+}
+
+const INITIAL_FOLDER_ALBUM_STATE: FolderAlbumState = {
+  status: "idle",
+  album: null,
+  attachedMediaIds: [],
+  error: null,
+  requiresManualRetry: false,
+};
+
+interface MediaUploadManagerContextValue {
+  files: UploadFileEntry[];
+  stats: ReturnType<typeof useGalleryUpload>["stats"];
+  pendingAlbumName: string | null;
+  folderAlbum: FolderAlbumState;
+  importingAlbum: MediaAlbum | null;
+  hasActiveFolderImport: boolean;
+  addFiles: ReturnType<typeof useGalleryUpload>["addFiles"];
+  removeFile: ReturnType<typeof useGalleryUpload>["removeFile"];
+  retryFile: ReturnType<typeof useGalleryUpload>["retryFile"];
+  retryAll: ReturnType<typeof useGalleryUpload>["retryAll"];
+  updateField: ReturnType<typeof useGalleryUpload>["updateField"];
+  updateTags: ReturnType<typeof useGalleryUpload>["updateTags"];
+  setPendingAlbumName: ReturnType<typeof useGalleryUpload>["setPendingAlbumName"];
+  clearPendingAlbum: ReturnType<typeof useGalleryUpload>["clearPendingAlbum"];
+  clearFolderImport: () => void;
+  retryAlbumProvision: () => void;
+  startFolderImport: (folderFiles: File[], folderName: string) => Promise<MediaAlbum | null>;
+}
+
+const MediaUploadManagerContext = createContext<MediaUploadManagerContextValue | null>(null);
+
+export function MediaUploadManagerProvider({
+  orgId,
+  children,
+}: {
+  orgId: string;
+  children: ReactNode;
+}) {
+  const pendingFolderSelectionRef = useRef<{ files: File[]; folderName: string } | null>(null);
+  const [folderAlbum, setFolderAlbum] = useState<FolderAlbumState>(INITIAL_FOLDER_ALBUM_STATE);
+
+  const handleUploadComplete = useCallback((entry: UploadFileEntry, mediaId: string) => {
+    setFolderAlbum((prev) => {
+      if (!prev.album || prev.attachedMediaIds.includes(mediaId)) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        attachedMediaIds: [...prev.attachedMediaIds, mediaId],
+        album: {
+          ...prev.album,
+          item_count: prev.album.item_count + 1,
+          updated_at: new Date().toISOString(),
+        },
+      };
+    });
+  }, []);
+
+  const upload = useGalleryUpload({
+    orgId,
+    targetAlbumId: folderAlbum.album?.id,
+    onFileComplete: handleUploadComplete,
+  });
+
+  const {
+    files,
+    stats,
+    pendingAlbumName,
+    addFiles,
+    removeFile,
+    cancelAll,
+    retryFile,
+    retryAll,
+    updateField,
+    updateTags,
+    setPendingAlbumName,
+    clearPendingAlbum,
+  } = upload;
+
+  const folderAlbumSummary = useMemo(
+    () =>
+      pendingAlbumName
+        ? summarizeFolderAlbumBatch(files, folderAlbum.attachedMediaIds)
+        : null,
+    [files, folderAlbum.attachedMediaIds, pendingAlbumName],
+  );
+
+  const importingAlbum = useMemo(
+    () => buildFolderImportAlbum(folderAlbum.album, files, folderAlbum.attachedMediaIds),
+    [files, folderAlbum.album, folderAlbum.attachedMediaIds],
+  );
+
+  const hasActiveFolderImport = isFolderImportSessionActive(
+    pendingAlbumName,
+    files,
+    folderAlbum.album?.id ?? null,
+  );
+
+  const resetFolderAlbum = useCallback(() => {
+    setFolderAlbum(INITIAL_FOLDER_ALBUM_STATE);
+  }, []);
+
+  const deleteDraftAlbum = useCallback(
+    async (albumId: string) => {
+      const response = await fetch(`/api/media/albums/${albumId}?orgId=${encodeURIComponent(orgId)}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.error || "Failed to delete album");
+      }
+    },
+    [orgId],
+  );
+
+  const clearFolderImport = useCallback(() => {
+    const emptyDraftAlbumId =
+      folderAlbum.album && folderAlbum.attachedMediaIds.length === 0
+        ? folderAlbum.album.id
+        : null;
+
+    pendingFolderSelectionRef.current = null;
+    cancelAll();
+    clearPendingAlbum();
+    resetFolderAlbum();
+
+    if (emptyDraftAlbumId) {
+      void deleteDraftAlbum(emptyDraftAlbumId).catch(() => {});
+    }
+  }, [
+    cancelAll,
+    clearPendingAlbum,
+    deleteDraftAlbum,
+    folderAlbum.album,
+    folderAlbum.attachedMediaIds.length,
+    resetFolderAlbum,
+  ]);
+
+  const startFolderImport = useCallback(
+    async (folderFiles: File[], folderName: string) => {
+      pendingFolderSelectionRef.current = { files: folderFiles, folderName };
+
+      const previousEmptyDraftAlbumId =
+        folderAlbum.album && folderAlbum.attachedMediaIds.length === 0
+          ? folderAlbum.album.id
+          : null;
+
+      cancelAll();
+      setPendingAlbumName(folderName);
+      setFolderAlbum({
+        ...INITIAL_FOLDER_ALBUM_STATE,
+        status: "creating_album",
+      });
+
+      try {
+        if (previousEmptyDraftAlbumId) {
+          await deleteDraftAlbum(previousEmptyDraftAlbumId);
+        }
+
+        const albumRes = await fetch("/api/media/albums", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ orgId, name: folderName, isUploadDraft: true }),
+        });
+
+        if (!albumRes.ok) {
+          const data = await albumRes.json().catch(() => null);
+          throw new Error(data?.error || "Failed to create album");
+        }
+
+        const album: MediaAlbum = await albumRes.json();
+        const addResult = addFiles(folderFiles, { replaceExisting: true });
+        const acceptedFiles = folderFiles.length - addResult.rejected.length;
+
+        if (acceptedFiles === 0) {
+          pendingFolderSelectionRef.current = null;
+          await deleteDraftAlbum(album.id);
+          setFolderAlbum({
+            ...INITIAL_FOLDER_ALBUM_STATE,
+            status: "failed",
+            error: addResult.rejected[0]?.error || "No valid files were added to the album.",
+          });
+          clearPendingAlbum();
+          return null;
+        }
+
+        pendingFolderSelectionRef.current = null;
+        setFolderAlbum({
+          ...INITIAL_FOLDER_ALBUM_STATE,
+          status: "waiting_for_uploads",
+          album,
+        });
+        return album;
+      } catch (err) {
+        setFolderAlbum({
+          ...INITIAL_FOLDER_ALBUM_STATE,
+          status: "failed",
+          error: err instanceof Error ? err.message : "Failed to create album",
+          requiresManualRetry: true,
+        });
+        return null;
+      }
+    },
+    [
+      addFiles,
+      cancelAll,
+      clearPendingAlbum,
+      deleteDraftAlbum,
+      folderAlbum.album,
+      folderAlbum.attachedMediaIds.length,
+      orgId,
+      setPendingAlbumName,
+    ],
+  );
+
+  useEffect(() => {
+    if (!pendingAlbumName || !folderAlbumSummary) return;
+    if (folderAlbum.requiresManualRetry) return;
+
+    const nextStatus = getFolderAlbumBatchStatus(folderAlbumSummary, folderAlbum.album?.id ?? null);
+
+    setFolderAlbum((prev) => {
+      if (!folderAlbumSummary.hasSuccessfulUploads && folderAlbumSummary.allSettled) {
+        const nextError = prev.error ?? "No files uploaded successfully. Retry failed files to create the album.";
+        if (prev.status === "failed" && prev.error === nextError) {
+          return prev;
+        }
+        return {
+          ...prev,
+          status: "failed",
+          error: nextError,
+        };
+      }
+
+      if ((nextStatus === "success" || nextStatus === "partial_success") && prev.album) {
+        return {
+          ...prev,
+          status: nextStatus,
+          error: null,
+        };
+      }
+
+      if (prev.status === nextStatus && prev.error === null) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        status: nextStatus,
+        error: nextStatus === "success" || nextStatus === "partial_success" ? null : prev.error,
+      };
+    });
+  }, [
+    folderAlbum.album,
+    folderAlbum.requiresManualRetry,
+    folderAlbumSummary,
+    pendingAlbumName,
+  ]);
+
+  useEffect(() => {
+    if (!folderAlbum.album || !pendingAlbumName) return;
+
+    const nextName = pendingAlbumName.trim();
+    if (!nextName || nextName === folderAlbum.album.name) return;
+
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const response = await fetch(`/api/media/albums/${folderAlbum.album?.id}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ orgId, name: nextName }),
+          });
+
+          if (!response.ok) {
+            const data = await response.json().catch(() => null);
+            throw new Error(data?.error || "Failed to update album");
+          }
+
+          const updatedAlbum = await response.json();
+          setFolderAlbum((prev) => {
+            if (!prev.album || prev.album.id !== updatedAlbum.id) {
+              return prev;
+            }
+            return {
+              ...prev,
+              album: {
+                ...prev.album,
+                name: updatedAlbum.name,
+                updated_at: updatedAlbum.updated_at,
+              },
+              error: prev.error === "Failed to update album" ? null : prev.error,
+            };
+          });
+        } catch (err) {
+          setFolderAlbum((prev) => ({
+            ...prev,
+            error: err instanceof Error ? err.message : "Failed to update album",
+          }));
+        }
+      })();
+    }, 500);
+
+    return () => window.clearTimeout(timer);
+  }, [folderAlbum.album, orgId, pendingAlbumName]);
+
+  useEffect(() => {
+    if (pendingAlbumName !== null || files.length > 0) return;
+    if (folderAlbum.status === "idle") return;
+    resetFolderAlbum();
+  }, [files.length, folderAlbum.status, pendingAlbumName, resetFolderAlbum]);
+
+  const retryAlbumProvision = useCallback(() => {
+    if (!pendingFolderSelectionRef.current) return;
+    void startFolderImport(
+      pendingFolderSelectionRef.current.files,
+      pendingFolderSelectionRef.current.folderName,
+    );
+  }, [startFolderImport]);
+
+  const value = useMemo<MediaUploadManagerContextValue>(
+    () => ({
+      files,
+      stats,
+      pendingAlbumName,
+      folderAlbum,
+      importingAlbum,
+      hasActiveFolderImport,
+      addFiles,
+      removeFile,
+      retryFile,
+      retryAll,
+      updateField,
+      updateTags,
+      setPendingAlbumName,
+      clearPendingAlbum,
+      clearFolderImport,
+      retryAlbumProvision,
+      startFolderImport,
+    }),
+    [
+      addFiles,
+      clearFolderImport,
+      clearPendingAlbum,
+      files,
+      folderAlbum,
+      hasActiveFolderImport,
+      importingAlbum,
+      pendingAlbumName,
+      removeFile,
+      retryAlbumProvision,
+      retryAll,
+      retryFile,
+      setPendingAlbumName,
+      startFolderImport,
+      stats,
+      updateField,
+      updateTags,
+    ],
+  );
+
+  return (
+    <MediaUploadManagerContext.Provider value={value}>
+      {children}
+    </MediaUploadManagerContext.Provider>
+  );
+}
+
+export function useMediaUploadManager() {
+  const context = useContext(MediaUploadManagerContext);
+  if (!context) {
+    throw new Error("useMediaUploadManager must be used within MediaUploadManagerProvider");
+  }
+  return context;
+}

--- a/src/components/media/MediaUploadPanel.tsx
+++ b/src/components/media/MediaUploadPanel.tsx
@@ -1,8 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useGalleryUpload, type UploadFileEntry } from "@/hooks/useGalleryUpload";
+import {
+  getFolderAlbumBatchStatus,
+  summarizeFolderAlbumBatch,
+  type FolderAlbumBatchStatus,
+} from "@/lib/media/gallery-upload-flow";
 import { DropZone } from "./DropZone";
 import { UploadFileCard } from "./UploadFileCard";
 import { UploadSummaryBar } from "./UploadSummaryBar";
@@ -19,6 +24,24 @@ interface MediaUploadPanelProps {
   onAlbumCreated?: (album: MediaAlbum) => void;
 }
 
+interface FolderAlbumState {
+  status: FolderAlbumBatchStatus;
+  album: MediaAlbum | null;
+  attachedMediaIds: string[];
+  error: string | null;
+  requiresManualRetry: boolean;
+  hasOpenedAlbum: boolean;
+}
+
+const INITIAL_FOLDER_ALBUM_STATE: FolderAlbumState = {
+  status: "idle",
+  album: null,
+  attachedMediaIds: [],
+  error: null,
+  requiresManualRetry: false,
+  hasOpenedAlbum: false,
+};
+
 export function MediaUploadPanel({
   orgId,
   open,
@@ -30,14 +53,11 @@ export function MediaUploadPanel({
   onAlbumCreated,
 }: MediaUploadPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
-  const [albumCreated, setAlbumCreated] = useState(false);
-  const [albumCreating, setAlbumCreating] = useState(false);
-  const [albumError, setAlbumError] = useState<string | null>(null);
+  const [folderAlbum, setFolderAlbum] = useState<FolderAlbumState>(INITIAL_FOLDER_ALBUM_STATE);
 
   const {
     files,
     stats,
-    completedMediaIds,
     pendingAlbumName,
     addFiles,
     removeFile,
@@ -47,32 +67,40 @@ export function MediaUploadPanel({
     updateField,
     updateTags,
     setPendingAlbumName,
-    clearPendingAlbum,
   } = useGalleryUpload({ orgId, targetAlbumId, onFileComplete });
 
   // Combine gallery tags + tags from the current batch for suggestions
   const batchTags = files.flatMap((f) => f.tags);
   const allSuggestions = [...new Set([...availableTags, ...batchTags])].sort();
 
-  // Auto-create album when all files are done and we have a pending album name
-  // Skip when uploading directly to a target album
-  useEffect(() => {
-    if (
-      targetAlbumId ||
-      !stats.allDone ||
-      !pendingAlbumName ||
-      completedMediaIds.length === 0 ||
-      albumCreated ||
-      albumCreating
-    ) {
-      return;
-    }
+  const folderAlbumSummary = useMemo(() => (
+    pendingAlbumName
+      ? summarizeFolderAlbumBatch(files, folderAlbum.attachedMediaIds)
+      : null
+  ), [files, folderAlbum.attachedMediaIds, pendingAlbumName]);
 
-    const createAlbum = async () => {
-      setAlbumCreating(true);
-      setAlbumError(null);
-      try {
-        // 1. Create the album
+  const resetFolderAlbum = useCallback(() => {
+    setFolderAlbum(INITIAL_FOLDER_ALBUM_STATE);
+  }, []);
+
+  const handleClearPendingAlbum = useCallback(() => {
+    cancelAll();
+    resetFolderAlbum();
+  }, [cancelAll, resetFolderAlbum]);
+
+  const processFolderAlbum = useCallback(async (mediaIds: string[]) => {
+    if (!pendingAlbumName || mediaIds.length === 0) return;
+
+    let nextAlbum = folderAlbum.album;
+    setFolderAlbum((prev) => ({
+      ...prev,
+      status: prev.album ? "adding_items" : "creating_album",
+      error: null,
+      requiresManualRetry: false,
+    }));
+
+    try {
+      if (!nextAlbum) {
         const albumRes = await fetch("/api/media/albums", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -82,58 +110,137 @@ export function MediaUploadPanel({
           const data = await albumRes.json().catch(() => null);
           throw new Error(data?.error || "Failed to create album");
         }
-        const album: MediaAlbum = await albumRes.json();
-
-        // 2. Batch-add all completed media to the album
-        const itemsRes = await fetch(`/api/media/albums/${album.id}/items`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ orgId, mediaIds: completedMediaIds }),
-        });
-        if (!itemsRes.ok) {
-          const data = await itemsRes.json().catch(() => null);
-          throw new Error(data?.error || "Failed to add items to album");
-        }
-
-        setAlbumCreated(true);
-        clearPendingAlbum();
-        onAlbumCreated?.(album);
-      } catch (err) {
-        setAlbumError(err instanceof Error ? err.message : "Failed to create album");
-      } finally {
-        setAlbumCreating(false);
+        nextAlbum = await albumRes.json();
       }
-    };
 
-    createAlbum();
+      setFolderAlbum((prev) => ({
+        ...prev,
+        album: nextAlbum,
+        status: "adding_items",
+      }));
+
+      if (!nextAlbum) {
+        throw new Error("Failed to create album");
+      }
+
+      const itemsRes = await fetch(`/api/media/albums/${nextAlbum.id}/items`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orgId, mediaIds }),
+      });
+      if (!itemsRes.ok) {
+        const data = await itemsRes.json().catch(() => null);
+        throw new Error(data?.error || "Failed to add items to album");
+      }
+
+      setFolderAlbum((prev) => ({
+        ...prev,
+        album: nextAlbum,
+        status: "waiting_for_uploads",
+        error: null,
+        requiresManualRetry: false,
+        attachedMediaIds: Array.from(new Set([...prev.attachedMediaIds, ...mediaIds])),
+      }));
+    } catch (err) {
+      setFolderAlbum((prev) => ({
+        ...prev,
+        album: nextAlbum ?? prev.album,
+        status: "failed",
+        error: err instanceof Error ? err.message : "Failed to create album",
+        requiresManualRetry: true,
+      }));
+    }
+  }, [folderAlbum.album, orgId, pendingAlbumName]);
+
+  useEffect(() => {
+    if (targetAlbumId || !pendingAlbumName || !folderAlbumSummary) return;
+    if (folderAlbum.requiresManualRetry) return;
+    if (folderAlbum.status === "creating_album" || folderAlbum.status === "adding_items") return;
+    if (!folderAlbumSummary.allSettled) return;
+    if (!folderAlbumSummary.hasSuccessfulUploads) return;
+    if (folderAlbumSummary.pendingMediaIds.length === 0) return;
+
+    void processFolderAlbum(folderAlbumSummary.pendingMediaIds);
   }, [
     targetAlbumId,
-    stats.allDone,
     pendingAlbumName,
-    completedMediaIds,
-    albumCreated,
-    albumCreating,
-    orgId,
-    clearPendingAlbum,
-    onAlbumCreated,
+    folderAlbumSummary,
+    folderAlbum.requiresManualRetry,
+    folderAlbum.status,
+    processFolderAlbum,
   ]);
 
-  // Reset album state when panel opens
   useEffect(() => {
-    if (open) {
-      setAlbumCreated(false);
-      setAlbumCreating(false);
-      setAlbumError(null);
-    }
-  }, [open]);
+    if (!pendingAlbumName || !folderAlbumSummary || targetAlbumId) return;
+
+    const nextStatus = folderAlbum.requiresManualRetry
+      ? folderAlbum.status
+      : getFolderAlbumBatchStatus(folderAlbumSummary, folderAlbum.album?.id ?? null);
+
+    setFolderAlbum((prev) => {
+      if (!folderAlbumSummary.hasSuccessfulUploads && folderAlbumSummary.allSettled) {
+        const nextError = prev.error ?? "No files uploaded successfully. Retry failed files to create the album.";
+        if (prev.status === "failed" && prev.error === nextError) {
+          return prev;
+        }
+        return {
+          ...prev,
+          status: "failed",
+          error: nextError,
+        };
+      }
+
+      if ((nextStatus === "success" || nextStatus === "partial_success") && prev.album) {
+        return {
+          ...prev,
+          status: nextStatus,
+          error: null,
+        };
+      }
+
+      if (prev.status === nextStatus && prev.error === null) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        status: nextStatus,
+        error: nextStatus === "success" || nextStatus === "partial_success" ? null : prev.error,
+      };
+    });
+  }, [
+    pendingAlbumName,
+    folderAlbumSummary,
+    folderAlbum.requiresManualRetry,
+    folderAlbum.status,
+    folderAlbum.album,
+    targetAlbumId,
+  ]);
+
+  useEffect(() => {
+    if (!folderAlbum.album || folderAlbum.hasOpenedAlbum) return;
+    if (folderAlbum.status !== "success" && folderAlbum.status !== "partial_success") return;
+
+    onAlbumCreated?.(folderAlbum.album);
+    setFolderAlbum((prev) => (prev.hasOpenedAlbum ? prev : { ...prev, hasOpenedAlbum: true }));
+  }, [folderAlbum.album, folderAlbum.hasOpenedAlbum, folderAlbum.status, onAlbumCreated]);
+
+  useEffect(() => {
+    if (pendingAlbumName !== null || files.length > 0) return;
+    if (folderAlbum.status === "idle") return;
+    resetFolderAlbum();
+  }, [files.length, folderAlbum.status, pendingAlbumName, resetFolderAlbum]);
 
   // Handle folder upload: add files + set pending album name (unless targeting an album)
   const handleFolder = useCallback(
     (folderFiles: File[], folderName: string) => {
-      addFiles(folderFiles);
+      addFiles(folderFiles, { replaceExisting: true });
       if (!targetAlbumId) {
         setPendingAlbumName(folderName);
-        setAlbumCreated(false);
+        setFolderAlbum({
+          ...INITIAL_FOLDER_ALBUM_STATE,
+          status: "waiting_for_uploads",
+        });
       }
     },
     [addFiles, setPendingAlbumName, targetAlbumId],
@@ -168,6 +275,24 @@ export function MediaUploadPanel({
     onClose();
   }, [stats.isUploading, onClose]);
 
+  const retryAlbumCreation = useCallback(() => {
+    if (!folderAlbumSummary || folderAlbumSummary.pendingMediaIds.length === 0) return;
+    void processFolderAlbum(folderAlbumSummary.pendingMediaIds);
+  }, [folderAlbumSummary, processFolderAlbum]);
+
+  const isFolderAlbumFlow = !targetAlbumId && pendingAlbumName !== null;
+  const isAlbumProcessing = folderAlbum.status === "creating_album" || folderAlbum.status === "adding_items";
+  const showAlbumSuccess = folderAlbum.status === "success" || folderAlbum.status === "partial_success";
+  const albumStatusLabel = isAlbumProcessing
+    ? folderAlbum.status === "creating_album"
+      ? "Creating album..."
+      : "Adding photos to album..."
+    : showAlbumSuccess
+      ? folderAlbum.status === "partial_success"
+        ? "Album created with partial success"
+        : "Album created!"
+      : "Creating album from folder";
+
   return (
     <>
       {/* Backdrop */}
@@ -192,13 +317,13 @@ export function MediaUploadPanel({
         <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--border)] shrink-0">
           <div>
             <h2 className="text-base font-semibold text-[var(--foreground)]">
-              {targetAlbumName ? "Upload to Album" : pendingAlbumName !== null && !albumCreated ? "New Album" : "Upload Media"}
+              {targetAlbumName ? "Upload to Album" : isFolderAlbumFlow ? "New Album" : "Upload Media"}
             </h2>
             {targetAlbumName ? (
               <p className="text-xs text-[var(--color-org-secondary)] mt-0.5 font-medium truncate max-w-[260px]">
                 {targetAlbumName}
               </p>
-            ) : pendingAlbumName !== null && !albumCreated ? (
+            ) : isFolderAlbumFlow ? (
               <p className="text-xs text-[var(--color-org-secondary)] mt-0.5 font-medium truncate max-w-[260px]">
                 {pendingAlbumName}
               </p>
@@ -231,14 +356,14 @@ export function MediaUploadPanel({
           />
 
           {/* Pending album name (from folder upload) */}
-          {pendingAlbumName !== null && !albumCreated && (
+          {isFolderAlbumFlow && (
             <div className="rounded-xl bg-[var(--color-org-secondary)]/8 border border-[var(--color-org-secondary)]/20 p-4 space-y-2.5">
               <div className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-[var(--color-org-secondary)] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776" />
                 </svg>
                 <span className="text-sm font-semibold text-[var(--foreground)]">
-                  {albumCreating ? "Creating album…" : "Creating album from folder"}
+                  {albumStatusLabel}
                 </span>
               </div>
               <div>
@@ -249,30 +374,47 @@ export function MediaUploadPanel({
                   onChange={(e) => setPendingAlbumName(e.target.value)}
                   placeholder="Album name"
                   maxLength={200}
-                  disabled={albumCreating}
+                  disabled={isAlbumProcessing || folderAlbum.album !== null}
                 />
               </div>
-              {albumError && (
-                <p className="text-xs text-red-600 dark:text-red-400">{albumError}</p>
+              {folderAlbum.error && (
+                <p className="text-xs text-red-600 dark:text-red-400">{folderAlbum.error}</p>
+              )}
+              {folderAlbum.status === "partial_success" && folderAlbumSummary && (
+                <p className="text-xs text-[var(--foreground)]">
+                  {folderAlbumSummary.completedMediaIds.length} uploaded to the album, {folderAlbumSummary.failedFileIds.length} still need attention.
+                </p>
+              )}
+              {folderAlbum.status === "failed" && folderAlbumSummary?.hasSuccessfulUploads && (
+                <button
+                  type="button"
+                  onClick={retryAlbumCreation}
+                  className="text-xs font-medium text-[var(--color-org-secondary)] hover:underline"
+                  disabled={isAlbumProcessing}
+                >
+                  Retry album creation
+                </button>
               )}
               <button
                 type="button"
-                onClick={clearPendingAlbum}
+                onClick={handleClearPendingAlbum}
                 className="text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-                disabled={albumCreating}
+                disabled={isAlbumProcessing}
               >
-                Cancel album creation
+                {folderAlbum.album ? "Stop adding to this album" : "Cancel album creation"}
               </button>
             </div>
           )}
 
           {/* Album created success */}
-          {albumCreated && (
+          {showAlbumSuccess && (
             <div className="rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/20 px-3 py-2 flex items-center gap-2">
               <svg className="w-4 h-4 text-emerald-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
-              <p className="text-xs text-emerald-700 dark:text-emerald-400">Album created!</p>
+              <p className="text-xs text-emerald-700 dark:text-emerald-400">
+                {folderAlbum.status === "partial_success" ? "Album created. Retry failed files to finish the folder." : "Album created!"}
+              </p>
             </div>
           )}
 

--- a/src/components/media/MediaUploadPanel.tsx
+++ b/src/components/media/MediaUploadPanel.tsx
@@ -53,7 +53,29 @@ export function MediaUploadPanel({
   onAlbumCreated,
 }: MediaUploadPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const pendingFolderSelectionRef = useRef<{ files: File[]; folderName: string } | null>(null);
   const [folderAlbum, setFolderAlbum] = useState<FolderAlbumState>(INITIAL_FOLDER_ALBUM_STATE);
+
+  const effectiveTargetAlbumId = targetAlbumId ?? folderAlbum.album?.id;
+
+  const handleUploadComplete = useCallback((entry: UploadFileEntry, mediaId: string) => {
+    setFolderAlbum((prev) => {
+      if (!prev.album || prev.attachedMediaIds.includes(mediaId)) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        attachedMediaIds: [...prev.attachedMediaIds, mediaId],
+        album: {
+          ...prev.album,
+          item_count: prev.album.item_count + 1,
+          updated_at: new Date().toISOString(),
+        },
+      };
+    });
+    onFileComplete?.(entry, mediaId);
+  }, [onFileComplete]);
 
   const {
     files,
@@ -67,7 +89,7 @@ export function MediaUploadPanel({
     updateField,
     updateTags,
     setPendingAlbumName,
-  } = useGalleryUpload({ orgId, targetAlbumId, onFileComplete });
+  } = useGalleryUpload({ orgId, targetAlbumId: effectiveTargetAlbumId, onFileComplete: handleUploadComplete });
 
   // Combine gallery tags + tags from the current batch for suggestions
   const batchTags = files.flatMap((f) => f.tags);
@@ -83,99 +105,106 @@ export function MediaUploadPanel({
     setFolderAlbum(INITIAL_FOLDER_ALBUM_STATE);
   }, []);
 
+  const deleteDraftAlbum = useCallback(async (albumId: string) => {
+    const response = await fetch(`/api/media/albums/${albumId}?orgId=${encodeURIComponent(orgId)}`, {
+      method: "DELETE",
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      throw new Error(data?.error || "Failed to delete album");
+    }
+  }, [orgId]);
+
   const handleClearPendingAlbum = useCallback(() => {
+    const emptyDraftAlbumId =
+      folderAlbum.album && folderAlbum.attachedMediaIds.length === 0
+        ? folderAlbum.album.id
+        : null;
+
+    pendingFolderSelectionRef.current = null;
     cancelAll();
     resetFolderAlbum();
-  }, [cancelAll, resetFolderAlbum]);
 
-  const processFolderAlbum = useCallback(async (mediaIds: string[]) => {
-    if (!pendingAlbumName || mediaIds.length === 0) return;
+    if (emptyDraftAlbumId) {
+      void deleteDraftAlbum(emptyDraftAlbumId).catch(() => {});
+    }
+  }, [cancelAll, deleteDraftAlbum, folderAlbum.album, folderAlbum.attachedMediaIds.length, resetFolderAlbum]);
 
-    let nextAlbum = folderAlbum.album;
-    setFolderAlbum((prev) => ({
-      ...prev,
-      status: prev.album ? "adding_items" : "creating_album",
-      error: null,
-      requiresManualRetry: false,
-    }));
+  const provisionFolderAlbum = useCallback(async (folderFiles: File[], folderName: string) => {
+    pendingFolderSelectionRef.current = { files: folderFiles, folderName };
+
+    const previousEmptyDraftAlbumId =
+      folderAlbum.album && folderAlbum.attachedMediaIds.length === 0
+        ? folderAlbum.album.id
+        : null;
+
+    cancelAll();
+    setPendingAlbumName(folderName);
+    setFolderAlbum({
+      ...INITIAL_FOLDER_ALBUM_STATE,
+      status: "creating_album",
+    });
 
     try {
-      if (!nextAlbum) {
-        const albumRes = await fetch("/api/media/albums", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ orgId, name: pendingAlbumName }),
-        });
-        if (!albumRes.ok) {
-          const data = await albumRes.json().catch(() => null);
-          throw new Error(data?.error || "Failed to create album");
-        }
-        nextAlbum = await albumRes.json();
+      if (previousEmptyDraftAlbumId) {
+        await deleteDraftAlbum(previousEmptyDraftAlbumId);
       }
 
-      setFolderAlbum((prev) => ({
-        ...prev,
-        album: nextAlbum,
-        status: "adding_items",
-      }));
-
-      if (!nextAlbum) {
-        throw new Error("Failed to create album");
-      }
-
-      const itemsRes = await fetch(`/api/media/albums/${nextAlbum.id}/items`, {
+      const albumRes = await fetch("/api/media/albums", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orgId, mediaIds }),
+        body: JSON.stringify({ orgId, name: folderName, isUploadDraft: true }),
       });
-      if (!itemsRes.ok) {
-        const data = await itemsRes.json().catch(() => null);
-        throw new Error(data?.error || "Failed to add items to album");
+      if (!albumRes.ok) {
+        const data = await albumRes.json().catch(() => null);
+        throw new Error(data?.error || "Failed to create album");
       }
 
-      setFolderAlbum((prev) => ({
-        ...prev,
-        album: nextAlbum,
+      const album: MediaAlbum = await albumRes.json();
+      const addResult = addFiles(folderFiles, { replaceExisting: true });
+      const acceptedFiles = folderFiles.length - addResult.rejected.length;
+
+      if (acceptedFiles === 0) {
+        pendingFolderSelectionRef.current = null;
+        await deleteDraftAlbum(album.id);
+        setFolderAlbum({
+          ...INITIAL_FOLDER_ALBUM_STATE,
+          status: "failed",
+          error: addResult.rejected[0]?.error || "No valid files were added to the album.",
+        });
+        return;
+      }
+
+      pendingFolderSelectionRef.current = null;
+      setFolderAlbum({
+        ...INITIAL_FOLDER_ALBUM_STATE,
         status: "waiting_for_uploads",
-        error: null,
-        requiresManualRetry: false,
-        attachedMediaIds: Array.from(new Set([...prev.attachedMediaIds, ...mediaIds])),
-      }));
+        album,
+      });
     } catch (err) {
-      setFolderAlbum((prev) => ({
-        ...prev,
-        album: nextAlbum ?? prev.album,
+      setFolderAlbum({
+        ...INITIAL_FOLDER_ALBUM_STATE,
         status: "failed",
         error: err instanceof Error ? err.message : "Failed to create album",
         requiresManualRetry: true,
-      }));
+      });
     }
-  }, [folderAlbum.album, orgId, pendingAlbumName]);
-
-  useEffect(() => {
-    if (targetAlbumId || !pendingAlbumName || !folderAlbumSummary) return;
-    if (folderAlbum.requiresManualRetry) return;
-    if (folderAlbum.status === "creating_album" || folderAlbum.status === "adding_items") return;
-    if (!folderAlbumSummary.allSettled) return;
-    if (!folderAlbumSummary.hasSuccessfulUploads) return;
-    if (folderAlbumSummary.pendingMediaIds.length === 0) return;
-
-    void processFolderAlbum(folderAlbumSummary.pendingMediaIds);
   }, [
-    targetAlbumId,
-    pendingAlbumName,
-    folderAlbumSummary,
-    folderAlbum.requiresManualRetry,
-    folderAlbum.status,
-    processFolderAlbum,
+    addFiles,
+    deleteDraftAlbum,
+    folderAlbum.album,
+    folderAlbum.attachedMediaIds.length,
+    orgId,
+    cancelAll,
+    setPendingAlbumName,
   ]);
 
   useEffect(() => {
     if (!pendingAlbumName || !folderAlbumSummary || targetAlbumId) return;
+    if (folderAlbum.requiresManualRetry) return;
 
-    const nextStatus = folderAlbum.requiresManualRetry
-      ? folderAlbum.status
-      : getFolderAlbumBatchStatus(folderAlbumSummary, folderAlbum.album?.id ?? null);
+    const nextStatus = getFolderAlbumBatchStatus(folderAlbumSummary, folderAlbum.album?.id ?? null);
 
     setFolderAlbum((prev) => {
       if (!folderAlbumSummary.hasSuccessfulUploads && folderAlbumSummary.allSettled) {
@@ -211,10 +240,10 @@ export function MediaUploadPanel({
   }, [
     pendingAlbumName,
     folderAlbumSummary,
-    folderAlbum.requiresManualRetry,
     folderAlbum.status,
     folderAlbum.album,
     targetAlbumId,
+    folderAlbum.requiresManualRetry,
   ]);
 
   useEffect(() => {
@@ -234,16 +263,10 @@ export function MediaUploadPanel({
   // Handle folder upload: add files + set pending album name (unless targeting an album)
   const handleFolder = useCallback(
     (folderFiles: File[], folderName: string) => {
-      addFiles(folderFiles, { replaceExisting: true });
-      if (!targetAlbumId) {
-        setPendingAlbumName(folderName);
-        setFolderAlbum({
-          ...INITIAL_FOLDER_ALBUM_STATE,
-          status: "waiting_for_uploads",
-        });
-      }
+      if (targetAlbumId) return;
+      void provisionFolderAlbum(folderFiles, folderName);
     },
-    [addFiles, setPendingAlbumName, targetAlbumId],
+    [provisionFolderAlbum, targetAlbumId],
   );
 
   // Escape to close (only when not uploading)
@@ -275,23 +298,71 @@ export function MediaUploadPanel({
     onClose();
   }, [stats.isUploading, onClose]);
 
-  const retryAlbumCreation = useCallback(() => {
-    if (!folderAlbumSummary || folderAlbumSummary.pendingMediaIds.length === 0) return;
-    void processFolderAlbum(folderAlbumSummary.pendingMediaIds);
-  }, [folderAlbumSummary, processFolderAlbum]);
+  useEffect(() => {
+    if (targetAlbumId || !folderAlbum.album || !pendingAlbumName) return;
+
+    const nextName = pendingAlbumName.trim();
+    if (!nextName || nextName === folderAlbum.album.name) return;
+
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const response = await fetch(`/api/media/albums/${folderAlbum.album?.id}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ orgId, name: nextName }),
+          });
+
+          if (!response.ok) {
+            const data = await response.json().catch(() => null);
+            throw new Error(data?.error || "Failed to update album");
+          }
+
+          const updatedAlbum = await response.json();
+          setFolderAlbum((prev) => {
+            if (!prev.album || prev.album.id !== updatedAlbum.id) {
+              return prev;
+            }
+            return {
+              ...prev,
+              album: {
+                ...prev.album,
+                name: updatedAlbum.name,
+                updated_at: updatedAlbum.updated_at,
+              },
+              error: prev.error === "Failed to update album" ? null : prev.error,
+            };
+          });
+        } catch (err) {
+          setFolderAlbum((prev) => ({
+            ...prev,
+            error: err instanceof Error ? err.message : "Failed to update album",
+          }));
+        }
+      })();
+    }, 500);
+
+    return () => window.clearTimeout(timer);
+  }, [folderAlbum.album, orgId, pendingAlbumName, targetAlbumId]);
+
+  const retryAlbumProvision = useCallback(() => {
+    if (!pendingFolderSelectionRef.current) return;
+    void provisionFolderAlbum(
+      pendingFolderSelectionRef.current.files,
+      pendingFolderSelectionRef.current.folderName,
+    );
+  }, [provisionFolderAlbum]);
 
   const isFolderAlbumFlow = !targetAlbumId && pendingAlbumName !== null;
-  const isAlbumProcessing = folderAlbum.status === "creating_album" || folderAlbum.status === "adding_items";
+  const isAlbumProcessing = folderAlbum.status === "creating_album";
   const showAlbumSuccess = folderAlbum.status === "success" || folderAlbum.status === "partial_success";
   const albumStatusLabel = isAlbumProcessing
-    ? folderAlbum.status === "creating_album"
-      ? "Creating album..."
-      : "Adding photos to album..."
+    ? "Creating album..."
     : showAlbumSuccess
       ? folderAlbum.status === "partial_success"
         ? "Album created with partial success"
         : "Album created!"
-      : "Creating album from folder";
+      : "Uploading folder to album";
 
   return (
     <>
@@ -352,7 +423,7 @@ export function MediaUploadPanel({
           <DropZone
             onFiles={addFiles}
             onFolder={handleFolder}
-            disabled={stats.isUploading && files.length >= 20}
+            disabled={stats.isUploading && files.length >= 100}
           />
 
           {/* Pending album name (from folder upload) */}
@@ -374,7 +445,7 @@ export function MediaUploadPanel({
                   onChange={(e) => setPendingAlbumName(e.target.value)}
                   placeholder="Album name"
                   maxLength={200}
-                  disabled={isAlbumProcessing || folderAlbum.album !== null}
+                  disabled={isAlbumProcessing}
                 />
               </div>
               {folderAlbum.error && (
@@ -385,10 +456,10 @@ export function MediaUploadPanel({
                   {folderAlbumSummary.completedMediaIds.length} uploaded to the album, {folderAlbumSummary.failedFileIds.length} still need attention.
                 </p>
               )}
-              {folderAlbum.status === "failed" && folderAlbumSummary?.hasSuccessfulUploads && (
+              {folderAlbum.requiresManualRetry && (
                 <button
                   type="button"
-                  onClick={retryAlbumCreation}
+                  onClick={retryAlbumProvision}
                   className="text-xs font-medium text-[var(--color-org-secondary)] hover:underline"
                   disabled={isAlbumProcessing}
                 >

--- a/src/components/media/MediaUploadPanel.tsx
+++ b/src/components/media/MediaUploadPanel.tsx
@@ -1,17 +1,13 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useGalleryUpload, type UploadFileEntry } from "@/hooks/useGalleryUpload";
-import {
-  getFolderAlbumBatchStatus,
-  summarizeFolderAlbumBatch,
-  type FolderAlbumBatchStatus,
-} from "@/lib/media/gallery-upload-flow";
+import { summarizeFolderAlbumBatch } from "@/lib/media/gallery-upload-flow";
 import { DropZone } from "./DropZone";
 import { UploadFileCard } from "./UploadFileCard";
 import { UploadSummaryBar } from "./UploadSummaryBar";
 import type { MediaAlbum } from "./AlbumCard";
+import { useMediaUploadManager } from "./MediaUploadManagerContext";
 
 interface MediaUploadPanelProps {
   orgId: string;
@@ -24,24 +20,6 @@ interface MediaUploadPanelProps {
   onAlbumCreated?: (album: MediaAlbum) => void;
 }
 
-interface FolderAlbumState {
-  status: FolderAlbumBatchStatus;
-  album: MediaAlbum | null;
-  attachedMediaIds: string[];
-  error: string | null;
-  requiresManualRetry: boolean;
-  hasOpenedAlbum: boolean;
-}
-
-const INITIAL_FOLDER_ALBUM_STATE: FolderAlbumState = {
-  status: "idle",
-  album: null,
-  attachedMediaIds: [],
-  error: null,
-  requiresManualRetry: false,
-  hasOpenedAlbum: false,
-};
-
 export function MediaUploadPanel({
   orgId,
   open,
@@ -53,235 +31,66 @@ export function MediaUploadPanel({
   onAlbumCreated,
 }: MediaUploadPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
-  const pendingFolderSelectionRef = useRef<{ files: File[]; folderName: string } | null>(null);
-  const [folderAlbum, setFolderAlbum] = useState<FolderAlbumState>(INITIAL_FOLDER_ALBUM_STATE);
+  const folderUpload = useMediaUploadManager();
+  const directUpload = useGalleryUpload({ orgId, targetAlbumId, onFileComplete });
 
-  const effectiveTargetAlbumId = targetAlbumId ?? folderAlbum.album?.id;
-
-  const handleUploadComplete = useCallback((entry: UploadFileEntry, mediaId: string) => {
-    setFolderAlbum((prev) => {
-      if (!prev.album || prev.attachedMediaIds.includes(mediaId)) {
-        return prev;
-      }
-
-      return {
-        ...prev,
-        attachedMediaIds: [...prev.attachedMediaIds, mediaId],
-        album: {
-          ...prev.album,
-          item_count: prev.album.item_count + 1,
-          updated_at: new Date().toISOString(),
-        },
-      };
-    });
-    onFileComplete?.(entry, mediaId);
-  }, [onFileComplete]);
-
+  const isFolderAlbumFlow = !targetAlbumId && folderUpload.hasActiveFolderImport;
+  const upload = isFolderAlbumFlow ? folderUpload : directUpload;
   const {
     files,
     stats,
     pendingAlbumName,
     addFiles,
     removeFile,
-    cancelAll,
     retryFile,
     retryAll,
     updateField,
     updateTags,
     setPendingAlbumName,
-  } = useGalleryUpload({ orgId, targetAlbumId: effectiveTargetAlbumId, onFileComplete: handleUploadComplete });
+  } = upload;
 
-  // Combine gallery tags + tags from the current batch for suggestions
+  const folderAlbum = folderUpload.folderAlbum;
+  const folderAlbumSummary = useMemo(
+    () =>
+      isFolderAlbumFlow && pendingAlbumName
+        ? summarizeFolderAlbumBatch(files, folderAlbum.attachedMediaIds)
+        : null,
+    [files, folderAlbum.attachedMediaIds, isFolderAlbumFlow, pendingAlbumName],
+  );
+
   const batchTags = files.flatMap((f) => f.tags);
   const allSuggestions = [...new Set([...availableTags, ...batchTags])].sort();
 
-  const folderAlbumSummary = useMemo(() => (
-    pendingAlbumName
-      ? summarizeFolderAlbumBatch(files, folderAlbum.attachedMediaIds)
-      : null
-  ), [files, folderAlbum.attachedMediaIds, pendingAlbumName]);
-
-  const resetFolderAlbum = useCallback(() => {
-    setFolderAlbum(INITIAL_FOLDER_ALBUM_STATE);
-  }, []);
-
-  const deleteDraftAlbum = useCallback(async (albumId: string) => {
-    const response = await fetch(`/api/media/albums/${albumId}?orgId=${encodeURIComponent(orgId)}`, {
-      method: "DELETE",
-    });
-
-    if (!response.ok) {
-      const data = await response.json().catch(() => null);
-      throw new Error(data?.error || "Failed to delete album");
-    }
-  }, [orgId]);
-
-  const handleClearPendingAlbum = useCallback(() => {
-    const emptyDraftAlbumId =
-      folderAlbum.album && folderAlbum.attachedMediaIds.length === 0
-        ? folderAlbum.album.id
-        : null;
-
-    pendingFolderSelectionRef.current = null;
-    cancelAll();
-    resetFolderAlbum();
-
-    if (emptyDraftAlbumId) {
-      void deleteDraftAlbum(emptyDraftAlbumId).catch(() => {});
-    }
-  }, [cancelAll, deleteDraftAlbum, folderAlbum.album, folderAlbum.attachedMediaIds.length, resetFolderAlbum]);
-
-  const provisionFolderAlbum = useCallback(async (folderFiles: File[], folderName: string) => {
-    pendingFolderSelectionRef.current = { files: folderFiles, folderName };
-
-    const previousEmptyDraftAlbumId =
-      folderAlbum.album && folderAlbum.attachedMediaIds.length === 0
-        ? folderAlbum.album.id
-        : null;
-
-    cancelAll();
-    setPendingAlbumName(folderName);
-    setFolderAlbum({
-      ...INITIAL_FOLDER_ALBUM_STATE,
-      status: "creating_album",
-    });
-
-    try {
-      if (previousEmptyDraftAlbumId) {
-        await deleteDraftAlbum(previousEmptyDraftAlbumId);
-      }
-
-      const albumRes = await fetch("/api/media/albums", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orgId, name: folderName, isUploadDraft: true }),
-      });
-      if (!albumRes.ok) {
-        const data = await albumRes.json().catch(() => null);
-        throw new Error(data?.error || "Failed to create album");
-      }
-
-      const album: MediaAlbum = await albumRes.json();
-      const addResult = addFiles(folderFiles, { replaceExisting: true });
-      const acceptedFiles = folderFiles.length - addResult.rejected.length;
-
-      if (acceptedFiles === 0) {
-        pendingFolderSelectionRef.current = null;
-        await deleteDraftAlbum(album.id);
-        setFolderAlbum({
-          ...INITIAL_FOLDER_ALBUM_STATE,
-          status: "failed",
-          error: addResult.rejected[0]?.error || "No valid files were added to the album.",
-        });
-        return;
-      }
-
-      pendingFolderSelectionRef.current = null;
-      setFolderAlbum({
-        ...INITIAL_FOLDER_ALBUM_STATE,
-        status: "waiting_for_uploads",
-        album,
-      });
-    } catch (err) {
-      setFolderAlbum({
-        ...INITIAL_FOLDER_ALBUM_STATE,
-        status: "failed",
-        error: err instanceof Error ? err.message : "Failed to create album",
-        requiresManualRetry: true,
-      });
-    }
-  }, [
-    addFiles,
-    deleteDraftAlbum,
-    folderAlbum.album,
-    folderAlbum.attachedMediaIds.length,
-    orgId,
-    cancelAll,
-    setPendingAlbumName,
-  ]);
-
-  useEffect(() => {
-    if (!pendingAlbumName || !folderAlbumSummary || targetAlbumId) return;
-    if (folderAlbum.requiresManualRetry) return;
-
-    const nextStatus = getFolderAlbumBatchStatus(folderAlbumSummary, folderAlbum.album?.id ?? null);
-
-    setFolderAlbum((prev) => {
-      if (!folderAlbumSummary.hasSuccessfulUploads && folderAlbumSummary.allSettled) {
-        const nextError = prev.error ?? "No files uploaded successfully. Retry failed files to create the album.";
-        if (prev.status === "failed" && prev.error === nextError) {
-          return prev;
-        }
-        return {
-          ...prev,
-          status: "failed",
-          error: nextError,
-        };
-      }
-
-      if ((nextStatus === "success" || nextStatus === "partial_success") && prev.album) {
-        return {
-          ...prev,
-          status: nextStatus,
-          error: null,
-        };
-      }
-
-      if (prev.status === nextStatus && prev.error === null) {
-        return prev;
-      }
-
-      return {
-        ...prev,
-        status: nextStatus,
-        error: nextStatus === "success" || nextStatus === "partial_success" ? null : prev.error,
-      };
-    });
-  }, [
-    pendingAlbumName,
-    folderAlbumSummary,
-    folderAlbum.status,
-    folderAlbum.album,
-    targetAlbumId,
-    folderAlbum.requiresManualRetry,
-  ]);
-
-  useEffect(() => {
-    if (!folderAlbum.album || folderAlbum.hasOpenedAlbum) return;
-    if (folderAlbum.status !== "success" && folderAlbum.status !== "partial_success") return;
-
-    onAlbumCreated?.(folderAlbum.album);
-    setFolderAlbum((prev) => (prev.hasOpenedAlbum ? prev : { ...prev, hasOpenedAlbum: true }));
-  }, [folderAlbum.album, folderAlbum.hasOpenedAlbum, folderAlbum.status, onAlbumCreated]);
-
-  useEffect(() => {
-    if (pendingAlbumName !== null || files.length > 0) return;
-    if (folderAlbum.status === "idle") return;
-    resetFolderAlbum();
-  }, [files.length, folderAlbum.status, pendingAlbumName, resetFolderAlbum]);
-
-  // Handle folder upload: add files + set pending album name (unless targeting an album)
   const handleFolder = useCallback(
-    (folderFiles: File[], folderName: string) => {
+    async (folderFiles: File[], folderName: string) => {
       if (targetAlbumId) return;
-      void provisionFolderAlbum(folderFiles, folderName);
+      directUpload.cancelAll();
+      const album = await folderUpload.startFolderImport(folderFiles, folderName);
+      if (album) {
+        onAlbumCreated?.(album);
+      }
     },
-    [provisionFolderAlbum, targetAlbumId],
+    [directUpload, folderUpload, onAlbumCreated, targetAlbumId],
   );
 
-  // Escape to close (only when not uploading)
+  const handleFiles = useCallback(
+    (newFiles: File[]) => addFiles(newFiles),
+    [addFiles],
+  );
+
+  const canCloseWhileUploading = isFolderAlbumFlow;
+
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !stats.isUploading) {
+      if (e.key === "Escape" && (canCloseWhileUploading || !stats.isUploading)) {
         onClose();
       }
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [open, stats.isUploading, onClose]);
+  }, [canCloseWhileUploading, onClose, open, stats.isUploading]);
 
-  // Focus trap: return focus on close
   const previousFocus = useRef<HTMLElement | null>(null);
   useEffect(() => {
     if (open) {
@@ -294,66 +103,10 @@ export function MediaUploadPanel({
   }, [open]);
 
   const handleClose = useCallback(() => {
-    if (stats.isUploading) return;
+    if (stats.isUploading && !canCloseWhileUploading) return;
     onClose();
-  }, [stats.isUploading, onClose]);
+  }, [canCloseWhileUploading, onClose, stats.isUploading]);
 
-  useEffect(() => {
-    if (targetAlbumId || !folderAlbum.album || !pendingAlbumName) return;
-
-    const nextName = pendingAlbumName.trim();
-    if (!nextName || nextName === folderAlbum.album.name) return;
-
-    const timer = window.setTimeout(() => {
-      void (async () => {
-        try {
-          const response = await fetch(`/api/media/albums/${folderAlbum.album?.id}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ orgId, name: nextName }),
-          });
-
-          if (!response.ok) {
-            const data = await response.json().catch(() => null);
-            throw new Error(data?.error || "Failed to update album");
-          }
-
-          const updatedAlbum = await response.json();
-          setFolderAlbum((prev) => {
-            if (!prev.album || prev.album.id !== updatedAlbum.id) {
-              return prev;
-            }
-            return {
-              ...prev,
-              album: {
-                ...prev.album,
-                name: updatedAlbum.name,
-                updated_at: updatedAlbum.updated_at,
-              },
-              error: prev.error === "Failed to update album" ? null : prev.error,
-            };
-          });
-        } catch (err) {
-          setFolderAlbum((prev) => ({
-            ...prev,
-            error: err instanceof Error ? err.message : "Failed to update album",
-          }));
-        }
-      })();
-    }, 500);
-
-    return () => window.clearTimeout(timer);
-  }, [folderAlbum.album, orgId, pendingAlbumName, targetAlbumId]);
-
-  const retryAlbumProvision = useCallback(() => {
-    if (!pendingFolderSelectionRef.current) return;
-    void provisionFolderAlbum(
-      pendingFolderSelectionRef.current.files,
-      pendingFolderSelectionRef.current.folderName,
-    );
-  }, [provisionFolderAlbum]);
-
-  const isFolderAlbumFlow = !targetAlbumId && pendingAlbumName !== null;
   const isAlbumProcessing = folderAlbum.status === "creating_album";
   const showAlbumSuccess = folderAlbum.status === "success" || folderAlbum.status === "partial_success";
   const albumStatusLabel = isAlbumProcessing
@@ -366,7 +119,6 @@ export function MediaUploadPanel({
 
   return (
     <>
-      {/* Backdrop */}
       {open && (
         <div
           className="fixed inset-0 z-40 bg-black/20 backdrop-blur-[2px] transition-opacity duration-300 lg:hidden"
@@ -374,7 +126,6 @@ export function MediaUploadPanel({
         />
       )}
 
-      {/* Panel */}
       <div
         ref={panelRef}
         tabIndex={-1}
@@ -384,11 +135,10 @@ export function MediaUploadPanel({
           open ? "translate-x-0" : "translate-x-full"
         }`}
       >
-        {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--border)] shrink-0">
           <div>
             <h2 className="text-base font-semibold text-[var(--foreground)]">
-              {targetAlbumName ? "Upload to Album" : isFolderAlbumFlow ? "New Album" : "Upload Media"}
+              {targetAlbumName ? "Upload to Album" : isFolderAlbumFlow ? "Album Import" : "Upload Media"}
             </h2>
             {targetAlbumName ? (
               <p className="text-xs text-[var(--color-org-secondary)] mt-0.5 font-medium truncate max-w-[260px]">
@@ -407,7 +157,7 @@ export function MediaUploadPanel({
           <button
             type="button"
             onClick={handleClose}
-            disabled={stats.isUploading}
+            disabled={stats.isUploading && !canCloseWhileUploading}
             className="w-8 h-8 rounded-full hover:bg-[var(--muted)] flex items-center justify-center transition-colors disabled:opacity-50"
             aria-label="Close upload panel"
           >
@@ -417,31 +167,26 @@ export function MediaUploadPanel({
           </button>
         </div>
 
-        {/* Body */}
         <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
-          {/* Drop zone */}
           <DropZone
-            onFiles={addFiles}
+            onFiles={handleFiles}
             onFolder={handleFolder}
             disabled={stats.isUploading && files.length >= 100}
           />
 
-          {/* Pending album name (from folder upload) */}
           {isFolderAlbumFlow && (
             <div className="rounded-xl bg-[var(--color-org-secondary)]/8 border border-[var(--color-org-secondary)]/20 p-4 space-y-2.5">
               <div className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-[var(--color-org-secondary)] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776" />
                 </svg>
-                <span className="text-sm font-semibold text-[var(--foreground)]">
-                  {albumStatusLabel}
-                </span>
+                <span className="text-sm font-semibold text-[var(--foreground)]">{albumStatusLabel}</span>
               </div>
               <div>
                 <label className="block text-xs text-[var(--muted-foreground)] mb-1">Album name</label>
                 <input
                   className="w-full text-base font-medium bg-transparent border-b border-[var(--border)] focus:border-[var(--color-org-secondary)] outline-none pb-1 text-[var(--foreground)] placeholder-[var(--muted-foreground)]"
-                  value={pendingAlbumName}
+                  value={pendingAlbumName ?? ""}
                   onChange={(e) => setPendingAlbumName(e.target.value)}
                   placeholder="Album name"
                   maxLength={200}
@@ -451,15 +196,18 @@ export function MediaUploadPanel({
               {folderAlbum.error && (
                 <p className="text-xs text-red-600 dark:text-red-400">{folderAlbum.error}</p>
               )}
-              {folderAlbum.status === "partial_success" && folderAlbumSummary && (
+              {folderAlbumSummary && (
                 <p className="text-xs text-[var(--foreground)]">
-                  {folderAlbumSummary.completedMediaIds.length} uploaded to the album, {folderAlbumSummary.failedFileIds.length} still need attention.
+                  {folderAlbumSummary.completedMediaIds.length} of {files.length} files imported
+                  {folderAlbumSummary.failedFileIds.length > 0
+                    ? `, ${folderAlbumSummary.failedFileIds.length} still need attention.`
+                    : "."}
                 </p>
               )}
               {folderAlbum.requiresManualRetry && (
                 <button
                   type="button"
-                  onClick={retryAlbumProvision}
+                  onClick={folderUpload.retryAlbumProvision}
                   className="text-xs font-medium text-[var(--color-org-secondary)] hover:underline"
                   disabled={isAlbumProcessing}
                 >
@@ -468,16 +216,20 @@ export function MediaUploadPanel({
               )}
               <button
                 type="button"
-                onClick={handleClearPendingAlbum}
+                onClick={folderUpload.clearFolderImport}
                 className="text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
                 disabled={isAlbumProcessing}
               >
                 {folderAlbum.album ? "Stop adding to this album" : "Cancel album creation"}
               </button>
+              {stats.isUploading && (
+                <p className="text-xs text-[var(--muted-foreground)]">
+                  You can close this panel or leave the media page while the album keeps importing.
+                </p>
+              )}
             </div>
           )}
 
-          {/* Album created success */}
           {showAlbumSuccess && (
             <div className="rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/20 px-3 py-2 flex items-center gap-2">
               <svg className="w-4 h-4 text-emerald-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -489,7 +241,6 @@ export function MediaUploadPanel({
             </div>
           )}
 
-          {/* File list */}
           {files.length > 0 && (
             <div className="space-y-3 stagger-children">
               {files.map((entry) => (
@@ -507,7 +258,6 @@ export function MediaUploadPanel({
           )}
         </div>
 
-        {/* Summary bar */}
         <div className="shrink-0">
           <UploadSummaryBar stats={stats} onRetryAll={retryAll} />
         </div>

--- a/src/hooks/useGalleryUpload.ts
+++ b/src/hooks/useGalleryUpload.ts
@@ -50,7 +50,7 @@ export interface UploadFileEntry {
 // ---------------------------------------------------------------------------
 
 type Action =
-  | { type: "ADD_FILES"; entries: UploadFileEntry[] }
+  | { type: "ADD_FILES"; entries: UploadFileEntry[]; replaceExisting?: boolean }
   | { type: "UPDATE_FIELD"; id: string; field: "title" | "description" | "takenAt"; value: string }
   | { type: "UPDATE_TAGS"; id: string; tags: string[] }
   | { type: "SET_STATUS"; id: string; status: FileUploadStatus; error?: string }
@@ -69,10 +69,12 @@ interface State {
   pendingAlbumName: string | null;
 }
 
-function reducer(state: State, action: Action): State {
+export function galleryUploadReducer(state: State, action: Action): State {
   switch (action.type) {
     case "ADD_FILES":
-      return { ...state, files: [...state.files, ...action.entries] };
+      return action.replaceExisting
+        ? { ...state, files: action.entries, completedMediaIds: [] }
+        : { ...state, files: [...state.files, ...action.entries] };
 
     case "UPDATE_FIELD":
       return {
@@ -183,7 +185,7 @@ interface UseGalleryUploadOptions {
 }
 
 export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGalleryUploadOptions) {
-  const [state, dispatch] = useReducer(reducer, {
+  const [state, dispatch] = useReducer(galleryUploadReducer, {
     files: [],
     completedMediaIds: [],
     pendingAlbumName: null,
@@ -194,15 +196,33 @@ export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGa
   const onFileCompleteRef = useRef(onFileComplete);
   onFileCompleteRef.current = onFileComplete;
 
+  const resetQueue = useCallback((entries: UploadFileEntry[] = []) => {
+    xhrRefs.current.forEach((xhr) => xhr.abort());
+    xhrRefs.current.clear();
+
+    state.files.forEach((f) => {
+      if (f.previewUrl) URL.revokeObjectURL(f.previewUrl);
+    });
+
+    processingRef.current.clear();
+
+    if (entries.length > 0) {
+      dispatch({ type: "ADD_FILES", entries, replaceExisting: true });
+      return;
+    }
+
+    dispatch({ type: "CLEAR_ALL" });
+  }, [state.files]);
+
   // ------- Add files -------
   const addFiles = useCallback(
-    (newFiles: File[]) => {
+    (newFiles: File[], options?: { replaceExisting?: boolean }) => {
       const batchCheck = checkBatchLimit(newFiles.length);
       if (!batchCheck.valid) {
         return { rejected: newFiles.map((f) => ({ name: f.name, error: batchCheck.error! })) };
       }
 
-      const existingEntries = state.files.map((f) => ({
+      const existingEntries = (options?.replaceExisting ? [] : state.files).map((f) => ({
         name: f.fileName,
         size: f.fileSize,
       }));
@@ -249,12 +269,16 @@ export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGa
       }
 
       if (entries.length > 0) {
-        dispatch({ type: "ADD_FILES", entries });
+        if (options?.replaceExisting) {
+          resetQueue(entries);
+        } else {
+          dispatch({ type: "ADD_FILES", entries });
+        }
       }
 
       return { rejected };
     },
-    [state.files],
+    [resetQueue, state.files],
   );
 
   // ------- Set pending album name (from folder upload) -------
@@ -492,16 +516,8 @@ export function useGalleryUpload({ orgId, targetAlbumId, onFileComplete }: UseGa
   );
 
   const cancelAll = useCallback(() => {
-    xhrRefs.current.forEach((xhr) => xhr.abort());
-    xhrRefs.current.clear();
-
-    state.files.forEach((f) => {
-      if (f.previewUrl) URL.revokeObjectURL(f.previewUrl);
-    });
-
-    processingRef.current.clear();
-    dispatch({ type: "CLEAR_ALL" });
-  }, [state.files]);
+    resetQueue();
+  }, [resetQueue]);
 
   // ------- Field updates -------
   const updateField = useCallback(

--- a/src/hooks/useGalleryUpload.ts
+++ b/src/hooks/useGalleryUpload.ts
@@ -170,7 +170,7 @@ export function galleryUploadReducer(state: State, action: Action): State {
 // Constants
 // ---------------------------------------------------------------------------
 
-const MAX_CONCURRENT = 3;
+const MAX_CONCURRENT = 4;
 const STAGGER_MS = 500;
 const MAX_RETRIES = 3;
 

--- a/src/lib/media/albums.ts
+++ b/src/lib/media/albums.ts
@@ -1,11 +1,13 @@
+import {
+  canDeleteAllMediaItems,
+  canDeleteMediaItem,
+  getBulkDeleteEligibleIds,
+  type MediaDeleteActor,
+} from "@/lib/media/delete-selection";
+
 interface AlbumCoverCandidate {
   media_type: string | null;
   status: string | null;
-}
-
-interface AlbumDeleteActor {
-  isAdmin: boolean;
-  currentUserId?: string;
 }
 
 interface AlbumItemLike {
@@ -38,25 +40,23 @@ export function getAlbumCoverPickerItems<T extends Pick<AlbumItemLike, "media_ty
 
 export function canDeleteMediaFromAlbumView(
   item: Pick<AlbumItemLike, "uploaded_by">,
-  actor: AlbumDeleteActor,
+  actor: MediaDeleteActor,
 ): boolean {
-  return actor.isAdmin || Boolean(actor.currentUserId && item.uploaded_by === actor.currentUserId);
+  return canDeleteMediaItem(item, actor);
 }
 
 export function getAlbumBulkDeleteEligibleIds<T extends Pick<AlbumItemLike, "id" | "uploaded_by">>(
   items: T[],
-  actor: AlbumDeleteActor,
+  actor: MediaDeleteActor,
 ): string[] {
-  return items
-    .filter((item) => canDeleteMediaFromAlbumView(item, actor))
-    .map((item) => item.id);
+  return getBulkDeleteEligibleIds(items, actor);
 }
 
 export function canDeleteAlbumAndMedia<T extends Pick<AlbumItemLike, "uploaded_by">>(
   items: T[],
-  actor: AlbumDeleteActor,
+  actor: MediaDeleteActor,
 ): boolean {
-  return items.every((item) => canDeleteMediaFromAlbumView(item, actor));
+  return canDeleteAllMediaItems(items, actor);
 }
 
 export function resolveAlbumDeleteMode(mode: string | null | undefined): AlbumDeleteMode {

--- a/src/lib/media/albums.ts
+++ b/src/lib/media/albums.ts
@@ -21,6 +21,8 @@ interface AlbumLike {
   item_count?: number;
 }
 
+export type AlbumDeleteMode = "album_only" | "album_and_media";
+
 export function canUploadDirectlyToAlbum(canUpload: boolean, canEdit: boolean): boolean {
   return canUpload && canEdit;
 }
@@ -48,6 +50,17 @@ export function getAlbumBulkDeleteEligibleIds<T extends Pick<AlbumItemLike, "id"
   return items
     .filter((item) => canDeleteMediaFromAlbumView(item, actor))
     .map((item) => item.id);
+}
+
+export function canDeleteAlbumAndMedia<T extends Pick<AlbumItemLike, "uploaded_by">>(
+  items: T[],
+  actor: AlbumDeleteActor,
+): boolean {
+  return items.every((item) => canDeleteMediaFromAlbumView(item, actor));
+}
+
+export function resolveAlbumDeleteMode(mode: string | null | undefined): AlbumDeleteMode {
+  return mode === "album_and_media" ? "album_and_media" : "album_only";
 }
 
 export function getAlbumCoverValidationError(candidate: AlbumCoverCandidate | null): string | null {

--- a/src/lib/media/delete-media-client.ts
+++ b/src/lib/media/delete-media-client.ts
@@ -1,0 +1,63 @@
+export const MEDIA_BULK_DELETE_BATCH_SIZE = 100;
+
+interface BulkDeleteRequest {
+  orgId: string;
+  mediaIds: string[];
+  batchSize?: number;
+  fetchImpl?: typeof fetch;
+}
+
+interface BulkDeleteResult {
+  deletedIds: string[];
+  deletedCount: number;
+}
+
+export function chunkBulkDeleteMediaIds(
+  mediaIds: string[],
+  batchSize = MEDIA_BULK_DELETE_BATCH_SIZE,
+): string[][] {
+  const uniqueIds = Array.from(new Set(mediaIds));
+  if (uniqueIds.length === 0) return [];
+
+  const chunks: string[][] = [];
+  for (let index = 0; index < uniqueIds.length; index += batchSize) {
+    chunks.push(uniqueIds.slice(index, index + batchSize));
+  }
+  return chunks;
+}
+
+export async function bulkDeleteSelectedMedia({
+  orgId,
+  mediaIds,
+  batchSize = MEDIA_BULK_DELETE_BATCH_SIZE,
+  fetchImpl = fetch,
+}: BulkDeleteRequest): Promise<BulkDeleteResult> {
+  const chunks = chunkBulkDeleteMediaIds(mediaIds, batchSize);
+  if (chunks.length === 0) {
+    return { deletedIds: [], deletedCount: 0 };
+  }
+
+  const deletedIds: string[] = [];
+
+  for (const chunk of chunks) {
+    const res = await fetchImpl("/api/media/bulk-delete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orgId, mediaIds: chunk }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => null);
+      throw new Error(data?.error || "Failed to delete");
+    }
+
+    const data = await res.json().catch(() => null);
+    const batchDeletedIds = Array.isArray(data?.deletedIds) ? data.deletedIds : [];
+    deletedIds.push(...batchDeletedIds);
+  }
+
+  return {
+    deletedIds,
+    deletedCount: deletedIds.length,
+  };
+}

--- a/src/lib/media/delete-media.ts
+++ b/src/lib/media/delete-media.ts
@@ -1,0 +1,93 @@
+import { createServiceClient } from "@/lib/supabase/service";
+
+interface MediaDeleteActor {
+  isAdmin: boolean;
+  userId: string;
+}
+
+interface SoftDeleteMediaItemsOptions {
+  orgId: string;
+  mediaIds: string[];
+  actor: MediaDeleteActor;
+  forbiddenMessage: string;
+  now?: string;
+}
+
+interface SoftDeleteMediaItemsSuccess {
+  ok: true;
+  deletedIds: string[];
+}
+
+interface SoftDeleteMediaItemsFailure {
+  ok: false;
+  status: 403 | 500;
+  error: string;
+}
+
+export type SoftDeleteMediaItemsResult =
+  | SoftDeleteMediaItemsSuccess
+  | SoftDeleteMediaItemsFailure;
+
+export async function softDeleteMediaItems(
+  serviceClient: ReturnType<typeof createServiceClient>,
+  options: SoftDeleteMediaItemsOptions,
+): Promise<SoftDeleteMediaItemsResult> {
+  const { orgId, actor, forbiddenMessage } = options;
+  const mediaIds = Array.from(new Set(options.mediaIds));
+  const now = options.now ?? new Date().toISOString();
+
+  if (mediaIds.length === 0) {
+    return { ok: true, deletedIds: [] };
+  }
+
+  if (!actor.isAdmin) {
+    const { data: items, error: fetchError } = await serviceClient
+      .from("media_items")
+      .select("id, uploaded_by")
+      .in("id", mediaIds)
+      .eq("organization_id", orgId)
+      .is("deleted_at", null);
+
+    if (fetchError) {
+      return { ok: false, status: 500, error: "Failed to verify ownership" };
+    }
+
+    const allOwned =
+      (items || []).length === mediaIds.length &&
+      (items || []).every((item) => item.uploaded_by === actor.userId);
+
+    if (!allOwned) {
+      return { ok: false, status: 403, error: forbiddenMessage };
+    }
+  }
+
+  const { error: clearCoverError } = await serviceClient
+    .from("media_albums")
+    .update({ cover_media_id: null, updated_at: now })
+    .eq("organization_id", orgId)
+    .in("cover_media_id", mediaIds)
+    .is("deleted_at", null);
+
+  if (clearCoverError) {
+    console.error("[media/delete-media] Failed to clear album covers:", clearCoverError);
+    return { ok: false, status: 500, error: "Failed to clear album covers" };
+  }
+
+  const { data, error: deleteError } = await serviceClient
+    .from("media_items")
+    .update({ deleted_at: now })
+    .eq("organization_id", orgId)
+    .in("id", mediaIds)
+    .is("deleted_at", null)
+    .select("id");
+
+  if (deleteError) {
+    console.error("[media/delete-media] Soft delete failed:", deleteError);
+    return { ok: false, status: 500, error: "Failed to delete media items" };
+  }
+
+  return {
+    ok: true,
+    deletedIds: (data ?? []).map((row) => row.id as string),
+  };
+}

--- a/src/lib/media/delete-selection.ts
+++ b/src/lib/media/delete-selection.ts
@@ -1,0 +1,41 @@
+export interface MediaDeleteActor {
+  isAdmin: boolean;
+  currentUserId?: string;
+}
+
+interface MediaDeleteCandidate {
+  id: string;
+  uploaded_by: string;
+}
+
+export function canDeleteMediaItem(
+  item: Pick<MediaDeleteCandidate, "uploaded_by">,
+  actor: MediaDeleteActor,
+): boolean {
+  return actor.isAdmin || Boolean(actor.currentUserId && item.uploaded_by === actor.currentUserId);
+}
+
+export function getBulkDeleteEligibleIds<T extends Pick<MediaDeleteCandidate, "id" | "uploaded_by">>(
+  items: T[],
+  actor: MediaDeleteActor,
+): string[] {
+  return items
+    .filter((item) => canDeleteMediaItem(item, actor))
+    .map((item) => item.id);
+}
+
+export function filterBulkDeleteSelection<T extends Pick<MediaDeleteCandidate, "id" | "uploaded_by">>(
+  items: T[],
+  selectedIds: Iterable<string>,
+  actor: MediaDeleteActor,
+): string[] {
+  const eligibleIds = new Set(getBulkDeleteEligibleIds(items, actor));
+  return Array.from(selectedIds).filter((id) => eligibleIds.has(id));
+}
+
+export function canDeleteAllMediaItems<T extends Pick<MediaDeleteCandidate, "uploaded_by">>(
+  items: T[],
+  actor: MediaDeleteActor,
+): boolean {
+  return items.every((item) => canDeleteMediaItem(item, actor));
+}

--- a/src/lib/media/folder-import-session.ts
+++ b/src/lib/media/folder-import-session.ts
@@ -1,0 +1,91 @@
+import {
+  getFolderAlbumBatchStatus,
+  summarizeFolderAlbumBatch,
+  type FolderAlbumBatchStatus,
+} from "@/lib/media/gallery-upload-flow";
+
+export interface FolderImportFileLike {
+  id: string;
+  status:
+    | "queued"
+    | "requesting"
+    | "uploading"
+    | "finalizing"
+    | "associating"
+    | "done"
+    | "error";
+  mediaId: string | null;
+}
+
+export interface AlbumImportFields {
+  import_status?: Exclude<FolderAlbumBatchStatus, "idle">;
+  import_expected_count?: number;
+  import_uploaded_count?: number;
+  import_failed_count?: number;
+}
+
+export interface AlbumImportLike {
+  id: string;
+  name: string;
+  description?: string | null;
+  cover_media_id?: string | null;
+  cover_url?: string | null;
+  item_count: number;
+  sort_order?: number;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export function buildFolderImportAlbum<T extends AlbumImportLike>(
+  album: T | null,
+  files: FolderImportFileLike[],
+  attachedMediaIds: string[],
+): (T & AlbumImportFields) | null {
+  if (!album) return null;
+
+  const summary = summarizeFolderAlbumBatch(files, attachedMediaIds);
+  const status = getFolderAlbumBatchStatus(summary, album.id);
+  const uploadedCount = summary.completedMediaIds.length;
+  const failedCount = summary.failedFileIds.length;
+  const expectedCount = files.length;
+
+  return {
+    ...album,
+    item_count: Math.max(album.item_count, attachedMediaIds.length),
+    import_status: status,
+    import_expected_count: expectedCount,
+    import_uploaded_count: uploadedCount,
+    import_failed_count: failedCount,
+  };
+}
+
+export function mergeFolderImportAlbum<T extends AlbumImportLike & Partial<AlbumImportFields>>(
+  albums: T[],
+  importingAlbum: T | null,
+): T[] {
+  if (!importingAlbum) return albums;
+
+  const existingIndex = albums.findIndex((album) => album.id === importingAlbum.id);
+  if (existingIndex === -1) {
+    return [importingAlbum, ...albums];
+  }
+
+  return albums.map((album) =>
+    album.id === importingAlbum.id
+      ? {
+          ...album,
+          ...importingAlbum,
+          cover_url: importingAlbum.cover_url ?? album.cover_url ?? null,
+        }
+      : album,
+  );
+}
+
+export function isFolderImportSessionActive(
+  pendingAlbumName: string | null,
+  files: FolderImportFileLike[],
+  albumId: string | null,
+): boolean {
+  return pendingAlbumName !== null || files.length > 0 || Boolean(albumId);
+}

--- a/src/lib/media/gallery-upload-client.ts
+++ b/src/lib/media/gallery-upload-client.ts
@@ -1,0 +1,47 @@
+import type { UploadFileEntry } from "@/hooks/useGalleryUpload";
+
+interface OptimisticMediaItem {
+  id: string;
+  title: string;
+  description: string | null;
+  media_type: "image" | "video";
+  url: string | null;
+  thumbnail_url: string | null;
+  tags: string[];
+  taken_at: string | null;
+  created_at: string;
+  uploaded_by: string;
+  status: "approved" | "pending";
+}
+
+export function buildOptimisticMediaItem(
+  entry: UploadFileEntry,
+  mediaId: string,
+  options: {
+    currentUserId?: string;
+    isAdmin: boolean;
+    nowIso?: string;
+  },
+): OptimisticMediaItem {
+  const isVideo = entry.mimeType.startsWith("video/");
+
+  return {
+    id: mediaId,
+    title: entry.title || entry.fileName,
+    description: entry.description || null,
+    media_type: isVideo ? "video" : "image",
+    url: entry.previewUrl,
+    thumbnail_url: isVideo ? null : entry.previewUrl,
+    tags: entry.tags,
+    taken_at: entry.takenAt ? new Date(entry.takenAt).toISOString() : null,
+    created_at: options.nowIso ?? new Date().toISOString(),
+    uploaded_by: options.currentUserId || "",
+    status: options.isAdmin ? "approved" : "pending",
+  };
+}
+
+export function mergeUploadTags(existingTags: string[], nextTags: string[]): string[] {
+  const merged = new Set(existingTags);
+  nextTags.forEach((tag) => merged.add(tag));
+  return Array.from(merged).sort();
+}

--- a/src/lib/media/gallery-upload-flow.ts
+++ b/src/lib/media/gallery-upload-flow.ts
@@ -4,6 +4,39 @@ interface UploadProcessingState {
   uploadFinalized: boolean;
 }
 
+type FileUploadStatusLike =
+  | "queued"
+  | "requesting"
+  | "uploading"
+  | "finalizing"
+  | "associating"
+  | "done"
+  | "error";
+
+export interface FolderAlbumFileLike {
+  id: string;
+  status: FileUploadStatusLike;
+  mediaId: string | null;
+}
+
+export interface FolderAlbumBatchSummary {
+  completedMediaIds: string[];
+  failedFileIds: string[];
+  pendingMediaIds: string[];
+  allSettled: boolean;
+  hasSuccessfulUploads: boolean;
+  hasFailures: boolean;
+}
+
+export type FolderAlbumBatchStatus =
+  | "idle"
+  | "waiting_for_uploads"
+  | "creating_album"
+  | "adding_items"
+  | "partial_success"
+  | "success"
+  | "failed";
+
 export function getGalleryUploadMode(
   state: UploadProcessingState,
 ): "upload" | "associate-only" {
@@ -15,4 +48,47 @@ export function getGalleryUploadMode(
 
 export function getGalleryRetryProgress(uploadFinalized: boolean): number {
   return uploadFinalized ? 100 : 0;
+}
+
+export function summarizeFolderAlbumBatch(
+  files: FolderAlbumFileLike[],
+  attachedMediaIds: string[] = [],
+): FolderAlbumBatchSummary {
+  const attachedSet = new Set(attachedMediaIds);
+  const completedMediaIds = files
+    .filter((file) => file.status === "done" && file.mediaId)
+    .map((file) => file.mediaId as string);
+  const failedFileIds = files
+    .filter((file) => file.status === "error")
+    .map((file) => file.id);
+  const pendingMediaIds = completedMediaIds.filter((mediaId) => !attachedSet.has(mediaId));
+  const allSettled = files.length > 0 && files.every((file) => file.status === "done" || file.status === "error");
+
+  return {
+    completedMediaIds,
+    failedFileIds,
+    pendingMediaIds,
+    allSettled,
+    hasSuccessfulUploads: completedMediaIds.length > 0,
+    hasFailures: failedFileIds.length > 0,
+  };
+}
+
+export function getFolderAlbumBatchStatus(
+  summary: FolderAlbumBatchSummary,
+  albumId: string | null,
+): FolderAlbumBatchStatus {
+  if (!summary.allSettled) {
+    return "waiting_for_uploads";
+  }
+
+  if (!summary.hasSuccessfulUploads) {
+    return "failed";
+  }
+
+  if (summary.pendingMediaIds.length > 0 || !albumId) {
+    return albumId ? "adding_items" : "creating_album";
+  }
+
+  return summary.hasFailures ? "partial_success" : "success";
 }

--- a/src/lib/media/gallery-upload-server.ts
+++ b/src/lib/media/gallery-upload-server.ts
@@ -1,0 +1,27 @@
+export const GALLERY_ALBUM_BATCH_RATE_LIMIT = {
+  limitPerIp: 180,
+  limitPerUser: 180,
+} as const;
+
+interface DraftAlbumLike {
+  is_upload_draft?: boolean | null;
+  item_count?: number | null;
+  created_at?: string | null;
+  deleted_at?: string | null;
+}
+
+export function getNextGallerySortOrder(currentMinSortOrder: number | null): number {
+  return currentMinSortOrder === null ? 0 : currentMinSortOrder - 1;
+}
+
+export function shouldListMediaAlbum(album: DraftAlbumLike): boolean {
+  return !(album.is_upload_draft && (album.item_count ?? 0) === 0);
+}
+
+export function isStaleEmptyUploadDraftAlbum(album: DraftAlbumLike, cutoffIso: string): boolean {
+  if (!album.is_upload_draft) return false;
+  if ((album.item_count ?? 0) > 0) return false;
+  if (album.deleted_at) return false;
+  if (!album.created_at) return false;
+  return album.created_at < cutoffIso;
+}

--- a/src/lib/media/gallery-upload-server.ts
+++ b/src/lib/media/gallery-upload-server.ts
@@ -3,11 +3,32 @@ export const GALLERY_ALBUM_BATCH_RATE_LIMIT = {
   limitPerUser: 180,
 } as const;
 
+interface DraftColumnErrorLike {
+  code?: string | null;
+  message?: string | null;
+  details?: string | null;
+  hint?: string | null;
+}
+
 interface DraftAlbumLike {
   is_upload_draft?: boolean | null;
   item_count?: number | null;
   created_at?: string | null;
   deleted_at?: string | null;
+}
+
+interface DraftColumnQueryResult<T> {
+  data: T | null;
+  error: unknown;
+}
+
+interface DraftColumnFallbackOptions<T> {
+  withDraftColumn: () => Promise<DraftColumnQueryResult<T>>;
+  withoutDraftColumn: () => Promise<DraftColumnQueryResult<T>>;
+}
+
+interface DraftColumnFallbackResult<T> extends DraftColumnQueryResult<T> {
+  usedDraftColumn: boolean;
 }
 
 export function getNextGallerySortOrder(currentMinSortOrder: number | null): number {
@@ -24,4 +45,41 @@ export function isStaleEmptyUploadDraftAlbum(album: DraftAlbumLike, cutoffIso: s
   if (album.deleted_at) return false;
   if (!album.created_at) return false;
   return album.created_at < cutoffIso;
+}
+
+export function isMissingMediaAlbumsDraftColumnError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const maybeError = error as DraftColumnErrorLike;
+  const haystack = [maybeError.code, maybeError.message, maybeError.details, maybeError.hint]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join(" ")
+    .toLowerCase();
+
+  if (!haystack.includes("is_upload_draft")) return false;
+
+  return (
+    haystack.includes("42703") ||
+    haystack.includes("pgrst204") ||
+    haystack.includes("does not exist") ||
+    haystack.includes("could not find")
+  );
+}
+
+export async function withMediaAlbumsDraftColumnFallback<T>(
+  options: DraftColumnFallbackOptions<T>,
+): Promise<DraftColumnFallbackResult<T>> {
+  const resultWithDraftColumn = await options.withDraftColumn();
+  if (!isMissingMediaAlbumsDraftColumnError(resultWithDraftColumn.error)) {
+    return {
+      ...resultWithDraftColumn,
+      usedDraftColumn: true,
+    };
+  }
+
+  const resultWithoutDraftColumn = await options.withoutDraftColumn();
+  return {
+    ...resultWithoutDraftColumn,
+    usedDraftColumn: false,
+  };
 }

--- a/src/lib/media/gallery-validation.ts
+++ b/src/lib/media/gallery-validation.ts
@@ -2,7 +2,7 @@ import { GALLERY_ALLOWED_MIME_TYPES } from "@/lib/schemas/media";
 
 const GALLERY_IMAGE_MAX_BYTES = 10 * 1024 * 1024; // 10MB
 const GALLERY_VIDEO_MAX_BYTES = 100 * 1024 * 1024; // 100MB
-const MAX_BATCH_SIZE = 20;
+const MAX_BATCH_SIZE = 100;
 
 const HEIC_EXTENSIONS = new Set([".heic", ".heif"]);
 

--- a/src/lib/schemas/media.ts
+++ b/src/lib/schemas/media.ts
@@ -82,6 +82,7 @@ export const mediaIdsSchema = z
 export const createAlbumSchema = z.object({
   name: safeString(200, 2),
   description: optionalSafeString(2000),
+  isUploadDraft: z.boolean().optional(),
 });
 export type CreateAlbumForm = z.infer<typeof createAlbumSchema>;
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -3107,6 +3107,7 @@ export type Database = {
           deleted_at: string | null
           description: string | null
           id: string
+          is_upload_draft: boolean
           item_count: number
           name: string
           organization_id: string
@@ -3120,6 +3121,7 @@ export type Database = {
           deleted_at?: string | null
           description?: string | null
           id?: string
+          is_upload_draft?: boolean
           item_count?: number
           name: string
           organization_id: string
@@ -3133,6 +3135,7 @@ export type Database = {
           deleted_at?: string | null
           description?: string | null
           id?: string
+          is_upload_draft?: boolean
           item_count?: number
           name?: string
           organization_id?: string

--- a/supabase/migrations/20260808000000_media_album_upload_drafts.sql
+++ b/supabase/migrations/20260808000000_media_album_upload_drafts.sql
@@ -1,0 +1,9 @@
+ALTER TABLE public.media_albums
+  ADD COLUMN IF NOT EXISTS is_upload_draft boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.media_albums.is_upload_draft IS
+  'Marks provisional folder-upload albums that should stay hidden until at least one media item is attached.';
+
+CREATE INDEX IF NOT EXISTS idx_media_albums_draft_cleanup
+  ON public.media_albums (is_upload_draft, item_count, created_at)
+  WHERE deleted_at IS NULL;

--- a/tests/folder-import-session.test.ts
+++ b/tests/folder-import-session.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildFolderImportAlbum,
+  isFolderImportSessionActive,
+  mergeFolderImportAlbum,
+  type AlbumImportLike,
+  type FolderImportFileLike,
+} from "@/lib/media/folder-import-session";
+
+function makeAlbum(overrides: Partial<AlbumImportLike> = {}): AlbumImportLike {
+  return {
+    id: "album-1",
+    name: "Spring Trip",
+    description: null,
+    cover_media_id: null,
+    cover_url: null,
+    item_count: 0,
+    sort_order: 0,
+    created_by: "user-1",
+    created_at: "2026-03-31T12:00:00.000Z",
+    updated_at: "2026-03-31T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeFile(id: string, overrides: Partial<FolderImportFileLike> = {}): FolderImportFileLike {
+  return {
+    id,
+    status: "queued",
+    mediaId: null,
+    ...overrides,
+  };
+}
+
+test("folder imports build an optimistic album that remains visible before the first item attaches", () => {
+  const importingAlbum = buildFolderImportAlbum(
+    makeAlbum(),
+    [
+      makeFile("file-1", { status: "done", mediaId: "media-1" }),
+      makeFile("file-2", { status: "uploading" }),
+    ],
+    [],
+  );
+
+  assert.deepEqual(importingAlbum, {
+    ...makeAlbum(),
+    import_status: "waiting_for_uploads",
+    import_expected_count: 2,
+    import_uploaded_count: 1,
+    import_failed_count: 0,
+  });
+});
+
+test("merging an active folder import overlays progress onto the fetched album list", () => {
+  const importingAlbum = {
+    ...makeAlbum({ item_count: 2 }),
+    import_status: "partial_success" as const,
+    import_expected_count: 3,
+    import_uploaded_count: 2,
+    import_failed_count: 1,
+  };
+
+  const merged = mergeFolderImportAlbum(
+    [
+      makeAlbum({ id: "album-2", name: "Other Album" }),
+      makeAlbum({ id: "album-1", name: "Old Name", item_count: 1 }),
+    ],
+    importingAlbum,
+  );
+
+  assert.equal(merged.length, 2);
+  assert.deepEqual(merged[1], importingAlbum);
+});
+
+test("closing the panel does not end an active folder import session", () => {
+  assert.equal(
+    isFolderImportSessionActive("Spring Trip", [makeFile("file-1")], "album-1"),
+    true,
+  );
+  assert.equal(isFolderImportSessionActive(null, [], null), false);
+});

--- a/tests/gallery-upload-client.test.ts
+++ b/tests/gallery-upload-client.test.ts
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildOptimisticMediaItem,
+  mergeUploadTags,
+} from "@/lib/media/gallery-upload-client";
+import type { UploadFileEntry } from "@/hooks/useGalleryUpload";
+
+function makeEntry(overrides: Partial<UploadFileEntry> = {}): UploadFileEntry {
+  return {
+    id: "entry-1",
+    file: null,
+    fileName: "spring-game.jpg",
+    fileSize: 1024,
+    mimeType: "image/jpeg",
+    previewUrl: "blob:preview",
+    title: "Spring Game",
+    description: "",
+    tags: ["team", "action"],
+    takenAt: "2026-03-30T12:00:00.000Z",
+    status: "done",
+    progress: 100,
+    error: null,
+    retryCount: 0,
+    mediaId: "media-1",
+    uploadFinalized: true,
+    ...overrides,
+  };
+}
+
+test("completed uploads stay optimistic without requiring a follow-up detail fetch", () => {
+  const item = buildOptimisticMediaItem(makeEntry(), "media-1", {
+    currentUserId: "user-1",
+    isAdmin: false,
+    nowIso: "2026-03-31T12:00:00.000Z",
+  });
+
+  assert.deepEqual(item, {
+    id: "media-1",
+    title: "Spring Game",
+    description: null,
+    media_type: "image",
+    url: "blob:preview",
+    thumbnail_url: "blob:preview",
+    tags: ["team", "action"],
+    taken_at: "2026-03-30T12:00:00.000Z",
+    created_at: "2026-03-31T12:00:00.000Z",
+    uploaded_by: "user-1",
+    status: "pending",
+  });
+});
+
+test("video uploads keep their optimistic preview off the thumbnail field", () => {
+  const item = buildOptimisticMediaItem(
+    makeEntry({
+      fileName: "highlight.mp4",
+      mimeType: "video/mp4",
+      previewUrl: "blob:video-preview",
+    }),
+    "media-video-1",
+    {
+      currentUserId: "user-1",
+      isAdmin: true,
+      nowIso: "2026-03-31T12:00:00.000Z",
+    },
+  );
+
+  assert.equal(item.media_type, "video");
+  assert.equal(item.url, "blob:video-preview");
+  assert.equal(item.thumbnail_url, null);
+  assert.equal(item.status, "approved");
+});
+
+test("upload tags merge into sorted suggestions without duplicates", () => {
+  assert.deepEqual(
+    mergeUploadTags(["captain", "team"], ["action", "team", "travel"]),
+    ["action", "captain", "team", "travel"],
+  );
+});

--- a/tests/gallery-upload-flow.test.ts
+++ b/tests/gallery-upload-flow.test.ts
@@ -1,8 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  getFolderAlbumBatchStatus,
   getGalleryRetryProgress,
   getGalleryUploadMode,
+  summarizeFolderAlbumBatch,
 } from "@/lib/media/gallery-upload-flow";
 
 test("retry resumes album association without re-uploading once media finalization already succeeded", () => {
@@ -30,4 +32,55 @@ test("upload flow performs a full upload when media has not finished finalizing"
 test("retry progress stays at 100 percent when only album association remains", () => {
   assert.equal(getGalleryRetryProgress(true), 100);
   assert.equal(getGalleryRetryProgress(false), 0);
+});
+
+test("folder album summary tracks successful, failed, and unattached media ids", () => {
+  const summary = summarizeFolderAlbumBatch([
+    { id: "file-1", status: "done", mediaId: "media-1" },
+    { id: "file-2", status: "error", mediaId: null },
+    { id: "file-3", status: "done", mediaId: "media-3" },
+  ], ["media-1"]);
+
+  assert.deepEqual(summary.completedMediaIds, ["media-1", "media-3"]);
+  assert.deepEqual(summary.failedFileIds, ["file-2"]);
+  assert.deepEqual(summary.pendingMediaIds, ["media-3"]);
+  assert.equal(summary.allSettled, true);
+  assert.equal(summary.hasSuccessfulUploads, true);
+  assert.equal(summary.hasFailures, true);
+});
+
+test("folder album status stays waiting while uploads are still in flight", () => {
+  const summary = summarizeFolderAlbumBatch([
+    { id: "file-1", status: "uploading", mediaId: null },
+    { id: "file-2", status: "done", mediaId: "media-2" },
+  ]);
+
+  assert.equal(getFolderAlbumBatchStatus(summary, "album-1"), "waiting_for_uploads");
+});
+
+test("folder album status fails when every file has settled and none succeeded", () => {
+  const summary = summarizeFolderAlbumBatch([
+    { id: "file-1", status: "error", mediaId: null },
+    { id: "file-2", status: "error", mediaId: null },
+  ]);
+
+  assert.equal(getFolderAlbumBatchStatus(summary, null), "failed");
+});
+
+test("folder album status is partial success after attaching all successful uploads when some files failed", () => {
+  const summary = summarizeFolderAlbumBatch([
+    { id: "file-1", status: "done", mediaId: "media-1" },
+    { id: "file-2", status: "error", mediaId: null },
+  ], ["media-1"]);
+
+  assert.equal(getFolderAlbumBatchStatus(summary, "album-1"), "partial_success");
+});
+
+test("folder album status is success after attaching all successful uploads when no files failed", () => {
+  const summary = summarizeFolderAlbumBatch([
+    { id: "file-1", status: "done", mediaId: "media-1" },
+    { id: "file-2", status: "done", mediaId: "media-2" },
+  ], ["media-1", "media-2"]);
+
+  assert.equal(getFolderAlbumBatchStatus(summary, "album-1"), "success");
 });

--- a/tests/gallery-upload-server.test.ts
+++ b/tests/gallery-upload-server.test.ts
@@ -3,8 +3,10 @@ import assert from "node:assert/strict";
 import {
   GALLERY_ALBUM_BATCH_RATE_LIMIT,
   getNextGallerySortOrder,
+  isMissingMediaAlbumsDraftColumnError,
   isStaleEmptyUploadDraftAlbum,
   shouldListMediaAlbum,
+  withMediaAlbumsDraftColumnFallback,
 } from "@/lib/media/gallery-upload-server";
 
 test("album batch rate limits allow large folder uploads", () => {
@@ -49,4 +51,82 @@ test("stale draft album cleanup only targets undeleted empty upload drafts older
     created_at: "2026-03-30T00:00:00.000Z",
     deleted_at: null,
   }, cutoff), false);
+});
+
+test("draft column fallback detects missing-column errors from postgres and schema cache", () => {
+  assert.equal(
+    isMissingMediaAlbumsDraftColumnError({
+      code: "42703",
+      message: 'column media_albums.is_upload_draft does not exist',
+    }),
+    true,
+  );
+
+  assert.equal(
+    isMissingMediaAlbumsDraftColumnError({
+      code: "PGRST204",
+      message: "Could not find the 'is_upload_draft' column of 'media_albums' in the schema cache",
+    }),
+    true,
+  );
+
+  assert.equal(
+    isMissingMediaAlbumsDraftColumnError({
+      code: "23505",
+      message: "duplicate key value violates unique constraint",
+    }),
+    false,
+  );
+});
+
+test("draft column fallback retries a query without the draft column when needed", async () => {
+  let fallbackCalls = 0;
+
+  const result = await withMediaAlbumsDraftColumnFallback({
+    withDraftColumn: async () => ({
+      data: null,
+      error: {
+        code: "42703",
+        message: 'column media_albums.is_upload_draft does not exist',
+      },
+    }),
+    withoutDraftColumn: async () => {
+      fallbackCalls += 1;
+      return {
+        data: [{ id: "album-1", name: "Spring" }],
+        error: null,
+      };
+    },
+  });
+
+  assert.equal(fallbackCalls, 1);
+  assert.equal(result.usedDraftColumn, false);
+  assert.deepEqual(result.data, [{ id: "album-1", name: "Spring" }]);
+  assert.equal(result.error, null);
+});
+
+test("draft column fallback does not retry for unrelated errors", async () => {
+  let fallbackCalls = 0;
+
+  const result = await withMediaAlbumsDraftColumnFallback({
+    withDraftColumn: async () => ({
+      data: null,
+      error: {
+        code: "42501",
+        message: "permission denied for table media_albums",
+      },
+    }),
+    withoutDraftColumn: async () => {
+      fallbackCalls += 1;
+      return { data: null, error: null };
+    },
+  });
+
+  assert.equal(fallbackCalls, 0);
+  assert.equal(result.usedDraftColumn, true);
+  assert.equal(result.data, null);
+  assert.deepEqual(result.error, {
+    code: "42501",
+    message: "permission denied for table media_albums",
+  });
 });

--- a/tests/gallery-upload-server.test.ts
+++ b/tests/gallery-upload-server.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  GALLERY_ALBUM_BATCH_RATE_LIMIT,
+  getNextGallerySortOrder,
+  isStaleEmptyUploadDraftAlbum,
+  shouldListMediaAlbum,
+} from "@/lib/media/gallery-upload-server";
+
+test("album batch rate limits allow large folder uploads", () => {
+  assert.deepEqual(GALLERY_ALBUM_BATCH_RATE_LIMIT, {
+    limitPerIp: 180,
+    limitPerUser: 180,
+  });
+});
+
+test("new gallery uploads prepend by using the next lowest sort order", () => {
+  assert.equal(getNextGallerySortOrder(null), 0);
+  assert.equal(getNextGallerySortOrder(0), -1);
+  assert.equal(getNextGallerySortOrder(-4), -5);
+});
+
+test("album list hides empty upload drafts but keeps normal empty albums visible", () => {
+  assert.equal(shouldListMediaAlbum({ is_upload_draft: true, item_count: 0 }), false);
+  assert.equal(shouldListMediaAlbum({ is_upload_draft: true, item_count: 1 }), true);
+  assert.equal(shouldListMediaAlbum({ is_upload_draft: false, item_count: 0 }), true);
+});
+
+test("stale draft album cleanup only targets undeleted empty upload drafts older than the cutoff", () => {
+  const cutoff = "2026-03-31T00:00:00.000Z";
+
+  assert.equal(isStaleEmptyUploadDraftAlbum({
+    is_upload_draft: true,
+    item_count: 0,
+    created_at: "2026-03-30T00:00:00.000Z",
+    deleted_at: null,
+  }, cutoff), true);
+
+  assert.equal(isStaleEmptyUploadDraftAlbum({
+    is_upload_draft: true,
+    item_count: 2,
+    created_at: "2026-03-30T00:00:00.000Z",
+    deleted_at: null,
+  }, cutoff), false);
+
+  assert.equal(isStaleEmptyUploadDraftAlbum({
+    is_upload_draft: false,
+    item_count: 0,
+    created_at: "2026-03-30T00:00:00.000Z",
+    deleted_at: null,
+  }, cutoff), false);
+});

--- a/tests/gallery-upload-state.test.ts
+++ b/tests/gallery-upload-state.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  galleryUploadReducer,
+  type UploadFileEntry,
+} from "@/hooks/useGalleryUpload";
+
+function makeEntry(id: string, overrides: Partial<UploadFileEntry> = {}): UploadFileEntry {
+  return {
+    id,
+    file: null,
+    fileName: `${id}.jpg`,
+    fileSize: 1234,
+    mimeType: "image/jpeg",
+    previewUrl: null,
+    title: id,
+    description: "",
+    tags: [],
+    takenAt: "",
+    status: "queued",
+    progress: 0,
+    error: null,
+    retryCount: 0,
+    mediaId: null,
+    uploadFinalized: false,
+    ...overrides,
+  };
+}
+
+test("replacing files for a new folder batch discards prior queue entries and completed media ids", () => {
+  const prevState = {
+    files: [
+      makeEntry("old-1", { status: "done", mediaId: "media-old-1", uploadFinalized: true, progress: 100 }),
+      makeEntry("old-2", { status: "error", error: "Upload failed" }),
+    ],
+    completedMediaIds: ["media-old-1"],
+    pendingAlbumName: "Old Folder",
+  };
+
+  const nextState = galleryUploadReducer(prevState, {
+    type: "ADD_FILES",
+    replaceExisting: true,
+    entries: [makeEntry("new-1"), makeEntry("new-2")],
+  });
+
+  assert.deepEqual(nextState.files.map((file) => file.id), ["new-1", "new-2"]);
+  assert.deepEqual(nextState.completedMediaIds, []);
+  assert.equal(nextState.pendingAlbumName, "Old Folder");
+});
+
+test("clearing all uploads resets the queue, album name, and completed media ids", () => {
+  const prevState = {
+    files: [makeEntry("file-1", { status: "done", mediaId: "media-1" })],
+    completedMediaIds: ["media-1"],
+    pendingAlbumName: "Spring Game",
+  };
+
+  const nextState = galleryUploadReducer(prevState, { type: "CLEAR_ALL" });
+
+  assert.deepEqual(nextState, {
+    files: [],
+    completedMediaIds: [],
+    pendingAlbumName: null,
+  });
+});

--- a/tests/gallery-validation.test.ts
+++ b/tests/gallery-validation.test.ts
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { checkBatchLimit } from "@/lib/media/gallery-validation";
+
+test("folder upload batch limit allows up to one hundred files", () => {
+  assert.equal(checkBatchLimit(100).valid, true);
+});
+
+test("folder upload batch limit rejects more than one hundred files", () => {
+  const result = checkBatchLimit(101);
+  assert.equal(result.valid, false);
+  assert.equal(result.error, "Maximum 100 files per batch.");
+});

--- a/tests/media-album-delete.test.ts
+++ b/tests/media-album-delete.test.ts
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { canDeleteAlbumAndMedia, resolveAlbumDeleteMode } from "@/lib/media/albums";
+
+function simulateAlbumDelete(params: {
+  isAdmin: boolean;
+  currentUserId?: string;
+  mode?: string | null;
+  uploadedBy: string[];
+}) {
+  const mode = resolveAlbumDeleteMode(params.mode);
+  const items = params.uploadedBy.map((uploaded_by, index) => ({ id: `item-${index + 1}`, uploaded_by }));
+
+  if (mode === "album_and_media" && !canDeleteAlbumAndMedia(items, {
+    isAdmin: params.isAdmin,
+    currentUserId: params.currentUserId,
+  })) {
+    return { status: 403, error: "forbidden_delete_all" };
+  }
+
+  return {
+    status: 200,
+    mode,
+    deletedAlbum: true,
+    deletedMediaCount: mode === "album_and_media" ? items.length : 0,
+  };
+}
+
+test("album-only delete leaves photos in all photos", () => {
+  assert.deepEqual(
+    simulateAlbumDelete({
+      isAdmin: false,
+      currentUserId: "user-1",
+      mode: "album_only",
+      uploadedBy: ["user-1", "user-2"],
+    }),
+    {
+      status: 200,
+      mode: "album_only",
+      deletedAlbum: true,
+      deletedMediaCount: 0,
+    },
+  );
+});
+
+test("delete album and all photos is rejected for non-admins when any item belongs to another uploader", () => {
+  assert.deepEqual(
+    simulateAlbumDelete({
+      isAdmin: false,
+      currentUserId: "user-1",
+      mode: "album_and_media",
+      uploadedBy: ["user-1", "user-2"],
+    }),
+    {
+      status: 403,
+      error: "forbidden_delete_all",
+    },
+  );
+});
+
+test("delete album and all photos is allowed for admins", () => {
+  assert.deepEqual(
+    simulateAlbumDelete({
+      isAdmin: true,
+      mode: "album_and_media",
+      uploadedBy: ["user-1", "user-2"],
+    }),
+    {
+      status: 200,
+      mode: "album_and_media",
+      deletedAlbum: true,
+      deletedMediaCount: 2,
+    },
+  );
+});
+
+test("album delete route supports an explicit delete mode and album view exposes both actions", () => {
+  const routeSource = readFileSync(
+    new URL("../src/app/api/media/albums/[albumId]/route.ts", import.meta.url),
+    "utf8",
+  );
+  const albumViewSource = readFileSync(
+    new URL("../src/components/media/AlbumView.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(routeSource, /searchParams\.get\("mode"\)/);
+  assert.match(routeSource, /album_and_media/);
+  assert.match(albumViewSource, /Delete album only/);
+  assert.match(albumViewSource, /Delete album and all photos/);
+});

--- a/tests/media-albums.test.ts
+++ b/tests/media-albums.test.ts
@@ -1,12 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  canDeleteAlbumAndMedia,
   canDeleteMediaFromAlbumView,
   canUploadDirectlyToAlbum,
   getAlbumBulkDeleteEligibleIds,
   getAlbumCoverPickerItems,
   getAlbumCoverValidationError,
   getAlbumUpdatesAfterMediaDelete,
+  resolveAlbumDeleteMode,
   shouldExposeAlbumCover,
 } from "@/lib/media/albums";
 
@@ -92,6 +94,33 @@ test("album bulk delete eligible ids only includes items the actor can delete", 
     getAlbumBulkDeleteEligibleIds(items, { isAdmin: true }),
     ["item-1", "item-2"],
   );
+});
+
+test("album delete-all mode is only available when every album item is deletable by the actor", () => {
+  const items = [
+    { id: "item-1", uploaded_by: "owner-1" },
+    { id: "item-2", uploaded_by: "owner-1" },
+  ];
+
+  assert.equal(
+    canDeleteAlbumAndMedia(items, { isAdmin: false, currentUserId: "owner-1" }),
+    true,
+  );
+  assert.equal(
+    canDeleteAlbumAndMedia(
+      [...items, { id: "item-3", uploaded_by: "owner-2" }],
+      { isAdmin: false, currentUserId: "owner-1" },
+    ),
+    false,
+  );
+  assert.equal(canDeleteAlbumAndMedia(items, { isAdmin: true }), true);
+});
+
+test("album delete mode defaults safely to album_only", () => {
+  assert.equal(resolveAlbumDeleteMode(null), "album_only");
+  assert.equal(resolveAlbumDeleteMode("album_only"), "album_only");
+  assert.equal(resolveAlbumDeleteMode("album_and_media"), "album_and_media");
+  assert.equal(resolveAlbumDeleteMode("unexpected"), "album_only");
 });
 
 test("album state clears deleted cover media and decrements item count", () => {

--- a/tests/media-delete-client.test.ts
+++ b/tests/media-delete-client.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  bulkDeleteSelectedMedia,
+  chunkBulkDeleteMediaIds,
+  MEDIA_BULK_DELETE_BATCH_SIZE,
+} from "@/lib/media/delete-media-client";
+import {
+  canDeleteAllMediaItems,
+  canDeleteMediaItem,
+  filterBulkDeleteSelection,
+  getBulkDeleteEligibleIds,
+} from "@/lib/media/delete-selection";
+
+test("non-admin gallery bulk delete only allows the user's own uploads", () => {
+  const items = [
+    { id: "media-1", uploaded_by: "user-1" },
+    { id: "media-2", uploaded_by: "user-2" },
+  ];
+
+  assert.equal(canDeleteMediaItem(items[0], { isAdmin: false, currentUserId: "user-1" }), true);
+  assert.equal(canDeleteMediaItem(items[1], { isAdmin: false, currentUserId: "user-1" }), false);
+  assert.deepEqual(
+    getBulkDeleteEligibleIds(items, { isAdmin: false, currentUserId: "user-1" }),
+    ["media-1"],
+  );
+  assert.deepEqual(
+    filterBulkDeleteSelection(items, ["media-1", "media-2"], { isAdmin: false, currentUserId: "user-1" }),
+    ["media-1"],
+  );
+  assert.equal(canDeleteAllMediaItems(items, { isAdmin: false, currentUserId: "user-1" }), false);
+});
+
+test("admins can bulk delete every visible upload", () => {
+  const items = [
+    { id: "media-1", uploaded_by: "user-1" },
+    { id: "media-2", uploaded_by: "user-2" },
+  ];
+
+  assert.deepEqual(
+    getBulkDeleteEligibleIds(items, { isAdmin: true }),
+    ["media-1", "media-2"],
+  );
+  assert.equal(canDeleteAllMediaItems(items, { isAdmin: true }), true);
+});
+
+test("bulk delete client chunks large selections into 100-item requests", () => {
+  const mediaIds = Array.from({ length: MEDIA_BULK_DELETE_BATCH_SIZE * 2 + 5 }, (_, index) => `media-${index + 1}`);
+
+  assert.deepEqual(
+    chunkBulkDeleteMediaIds(mediaIds).map((chunk) => chunk.length),
+    [100, 100, 5],
+  );
+});
+
+test("bulk delete client aggregates batched responses", async () => {
+  const calls: string[][] = [];
+  const fetchImpl: typeof fetch = (async (_input, init) => {
+    const parsed = JSON.parse(String(init?.body ?? "{}")) as { mediaIds: string[] };
+    calls.push(parsed.mediaIds);
+
+    return {
+      ok: true,
+      json: async () => ({ deletedIds: parsed.mediaIds }),
+    } as Response;
+  }) as typeof fetch;
+
+  const result = await bulkDeleteSelectedMedia({
+    orgId: "org-1",
+    mediaIds: Array.from({ length: 205 }, (_, index) => `media-${index + 1}`),
+    fetchImpl,
+  });
+
+  assert.deepEqual(calls.map((chunk) => chunk.length), [100, 100, 5]);
+  assert.equal(result.deletedCount, 205);
+  assert.equal(result.deletedIds[0], "media-1");
+  assert.equal(result.deletedIds.at(-1), "media-205");
+});

--- a/tests/media-gallery-bulk-delete-source.test.ts
+++ b/tests/media-gallery-bulk-delete-source.test.ts
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+test("all photos bulk delete disables ineligible selections and uses shared batched deletion", () => {
+  const gallerySource = readFileSync(
+    new URL("../src/components/media/MediaGallery.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(gallerySource, /selectionDisabled=\{/);
+  assert.match(gallerySource, /getBulkDeleteEligibleIds|canDeleteMediaItem/);
+  assert.match(gallerySource, /bulkDeleteSelectedMedia/);
+  assert.doesNotMatch(gallerySource, /items\.filter\(\(i\) => selectedIds\.has\(i\.id\)\)\.every/);
+});
+
+test("album view bulk delete also uses shared batched deletion", () => {
+  const albumViewSource = readFileSync(
+    new URL("../src/components/media/AlbumView.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(albumViewSource, /bulkDeleteSelectedMedia/);
+});

--- a/tests/media-schema-validation.test.ts
+++ b/tests/media-schema-validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  createAlbumSchema,
   galleryUploadIntentSchema,
   galleryUpdateMediaSchema,
   moderateMediaSchema,
@@ -163,6 +164,17 @@ describe("galleryUpdateMediaSchema", () => {
   it("accepts empty object (no fields)", () => {
     const result = galleryUpdateMediaSchema.safeParse({});
     assert.ok(result.success);
+  });
+});
+
+describe("createAlbumSchema", () => {
+  it("accepts upload draft albums in the internal create payload", () => {
+    const result = createAlbumSchema.safeParse({
+      name: "Spring Photos",
+      isUploadDraft: true,
+    });
+    assert.ok(result.success);
+    assert.equal(result.data.isUploadDraft, true);
   });
 });
 


### PR DESCRIPTION
## Summary
- fix the media page folder-upload flow so it no longer stalls on `Creating album…`
- add explicit folder album batch state handling for success, partial success, retry, and failure
- preserve the current folder batch when the upload panel closes and reopens
- start a fresh batch when a different folder is selected so prior uploads do not leak into the new album
- preserve successful uploads across album-creation failures and retry against the same album instead of starting over
- keep failed files visible with inline retry in the same upload panel
- preserve the current success behavior of opening the created album automatically

## Why
Uploading a folder as an album is already an intended media-page workflow, but the current client orchestration can get stuck in a nonterminal `Creating album…` state. It also risked duplicating album creation on panel reopen and mixing uploads across separate folder batches. This change makes the flow reach a clear end state every time, keeps batch state aligned with the upload queue lifecycle, and avoids forcing users to reupload successful files when album creation or item association fails.

## Key Decisions
- keep this as a small reliability fix, not a media UX redesign
- allow partial success: if some files upload successfully, create the album with those files
- if album creation succeeds once, reuse that album on retries instead of creating duplicates
- preserve the active folder batch across panel reopen so closing the drawer does not drop album state
- when a new folder is selected, replace the prior folder queue so media from separate batches cannot mix
- if all files fail, create no album and show a clear terminal error state
- keep the success destination as the newly opened album

## Testing
- added characterization/flow coverage for:
  - folder album batch summary and status derivation
  - replacing files for a new folder batch clears prior queue entries and completed media ids
  - clearing uploads resets queue, pending album state, and completed media ids
- ran `node --test --loader ./tests/ts-loader.js tests/gallery-upload-flow.test.ts tests/gallery-upload-state.test.ts`
- ran `npm run test`
- ran `npm run lint`
- ran `npm run build`

## Post-Deploy Monitoring & Validation
- What to monitor/search:
  - `Failed to create album`
  - `Failed to add items to album`
  - `Failed to finalize upload`
  - `[media/albums]`
  - `[media/albums/items]`
- Validation checks:
  - upload a folder with all valid files and confirm one album is created and opened
  - upload a folder with one intentionally bad file and confirm partial success plus inline retry
  - close and reopen the upload panel mid-batch and confirm the same album batch resumes without duplication
  - start a second folder upload and confirm it does not inherit media from the first folder
  - simulate album-creation failure and confirm retry does not require reuploading successful files
- Expected healthy behavior:
  - folder upload reaches a visible terminal state
  - successful uploads produce exactly one album
  - retry after album-level failure reuses the existing album instead of duplicating it
  - closing and reopening the panel does not recreate the album
- Failure signals / rollback trigger:
  - users still report indefinite `Creating album…`
  - duplicate albums created from a single folder upload
  - media from one folder appears in a later folder-created album
  - successful uploads disappear or require full reupload after album-level failure
- Validation window & owner:
  - first 24 hours after deploy
  - media upload feature owner

## Screenshots
- Not included. This change is covered by automated tests plus existing media upload UI.

## Notes
- no permission model changes
- no album-management redesign
- no API contract changes expected
