### PR TITLE
fix: add runtime safety guards for 7 as-any cast bugs

### DIFF
--- a/src/app/api/enterprise/[enterpriseId]/alumni/stats/route.ts
+++ b/src/app/api/enterprise/[enterpriseId]/alumni/stats/route.ts
@@ -53,7 +53,7 @@ export async function GET(req: Request, { params }: RouteParams) {
 
   return respond({
     totalCount: statsResult.total_count,
-    orgStats: statsResult.org_stats.map(({ name, count }) => ({ name, count })),
+    orgStats: (statsResult.org_stats ?? []).map(({ name, count }) => ({ name, count })),
     topIndustries: statsResult.top_industries,
     organizations,
     filterOptions: statsResult.filter_options,

--- a/src/app/api/enterprise/[enterpriseId]/invites/route.ts
+++ b/src/app/api/enterprise/[enterpriseId]/invites/route.ts
@@ -187,6 +187,13 @@ export async function POST(req: Request, { params }: RouteParams) {
     return respond({ error: rpcError.message || "Failed to create invite" }, 400);
   }
 
+  if (!invite || typeof invite.id !== "string") {
+    console.error("[enterprise/invites POST] RPC returned null or invalid invite", {
+      enterpriseId: ctx.enterpriseId,
+    });
+    return respond({ error: "Failed to create invite" }, 500);
+  }
+
   logEnterpriseAuditAction({
     actorUserId: ctx.userId,
     actorEmail: ctx.userEmail,

--- a/src/app/api/stripe/webhook/handler.ts
+++ b/src/app/api/stripe/webhook/handler.ts
@@ -411,7 +411,10 @@ export async function handleStripeWebhookPost(
               error: subError.message,
               enterpriseId: enterprise.id,
             });
-            // Don't fail the webhook - enterprise exists, subscription can be fixed
+            return NextResponse.json(
+              { error: "Enterprise subscription provisioning failed" },
+              { status: 500 }
+            );
           }
 
           // Grant owner role to creator (idempotent)

--- a/src/lib/enterprise/adoption.ts
+++ b/src/lib/enterprise/adoption.ts
@@ -150,9 +150,16 @@ export async function createAdoptionRequest(
 
 export async function acceptAdoptionRequest(
   requestId: string,
-  respondedBy: string
+  respondedBy: string,
+  deps?: {
+    supabase?: ReturnType<typeof createServiceClient>;
+    checkAdoptionQuotaFn?: typeof checkAdoptionQuota;
+    canEnterpriseAddSubOrgFn?: typeof canEnterpriseAddSubOrg;
+  }
 ): Promise<{ success: boolean; error?: string; status?: number }> {
-  const supabase = createServiceClient();
+  const supabase = deps?.supabase ?? createServiceClient();
+  const checkAdoptionQuotaFn = deps?.checkAdoptionQuotaFn ?? checkAdoptionQuota;
+  const canEnterpriseAddSubOrgFn = deps?.canEnterpriseAddSubOrgFn ?? canEnterpriseAddSubOrg;
 
   // Get request with org and enterprise info
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -198,23 +205,35 @@ export async function acceptAdoptionRequest(
     return { success: false, error: "Internal error", status: 503 };
   }
 
+  const isRetryingAcceptedAdoption = org?.enterprise_id === request.enterprise_id;
+
   if (org?.enterprise_id) {
-    return { success: false, error: "Organization already belongs to an enterprise" };
-  }
-
-  // Check alumni quota again
-  const quotaCheck = await checkAdoptionQuota(request.enterprise_id, request.organization_id);
-  if (!quotaCheck.allowed) {
-    if (quotaCheck.status) {
-      return { success: false, error: quotaCheck.error, status: quotaCheck.status };
+    if (isRetryingAcceptedAdoption) {
+      console.warn("[acceptAdoptionRequest] Retrying partially completed adoption:", {
+        requestId,
+        organizationId: request.organization_id,
+        enterpriseId: request.enterprise_id,
+      });
+    } else {
+      return { success: false, error: "Organization already belongs to an enterprise" };
     }
-    return { success: false, error: quotaCheck.error };
   }
 
-  // Check seat limit for enterprise-managed orgs
-  const seatQuota = await canEnterpriseAddSubOrg(request.enterprise_id);
-  if (seatQuota.error) {
-    return { success: false, error: "Unable to verify seat limit. Please try again.", status: 503 };
+  if (!isRetryingAcceptedAdoption) {
+    // Check alumni quota again
+    const quotaCheck = await checkAdoptionQuotaFn(request.enterprise_id, request.organization_id);
+    if (!quotaCheck.allowed) {
+      if (quotaCheck.status) {
+        return { success: false, error: quotaCheck.error, status: quotaCheck.status };
+      }
+      return { success: false, error: quotaCheck.error };
+    }
+
+    // Check seat limit for enterprise-managed orgs
+    const seatQuota = await canEnterpriseAddSubOrgFn(request.enterprise_id);
+    if (seatQuota.error) {
+      return { success: false, error: "Unable to verify seat limit. Please try again.", status: 503 };
+    }
   }
 
   // Get org's current subscription for preservation
@@ -224,22 +243,24 @@ export async function acceptAdoptionRequest(
     .eq("organization_id", request.organization_id)
     .maybeSingle() as { data: OrgSubscriptionRow | null };
 
-  // Execute adoption
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error: updateError } = await (supabase as any)
-    .from("organizations")
-    .update({
-      enterprise_id: request.enterprise_id,
-      enterprise_relationship_type: "adopted",
-      enterprise_adopted_at: new Date().toISOString(),
-      original_subscription_id: orgSub?.id ?? null,
-      original_subscription_status: orgSub?.status ?? null,
-    })
-    .eq("id", request.organization_id);
+  if (!isRetryingAcceptedAdoption) {
+    // Execute adoption
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error: updateError } = await (supabase as any)
+      .from("organizations")
+      .update({
+        enterprise_id: request.enterprise_id,
+        enterprise_relationship_type: "adopted",
+        enterprise_adopted_at: new Date().toISOString(),
+        original_subscription_id: orgSub?.id ?? null,
+        original_subscription_status: orgSub?.status ?? null,
+      })
+      .eq("id", request.organization_id);
 
-  if (updateError) {
-    console.error("[acceptAdoptionRequest] Org update failed:", updateError);
-    return { success: false, error: "Failed to update organization", status: 500 };
+    if (updateError) {
+      console.error("[acceptAdoptionRequest] Org update failed:", updateError);
+      return { success: false, error: "Failed to update organization", status: 500 };
+    }
   }
 
   // Ensure org has a subscription row so the enterprise_alumni_counts view can
@@ -252,8 +273,10 @@ export async function acceptAdoptionRequest(
 
     if (updateSubError) {
       console.error("[acceptAdoptionRequest] Failed to update organization subscription:", updateSubError);
-      // Compensating rollback: revert enterprise_id on subscription failure (with retry)
-      await rollbackOrgEnterprise(supabase, request.organization_id);
+      if (!isRetryingAcceptedAdoption) {
+        // Compensating rollback: revert enterprise_id on subscription failure (with retry)
+        await rollbackOrgEnterprise(supabase, request.organization_id);
+      }
       return { success: false, error: "Failed to update organization subscription" };
     }
   } else {
@@ -268,8 +291,10 @@ export async function acceptAdoptionRequest(
 
     if (createSubError) {
       console.error("[acceptAdoptionRequest] Failed to create organization subscription:", createSubError);
-      // Compensating rollback: revert enterprise_id on subscription failure (with retry)
-      await rollbackOrgEnterprise(supabase, request.organization_id);
+      if (!isRetryingAcceptedAdoption) {
+        // Compensating rollback: revert enterprise_id on subscription failure (with retry)
+        await rollbackOrgEnterprise(supabase, request.organization_id);
+      }
       return { success: false, error: "Failed to create organization subscription" };
     }
   }
@@ -288,21 +313,23 @@ export async function acceptAdoptionRequest(
   if (markAcceptedError) {
     console.error("[acceptAdoptionRequest] Step 3 (mark accepted) failed:", markAcceptedError);
 
-    // Rollback step 1: revert org enterprise_id
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { error: rollbackOrgError } = await (supabase as any)
-      .from("organizations")
-      .update({
-        enterprise_id: null,
-        enterprise_relationship_type: null,
-        enterprise_adopted_at: null,
-        original_subscription_id: null,
-        original_subscription_status: null,
-      })
-      .eq("id", request.organization_id);
+    if (!isRetryingAcceptedAdoption) {
+      // Rollback step 1: revert org enterprise_id
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error: rollbackOrgError } = await (supabase as any)
+        .from("organizations")
+        .update({
+          enterprise_id: null,
+          enterprise_relationship_type: null,
+          enterprise_adopted_at: null,
+          original_subscription_id: null,
+          original_subscription_status: null,
+        })
+        .eq("id", request.organization_id);
 
-    if (rollbackOrgError) {
-      console.error("[acceptAdoptionRequest] CRITICAL: step-3 rollback of org failed:", rollbackOrgError);
+      if (rollbackOrgError) {
+        console.error("[acceptAdoptionRequest] CRITICAL: step-3 rollback of org failed:", rollbackOrgError);
+      }
     }
 
     // Rollback step 2: revert subscription

--- a/src/lib/graduation/queries.ts
+++ b/src/lib/graduation/queries.ts
@@ -222,6 +222,11 @@ export async function transitionToAlumni(
     return { success: false, error: error.message };
   }
 
+  if (!data) {
+    debugLog("graduation", "transitionToAlumni: RPC returned null data");
+    return { success: false, error: "RPC returned no data" };
+  }
+
   const result = data as { success: boolean; skipped?: boolean; error?: string };
   debugLog("graduation", "transitionToAlumni result", result);
   return result;
@@ -250,6 +255,10 @@ export async function revokeMemberAccess(
 
   if (error) {
     return { success: false, error: error.message };
+  }
+
+  if (!data) {
+    return { success: false, error: "RPC returned no data" };
   }
 
   const result = data as { success: boolean; skipped?: boolean; error?: string };
@@ -310,6 +319,11 @@ export async function reinstateToActiveMember(
   if (error) {
     debugLog("graduation", "reinstateToActiveMember RPC error", error.message);
     return { success: false, error: error.message };
+  }
+
+  if (!data) {
+    debugLog("graduation", "reinstateToActiveMember: RPC returned null data");
+    return { success: false, error: "RPC returned no data" };
   }
 
   const result = data as { success: boolean; skipped?: boolean; error?: string };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,6 +18,20 @@ import type { SupportedLocale } from "./i18n/config";
 // Validate at module load
 validateAuthTestMode();
 
+interface OrgContextRpcResult {
+  found: boolean;
+  organization?: { default_language?: string | null } | null;
+  membership?: {
+    status?: string | null;
+    language_override?: string | null;
+  } | null;
+}
+
+function isOrgContextRpcResult(value: unknown): value is OrgContextRpcResult {
+  return typeof value === "object" && value !== null && "found" in value &&
+    typeof (value as Record<string, unknown>).found === "boolean";
+}
+
 /** Sync the NEXT_LOCALE cookie from DB language preferences (user override → org default → 'en'). */
 function syncLocaleCookie(
   request: NextRequest,
@@ -417,13 +431,13 @@ export async function middleware(request: NextRequest) {
 
               membershipStatus = membership?.status;
             }
-          } else if (ctx?.found) {
+          } else if (isOrgContextRpcResult(ctx) && ctx.found) {
             membershipStatus = ctx.membership?.status;
             // Capture language fields from RPC for locale cookie sync (no extra query)
             orgDefaultLang = ctx.organization?.default_language ?? null;
             userLangOverride = ctx.membership?.language_override ?? null;
           }
-          // If !ctx?.found the org doesn't exist — layout.tsx handles the 404 gate
+          // If ctx is invalid or !ctx.found the org doesn't exist — layout.tsx handles the 404 gate
 
           const membershipRedirect = getRedirectForMembershipStatus(membershipStatus, orgSlug);
           if (membershipRedirect) {
@@ -439,7 +453,7 @@ export async function middleware(request: NextRequest) {
         // Dev-admin bypasses membership checks but still needs language data
         try {
           const { data: ctx } = await supabase.rpc("get_org_context_by_slug", { p_slug: orgSlug });
-          if (ctx?.found) {
+          if (isOrgContextRpcResult(ctx) && ctx.found) {
             orgDefaultLang = ctx.organization?.default_language ?? null;
             userLangOverride = ctx.membership?.language_override ?? null;
           }

--- a/supabase/migrations/20260811000000_fix_function_search_path_mutable.sql
+++ b/supabase/migrations/20260811000000_fix_function_search_path_mutable.sql
@@ -1,0 +1,159 @@
+-- Fix function_search_path_mutable warnings for 4 functions.
+-- Sets search_path = '' and fully qualifies all table/function references.
+
+-- 1. claim_stale_stripe_event
+CREATE OR REPLACE FUNCTION public.claim_stale_stripe_event(p_event_id text)
+RETURNS SETOF public.stripe_events
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  UPDATE public.stripe_events
+  SET leased_at = NOW()
+  WHERE event_id = p_event_id
+    AND processed_at IS NULL
+    AND leased_at < NOW() - INTERVAL '5 minutes'
+  RETURNING *;
+$$;
+
+-- 2. update_thread_reply_count
+CREATE OR REPLACE FUNCTION public.update_thread_reply_count()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    -- Increment reply_count and update last_activity_at
+    UPDATE public.discussion_threads
+    SET
+      reply_count = reply_count + 1,
+      last_activity_at = NEW.created_at
+    WHERE id = NEW.thread_id;
+    RETURN NEW;
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- Check if this is a soft delete (deleted_at changing from NULL to non-NULL)
+    IF OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL THEN
+      -- Decrement reply_count
+      UPDATE public.discussion_threads
+      SET reply_count = GREATEST(reply_count - 1, 0)
+      WHERE id = NEW.thread_id;
+    END IF;
+    RETURN NEW;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+-- 3. create_org_invite
+CREATE OR REPLACE FUNCTION public.create_org_invite(
+  p_organization_id uuid,
+  p_role            text DEFAULT 'active_member',
+  p_uses            int  DEFAULT NULL,
+  p_expires_at      timestamptz DEFAULT NULL,
+  p_require_approval boolean DEFAULT NULL
+)
+RETURNS public.organization_invites
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_code   text;
+  v_token  text;
+  v_result public.organization_invites;
+BEGIN
+  -- Verify caller is admin of the organization
+  IF NOT public.is_org_admin(p_organization_id) THEN
+    RAISE EXCEPTION 'Only organization admins can create invites';
+  END IF;
+
+  -- Validate role
+  IF p_role NOT IN ('admin', 'active_member', 'alumni', 'parent') THEN
+    RAISE EXCEPTION 'Invalid role. Must be admin, active_member, alumni, or parent';
+  END IF;
+
+  -- Respect alumni quota for alumni invites
+  IF p_role = 'alumni' THEN
+    PERFORM public.assert_alumni_quota(p_organization_id);
+  END IF;
+
+  -- Generate secure random code (8 chars, alphanumeric)
+  v_code := upper(substr(
+    replace(replace(replace(
+      encode(gen_random_bytes(6), 'base64'),
+      '/', ''), '+', ''), '=', ''),
+    1, 8
+  ));
+
+  -- Generate secure token (URL-safe base64, 32 chars)
+  v_token := replace(replace(replace(
+    encode(gen_random_bytes(24), 'base64'),
+    '/', '_'), '+', '-'), '=', '');
+
+  INSERT INTO public.organization_invites (
+    organization_id,
+    code,
+    token,
+    role,
+    uses_remaining,
+    expires_at,
+    created_by_user_id,
+    require_approval
+  ) VALUES (
+    p_organization_id,
+    v_code,
+    v_token,
+    p_role,
+    p_uses,
+    p_expires_at,
+    auth.uid(),
+    p_require_approval
+  )
+  RETURNING * INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+-- 4. can_view_announcement
+CREATE OR REPLACE FUNCTION public.can_view_announcement(announcement_row public.announcements)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  user_role text;
+  v_user_id uuid;
+BEGIN
+  v_user_id := auth.uid();
+
+  SELECT role INTO user_role
+  FROM public.user_organization_roles
+  WHERE user_organization_roles.user_id = v_user_id
+    AND organization_id = announcement_row.organization_id
+    AND status = 'active'
+  LIMIT 1;
+
+  IF user_role = 'admin' THEN
+    RETURN true;
+  END IF;
+
+  CASE announcement_row.audience
+    WHEN 'all' THEN
+      RETURN user_role IS NOT NULL;
+    WHEN 'members' THEN
+      RETURN user_role IN ('admin', 'active_member', 'member');
+    WHEN 'active_members' THEN
+      RETURN user_role IN ('admin', 'active_member');
+    WHEN 'alumni' THEN
+      RETURN user_role IN ('admin', 'alumni', 'parent');
+    WHEN 'individuals' THEN
+      RETURN v_user_id = ANY(announcement_row.audience_user_ids);
+    ELSE
+      RETURN user_role IS NOT NULL;
+  END CASE;
+END;
+$$;

--- a/tests/enterprise/admin-invite-lookup.test.ts
+++ b/tests/enterprise/admin-invite-lookup.test.ts
@@ -125,3 +125,62 @@ test("handles null raw_user_meta_data as empty object", () => {
   const result = simulateUserLookup("carol@test.org", testUsers);
   assert.deepStrictEqual(result.targetUser?.user_metadata, {});
 });
+
+// ── Null invite shape guard (enterprise/invites POST) ────────────────────────
+
+/**
+ * Simulates the invite shape guard added to enterprise/invites/route.ts POST.
+ * Before fix: null invite spread into response = HTTP 200 with no invite data.
+ * After fix: null or missing id returns 500.
+ */
+function simulateInviteShapeGuard(
+  invite: Record<string, unknown> | null,
+  rpcError: { message: string } | null
+): { status: number; body: Record<string, unknown> } {
+  if (rpcError) {
+    return { status: 400, body: { error: rpcError.message || "Failed to create invite" } };
+  }
+
+  if (!invite || typeof invite.id !== "string") {
+    return { status: 500, body: { error: "Failed to create invite" } };
+  }
+
+  return {
+    status: 200,
+    body: {
+      ...invite,
+      organization_name: "Test Org",
+      is_enterprise_wide: false,
+    },
+  };
+}
+
+test("invite shape guard: null invite returns 500", () => {
+  const result = simulateInviteShapeGuard(null, null);
+  assert.strictEqual(result.status, 500);
+  assert.strictEqual(result.body.error, "Failed to create invite");
+});
+
+test("invite shape guard: invite without id returns 500", () => {
+  const result = simulateInviteShapeGuard({ role: "admin" }, null);
+  assert.strictEqual(result.status, 500);
+});
+
+test("invite shape guard: invite with numeric id returns 500", () => {
+  const result = simulateInviteShapeGuard({ id: 123 }, null);
+  assert.strictEqual(result.status, 500);
+});
+
+test("invite shape guard: valid invite returns 200 with spread data", () => {
+  const result = simulateInviteShapeGuard({ id: "inv-1", role: "admin", code: "ABC123" }, null);
+  assert.strictEqual(result.status, 200);
+  assert.strictEqual(result.body.id, "inv-1");
+  assert.strictEqual(result.body.organization_name, "Test Org");
+  assert.strictEqual(result.body.code, "ABC123");
+});
+
+test("invite shape guard: RPC error takes precedence", () => {
+  const result = simulateInviteShapeGuard(null, { message: "permission denied" });
+  assert.strictEqual(result.status, 400);
+  assert.strictEqual(result.body.error, "permission denied");
+});

--- a/tests/enterprise/adoption.test.ts
+++ b/tests/enterprise/adoption.test.ts
@@ -1,10 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
+import { acceptAdoptionRequest } from "../../src/lib/enterprise/adoption.ts";
+import { createSupabaseStub } from "../utils/supabaseStub.ts";
 
 /**
  * Tests for enterprise adoption library functions.
  *
- * Because createAdoptionRequest/acceptAdoptionRequest/rejectAdoptionRequest
+ * Because createAdoptionRequest/rejectAdoptionRequest
  * call createServiceClient() and checkAdoptionQuota() internally, we test them
  * via simulation functions that replicate the exact branching logic from
  * adoption.ts, using dependency-injected mocks — the same pattern used in
@@ -754,6 +756,22 @@ describe("acceptAdoptionRequest", () => {
     assert.strictEqual(result.error, "Internal error");
   });
 
+  it("org points to different enterprise → returns error", () => {
+    const result = simulateAcceptAdoptionRequest({
+      request: makeRequest({ enterprise_id: "enterprise-1" }),
+      reVerifiedOrg: { enterprise_id: "enterprise-other" },
+      quotaCheck: { allowed: true },
+      seatQuota: { currentCount: 0, maxAllowed: null },
+      orgSub: null,
+      orgUpdateError: null,
+      subUpdateError: null,
+      subCreateError: null,
+    });
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error, "Organization already belongs to an enterprise");
+  });
+
   it("returns 503 when org re-verify DB errors", () => {
     const result = simulateAcceptAdoptionRequest({
       request: makeRequest(),
@@ -770,6 +788,42 @@ describe("acceptAdoptionRequest", () => {
     assert.strictEqual(result.success, false);
     assert.strictEqual(result.status, 503);
     assert.strictEqual(result.error, "Internal error");
+  });
+
+  it("retries partial adoption by reconciling subscription before accepting", async () => {
+    const supabase = createSupabaseStub();
+
+    supabase.seed("enterprise_adoption_requests", [{
+      id: "request-1",
+      enterprise_id: "enterprise-1",
+      organization_id: "org-1",
+      requested_by: "user-requester",
+      status: "pending",
+      expires_at: null,
+    }]);
+    supabase.seed("organizations", [{
+      id: "org-1",
+      enterprise_id: "enterprise-1",
+      enterprise_relationship_type: "adopted",
+      enterprise_adopted_at: "2026-01-01T00:00:00.000Z",
+    }]);
+
+    const result = await acceptAdoptionRequest("request-1", "user-admin", {
+      supabase: supabase as never,
+      checkAdoptionQuotaFn: async () => ({ allowed: true }),
+      canEnterpriseAddSubOrgFn: async () => ({ currentCount: 0, maxAllowed: null }),
+    });
+
+    assert.deepStrictEqual(result, { success: true });
+
+    const requests = supabase.getRows("enterprise_adoption_requests");
+    assert.strictEqual(requests[0].status, "accepted");
+    assert.strictEqual(requests[0].responded_by, "user-admin");
+
+    const subscriptions = supabase.getRows("organization_subscriptions");
+    assert.strictEqual(subscriptions.length, 1);
+    assert.strictEqual(subscriptions[0].organization_id, "org-1");
+    assert.strictEqual(subscriptions[0].status, "enterprise_managed");
   });
 });
 

--- a/tests/graduation-bugs.test.ts
+++ b/tests/graduation-bugs.test.ts
@@ -121,6 +121,83 @@ describe("Graduation System Bug Fixes", () => {
     });
   });
 
+  describe("[P3] RPC null data guards", () => {
+    /**
+     * Simulates the RPC call + null-data guard pattern used in:
+     * - transitionToAlumni
+     * - revokeMemberAccess
+     * - reinstateToActiveMember
+     *
+     * Before fix: `data as { success: boolean }` crashes on null.success
+     * After fix: null data returns { success: false, error: "RPC returned no data" }
+     */
+    function simulateRpcWithNullGuard(
+      data: { success: boolean; skipped?: boolean; error?: string } | null,
+      error: { message: string } | null
+    ): { success: boolean; skipped?: boolean; error?: string } {
+      if (error) {
+        return { success: false, error: error.message };
+      }
+
+      if (!data) {
+        return { success: false, error: "RPC returned no data" };
+      }
+
+      return data;
+    }
+
+    it("transitionToAlumni returns { success: false } when data is null", () => {
+      const result = simulateRpcWithNullGuard(null, null);
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.error, "RPC returned no data");
+    });
+
+    it("revokeMemberAccess returns { success: false } when data is null", () => {
+      const result = simulateRpcWithNullGuard(null, null);
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.error, "RPC returned no data");
+    });
+
+    it("reinstateToActiveMember returns { success: false } when data is null", () => {
+      const result = simulateRpcWithNullGuard(null, null);
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.error, "RPC returned no data");
+    });
+
+    it("still returns error when RPC itself errors", () => {
+      const result = simulateRpcWithNullGuard(null, { message: "connection timeout" });
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.error, "connection timeout");
+    });
+
+    it("passes through valid data", () => {
+      const result = simulateRpcWithNullGuard({ success: true, skipped: false }, null);
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.skipped, false);
+    });
+  });
+
+  describe("[P3] Enterprise alumni stats null org_stats", () => {
+    it("null org_stats produces empty array via null coalesce", () => {
+      // Simulates: (statsResult.org_stats ?? []).map(...)
+      const orgStats: { name: string; count: number }[] | null = null;
+      const result = (orgStats ?? []).map(({ name, count }) => ({ name, count }));
+      assert.deepStrictEqual(result, []);
+    });
+
+    it("valid org_stats maps correctly", () => {
+      const orgStats = [
+        { name: "Org A", count: 5 },
+        { name: "Org B", count: 10 },
+      ];
+      const result = (orgStats ?? []).map(({ name, count }) => ({ name, count }));
+      assert.deepStrictEqual(result, [
+        { name: "Org A", count: 5 },
+        { name: "Org B", count: 10 },
+      ]);
+    });
+  });
+
   describe("[P2] Graduation year parsing should be timezone-safe", () => {
     it("should correctly parse year from YYYY-MM-DD without timezone issues", () => {
       // This is the buggy pattern:

--- a/tests/middleware-routing.test.ts
+++ b/tests/middleware-routing.test.ts
@@ -67,6 +67,58 @@ describe("middleware routing decisions", () => {
     it("undefined → null", () => assert.strictEqual(getRedirectForMembershipStatus(undefined, "my-org"), null));
   });
 
+  describe("isOrgContextRpcResult type guard", () => {
+    /**
+     * Mirrors the type guard in middleware.ts that validates the RPC result shape
+     * before accessing .organization?.default_language and .membership?.language_override.
+     */
+    function isOrgContextRpcResult(value: unknown): value is {
+      found: boolean;
+      organization?: { default_language?: string | null } | null;
+      membership?: { status?: string | null; language_override?: string | null } | null;
+    } {
+      return typeof value === "object" && value !== null && "found" in value &&
+        typeof (value as Record<string, unknown>).found === "boolean";
+    }
+
+    it("accepts valid found=true result", () => {
+      const ctx = { found: true, organization: { default_language: "es" }, membership: { status: "active", language_override: null } };
+      assert.strictEqual(isOrgContextRpcResult(ctx), true);
+    });
+
+    it("accepts valid found=false result", () => {
+      assert.strictEqual(isOrgContextRpcResult({ found: false }), true);
+    });
+
+    it("rejects null", () => {
+      assert.strictEqual(isOrgContextRpcResult(null), false);
+    });
+
+    it("rejects undefined", () => {
+      assert.strictEqual(isOrgContextRpcResult(undefined), false);
+    });
+
+    it("rejects string", () => {
+      assert.strictEqual(isOrgContextRpcResult("not an object"), false);
+    });
+
+    it("rejects array", () => {
+      assert.strictEqual(isOrgContextRpcResult([1, 2, 3]), false);
+    });
+
+    it("rejects object without found property", () => {
+      assert.strictEqual(isOrgContextRpcResult({ organization: {} }), false);
+    });
+
+    it("rejects object with non-boolean found", () => {
+      assert.strictEqual(isOrgContextRpcResult({ found: "true" }), false);
+    });
+
+    it("rejects number", () => {
+      assert.strictEqual(isOrgContextRpcResult(42), false);
+    });
+  });
+
   describe("shouldRedirectToCanonicalHost", () => {
     it("bare domain → true", () => assert.strictEqual(shouldRedirectToCanonicalHost("myteamnetwork.com"), true));
     it("www domain → false", () => assert.strictEqual(shouldRedirectToCanonicalHost("www.myteamnetwork.com"), false));

--- a/tests/routes/stripe/webhook-trial.test.ts
+++ b/tests/routes/stripe/webhook-trial.test.ts
@@ -109,6 +109,42 @@ beforeEach(() => {
 });
 
 describe("POST /api/stripe/webhook trial flows", () => {
+  test("enterprise subscription upsert failure returns 500 and leaves the event retryable", async () => {
+    supabase.simulateError("enterprise_subscriptions", { message: "unique constraint violation" });
+
+    event = {
+      id: "evt_enterprise_sub_failure",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_enterprise_123",
+          object: "checkout.session",
+          mode: "subscription",
+          payment_status: "paid",
+          customer: "cus_enterprise_123",
+          subscription: "sub_enterprise_123",
+          metadata: {
+            type: "enterprise",
+            creatorId: "user_enterprise_1",
+            enterpriseName: "Acme Enterprise",
+            enterpriseSlug: "acme-enterprise",
+            billingInterval: "year",
+          },
+        },
+      },
+    };
+
+    const { response, body } = await postWebhook();
+
+    assert.equal(response.status, 500);
+    assert.deepEqual(body, { error: "Enterprise subscription provisioning failed" });
+
+    const eventRows = supabase.getRows("stripe_events");
+    assert.equal(eventRows.length, 1);
+    assert.equal(eventRows[0].event_id, "evt_enterprise_sub_failure");
+    assert.equal(eventRows[0].processed_at ?? null, null);
+  });
+
   test("checkout.session.completed provisions orgs for no-payment-required trial checkouts", async () => {
     supabase.seed("payment_attempts", [
       {

--- a/tests/stripe-webhook-dedupe.test.ts
+++ b/tests/stripe-webhook-dedupe.test.ts
@@ -1,4 +1,4 @@
-import test from "node:test";
+import test, { describe, it } from "node:test";
 import assert from "node:assert";
 import { markStripeEventProcessed, registerStripeEvent } from "../src/lib/payments/stripe-events.ts";
 import { createSupabaseStub } from "./utils/supabaseStub.ts";
@@ -30,4 +30,31 @@ test("stripe webhook events are only processed once", async () => {
 
   const stored = supabase.getRows("stripe_events");
   assert.ok(stored[0]?.processed_at, "processed_at should be set after handling");
+});
+
+// ── Enterprise subscription upsert failure ───────────────────────────────────
+
+describe("enterprise subscription upsert failure", () => {
+  /**
+   * Simulates the webhook handler behavior when enterprise_subscriptions upsert fails.
+   * Before fix: logs error, returns 200 (Stripe stops retrying, enterprise has no subscription row).
+   * After fix: returns 500 so Stripe retries with exponential backoff.
+   */
+  function simulateWebhookSubUpsert(subError: { message: string } | null): { status: number } {
+    if (subError) {
+      // After fix: return 500 instead of swallowing
+      return { status: 500 };
+    }
+    return { status: 200 };
+  }
+
+  it("returns 500 when enterprise subscription upsert fails", () => {
+    const result = simulateWebhookSubUpsert({ message: "unique constraint violation" });
+    assert.strictEqual(result.status, 500);
+  });
+
+  it("returns 200 when enterprise subscription upsert succeeds", () => {
+    const result = simulateWebhookSubUpsert(null);
+    assert.strictEqual(result.status, 200);
+  });
 });

--- a/tests/utils/supabaseStub.ts
+++ b/tests/utils/supabaseStub.ts
@@ -44,6 +44,7 @@ type TableName =
   | "chat_poll_votes"
   | "chat_form_responses"
   | "enterprise_subscriptions"
+  | "enterprise_adoption_requests"
   | "user_enterprise_roles";
 
 type Row = Record<string, unknown>;
@@ -104,6 +105,7 @@ const uniqueKeys: Record<TableName, UniqueConstraint[]> = {
   chat_poll_votes: [["message_id", "user_id"]],
   chat_form_responses: [["message_id", "user_id"]],
   enterprise_subscriptions: ["enterprise_id"],
+  enterprise_adoption_requests: [],
   user_enterprise_roles: [["user_id", "enterprise_id"]],
 };
 
@@ -156,6 +158,7 @@ export function createSupabaseStub() {
     chat_poll_votes: [],
     chat_form_responses: [],
     enterprise_subscriptions: [],
+    enterprise_adoption_requests: [],
     user_enterprise_roles: [],
   };
 
@@ -222,6 +225,14 @@ export function createSupabaseStub() {
     },
 
     upsert: (payload: Row | Row[], options?: { onConflict?: string }) => {
+      if (errorSimulation[table]) {
+        return {
+          then(resolve: (value: SupabaseResponse<null>) => void) {
+            resolve({ data: null, error: errorSimulation[table] ?? null });
+          },
+        };
+      }
+
       const records = Array.isArray(payload) ? payload : [payload];
       const conflictColumns = options?.onConflict?.split(",").map((c) => c.trim()) ?? [];
 


### PR DESCRIPTION
## Summary

- **Graduation RPCs** (`queries.ts`): null-guard `data` before accessing `.success` — prevents cron crash that skips remaining members
- **Enterprise alumni stats** (`stats/route.ts`): null-coalesce `org_stats` — prevents crash for new enterprises with no alumni
- **Enterprise invites** (`invites/route.ts`): shape-guard null invite before spreading into HTTP 200 — prevents silent data corruption
- **Stripe webhook** (`handler.ts`): return 500 on subscription upsert failure — was returning 200, which told Stripe to stop retrying and left enterprise with no subscription row
- **Adoption** (`adoption.ts`): idempotent completion when org already points to same enterprise — prevents permanent stuck state after partial failure
- **Middleware** (`middleware.ts`): type guard for `get_org_context_by_slug` RPC result shape — prevents silent locale breakage on shape change

## Test plan

- [x] `npm run test:unit` — 2300 pass, 0 fail
- [x] `npm run lint` — clean
- [x] `npm run build` — production build succeeds
- [ ] Manual: verify graduation cron completes without error in staging
- [ ] Manual: verify new enterprise alumni stats page loads (empty state)
- [ ] Manual: verify Stripe webhook retry on subscription failure (test mode)