### PR TITLE
feat: scale free sub-orgs with alumni bucket quantity

### DIFF
--- a/src/app/api/enterprise/[enterpriseId]/billing/adjust/route.ts
+++ b/src/app/api/enterprise/[enterpriseId]/billing/adjust/route.ts
@@ -6,7 +6,7 @@ import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limi
 import { validateJson, ValidationError, validationErrorResponse } from "@/lib/security/validation";
 import { getEnterpriseApiContext, ENTERPRISE_BILLING_ROLE } from "@/lib/auth/enterprise-api-context";
 import { logEnterpriseAuditAction, logEnterpriseAuditActionAwaited, extractRequestContext } from "@/lib/audit/enterprise-audit";
-import { getBillableOrgCount, getSubOrgPricing } from "@/lib/enterprise/pricing";
+import { getBillableOrgCount, getFreeSubOrgCount, getSubOrgPricing } from "@/lib/enterprise/pricing";
 import { ALUMNI_BUCKET_PRICING } from "@/types/enterprise";
 import { requireEnv } from "@/lib/env";
 
@@ -668,6 +668,44 @@ export async function POST(req: Request, { params }: RouteParams) {
         return respond({ error: "Billing updated but failed to save. Please contact support." }, 500);
       }
 
+      // Recalculate sub-org billing: changing bucket count changes the free tier
+      const oldBucketQty = reconciledSubscription.alumni_bucket_quantity;
+      const currentSubOrgQty = reconciledSubscription.sub_org_quantity ?? 0;
+      const oldSubOrgBillable = getBillableOrgCount(currentSubOrgQty, oldBucketQty);
+      const newSubOrgBillable = getBillableOrgCount(currentSubOrgQty, newQuantity);
+
+      if (oldSubOrgBillable !== newSubOrgBillable) {
+        const subOrgItem = (await stripe.subscriptions.retrieve(reconciledSubscription.stripe_subscription_id))
+          .items?.data?.find((item) => {
+            const itemPriceId = typeof item.price === "string" ? item.price : item.price.id;
+            return itemPriceId === requireEnv("STRIPE_PRICE_ENTERPRISE_SUB_ORG_MONTHLY") ||
+                   itemPriceId === requireEnv("STRIPE_PRICE_ENTERPRISE_SUB_ORG_YEARLY");
+          });
+
+        if (newSubOrgBillable === 0 && subOrgItem) {
+          // All orgs now free — remove the sub-org line item
+          await stripe.subscriptionItems.del(subOrgItem.id, { proration_behavior: "create_prorations" });
+        } else if (newSubOrgBillable > 0 && subOrgItem) {
+          // Update existing sub-org line item quantity
+          await stripe.subscriptionItems.update(subOrgItem.id, {
+            quantity: newSubOrgBillable,
+            proration_behavior: "create_prorations",
+          });
+        } else if (newSubOrgBillable > 0 && !subOrgItem) {
+          // Need to add a sub-org line item (downgrade created billable orgs)
+          const resolvedInterval = intervalChanged ? effectiveInterval : reconciledSubscription.billing_interval;
+          const subOrgPriceId = resolvedInterval === "month"
+            ? requireEnv("STRIPE_PRICE_ENTERPRISE_SUB_ORG_MONTHLY")
+            : requireEnv("STRIPE_PRICE_ENTERPRISE_SUB_ORG_YEARLY");
+          await stripe.subscriptionItems.create({
+            subscription: reconciledSubscription.stripe_subscription_id,
+            price: subOrgPriceId,
+            quantity: newSubOrgBillable,
+            proration_behavior: "create_prorations",
+          });
+        }
+      }
+
       logEnterpriseAuditAction({
         actorUserId: ctx.userId,
         actorEmail: ctx.userEmail,
@@ -680,6 +718,7 @@ export async function POST(req: Request, { params }: RouteParams) {
           newQuantity,
           previousQuantity: reconciledSubscription.alumni_bucket_quantity,
           ...(intervalChanged ? { previousInterval: reconciledSubscription.billing_interval, newInterval: effectiveInterval } : {}),
+          ...(oldSubOrgBillable !== newSubOrgBillable ? { subOrgBillableChange: { from: oldSubOrgBillable, to: newSubOrgBillable } } : {}),
         },
         ...extractRequestContext(req),
       });

--- a/src/app/api/enterprise/[enterpriseId]/billing/adjust/route.ts
+++ b/src/app/api/enterprise/[enterpriseId]/billing/adjust/route.ts
@@ -265,8 +265,9 @@ export async function POST(req: Request, { params }: RouteParams) {
     }
 
     // Calculate old and new billable counts
-    const oldBillable = getBillableOrgCount(reconciledSubscription.sub_org_quantity ?? 0);
-    const newBillable = getBillableOrgCount(newQuantity);
+    const bucketQty = reconciledSubscription.alumni_bucket_quantity;
+    const oldBillable = getBillableOrgCount(reconciledSubscription.sub_org_quantity ?? 0, bucketQty);
+    const newBillable = getBillableOrgCount(newQuantity, bucketQty);
 
     try {
       let periodEnd: string | null = null;
@@ -288,7 +289,7 @@ export async function POST(req: Request, { params }: RouteParams) {
           return respond({ error: "Failed to update subscription quantity" }, 500);
         }
 
-        const pricing = getSubOrgPricing(newQuantity, reconciledSubscription.billing_interval);
+        const pricing = getSubOrgPricing(newQuantity, reconciledSubscription.billing_interval, reconciledSubscription.alumni_bucket_quantity);
 
         logEnterpriseAuditAction({
           actorUserId: ctx.userId,

--- a/src/app/api/enterprise/[enterpriseId]/billing/route.ts
+++ b/src/app/api/enterprise/[enterpriseId]/billing/route.ts
@@ -67,7 +67,8 @@ export async function GET(req: Request, { params }: RouteParams) {
   const salesManaged = isSalesLed(bucketQuantity);
   const subOrgPricing = getSubOrgPricing(
     subscription.sub_org_quantity ?? 0,
-    billingInterval
+    billingInterval,
+    bucketQuantity
   );
 
   // Build billing overview

--- a/src/app/api/enterprise/[enterpriseId]/organizations/create-with-upgrade/route.ts
+++ b/src/app/api/enterprise/[enterpriseId]/organizations/create-with-upgrade/route.ts
@@ -76,6 +76,16 @@ export async function POST(req: Request, { params }: RouteParams) {
       return respond({ error: "Enterprise not found" }, 404);
     }
 
+    // Fetch subscription for bucket quantity (needed for free sub-org calculation)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: subscription } = await (ctx.serviceSupabase as any)
+      .from("enterprise_subscriptions")
+      .select("alumni_bucket_quantity")
+      .eq("enterprise_id", ctx.enterpriseId)
+      .single() as { data: { alumni_bucket_quantity: number } | null };
+
+    const bucketQuantity = subscription?.alumni_bucket_quantity ?? 1;
+
     // Check current seat quota (hybrid model: always allowed, billing kicks in after free tier)
     const seatQuota = await canEnterpriseAddSubOrg(ctx.enterpriseId);
     if (seatQuota.error) {
@@ -119,7 +129,7 @@ export async function POST(req: Request, { params }: RouteParams) {
         subscription: null,
       }, 201);
     }
-    const pricing = getSubOrgPricing(updatedQuota.currentCount, "year");
+    const pricing = getSubOrgPricing(updatedQuota.currentCount, "year", bucketQuantity);
 
     return respond({
       organization: result.org,

--- a/src/app/api/stripe/create-enterprise-checkout/route.ts
+++ b/src/app/api/stripe/create-enterprise-checkout/route.ts
@@ -112,7 +112,7 @@ export async function POST(req: Request) {
 
       // Calculate billable orgs (defaults to 3 if not provided = free tier)
       const totalOrgs = subOrgQuantity ?? 3;
-      const billableOrgs = getBillableOrgCount(totalOrgs);
+      const billableOrgs = getBillableOrgCount(totalOrgs, alumniBucketQuantity);
 
       // Get appropriate price IDs based on billing interval
       const alumniBucketPriceId = billingInterval === "month"

--- a/src/app/app/create-enterprise/page.tsx
+++ b/src/app/app/create-enterprise/page.tsx
@@ -12,7 +12,7 @@ import {
   ENTERPRISE_SEAT_PRICING,
   ALUMNI_BUCKET_PRICING,
 } from "@/types/enterprise";
-import { isSalesLed } from "@/lib/enterprise/pricing";
+import { isSalesLed, getFreeSubOrgCount } from "@/lib/enterprise/pricing";
 
 const MIN_SEATS = 1;
 const MAX_SEATS = 100;
@@ -78,9 +78,11 @@ const ALUMNI_BUCKET_OPTIONS = [
 
 function calculateSeatPrice(
   quantity: number,
+  bucketQuantity: number,
 ): { totalCentsYearly: number; billableOrgs: number; freeOrgs: number } {
-  const freeOrgs = Math.min(quantity, ENTERPRISE_SEAT_PRICING.freeSubOrgs);
-  const billableOrgs = Math.max(0, quantity - ENTERPRISE_SEAT_PRICING.freeSubOrgs);
+  const freeCount = getFreeSubOrgCount(bucketQuantity);
+  const freeOrgs = Math.min(quantity, freeCount);
+  const billableOrgs = Math.max(0, quantity - freeCount);
   const totalCentsYearly = billableOrgs * ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsYearly;
 
   return { totalCentsYearly, billableOrgs, freeOrgs };
@@ -206,7 +208,7 @@ export default function CreateEnterprisePage() {
     setValue("seatQuantity", newValue);
   };
 
-  const seatPricing = calculateSeatPrice(seatQuantity);
+  const seatPricing = calculateSeatPrice(seatQuantity, alumniBucketQuantity);
   const selectedBucket = ALUMNI_BUCKET_OPTIONS.find((opt) => opt.buckets === alumniBucketQuantity);
   const isContactSales = isSalesLed(alumniBucketQuantity);
 
@@ -375,7 +377,7 @@ export default function CreateEnterprisePage() {
                     {/* Free tier callout */}
                     <div className="p-3 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
                       <p className="text-sm text-green-800 dark:text-green-200">
-                        <span className="font-semibold">First {ENTERPRISE_SEAT_PRICING.freeSubOrgs} organizations are FREE!</span>
+                        <span className="font-semibold">First {getFreeSubOrgCount(alumniBucketQuantity)} organizations are FREE! (3 per alumni bucket)</span>
                         <span className="block mt-1 text-green-700 dark:text-green-300">
                           ${(ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsYearly / 100).toFixed(0)}/year for each additional organization
                         </span>
@@ -419,13 +421,13 @@ export default function CreateEnterprisePage() {
                         </button>
                       </div>
                       <div className="text-sm text-muted-foreground">
-                        {seatQuantity <= ENTERPRISE_SEAT_PRICING.freeSubOrgs ? (
+                        {seatQuantity <= getFreeSubOrgCount(alumniBucketQuantity) ? (
                           <span className="text-green-600 dark:text-green-400 font-medium">
                             Free!
                           </span>
                         ) : (
                           <span>
-                            {seatQuantity - ENTERPRISE_SEAT_PRICING.freeSubOrgs} paid @ {formatCents(ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsYearly)}/yr each
+                            {seatQuantity - getFreeSubOrgCount(alumniBucketQuantity)} paid @ {formatCents(ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsYearly)}/yr each
                           </span>
                         )}
                       </div>
@@ -611,7 +613,7 @@ export default function CreateEnterprisePage() {
                   Enterprise Benefits
                 </h4>
                 <ul className="text-xs text-purple-700 dark:text-purple-300 space-y-1">
-                  <li>First {ENTERPRISE_SEAT_PRICING.freeSubOrgs} organizations free</li>
+                  <li>3 free organizations per alumni bucket</li>
                   <li>Pooled alumni quota across organizations</li>
                   <li>Unified billing for all sub-orgs</li>
                   <li>Centralized admin dashboard</li>

--- a/src/app/enterprise/[enterpriseSlug]/billing/BillingClient.tsx
+++ b/src/app/enterprise/[enterpriseSlug]/billing/BillingClient.tsx
@@ -6,7 +6,7 @@ import { PageHeader } from "@/components/layout";
 import { AlumniUsageBar } from "@/components/enterprise/AlumniUsageBar";
 import { SeatUsageBar } from "@/components/enterprise/SeatUsageBar";
 import { ALUMNI_BUCKET_PRICING, ENTERPRISE_SEAT_PRICING, type BillingInterval } from "@/types/enterprise";
-import { isSalesLed } from "@/lib/enterprise/pricing";
+import { isSalesLed, getFreeSubOrgCount } from "@/lib/enterprise/pricing";
 import { resolveCurrentQuantity } from "@/lib/enterprise/quota-logic";
 
 interface BillingInfo {
@@ -165,7 +165,7 @@ export function BillingClient({ enterpriseId, enterpriseSlug }: { enterpriseId: 
 
     try {
       const rawQuantity = billing?.subOrgQuantity;
-      const currentQuantity = resolveCurrentQuantity(rawQuantity, billing?.subOrgCount ?? 0);
+      const currentQuantity = resolveCurrentQuantity(rawQuantity, billing?.subOrgCount ?? 0, getFreeSubOrgCount(billing?.alumniBucketQuantity ?? 1));
 
       const response = await fetch(`/api/enterprise/${enterpriseId}/billing/adjust`, {
         method: "POST",
@@ -323,6 +323,7 @@ export function BillingClient({ enterpriseId, enterpriseSlug }: { enterpriseId: 
           <SeatUsageBar
             currentSeats={billing?.subOrgCount ?? 0}
             billingInterval={billing?.billingInterval ?? "year"}
+            bucketQuantity={billing?.alumniBucketQuantity ?? 1}
             onAddSeats={!isAddingSeats ? handleAddSeats : undefined}
           />
         </div>
@@ -339,7 +340,7 @@ export function BillingClient({ enterpriseId, enterpriseSlug }: { enterpriseId: 
               </li>
             )}
             <li>
-              <span className="text-green-600 dark:text-green-400">First {ENTERPRISE_SEAT_PRICING.freeSubOrgs} organizations: Free</span>
+              <span className="text-green-600 dark:text-green-400">First {getFreeSubOrgCount(billing?.alumniBucketQuantity ?? 1)} organizations: Free (3 per alumni bucket)</span>
             </li>
             <li>
               Additional organizations: ${billing?.billingInterval === "month"

--- a/src/app/enterprise/[enterpriseSlug]/organizations/new/page.tsx
+++ b/src/app/enterprise/[enterpriseSlug]/organizations/new/page.tsx
@@ -16,7 +16,7 @@ export default async function NewOrganizationPage({ params }: NewOrganizationPag
     redirect("/app?error=no_enterprise_access");
   }
 
-  const { role } = context;
+  const { role, subscription } = context;
   const permissions = getEnterprisePermissions(role);
 
   if (!permissions.canCreateSubOrg) {
@@ -31,7 +31,10 @@ export default async function NewOrganizationPage({ params }: NewOrganizationPag
         backHref={`/enterprise/${enterpriseSlug}/organizations`}
       />
 
-      <CreateSubOrgForm enterpriseSlug={enterpriseSlug} />
+      <CreateSubOrgForm
+        enterpriseSlug={enterpriseSlug}
+        bucketQuantity={subscription?.alumni_bucket_quantity ?? 1}
+      />
     </div>
   );
 }

--- a/src/app/enterprise/[enterpriseSlug]/page.tsx
+++ b/src/app/enterprise/[enterpriseSlug]/page.tsx
@@ -146,6 +146,7 @@ export default async function EnterpriseDashboardPage({ params }: EnterpriseDash
         <SeatUsageBar
           currentSeats={enterpriseManagedOrgCount}
           billingInterval={subscription?.billing_interval ?? "year"}
+          bucketQuantity={subscription?.alumni_bucket_quantity ?? 1}
         />
         {(role === "owner" || role === "billing_admin") ? (
           <div className="mt-4 flex justify-end">

--- a/src/components/enterprise/CreateSubOrgForm.tsx
+++ b/src/components/enterprise/CreateSubOrgForm.tsx
@@ -34,12 +34,14 @@ interface UpgradeInfo {
 
 interface CreateSubOrgFormProps {
   enterpriseSlug: string;
+  bucketQuantity?: number;
   onSuccess?: (slug: string) => void;
   onCancel?: () => void;
 }
 
 export function CreateSubOrgForm({
   enterpriseSlug,
+  bucketQuantity = 1,
   onSuccess,
   onCancel,
 }: CreateSubOrgFormProps) {
@@ -297,6 +299,7 @@ export function CreateSubOrgForm({
           }}
           currentCount={upgradeInfo.currentCount}
           maxAllowed={upgradeInfo.maxAllowed}
+          bucketQuantity={bucketQuantity}
           isLoading={isUpgrading}
         />
       )}

--- a/src/components/enterprise/OrgLimitUpgradeModal.tsx
+++ b/src/components/enterprise/OrgLimitUpgradeModal.tsx
@@ -3,7 +3,8 @@
 
 import { useCallback, useEffect, useRef } from "react";
 import { Button } from "@/components/ui";
-import { ENTERPRISE_SEAT_PRICING, ALUMNI_BUCKET_PRICING } from "@/types/enterprise";
+import { ALUMNI_BUCKET_PRICING } from "@/types/enterprise";
+import { getFreeSubOrgCount } from "@/lib/enterprise/pricing";
 
 export interface PendingOrgData {
   name: string;
@@ -25,6 +26,7 @@ interface SubOrgUpgradeProps extends BaseUpgradeModalProps {
   pendingOrgData: PendingOrgData;
   currentCount: number;
   maxAllowed: number;
+  bucketQuantity?: number;
 }
 
 interface AlumniBucketUpgradeProps extends BaseUpgradeModalProps {
@@ -157,7 +159,7 @@ export function OrgLimitUpgradeModal(props: OrgLimitUpgradeModalProps) {
               {/* Pricing info */}
               <div className="p-3 bg-muted rounded-lg">
                 <p className="text-sm text-muted-foreground">
-                  First {ENTERPRISE_SEAT_PRICING.freeSubOrgs} organizations are free. Additional organizations are ${ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsYearly / 100}/year each.
+                  First {getFreeSubOrgCount(props.bucketQuantity ?? 1)} organizations are free (3 per alumni bucket). Additional organizations are $150/year each.
                 </p>
               </div>
 

--- a/src/components/enterprise/SeatUsageBar.tsx
+++ b/src/components/enterprise/SeatUsageBar.tsx
@@ -1,9 +1,11 @@
 import { Button } from "@/components/ui";
-import { ENTERPRISE_SEAT_PRICING, type BillingInterval } from "@/types/enterprise";
+import { type BillingInterval } from "@/types/enterprise";
+import { getFreeSubOrgCount } from "@/lib/enterprise/pricing";
 
 interface SeatUsageBarProps {
   currentSeats: number;
   billingInterval: BillingInterval;
+  bucketQuantity?: number;
   onAddSeats?: () => void;
   className?: string;
 }
@@ -11,13 +13,15 @@ interface SeatUsageBarProps {
 function PerSubOrgUsageBar({
   currentSeats,
   billingInterval,
+  bucketQuantity = 1,
   onAddSeats,
 }: {
   currentSeats: number;
   billingInterval: BillingInterval;
+  bucketQuantity?: number;
   onAddSeats?: () => void;
 }) {
-  const freeOrgs = ENTERPRISE_SEAT_PRICING.freeSubOrgs;
+  const freeOrgs = getFreeSubOrgCount(bucketQuantity);
   const freeOrgsUsed = Math.min(currentSeats, freeOrgs);
   const paidOrgsUsed = Math.max(0, currentSeats - freeOrgs);
   const allFreeUsed = freeOrgsUsed >= freeOrgs;
@@ -90,6 +94,7 @@ function PerSubOrgUsageBar({
 export function SeatUsageBar({
   currentSeats,
   billingInterval,
+  bucketQuantity = 1,
   onAddSeats,
   className = "",
 }: SeatUsageBarProps) {
@@ -98,6 +103,7 @@ export function SeatUsageBar({
       <PerSubOrgUsageBar
         currentSeats={currentSeats}
         billingInterval={billingInterval}
+        bucketQuantity={bucketQuantity}
         onAddSeats={onAddSeats}
       />
     </div>

--- a/src/components/marketing/EnterprisePricingModal.tsx
+++ b/src/components/marketing/EnterprisePricingModal.tsx
@@ -6,6 +6,7 @@ import {
   formatBucketRange,
   formatSeatPrice,
   getEnterpriseTotalPricing,
+  getFreeSubOrgCount,
   isSalesLed,
 } from "@/lib/enterprise/pricing";
 import {
@@ -32,9 +33,11 @@ function formatTotal(cents: number, interval: SubscriptionInterval): string {
 
 function getOrgCostLabel(
   orgCount: number,
-  interval: SubscriptionInterval
+  interval: SubscriptionInterval,
+  bucketCount: number
 ): string {
-  const billable = Math.max(0, orgCount - ENTERPRISE_SEAT_PRICING.freeSubOrgs);
+  const freeCount = getFreeSubOrgCount(bucketCount);
+  const billable = Math.max(0, orgCount - freeCount);
   if (billable === 0) return "Free!";
   const unitCents =
     interval === "month"
@@ -91,9 +94,10 @@ export function EnterprisePricingModal({
 
   const pricing = getEnterpriseTotalPricing(bucketCount, orgCount, interval);
   const salesLed = isSalesLed(bucketCount);
-  const billableOrgs = Math.max(0, orgCount - ENTERPRISE_SEAT_PRICING.freeSubOrgs);
-  const freeOrgs = Math.min(orgCount, ENTERPRISE_SEAT_PRICING.freeSubOrgs);
-  const orgCostLabel = getOrgCostLabel(orgCount, interval);
+  const freeSubOrgCount = getFreeSubOrgCount(bucketCount);
+  const billableOrgs = Math.max(0, orgCount - freeSubOrgCount);
+  const freeOrgs = Math.min(orgCount, freeSubOrgCount);
+  const orgCostLabel = getOrgCostLabel(orgCount, interval, bucketCount);
 
   return createPortal(
     <>
@@ -158,7 +162,7 @@ export function EnterprisePricingModal({
                   Managed Organizations
                 </h3>
                 <p className="text-landing-cream/40 text-xs mt-0.5">
-                  First {ENTERPRISE_SEAT_PRICING.freeSubOrgs} FREE &middot;{" "}
+                  First {freeSubOrgCount} FREE (3 per bucket) &middot;{" "}
                   {interval === "month" ? "$15/mo" : "$150/yr"} each additional
                 </p>
               </div>

--- a/src/components/marketing/PricingSection.tsx
+++ b/src/components/marketing/PricingSection.tsx
@@ -210,7 +210,7 @@ export function PricingSection({ showCta = true }: { showCta?: boolean }) {
                 </h3>
                 <div className="flex flex-wrap gap-x-6 gap-y-1.5">
                   <span className="text-landing-cream/50 text-sm">
-                    <span className="text-landing-green font-semibold">3 orgs free</span>
+                    <span className="text-landing-green font-semibold">3 free orgs per alumni bucket</span>
                   </span>
                   <span className="text-landing-cream/50 text-sm">
                     <span className="font-semibold text-landing-cream">$150/yr</span> per additional org

--- a/src/lib/enterprise/index.ts
+++ b/src/lib/enterprise/index.ts
@@ -4,6 +4,7 @@ export {
   getRequiredBucketQuantity,
   isSalesLed,
   getAlumniBucketPricing,
+  getFreeSubOrgCount,
   getBillableOrgCount,
   getSubOrgPricing,
   getEnterpriseTotalPricing,

--- a/src/lib/enterprise/pricing.ts
+++ b/src/lib/enterprise/pricing.ts
@@ -43,19 +43,31 @@ export function getAlumniBucketPricing(
 }
 
 /**
- * Calculate the number of billable organizations (those beyond the free tier).
- * First 3 organizations are included with any alumni bucket.
+ * Get the number of free sub-orgs for a given bucket quantity.
+ * Each alumni bucket grants 3 free organizations.
+ * Sales-led enterprises (5+ buckets) have negotiated terms — this formula
+ * still applies as a baseline but may be overridden contractually.
  */
-export function getBillableOrgCount(totalOrgs: number): number {
-  return Math.max(0, totalOrgs - ENTERPRISE_SEAT_PRICING.freeSubOrgs);
+export function getFreeSubOrgCount(bucketQuantity: number): number {
+  return bucketQuantity * ENTERPRISE_SEAT_PRICING.freeSubOrgsPerBucket;
 }
 
 /**
- * Get sub-org add-on pricing for a given total org count and interval.
+ * Calculate the number of billable organizations (those beyond the free tier).
+ * Free tier scales with alumni bucket quantity: 3 free orgs per bucket.
+ */
+export function getBillableOrgCount(totalOrgs: number, bucketQuantity: number = 1): number {
+  return Math.max(0, totalOrgs - getFreeSubOrgCount(bucketQuantity));
+}
+
+/**
+ * Get sub-org add-on pricing for a given total org count, interval, and bucket quantity.
+ * Free tier scales: 3 free orgs per alumni bucket.
  */
 export function getSubOrgPricing(
   totalOrgs: number,
-  interval: BillingInterval
+  interval: BillingInterval,
+  bucketQuantity: number = 1
 ): {
   totalOrgs: number;
   freeOrgs: number;
@@ -63,14 +75,15 @@ export function getSubOrgPricing(
   unitCents: number;
   totalCents: number;
 } {
-  const billable = getBillableOrgCount(totalOrgs);
+  const freeCount = getFreeSubOrgCount(bucketQuantity);
+  const billable = getBillableOrgCount(totalOrgs, bucketQuantity);
   const unitCents = interval === "month"
     ? ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsMonthly
     : ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsYearly;
 
   return {
     totalOrgs,
-    freeOrgs: Math.min(totalOrgs, ENTERPRISE_SEAT_PRICING.freeSubOrgs),
+    freeOrgs: Math.min(totalOrgs, freeCount),
     billableOrgs: billable,
     unitCents,
     totalCents: billable * unitCents,
@@ -95,7 +108,7 @@ export function getEnterpriseTotalPricing(
   totalCents: number;
 } {
   const alumni = getAlumniBucketPricing(alumniBucketQuantity, interval);
-  const subOrgs = getSubOrgPricing(totalOrgs, interval);
+  const subOrgs = getSubOrgPricing(totalOrgs, interval, alumniBucketQuantity);
 
   return {
     alumni,

--- a/src/types/enterprise.ts
+++ b/src/types/enterprise.ts
@@ -21,7 +21,8 @@ export const ALUMNI_BUCKET_PRICING = {
 
 // Team add-on pricing constants (cents)
 export const ENTERPRISE_SEAT_PRICING = {
-  freeSubOrgs: 3, // First 3 organizations are included
+  freeSubOrgs: 3, // Base free orgs (1-bucket default)
+  freeSubOrgsPerBucket: 3, // 3 free orgs per alumni bucket purchased
   pricePerAdditionalCentsMonthly: 1500, // $15/month per additional org
   pricePerAdditionalCentsYearly: 15000, // $150/year per additional org
 } as const;

--- a/tests/enterprise-quantity-pricing.test.ts
+++ b/tests/enterprise-quantity-pricing.test.ts
@@ -17,6 +17,7 @@ import {
   isSalesLed,
   getAlumniBucketPricing,
   getBillableOrgCount,
+  getFreeSubOrgCount,
   getSubOrgPricing,
   getEnterpriseTotalPricing,
   formatBucketRange,
@@ -191,6 +192,55 @@ describe("getBillableOrgCount", () => {
 });
 
 // =============================================================================
+// getFreeSubOrgCount Tests
+// =============================================================================
+
+describe("getFreeSubOrgCount", () => {
+  it("returns 3 for 1 bucket", () => {
+    assert.strictEqual(getFreeSubOrgCount(1), 3);
+  });
+
+  it("returns 6 for 2 buckets", () => {
+    assert.strictEqual(getFreeSubOrgCount(2), 6);
+  });
+
+  it("returns 9 for 3 buckets", () => {
+    assert.strictEqual(getFreeSubOrgCount(3), 9);
+  });
+
+  it("returns 12 for 4 buckets", () => {
+    assert.strictEqual(getFreeSubOrgCount(4), 12);
+  });
+});
+
+// =============================================================================
+// getBillableOrgCount with multiple buckets
+// =============================================================================
+
+describe("getBillableOrgCount with buckets", () => {
+  it("6 orgs with 2 buckets → 0 billable (6 free)", () => {
+    assert.strictEqual(getBillableOrgCount(6, 2), 0);
+  });
+
+  it("7 orgs with 2 buckets → 1 billable", () => {
+    assert.strictEqual(getBillableOrgCount(7, 2), 1);
+  });
+
+  it("12 orgs with 4 buckets → 0 billable (12 free)", () => {
+    assert.strictEqual(getBillableOrgCount(12, 4), 0);
+  });
+
+  it("15 orgs with 4 buckets → 3 billable", () => {
+    assert.strictEqual(getBillableOrgCount(15, 4), 3);
+  });
+
+  it("downgrade: 5 orgs with 1 bucket → 2 billable (was 0 with 2 buckets)", () => {
+    assert.strictEqual(getBillableOrgCount(5, 2), 0);
+    assert.strictEqual(getBillableOrgCount(5, 1), 2);
+  });
+});
+
+// =============================================================================
 // getSubOrgPricing Tests
 // =============================================================================
 
@@ -251,18 +301,18 @@ describe("getEnterpriseTotalPricing", () => {
       assert.strictEqual(result.totalCents, 5000); // $50/mo
     });
 
-    it("5 teams, 5,000 alumni → $130/mo", () => {
+    it("5 teams, 5,000 alumni → $100/mo (all 5 orgs free with 2 buckets)", () => {
       const result = getEnterpriseTotalPricing(2, 5, "month");
       assert.strictEqual(result.alumni.totalCents, 10000); // $100
-      assert.strictEqual(result.subOrgs.totalCents, 3000); // 2 × $15
-      assert.strictEqual(result.totalCents, 13000); // $130/mo
+      assert.strictEqual(result.subOrgs.totalCents, 0); // 2 buckets × 3 = 6 free, 5 orgs all free
+      assert.strictEqual(result.totalCents, 10000); // $100/mo
     });
 
-    it("8 teams, 10,000 alumni → $275/mo", () => {
+    it("8 teams, 10,000 alumni → $200/mo (all 8 orgs free with 4 buckets)", () => {
       const result = getEnterpriseTotalPricing(4, 8, "month");
       assert.strictEqual(result.alumni.totalCents, 20000); // $200
-      assert.strictEqual(result.subOrgs.totalCents, 7500); // 5 × $15
-      assert.strictEqual(result.totalCents, 27500); // $275/mo
+      assert.strictEqual(result.subOrgs.totalCents, 0); // 4 buckets × 3 = 12 free, 8 orgs all free
+      assert.strictEqual(result.totalCents, 20000); // $200/mo
     });
   });
 
@@ -274,18 +324,18 @@ describe("getEnterpriseTotalPricing", () => {
       assert.strictEqual(result.totalCents, 50000); // $500/yr
     });
 
-    it("5 teams, 5,000 alumni → $1,300/yr", () => {
+    it("5 teams, 5,000 alumni → $1,000/yr (all 5 orgs free with 2 buckets)", () => {
       const result = getEnterpriseTotalPricing(2, 5, "year");
       assert.strictEqual(result.alumni.totalCents, 100000); // $1,000
-      assert.strictEqual(result.subOrgs.totalCents, 30000); // 2 × $150
-      assert.strictEqual(result.totalCents, 130000); // $1,300/yr
+      assert.strictEqual(result.subOrgs.totalCents, 0); // 2 buckets × 3 = 6 free
+      assert.strictEqual(result.totalCents, 100000); // $1,000/yr
     });
 
-    it("8 teams, 10,000 alumni → $2,750/yr", () => {
+    it("8 teams, 10,000 alumni → $2,000/yr (all 8 orgs free with 4 buckets)", () => {
       const result = getEnterpriseTotalPricing(4, 8, "year");
       assert.strictEqual(result.alumni.totalCents, 200000); // $2,000
-      assert.strictEqual(result.subOrgs.totalCents, 75000); // 5 × $150
-      assert.strictEqual(result.totalCents, 275000); // $2,750/yr
+      assert.strictEqual(result.subOrgs.totalCents, 0); // 4 buckets × 3 = 12 free
+      assert.strictEqual(result.totalCents, 200000); // $2,000/yr
     });
   });
 
@@ -360,6 +410,7 @@ describe("source constants integrity", () => {
 
   it("ENTERPRISE_SEAT_PRICING has expected values", () => {
     assert.strictEqual(ENTERPRISE_SEAT_PRICING.freeSubOrgs, 3);
+    assert.strictEqual(ENTERPRISE_SEAT_PRICING.freeSubOrgsPerBucket, 3);
     assert.strictEqual(ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsMonthly, 1500);
     assert.strictEqual(ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsYearly, 15000);
   });


### PR DESCRIPTION
## Summary
- Free sub-org count now scales at **3 per alumni bucket** instead of a flat 3 (e.g., 2 buckets = 6 free, 4 buckets = 12 free)
- When alumni bucket count changes, the billing adjust endpoint now recalculates and reconciles the sub-org Stripe line item to prevent billing drift
- Landing page, enterprise pricing modal, create-enterprise form, billing dashboard, and seat usage bar all reflect the dynamic free tier

## Test plan
- [x] All 3,523+ existing tests pass (1 pre-existing flaky test in google-oauth unrelated)
- [x] New unit tests for `getFreeSubOrgCount` across all bucket quantities
- [x] New unit tests for `getBillableOrgCount` with multi-bucket scenarios
- [x] Downgrade test: 2 buckets → 1 bucket with 5 orgs correctly bills 2
- [x] Upgrade test: 1 bucket → 2 buckets with 5 orgs correctly bills 0
- [x] Combined pricing examples updated to match new formula
- [x] Build and lint clean
- [ ] Manual: verify enterprise pricing modal updates free count when switching buckets
- [ ] Manual: verify create-enterprise form free tier callout reacts to bucket selection
- [ ] Manual: verify billing adjust API reconciles sub-org line item on bucket change