### PR TITLE
fix(db): enforce locked thread constraint on discussion replies

### DIFF
--- a/supabase/migrations/20260704000002_lock_discussion_replies.sql
+++ b/supabase/migrations/20260704000002_lock_discussion_replies.sql
@@ -1,0 +1,15 @@
+DROP POLICY IF EXISTS "discussion_replies_insert" ON public.discussion_replies;
+
+CREATE POLICY "discussion_replies_insert" ON public.discussion_replies
+  FOR INSERT WITH CHECK (
+    author_id = auth.uid()
+    AND has_active_role(organization_id, array['admin','active_member','alumni'])
+    AND EXISTS (
+      SELECT 1
+      FROM public.discussion_threads
+      WHERE public.discussion_threads.id = public.discussion_replies.thread_id
+        AND public.discussion_threads.organization_id = public.discussion_replies.organization_id
+        AND public.discussion_threads.deleted_at IS NULL
+        AND public.discussion_threads.is_locked = false
+    )
+  );


### PR DESCRIPTION
## Summary
- Adds RLS policy to prevent replies on locked discussion threads
- Checks `is_locked = false` on parent thread before allowing insert

## Test plan
- [ ] Run `supabase db push` to apply migration
- [ ] Verify locked threads reject new replies
- [ ] Verify unlocked threads still accept replies