### PR TITLE
perf(media): reduce storage egress with longer cache + batch signing

### DIFF
--- a/scripts/backfill-previews.mjs
+++ b/scripts/backfill-previews.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+/**
+ * Backfill preview images for media_items missing preview_storage_path.
+ *
+ * Downloads originals from Supabase Storage, resizes to 1024px max dimension
+ * at 82% JPEG quality, uploads the preview, and updates the DB row.
+ *
+ * Usage: node scripts/backfill-previews.mjs [--dry-run]
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import sharp from "sharp";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  console.error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const BUCKET = "org-media";
+const PREVIEW_MAX_EDGE = 1024;
+const JPEG_QUALITY = 82;
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+async function fetchImagesMissingPreviews() {
+  const { data, error } = await supabase
+    .from("media_items")
+    .select("id, storage_path, mime_type")
+    .is("deleted_at", null)
+    .eq("media_type", "image")
+    .is("preview_storage_path", null)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`Query failed: ${error.message}`);
+  }
+
+  return data ?? [];
+}
+
+function buildPreviewPath(storagePath) {
+  return `${storagePath.replace(/\.[^.]+$/, "")}-preview.jpg`;
+}
+
+async function processItem(item) {
+  const { id, storage_path } = item;
+  const previewPath = buildPreviewPath(storage_path);
+
+  // Download original
+  const { data: downloadData, error: downloadError } = await supabase.storage
+    .from(BUCKET)
+    .download(storage_path);
+
+  if (downloadError || !downloadData) {
+    console.error(`  SKIP ${id}: download failed — ${downloadError?.message ?? "no data"}`);
+    return { id, status: "download_failed" };
+  }
+
+  // Resize with sharp
+  const buffer = Buffer.from(await downloadData.arrayBuffer());
+  let previewBuffer;
+  try {
+    previewBuffer = await sharp(buffer)
+      .resize(PREVIEW_MAX_EDGE, PREVIEW_MAX_EDGE, { fit: "inside", withoutEnlargement: true })
+      .jpeg({ quality: JPEG_QUALITY })
+      .toBuffer();
+  } catch (err) {
+    console.error(`  SKIP ${id}: resize failed — ${err.message}`);
+    return { id, status: "resize_failed" };
+  }
+
+  if (DRY_RUN) {
+    const savings = ((1 - previewBuffer.length / buffer.length) * 100).toFixed(1);
+    console.log(`  DRY RUN ${id}: ${storage_path} → ${previewPath} (${savings}% smaller)`);
+    return { id, status: "dry_run" };
+  }
+
+  // Upload preview
+  const { error: uploadError } = await supabase.storage
+    .from(BUCKET)
+    .upload(previewPath, previewBuffer, {
+      contentType: "image/jpeg",
+      upsert: false,
+    });
+
+  if (uploadError) {
+    // If preview already exists in storage, still update the DB
+    if (!uploadError.message?.includes("already exists")) {
+      console.error(`  SKIP ${id}: upload failed — ${uploadError.message}`);
+      return { id, status: "upload_failed" };
+    }
+    console.log(`  ${id}: preview already in storage, updating DB pointer`);
+  }
+
+  // Update DB row
+  const { error: updateError } = await supabase
+    .from("media_items")
+    .update({ preview_storage_path: previewPath })
+    .eq("id", id);
+
+  if (updateError) {
+    console.error(`  SKIP ${id}: DB update failed — ${updateError.message}`);
+    return { id, status: "update_failed" };
+  }
+
+  const savings = ((1 - previewBuffer.length / buffer.length) * 100).toFixed(1);
+  console.log(`  OK ${id}: ${previewPath} (${savings}% smaller)`);
+  return { id, status: "ok" };
+}
+
+async function main() {
+  console.log(`Backfill previews${DRY_RUN ? " (DRY RUN)" : ""}\n`);
+
+  const items = await fetchImagesMissingPreviews();
+  console.log(`Found ${items.length} images missing previews\n`);
+
+  if (items.length === 0) return;
+
+  const results = [];
+  for (const item of items) {
+    const result = await processItem(item);
+    results.push(result);
+  }
+
+  const counts = results.reduce((acc, r) => {
+    acc[r.status] = (acc[r.status] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  console.log(`\nResults:`, counts);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/backfill-previews.mjs
+++ b/scripts/backfill-previews.mjs
@@ -6,7 +6,8 @@
  * Downloads originals from Supabase Storage, resizes to 1024px max dimension
  * at 82% JPEG quality, uploads the preview, and updates the DB row.
  *
- * Usage: node scripts/backfill-previews.mjs [--dry-run]
+ * Prerequisites: npm install --no-save sharp
+ * Usage: node --env-file=.env.local scripts/backfill-previews.mjs [--dry-run]
  */
 
 import { createClient } from "@supabase/supabase-js";
@@ -27,20 +28,34 @@ const JPEG_QUALITY = 82;
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
-async function fetchImagesMissingPreviews() {
-  const { data, error } = await supabase
-    .from("media_items")
-    .select("id, storage_path, mime_type")
-    .is("deleted_at", null)
-    .eq("media_type", "image")
-    .is("preview_storage_path", null)
-    .order("created_at", { ascending: true });
+const PAGE_SIZE = 100;
 
-  if (error) {
-    throw new Error(`Query failed: ${error.message}`);
+async function fetchImagesMissingPreviews() {
+  const allRows = [];
+  let offset = 0;
+
+  while (true) {
+    const { data, error } = await supabase
+      .from("media_items")
+      .select("id, storage_path, mime_type")
+      .is("deleted_at", null)
+      .eq("media_type", "image")
+      .is("preview_storage_path", null)
+      .order("created_at", { ascending: true })
+      .range(offset, offset + PAGE_SIZE - 1);
+
+    if (error) {
+      throw new Error(`Query failed: ${error.message}`);
+    }
+
+    const rows = data ?? [];
+    allRows.push(...rows);
+
+    if (rows.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
   }
 
-  return data ?? [];
+  return allRows;
 }
 
 function buildPreviewPath(storagePath) {
@@ -89,8 +104,11 @@ async function processItem(item) {
     });
 
   if (uploadError) {
-    // If preview already exists in storage, still update the DB
-    if (!uploadError.message?.includes("already exists")) {
+    // 409 = file already exists in storage — still update the DB pointer
+    const isConflict =
+      uploadError.statusCode === "409" || uploadError.statusCode === 409 ||
+      uploadError.message?.includes("already exists");
+    if (!isConflict) {
       console.error(`  SKIP ${id}: upload failed — ${uploadError.message}`);
       return { id, status: "upload_failed" };
     }

--- a/src/lib/media/urls.ts
+++ b/src/lib/media/urls.ts
@@ -1,5 +1,9 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
+// 24-hour signed URLs + 2-hour browser cache reduce storage egress significantly.
+// Tradeoff: a revoked member or moderated image stays accessible via cached/signed
+// URLs for up to 24h. Acceptable because auth is checked at the API layer before
+// URLs are issued, and the bucket is private (not publicly accessible).
 const SIGNED_URL_EXPIRY = 86400;
 const BUCKET = "org-media";
 
@@ -66,6 +70,7 @@ export async function batchGetMediaBrowseUrls(
     .createSignedUrls(paths, SIGNED_URL_EXPIRY);
 
   if (error || !data) {
+    console.error("createSignedUrls failed (browse):", error?.message);
     for (const m of media) {
       results.set(m.id, { thumbnailUrl: null });
     }
@@ -93,7 +98,7 @@ export async function batchGetGridPreviewUrls(
 ): Promise<Map<string, GridPreviewUrlResult>> {
   const results = new Map<string, GridPreviewUrlResult>();
 
-  const images: Array<{ index: number; id: string; path: string }> = [];
+  const images: Array<{ id: string; path: string }> = [];
 
   for (let i = 0; i < media.length; i++) {
     const m = media[i];
@@ -101,7 +106,7 @@ export async function batchGetGridPreviewUrls(
     if (isVideo) {
       results.set(m.id, { thumbnailUrl: null });
     } else {
-      images.push({ index: i, id: m.id, path: m.preview_storage_path ?? m.storage_path });
+      images.push({ id: m.id, path: m.preview_storage_path ?? m.storage_path });
     }
   }
 
@@ -114,6 +119,7 @@ export async function batchGetGridPreviewUrls(
     .createSignedUrls(paths, SIGNED_URL_EXPIRY);
 
   if (error || !data) {
+    console.error("createSignedUrls failed (grid):", error?.message);
     for (const img of images) {
       results.set(img.id, { thumbnailUrl: null });
     }

--- a/src/lib/media/urls.ts
+++ b/src/lib/media/urls.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-const SIGNED_URL_EXPIRY = 3600;
+const SIGNED_URL_EXPIRY = 86400;
 const BUCKET = "org-media";
 
 // Keep cached responses comfortably shorter than the signed URL lifetime so
@@ -57,18 +57,25 @@ export async function batchGetMediaBrowseUrls(
 ): Promise<Map<string, GridPreviewUrlResult>> {
   const results = new Map<string, GridPreviewUrlResult>();
 
-  const entries = await Promise.all(
-    media.map(async (m) => {
-      const previewUrl = await signStoragePath(
-        serviceClient,
-        m.preview_storage_path ?? m.storage_path,
-      );
-      return [m.id, { thumbnailUrl: previewUrl }] as const;
-    }),
-  );
+  if (media.length === 0) return results;
 
-  for (const [id, urls] of entries) {
-    results.set(id, urls);
+  const paths = media.map((m) => m.preview_storage_path ?? m.storage_path);
+
+  const { data, error } = await serviceClient.storage
+    .from(BUCKET)
+    .createSignedUrls(paths, SIGNED_URL_EXPIRY);
+
+  if (error || !data) {
+    for (const m of media) {
+      results.set(m.id, { thumbnailUrl: null });
+    }
+    return results;
+  }
+
+  for (let i = 0; i < media.length; i++) {
+    const item = data[i];
+    const url = item?.error ? null : (item?.signedUrl ?? null);
+    results.set(media[i].id, { thumbnailUrl: url });
   }
 
   return results;
@@ -86,24 +93,37 @@ export async function batchGetGridPreviewUrls(
 ): Promise<Map<string, GridPreviewUrlResult>> {
   const results = new Map<string, GridPreviewUrlResult>();
 
-  const entries = await Promise.all(
-    media.map(async (m) => {
-      const isVideo = m.media_type === "video" || m.mime_type.startsWith("video/");
-      if (isVideo) {
-        return [m.id, { thumbnailUrl: null }] as const;
-      }
+  const images: Array<{ index: number; id: string; path: string }> = [];
 
-      const previewUrl = await signStoragePath(
-        serviceClient,
-        m.preview_storage_path ?? m.storage_path,
-      );
+  for (let i = 0; i < media.length; i++) {
+    const m = media[i];
+    const isVideo = m.media_type === "video" || m.mime_type.startsWith("video/");
+    if (isVideo) {
+      results.set(m.id, { thumbnailUrl: null });
+    } else {
+      images.push({ index: i, id: m.id, path: m.preview_storage_path ?? m.storage_path });
+    }
+  }
 
-      return [m.id, { thumbnailUrl: previewUrl }] as const;
-    }),
-  );
+  if (images.length === 0) return results;
 
-  for (const [id, urls] of entries) {
-    results.set(id, urls);
+  const paths = images.map((img) => img.path);
+
+  const { data, error } = await serviceClient.storage
+    .from(BUCKET)
+    .createSignedUrls(paths, SIGNED_URL_EXPIRY);
+
+  if (error || !data) {
+    for (const img of images) {
+      results.set(img.id, { thumbnailUrl: null });
+    }
+    return results;
+  }
+
+  for (let i = 0; i < images.length; i++) {
+    const item = data[i];
+    const url = item?.error ? null : (item?.signedUrl ?? null);
+    results.set(images[i].id, { thumbnailUrl: url });
   }
 
   return results;

--- a/tests/media-grid-urls.test.ts
+++ b/tests/media-grid-urls.test.ts
@@ -9,6 +9,7 @@ import { getCardDisplayUrl } from "@/lib/media/display-url";
 
 function createMockClient() {
   const calls: string[] = [];
+  const batchCalls: string[][] = [];
   const mockClient = {
     storage: {
       from: () => ({
@@ -16,16 +17,23 @@ function createMockClient() {
           calls.push(path);
           return { data: { signedUrl: `https://example.com/${path}` } };
         },
+        createSignedUrls: async (paths: string[]) => {
+          batchCalls.push(paths);
+          return {
+            data: paths.map((p) => ({ path: p, signedUrl: `https://example.com/${p}`, error: null })),
+            error: null,
+          };
+        },
       }),
     },
   };
 
-  return { calls, mockClient };
+  return { calls, batchCalls, mockClient };
 }
 
 describe("batchGetGridPreviewUrls", () => {
   it("uses stored preview assets for images and skips video originals", async () => {
-    const { calls, mockClient } = createMockClient();
+    const { batchCalls, mockClient } = createMockClient();
 
     const map = await batchGetGridPreviewUrls(mockClient as never, [
       {
@@ -38,32 +46,58 @@ describe("batchGetGridPreviewUrls", () => {
       { id: "b", storage_path: "o/v/1.mp4", mime_type: "video/mp4", media_type: "video" },
     ]);
 
-    assert.deepEqual(calls, ["o/i/1-preview.jpg"]);
+    assert.equal(batchCalls.length, 1);
+    assert.deepEqual(batchCalls[0], ["o/i/1-preview.jpg"]);
     assert.equal(map.get("a")?.thumbnailUrl, "https://example.com/o/i/1-preview.jpg");
     assert.equal(map.get("b")?.thumbnailUrl, null);
+  });
+
+  it("makes exactly 1 batch call for multiple images", async () => {
+    const { batchCalls, mockClient } = createMockClient();
+
+    const media = Array.from({ length: 5 }, (_, i) => ({
+      id: `img-${i}`,
+      storage_path: `o/i/${i}.jpg`,
+      preview_storage_path: `o/i/${i}-preview.jpg`,
+      mime_type: "image/jpeg" as const,
+      media_type: "image" as const,
+    }));
+
+    const map = await batchGetGridPreviewUrls(mockClient as never, media);
+
+    assert.equal(batchCalls.length, 1, "should make exactly 1 batch SDK call");
+    assert.equal(batchCalls[0].length, 5, "batch call should contain all 5 paths");
+    for (let i = 0; i < 5; i++) {
+      assert.equal(
+        map.get(`img-${i}`)?.thumbnailUrl,
+        `https://example.com/o/i/${i}-preview.jpg`,
+      );
+    }
   });
 });
 
 describe("batchGetMediaBrowseUrls", () => {
   it("does not sign originals when a preview path exists", async () => {
-    const { calls, mockClient } = createMockClient();
+    const { batchCalls, mockClient } = createMockClient();
 
     const map = await batchGetMediaBrowseUrls(mockClient as never, [
       { id: "browse-1", storage_path: "feed/full.jpg", preview_storage_path: "feed/preview.jpg" },
     ]);
 
-    assert.deepEqual(calls, ["feed/preview.jpg"]);
+    assert.equal(batchCalls.length, 1);
+    assert.deepEqual(batchCalls[0], ["feed/preview.jpg"]);
     assert.equal(map.get("browse-1")?.thumbnailUrl, "https://example.com/feed/preview.jpg");
   });
 
   it("falls back to the original path for older rows without stored previews", async () => {
-    const { calls, mockClient } = createMockClient();
+    const { batchCalls, mockClient } = createMockClient();
 
     const map = await batchGetMediaBrowseUrls(mockClient as never, [
       { id: "browse-2", storage_path: "feed/legacy.jpg" },
     ]);
 
-    assert.deepEqual(calls, ["feed/legacy.jpg"]);
+    assert.equal(batchCalls.length, 1);
+    assert.deepEqual(batchCalls[0], ["feed/legacy.jpg"]);
     assert.equal(map.get("browse-2")?.thumbnailUrl, "https://example.com/feed/legacy.jpg");
   });
 });

--- a/tests/media-grid-urls.test.ts
+++ b/tests/media-grid-urls.test.ts
@@ -52,6 +52,24 @@ describe("batchGetGridPreviewUrls", () => {
     assert.equal(map.get("b")?.thumbnailUrl, null);
   });
 
+  it("returns null thumbnails when createSignedUrls fails", async () => {
+    const errorClient = {
+      storage: {
+        from: () => ({
+          createSignedUrls: async () => ({ data: null, error: { message: "storage down" } }),
+        }),
+      },
+    };
+
+    const map = await batchGetGridPreviewUrls(errorClient as never, [
+      { id: "err-a", storage_path: "o/i/1.jpg", mime_type: "image/jpeg", media_type: "image" as const },
+      { id: "err-b", storage_path: "o/i/2.jpg", mime_type: "image/jpeg", media_type: "image" as const },
+    ]);
+
+    assert.equal(map.get("err-a")?.thumbnailUrl, null);
+    assert.equal(map.get("err-b")?.thumbnailUrl, null);
+  });
+
   it("makes exactly 1 batch call for multiple images", async () => {
     const { batchCalls, mockClient } = createMockClient();
 
@@ -99,6 +117,24 @@ describe("batchGetMediaBrowseUrls", () => {
     assert.equal(batchCalls.length, 1);
     assert.deepEqual(batchCalls[0], ["feed/legacy.jpg"]);
     assert.equal(map.get("browse-2")?.thumbnailUrl, "https://example.com/feed/legacy.jpg");
+  });
+
+  it("returns null thumbnails when createSignedUrls fails", async () => {
+    const errorClient = {
+      storage: {
+        from: () => ({
+          createSignedUrls: async () => ({ data: null, error: { message: "storage down" } }),
+        }),
+      },
+    };
+
+    const map = await batchGetMediaBrowseUrls(errorClient as never, [
+      { id: "err-1", storage_path: "feed/a.jpg" },
+      { id: "err-2", storage_path: "feed/b.jpg" },
+    ]);
+
+    assert.equal(map.get("err-1")?.thumbnailUrl, null);
+    assert.equal(map.get("err-2")?.thumbnailUrl, null);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Signed URL expiry**: 1h → 24h; browser cache TTL: 5min → 2h (auto-computed via `SIGNED_URL_EXPIRY / 12`)
- **Batch signing**: `batchGetGridPreviewUrls` and `batchGetMediaBrowseUrls` now use a single `createSignedUrls` SDK call instead of N individual `createSignedUrl` calls per page load
- **Detail views unchanged**: `getMediaUrls` still signs 2 paths via `Promise.all` (not worth batching)

## Motivation

On Supabase Free Plan (5 GB uncached egress/mo). Every gallery view was generating N fresh signed URLs with 5-minute cache. This compounds into unnecessary egress and API overhead.

## Phase 3 Audit Results

| Table | Total Images | Missing Preview | % |
|---|---|---|---|
| `media_items` | 119 | 59 | 50% |
| `media_uploads` | 8 | 8 | 100% |

Preview backfill is a follow-up candidate to further reduce egress on legacy rows.

## Test plan

- [x] `tests/media-grid-urls.test.ts` — 6 tests pass (including new batch-count regression test)
- [x] `tests/media-review-regressions.test.ts` — 10 tests pass (formula assertion unchanged)
- [x] Full suite: 3722 tests pass, 0 failures
- [x] Lint clean
- [ ] Manual: verify gallery loads signed URLs in browser Network tab
- [ ] Monitor Supabase egress dashboard over next 48h