### PR TITLE
fix(calendar): resolve React hydration errors and harden middleware

### DIFF
--- a/src/components/calendar/CalendarMonthView.tsx
+++ b/src/components/calendar/CalendarMonthView.tsx
@@ -8,6 +8,7 @@ import {
   type UnifiedEvent,
 } from "@/lib/calendar/unified-events";
 import { getUnifiedEventHref } from "@/lib/calendar/navigation";
+import { resolveOrgTimezone } from "@/lib/utils/timezone";
 
 type CalendarMonthViewProps = {
   orgId: string;
@@ -19,6 +20,17 @@ type CalendarMonthViewProps = {
 
 const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const MAX_VISIBLE_EVENTS = 3;
+
+type CalendarMonthCursor = {
+  year: number;
+  month: number;
+};
+
+type CalendarMonthCell = {
+  dateKey: string;
+  dayOfMonth: number;
+  month: number;
+};
 
 function toDateKeyInTimeZone(date: Date, timeZone?: string): string {
   const opts: Intl.DateTimeFormatOptions = {
@@ -32,22 +44,52 @@ function toDateKeyInTimeZone(date: Date, timeZone?: string): string {
   return `${get("year")}-${get("month")}-${get("day")}`;
 }
 
-function buildMonthGrid(year: number, month: number): Date[][] {
-  const firstDay = new Date(year, month, 1);
-  const startSunday = new Date(firstDay);
-  startSunday.setDate(1 - firstDay.getDay());
+function toUtcDateKey(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
+}
 
-  const weeks: Date[][] = [];
+export function getCalendarMonthCursor(date: Date, timeZone?: string): CalendarMonthCursor {
+  const resolvedTimeZone = resolveOrgTimezone(timeZone);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: resolvedTimeZone,
+    year: "numeric",
+    month: "2-digit",
+  }).formatToParts(date);
+  const get = (type: Intl.DateTimeFormatPartTypes) => Number(parts.find((part) => part.type === type)?.value ?? "0");
+
+  return {
+    year: get("year"),
+    month: get("month") - 1,
+  };
+}
+
+export function buildCalendarMonthGrid(year: number, month: number): CalendarMonthCell[][] {
+  const firstDay = new Date(Date.UTC(year, month, 1));
+  const startSunday = new Date(Date.UTC(year, month, 1 - firstDay.getUTCDay()));
+
+  const weeks: CalendarMonthCell[][] = [];
   const cursor = new Date(startSunday);
   for (let w = 0; w < 6; w++) {
-    const week: Date[] = [];
+    const week: CalendarMonthCell[] = [];
     for (let d = 0; d < 7; d++) {
-      week.push(new Date(cursor));
-      cursor.setDate(cursor.getDate() + 1);
+      week.push({
+        dateKey: toUtcDateKey(cursor),
+        dayOfMonth: cursor.getUTCDate(),
+        month: cursor.getUTCMonth(),
+      });
+      cursor.setUTCDate(cursor.getUTCDate() + 1);
     }
     weeks.push(week);
   }
   return weeks;
+}
+
+export function formatCalendarMonthName(year: number, month: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(Date.UTC(year, month, 1, 12)));
 }
 
 function getSourceColors(sourceType: string): { dot: string; text: string } {
@@ -82,7 +124,9 @@ function ChevronRightIcon() {
 }
 
 export function CalendarMonthView({ orgId, orgSlug, initialEvents, timeZone, rightSlot }: CalendarMonthViewProps) {
-  const [displayDate, setDisplayDate] = useState<Date>(() => new Date());
+  const resolvedTimeZone = resolveOrgTimezone(timeZone);
+  const [mounted, setMounted] = useState(false);
+  const [displayMonth, setDisplayMonth] = useState<CalendarMonthCursor>(() => getCalendarMonthCursor(new Date(), resolvedTimeZone));
   const [events, setEvents] = useState<UnifiedEvent[]>(initialEvents ?? []);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -91,21 +135,22 @@ export function CalendarMonthView({ orgId, orgSlug, initialEvents, timeZone, rig
   const initialDataRangeRef = useRef(buildUnifiedCalendarDateRange());
   const initialEventsRef = useRef(initialEvents);
 
-  const year = displayDate.getFullYear();
-  const month = displayDate.getMonth();
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
-  const today = useMemo(() => new Date(), []);
-  const todayKey = useMemo(() => toDateKeyInTimeZone(today, timeZone), [today, timeZone]);
+  const { year, month } = displayMonth;
 
-  const monthGrid = useMemo(() => buildMonthGrid(year, month), [year, month]);
-
-  const monthName = useMemo(
-    () =>
-      new Intl.DateTimeFormat("en-US", { month: "long", year: "numeric" }).format(
-        new Date(year, month, 1)
-      ),
-    [year, month]
+  // todayKey drives the "isToday" highlight — only compute on client to avoid
+  // hydration mismatch between server and browser timezones.
+  const todayKey = useMemo(
+    () => (mounted ? toDateKeyInTimeZone(new Date(), resolvedTimeZone) : ""),
+    [mounted, resolvedTimeZone]
   );
+
+  const monthGrid = useMemo(() => buildCalendarMonthGrid(year, month), [year, month]);
+
+  const monthName = useMemo(() => formatCalendarMonthName(year, month), [year, month]);
 
   const fetchMonthEvents = useCallback(
     async (start: Date, end: Date) => {
@@ -169,7 +214,7 @@ export function CalendarMonthView({ orgId, orgSlug, initialEvents, timeZone, rig
       } else if (event.allDay && /^\d{4}-\d{2}-\d{2}$/.test(event.startAt)) {
         dateKey = event.startAt;
       } else {
-        dateKey = toDateKeyInTimeZone(new Date(event.startAt), timeZone);
+        dateKey = toDateKeyInTimeZone(new Date(event.startAt), resolvedTimeZone);
       }
 
       const existing = map.get(dateKey) ?? [];
@@ -178,19 +223,27 @@ export function CalendarMonthView({ orgId, orgSlug, initialEvents, timeZone, rig
     });
 
     return map;
-  }, [events, timeZone]);
+  }, [events, resolvedTimeZone]);
 
   const goToPrevMonth = useCallback(() => {
-    setDisplayDate((d) => new Date(d.getFullYear(), d.getMonth() - 1, 1));
+    setDisplayMonth((current) => (
+      current.month === 0
+        ? { year: current.year - 1, month: 11 }
+        : { year: current.year, month: current.month - 1 }
+    ));
   }, []);
 
   const goToNextMonth = useCallback(() => {
-    setDisplayDate((d) => new Date(d.getFullYear(), d.getMonth() + 1, 1));
+    setDisplayMonth((current) => (
+      current.month === 11
+        ? { year: current.year + 1, month: 0 }
+        : { year: current.year, month: current.month + 1 }
+    ));
   }, []);
 
   const goToToday = useCallback(() => {
-    setDisplayDate(new Date());
-  }, []);
+    setDisplayMonth(getCalendarMonthCursor(new Date(), resolvedTimeZone));
+  }, [resolvedTimeZone]);
 
   return (
     <div>
@@ -250,9 +303,9 @@ export function CalendarMonthView({ orgId, orgSlug, initialEvents, timeZone, rig
 
       {/* Month grid */}
       <div className="grid grid-cols-7 border-l border-t border-border/60 rounded-sm">
-        {monthGrid.flat().map((cellDate, idx) => {
-          const cellKey = toDateKeyInTimeZone(cellDate, timeZone);
-          const isCurrentMonth = cellDate.getMonth() === month;
+        {monthGrid.flat().map((cell, idx) => {
+          const cellKey = cell.dateKey;
+          const isCurrentMonth = cell.month === month;
           const isToday = cellKey === todayKey;
           const cellEvents = eventsByDateKey.get(cellKey) ?? [];
           const visibleEvents = cellEvents.slice(0, MAX_VISIBLE_EVENTS);
@@ -277,7 +330,7 @@ export function CalendarMonthView({ orgId, orgSlug, initialEvents, timeZone, rig
                     }
                   `}
                 >
-                  {cellDate.getDate()}
+                  {cell.dayOfMonth}
                 </span>
               </div>
 

--- a/src/components/calendar/UnifiedEventFeed.tsx
+++ b/src/components/calendar/UnifiedEventFeed.tsx
@@ -100,8 +100,8 @@ function groupEventsByDate(events: UnifiedEvent[], timeZone?: string): Map<strin
 
     if (floatingMatch) {
       const [, year, month, day] = floatingMatch;
-      const floatingDate = new Date(Number(year), Number(month) - 1, Number(day), 12);
-      dateKey = floatingDate.toLocaleDateString("en-US", opts);
+      const floatingDate = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day), 12));
+      dateKey = floatingDate.toLocaleDateString("en-US", { ...opts, timeZone: "UTC" });
     } else {
       if (timeZone) opts.timeZone = timeZone;
       dateKey = new Date(event.startAt).toLocaleDateString("en-US", opts);

--- a/src/components/schedules/PersonalAvailabilityAgenda.tsx
+++ b/src/components/schedules/PersonalAvailabilityAgenda.tsx
@@ -82,11 +82,18 @@ function ChevronRightIcon() {
 }
 
 export function PersonalAvailabilityAgenda({ schedules, orgId, orgSlug, timeZone }: PersonalAvailabilityAgendaProps) {
+  const [mounted, setMounted] = useState(false);
   const [weekOffset, setWeekOffset] = useState(0);
   const [calendarEvents, setCalendarEvents] = useState<CalendarEvent[]>([]);
   const [loading, setLoading] = useState(false);
 
-  const week = useMemo(() => buildAvailabilityWeek(new Date(), weekOffset, timeZone), [weekOffset, timeZone]);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const week = useMemo(() => buildAvailabilityWeek(new Date(), weekOffset, timeZone), [weekOffset, timeZone]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Suppress todayKey during SSR to avoid hydration mismatch
+  const todayKey = mounted ? week.todayKey : "";
 
   const fetchEvents = useCallback(async () => {
     setLoading(true);
@@ -204,7 +211,7 @@ export function PersonalAvailabilityAgenda({ schedules, orgId, orgSlug, timeZone
             const blocks: EventBlock[] = (eventBlocksByDay.get(dateKey) ?? []).sort(
               (a, b) => a.startMinute - b.startMinute
             );
-            const isToday = dateKey === week.todayKey;
+            const isToday = dateKey === todayKey;
 
             const dayLabel = day.toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" });
 

--- a/src/components/schedules/TeamAvailabilityRows.tsx
+++ b/src/components/schedules/TeamAvailabilityRows.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Fragment, useState, useEffect, useMemo, useCallback } from "react";
-import { buildAvailabilityWeek } from "@/components/schedules/availability-week";
+import { buildAvailabilityWeek, getCurrentTimeMarker } from "@/components/schedules/availability-week";
 import { computeEventBlocks, type EventBlock } from "@/components/schedules/availability-blocks";
 import { computeSummaryStats, formatDateKey } from "@/components/schedules/availability-stats";
 import type { AcademicSchedule, User } from "@/types/database";
@@ -52,6 +52,10 @@ function getInitials(name: string): string {
     .map((n) => n[0])
     .join("")
     .toUpperCase();
+}
+
+export function getCurrentAvailabilityHour(now: Date, timeZone?: string): number {
+  return Math.floor(getCurrentTimeMarker(now, timeZone).minute / 60);
 }
 
 function computeBestWindow(
@@ -129,12 +133,21 @@ function ChevronRightIcon() {
 }
 
 export function TeamAvailabilityRows({ schedules, orgId, timeZone }: TeamAvailabilityRowsProps) {
+  const [mounted, setMounted] = useState(false);
   const [weekOffset, setWeekOffset] = useState(0);
   const [calendarEvents, setCalendarEvents] = useState<CalendarEvent[]>([]);
   const [loading, setLoading] = useState(false);
   const [selectedCell, setSelectedCell] = useState<string | null>(null);
 
-  const week = useMemo(() => buildAvailabilityWeek(new Date(), weekOffset, timeZone), [weekOffset, timeZone]);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const week = useMemo(() => buildAvailabilityWeek(new Date(), weekOffset, timeZone), [weekOffset, timeZone]); // eslint-disable-line react-hooks/exhaustive-deps
+  // todayKey is only used for "isToday" highlights — suppress during SSR to
+  // avoid hydration mismatch between server/client timezones.
+  const todayKey = mounted ? week.todayKey : "";
+  const currentHour = mounted ? getCurrentAvailabilityHour(new Date(), timeZone) : null;
 
   const fetchEvents = useCallback(async () => {
     setLoading(true);
@@ -360,7 +373,7 @@ export function TeamAvailabilityRows({ schedules, orgId, timeZone }: TeamAvailab
             {/* ── Day headers ── */}
             {week.weekDays.map((day) => {
               const dateKey = formatDateKey(day);
-              const isToday = dateKey === week.todayKey;
+              const isToday = dateKey === todayKey;
               const bw = bestWindowByDay.get(dateKey);
               return (
                 <div
@@ -406,8 +419,8 @@ export function TeamAvailabilityRows({ schedules, orgId, timeZone }: TeamAvailab
                     const dateKey = formatDateKey(day);
                     const gridKey = `${dateKey}-${hour}`;
                     const cellData = freeCountGrid.get(gridKey);
-                    const isToday = dateKey === week.todayKey;
-                    const isNow = isToday && hour === new Date().getHours();
+                    const isToday = dateKey === todayKey;
+                    const isNow = isToday && hour === currentHour;
                     const isSelected = selectedCell === gridKey;
 
                     if (!cellData) return <div key={gridKey} className="border-b border-l border-border/20" />;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -410,24 +410,32 @@ export async function middleware(request: NextRequest) {
           let membershipStatus: string | null | undefined;
 
           if (rpcError) {
-            // RPC failed — fall back to sequential queries so users are not blocked
+            // RPC failed — try sequential queries before failing closed
             if (shouldLog) {
               console.error("[AUTH-MW] get_org_context_by_slug RPC failed, falling back:", rpcError);
             }
 
-            const { data: org } = await supabase
+            const { data: org, error: orgError } = await supabase
               .from("organizations")
               .select("id")
               .eq("slug", orgSlug)
               .maybeSingle();
 
+            if (orgError) {
+              throw orgError;
+            }
+
             if (org) {
-              const { data: membership } = await supabase
+              const { data: membership, error: membershipError } = await supabase
                 .from("user_organization_roles")
                 .select("status")
                 .eq("organization_id", org.id)
                 .eq("user_id", user.id)
                 .maybeSingle();
+
+              if (membershipError) {
+                throw membershipError;
+              }
 
               membershipStatus = membership?.status;
             }
@@ -436,6 +444,8 @@ export async function middleware(request: NextRequest) {
             // Capture language fields from RPC for locale cookie sync (no extra query)
             orgDefaultLang = ctx.organization?.default_language ?? null;
             userLangOverride = ctx.membership?.language_override ?? null;
+          } else if (ctx !== null && ctx !== undefined && !isOrgContextRpcResult(ctx)) {
+            throw new Error("get_org_context_by_slug returned an invalid payload");
           }
           // If ctx is invalid or !ctx.found the org doesn't exist — layout.tsx handles the 404 gate
 
@@ -444,10 +454,8 @@ export async function middleware(request: NextRequest) {
             return NextResponse.redirect(new URL(membershipRedirect, request.url));
           }
         } catch (e) {
-          // Log error but don't block the request
-          if (shouldLog) {
-            console.error("[AUTH-MW] Error checking membership status:", e);
-          }
+          console.error("[AUTH-MW] Error checking membership status, failing closed:", e);
+          return NextResponse.redirect(new URL("/app?error=org_access_check_failed", request.url));
         }
       } else {
         // Dev-admin bypasses membership checks but still needs language data

--- a/supabase/migrations/20261008000001_harden_remaining_security_definer_search_paths.sql
+++ b/supabase/migrations/20261008000001_harden_remaining_security_definer_search_paths.sql
@@ -1,0 +1,304 @@
+-- Harden remaining SECURITY DEFINER functions by pinning search_path to ''.
+-- For functions that still relied on implicit public resolution, recompile the
+-- body with fully-qualified names so runtime behavior stays unchanged.
+
+BEGIN;
+
+ALTER FUNCTION public.can_enterprise_add_alumni(uuid) SET search_path = '';
+ALTER FUNCTION public.complete_enterprise_invite_redemption(text, uuid) SET search_path = '';
+ALTER FUNCTION public.create_enterprise_invite(uuid, uuid, text, integer, timestamptz) SET search_path = '';
+ALTER FUNCTION public.is_chat_group_creator(uuid) SET search_path = '';
+ALTER FUNCTION public.is_chat_group_member(uuid) SET search_path = '';
+ALTER FUNCTION public.is_chat_group_moderator(uuid) SET search_path = '';
+ALTER FUNCTION public.is_enterprise_admin(uuid) SET search_path = '';
+ALTER FUNCTION public.is_enterprise_member(uuid) SET search_path = '';
+ALTER FUNCTION public.is_enterprise_owner(uuid) SET search_path = '';
+ALTER FUNCTION public.is_org_admin(uuid) SET search_path = '';
+ALTER FUNCTION public.is_org_member(uuid) SET search_path = '';
+ALTER FUNCTION public.purge_expired_ai_semantic_cache() SET search_path = '';
+ALTER FUNCTION public.purge_old_enterprise_audit_logs() SET search_path = '';
+ALTER FUNCTION public.redeem_enterprise_invite(text) SET search_path = '';
+ALTER FUNCTION public.redeem_org_invite(text) SET search_path = '';
+ALTER FUNCTION public.reorder_media_albums(uuid, uuid[]) SET search_path = '';
+ALTER FUNCTION public.reorder_media_gallery(uuid, uuid[]) SET search_path = '';
+ALTER FUNCTION public.shift_media_album_sort_orders(uuid) SET search_path = '';
+ALTER FUNCTION public.shift_media_gallery_sort_orders(uuid) SET search_path = '';
+ALTER FUNCTION public.sync_enterprise_nav_to_org(uuid, uuid) SET search_path = '';
+ALTER FUNCTION public.update_calendar_sync_preferences_updated_at() SET search_path = '';
+ALTER FUNCTION public.update_event_calendar_entries_updated_at() SET search_path = '';
+ALTER FUNCTION public.update_user_calendar_connections_updated_at() SET search_path = '';
+
+CREATE OR REPLACE FUNCTION public.update_thread_activity()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE public.discussion_threads
+    SET reply_count = reply_count + 1,
+        last_activity_at = now(),
+        updated_at = now()
+    WHERE id = NEW.thread_id;
+  ELSIF TG_OP = 'UPDATE' AND NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS NULL THEN
+    UPDATE public.discussion_threads
+    SET reply_count = GREATEST(reply_count - 1, 0),
+        updated_at = now()
+    WHERE id = NEW.thread_id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_media_gallery_upload(
+  p_org_id uuid,
+  p_uploaded_by uuid,
+  p_storage_path text,
+  p_file_name text,
+  p_mime_type text,
+  p_file_size_bytes bigint,
+  p_media_type text,
+  p_title text,
+  p_description text DEFAULT NULL::text,
+  p_tags text[] DEFAULT ARRAY[]::text[],
+  p_taken_at timestamptz DEFAULT NULL::timestamptz,
+  p_status text DEFAULT 'uploading'::text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_media_id uuid;
+BEGIN
+  UPDATE public.media_items
+  SET gallery_sort_order = gallery_sort_order + 1,
+      updated_at = now()
+  WHERE organization_id = p_org_id AND deleted_at IS NULL;
+
+  INSERT INTO public.media_items (
+    organization_id,
+    uploaded_by,
+    storage_path,
+    file_name,
+    mime_type,
+    file_size_bytes,
+    media_type,
+    title,
+    description,
+    tags,
+    taken_at,
+    status,
+    gallery_sort_order
+  )
+  VALUES (
+    p_org_id,
+    p_uploaded_by,
+    p_storage_path,
+    p_file_name,
+    p_mime_type,
+    p_file_size_bytes,
+    p_media_type,
+    p_title,
+    p_description,
+    COALESCE(p_tags, ARRAY[]::text[]),
+    p_taken_at,
+    p_status::public.media_status,
+    0
+  )
+  RETURNING id INTO v_media_id;
+
+  RETURN v_media_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_media_gallery_upload(
+  p_org_id uuid,
+  p_uploaded_by uuid,
+  p_storage_path text,
+  p_preview_storage_path text,
+  p_file_name text,
+  p_mime_type text,
+  p_file_size_bytes bigint,
+  p_media_type text,
+  p_title text,
+  p_description text DEFAULT NULL::text,
+  p_tags text[] DEFAULT ARRAY[]::text[],
+  p_taken_at timestamptz DEFAULT NULL::timestamptz,
+  p_status text DEFAULT 'uploading'::text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_media_id uuid;
+BEGIN
+  UPDATE public.media_items
+  SET gallery_sort_order = gallery_sort_order + 1,
+      updated_at = now()
+  WHERE organization_id = p_org_id AND deleted_at IS NULL;
+
+  INSERT INTO public.media_items (
+    organization_id,
+    uploaded_by,
+    storage_path,
+    preview_storage_path,
+    file_name,
+    mime_type,
+    file_size_bytes,
+    media_type,
+    title,
+    description,
+    tags,
+    taken_at,
+    status,
+    gallery_sort_order
+  )
+  VALUES (
+    p_org_id,
+    p_uploaded_by,
+    p_storage_path,
+    p_preview_storage_path,
+    p_file_name,
+    p_mime_type,
+    p_file_size_bytes,
+    p_media_type,
+    p_title,
+    p_description,
+    COALESCE(p_tags, ARRAY[]::text[]),
+    p_taken_at,
+    p_status::public.media_status,
+    0
+  )
+  RETURNING id INTO v_media_id;
+
+  RETURN v_media_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.create_media_gallery_upload(
+  uuid,
+  uuid,
+  text,
+  text,
+  text,
+  bigint,
+  text,
+  text,
+  text,
+  text[],
+  timestamptz,
+  text
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.create_media_gallery_upload(
+  uuid,
+  uuid,
+  text,
+  text,
+  text,
+  bigint,
+  text,
+  text,
+  text,
+  text[],
+  timestamptz,
+  text
+) TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.create_media_gallery_upload(
+  uuid,
+  uuid,
+  text,
+  text,
+  text,
+  text,
+  bigint,
+  text,
+  text,
+  text,
+  text[],
+  timestamptz,
+  text
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.create_media_gallery_upload(
+  uuid,
+  uuid,
+  text,
+  text,
+  text,
+  text,
+  bigint,
+  text,
+  text,
+  text,
+  text[],
+  timestamptz,
+  text
+) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.update_error_baselines()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  UPDATE public.error_groups
+  SET
+    baseline_rate_1h = COALESCE(baseline_rate_1h, 0) * 0.9 + count_1h * 0.1,
+    count_24h = GREATEST(0, count_24h - CEIL(count_24h::numeric / 24)),
+    count_1h = 0;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.upsert_error_group(
+  p_fingerprint text,
+  p_title text,
+  p_severity text,
+  p_env text,
+  p_sample_event jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_group_id uuid;
+BEGIN
+  INSERT INTO public.error_groups (fingerprint, title, severity, env, sample_event)
+  VALUES (p_fingerprint, p_title, p_severity, p_env, p_sample_event)
+  ON CONFLICT (env, fingerprint) DO UPDATE SET
+    last_seen_at = now(),
+    count_1h = public.error_groups.count_1h + 1,
+    count_24h = public.error_groups.count_24h + 1,
+    total_count = public.error_groups.total_count + 1,
+    sample_event = CASE
+      WHEN public.error_groups.last_seen_at < now() - interval '5 minutes'
+      THEN p_sample_event
+      ELSE public.error_groups.sample_event
+    END,
+    status = CASE
+      WHEN public.error_groups.status = 'resolved' THEN 'open'
+      ELSE public.error_groups.status
+    END
+  RETURNING id INTO v_group_id;
+
+  RETURN v_group_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_error_group IS 'Atomically insert or update error group with count increment. sample_event refreshed only when last seen >5min ago to reduce write amplification.';
+
+REVOKE ALL ON FUNCTION public.upsert_error_group(text, text, text, text, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.upsert_error_group(text, text, text, text, jsonb) FROM anon;
+REVOKE ALL ON FUNCTION public.upsert_error_group(text, text, text, text, jsonb) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.upsert_error_group(text, text, text, text, jsonb) TO service_role;
+
+COMMIT;

--- a/tests/calendar-hydration-regressions.test.ts
+++ b/tests/calendar-hydration-regressions.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildCalendarMonthGrid,
+  formatCalendarMonthName,
+  getCalendarMonthCursor,
+} from "../src/components/calendar/CalendarMonthView";
+import { getCurrentAvailabilityHour } from "../src/components/schedules/TeamAvailabilityRows";
+
+describe("calendar month timezone stability", () => {
+  it("derives the rendered month from the org timezone instead of the machine timezone", () => {
+    const losAngelesMonth = getCalendarMonthCursor(
+      new Date("2026-04-01T05:30:00.000Z"),
+      "America/Los_Angeles",
+    );
+    const newYorkMonth = getCalendarMonthCursor(
+      new Date("2026-04-01T05:30:00.000Z"),
+      "America/New_York",
+    );
+
+    assert.deepStrictEqual(losAngelesMonth, { year: 2026, month: 2 });
+    assert.deepStrictEqual(newYorkMonth, { year: 2026, month: 3 });
+    assert.equal(formatCalendarMonthName(newYorkMonth.year, newYorkMonth.month), "April 2026");
+  });
+
+  it("builds a stable plain-date grid for the rendered month", () => {
+    const grid = buildCalendarMonthGrid(2026, 3);
+
+    assert.equal(grid[0]?.[0]?.dateKey, "2026-03-29");
+    assert.equal(grid[0]?.[3]?.dateKey, "2026-04-01");
+    assert.equal(grid[5]?.[6]?.dateKey, "2026-05-09");
+  });
+});
+
+describe("team availability current-hour marker", () => {
+  it("uses the org timezone for the highlighted current hour", () => {
+    const now = new Date("2026-04-01T01:00:00.000Z");
+
+    assert.equal(getCurrentAvailabilityHour(now, "America/New_York"), 21);
+    assert.equal(getCurrentAvailabilityHour(now, "America/Los_Angeles"), 18);
+  });
+});

--- a/tests/function-search-path-regressions.test.ts
+++ b/tests/function-search-path-regressions.test.ts
@@ -1,0 +1,100 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const migrationFile = "../supabase/migrations/20261008000001_harden_remaining_security_definer_search_paths.sql";
+const migration = readFileSync(new URL(migrationFile, import.meta.url), "utf8");
+const calendarMigrationFile = "../supabase/migrations/20260420120000_google_calendar_sync.sql";
+const calendarMigration = readFileSync(new URL(calendarMigrationFile, import.meta.url), "utf8");
+
+function countMatches(input: string, pattern: RegExp): number {
+  return Array.from(input.matchAll(pattern)).length;
+}
+
+describe("remaining SECURITY DEFINER search_path hardening", () => {
+  it("pins the org and enterprise invite paths to an empty search_path", () => {
+    assert.match(migration, /ALTER FUNCTION public\.redeem_org_invite\(text\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.create_enterprise_invite\(uuid, uuid, text, integer, timestamptz\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.redeem_enterprise_invite\(text\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.complete_enterprise_invite_redemption\(text, uuid\) SET search_path = '';/);
+  });
+
+  it("pins org membership, chat helper, and calendar timestamp functions to an empty search_path", () => {
+    assert.match(migration, /ALTER FUNCTION public\.is_org_member\(uuid\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.is_org_admin\(uuid\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.is_chat_group_member\(uuid\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.is_chat_group_moderator\(uuid\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.is_chat_group_creator\(uuid\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.update_user_calendar_connections_updated_at\(\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.update_event_calendar_entries_updated_at\(\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.update_calendar_sync_preferences_updated_at\(\) SET search_path = '';/);
+  });
+
+  it("pins remaining service-role helpers to an empty search_path", () => {
+    assert.match(migration, /ALTER FUNCTION public\.can_enterprise_add_alumni\(uuid\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.purge_expired_ai_semantic_cache\(\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.purge_old_enterprise_audit_logs\(\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.shift_media_album_sort_orders\(uuid\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.reorder_media_albums\(uuid, uuid\[\]\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.shift_media_gallery_sort_orders\(uuid\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.reorder_media_gallery\(uuid, uuid\[\]\) SET search_path = '';/);
+    assert.match(migration, /ALTER FUNCTION public\.sync_enterprise_nav_to_org\(uuid, uuid\) SET search_path = '';/);
+  });
+
+  it("rebuilds both media gallery upload overloads for empty search_path enum casts", () => {
+    const normalized = migration.replace(/\s+/g, " ");
+
+    assert.equal(
+      countMatches(
+        migration,
+        /CREATE OR REPLACE FUNCTION public\.create_media_gallery_upload\(/g
+      ),
+      2,
+      "expected both create_media_gallery_upload overloads to be recreated"
+    );
+    assert.equal(
+      countMatches(migration, /SET search_path = ''/g) >= 2,
+      true,
+      "create_media_gallery_upload overloads should run with an empty search_path"
+    );
+    assert.ok(
+      normalized.includes("p_status::public.media_status"),
+      "create_media_gallery_upload must schema-qualify media_status casts under SET search_path = ''"
+    );
+  });
+
+  it("only hardens calendar timestamp triggers that mutate NEW rows", () => {
+    assert.match(
+      calendarMigration,
+      /create or replace function public\.update_user_calendar_connections_updated_at\(\)[\s\S]*?begin[\s\S]*?new\.updated_at = now\(\);[\s\S]*?return new;[\s\S]*?end;/i
+    );
+    assert.match(
+      calendarMigration,
+      /create or replace function public\.update_event_calendar_entries_updated_at\(\)[\s\S]*?begin[\s\S]*?new\.updated_at = now\(\);[\s\S]*?return new;[\s\S]*?end;/i
+    );
+    assert.match(
+      calendarMigration,
+      /create or replace function public\.update_calendar_sync_preferences_updated_at\(\)[\s\S]*?begin[\s\S]*?new\.updated_at = now\(\);[\s\S]*?return new;[\s\S]*?end;/i
+    );
+  });
+
+  it("rebuilds trigger and error-tracking helpers with public-qualified table references", () => {
+    assert.match(
+      migration,
+      /CREATE OR REPLACE FUNCTION public\.update_thread_activity\(\)[\s\S]*?SET search_path = ''[\s\S]*?UPDATE public\.discussion_threads/i
+    );
+    assert.match(
+      migration,
+      /CREATE OR REPLACE FUNCTION public\.update_error_baselines\(\)[\s\S]*?SET search_path = ''[\s\S]*?UPDATE public\.error_groups/i
+    );
+    assert.match(
+      migration,
+      /CREATE OR REPLACE FUNCTION public\.upsert_error_group\([\s\S]*?SET search_path = ''[\s\S]*?INSERT INTO public\.error_groups/i
+    );
+  });
+
+  it("does not reintroduce public search_path settings in the hardening migration", () => {
+    const strippedComments = migration.replace(/--[^\n]*/g, "");
+    assert.doesNotMatch(strippedComments, /SET search_path(?:\s+TO)?\s+'?public/i);
+  });
+});

--- a/tests/middleware-membership-fail-closed.test.ts
+++ b/tests/middleware-membership-fail-closed.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+test("middleware fails closed when org membership verification errors", () => {
+  const source = readSource("src/middleware.ts");
+  const orgRouteSection = source.slice(
+    source.indexOf("if (isOrgRoute(pathname) && user)"),
+    source.indexOf("// ── Locale cookie sync ──")
+  );
+
+  assert.match(orgRouteSection, /const \{ data: org, error: orgError \}/);
+  assert.match(orgRouteSection, /if \(orgError\) \{\s*throw orgError;/);
+  assert.match(orgRouteSection, /const \{ data: membership, error: membershipError \}/);
+  assert.match(orgRouteSection, /if \(membershipError\) \{\s*throw membershipError;/);
+  assert.match(orgRouteSection, /get_org_context_by_slug returned an invalid payload/);
+  assert.match(orgRouteSection, /Error checking membership status, failing closed/);
+  assert.match(
+    orgRouteSection,
+    /return NextResponse\.redirect\(new URL\("\/app\?error=org_access_check_failed", request\.url\)\);/
+  );
+  assert.doesNotMatch(orgRouteSection, /don't block the request/i);
+});

--- a/tests/ts-loader.js
+++ b/tests/ts-loader.js
@@ -14,6 +14,11 @@ export async function resolve(specifier, context, defaultResolve) {
     return { ...result, shortCircuit: true };
   }
 
+  if (specifier === "next/link") {
+    const result = await defaultResolve("next/link.js", context, defaultResolve);
+    return { ...result, shortCircuit: true };
+  }
+
   if (typeof specifier === "string" && specifier.startsWith("@/")) {
     const basePath = path.join(process.cwd(), "src", specifier.slice(2));
     const candidates = [


### PR DESCRIPTION
## Summary
- **Fix React hydration errors #418/#422** on the calendar page caused by `new Date()` producing different values on server (UTC) vs browser (local timezone)
- **Harden middleware** RPC fallback path to fail closed instead of silently proceeding on query failure
- **Harden remaining SECURITY DEFINER** function search paths

## Calendar Hydration Fixes
| File | Change |
|------|--------|
| `CalendarMonthView.tsx` | Replace `Date`-based display state with `{year, month}` cursor derived via org timezone. Month grid uses UTC dates for deterministic cell keys. `todayKey` suppressed during SSR via `mounted` guard. |
| `UnifiedEventFeed.tsx` | Floating-date events use `Date.UTC()` + `timeZone: "UTC"` for deterministic date group labels |
| `TeamAvailabilityRows.tsx` | `mounted` guard for `todayKey`. Org-timezone-aware `getCurrentAvailabilityHour()` replaces bare `new Date().getHours()` |
| `PersonalAvailabilityAgenda.tsx` | `mounted` guard suppresses `todayKey` during SSR |

## Middleware Hardening
- RPC fallback path captures `orgError`/`membershipError` and throws instead of silently proceeding
- Redirects to `/app?error=org_access_check_failed` on failure (fail closed)
- Validates RPC return shape

## Test plan
- [x] `tests/calendar-hydration-regressions.test.ts` — UTC month-boundary cursor and org-timezone current-hour regression tests
- [x] `tests/middleware-membership-fail-closed.test.ts` — middleware fail-closed behavior
- [x] `tests/function-search-path-regressions.test.ts` — search path hardening
- [x] All existing calendar tests pass (36/36)
- [x] TypeScript clean, ESLint clean, build passes
- [ ] Manual: verify calendar page loads with events and no console errors
- [ ] Manual: verify "today" highlight appears after page load
- [ ] Manual: verify availability tab todayKey and current-hour ring work