### PR TITLE
fix(enterprise): resolve invite role cast, dashboard visibility, and adoption role grant

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -122,7 +122,9 @@ export default async function AppHomePage({ searchParams }: AppHomePageProps) {
     .filter(Boolean) as Array<OrganizationSummary & { role: string }>;
 
   // Split into regular orgs and enterprise sub-orgs
-  const orgs = allOrgs.filter((o) => !o.enterprise_id);
+  // Orgs with enterprise_id are shown nested under their enterprise card,
+  // but only if the user has an enterprise-level role. Otherwise they
+  // appear in the main org grid so they're never invisible.
   const knownEnterpriseIds = new Set(
     enterprises.map((e) => e.enterprise?.id).filter(Boolean)
   );
@@ -132,6 +134,9 @@ export default async function AppHomePage({ searchParams }: AppHomePageProps) {
       ...acc,
       [org.enterprise_id!]: [...(acc[org.enterprise_id!] ?? []), org],
     }), {});
+  const orgs = allOrgs.filter(
+    (o) => !o.enterprise_id || !knownEnterpriseIds.has(o.enterprise_id)
+  );
 
   // Get pending memberships for display
   const pendingDisplayMemberships = pendingMemberships
@@ -305,6 +310,14 @@ export default async function AppHomePage({ searchParams }: AppHomePageProps) {
                     </div>
                     <Badge variant="muted" className="ml-auto capitalize">{org.role}</Badge>
                   </div>
+                  {org.enterprise_id && (
+                    <div className="flex items-center gap-1.5 text-xs text-purple-600 dark:text-purple-400">
+                      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" />
+                      </svg>
+                      <span>Enterprise</span>
+                    </div>
+                  )}
                   {org.description && (
                     <p className="text-sm text-muted-foreground line-clamp-2">{org.description}</p>
                   )}

--- a/src/lib/enterprise/adoption.ts
+++ b/src/lib/enterprise/adoption.ts
@@ -299,7 +299,38 @@ export async function acceptAdoptionRequest(
     }
   }
 
-  // Step 3: Mark request as accepted
+  // Step 3: Grant enterprise org_admin role to all active org admins
+  // so they can access the enterprise dashboard after adoption.
+  const { data: orgAdmins, error: orgAdminsError } = await supabase
+    .from("user_organization_roles")
+    .select("user_id")
+    .eq("organization_id", request.organization_id)
+    .eq("role", "admin")
+    .eq("status", "active");
+
+  if (orgAdminsError) {
+    console.error("[acceptAdoptionRequest] Failed to fetch org admins for enterprise role grant:", orgAdminsError);
+    // Non-fatal: proceed with adoption even if enterprise role grant fails.
+    // Admins can be manually added to the enterprise later.
+  } else if (orgAdmins && orgAdmins.length > 0) {
+    const enterpriseRoleRows = orgAdmins.map((admin) => ({
+      user_id: admin.user_id,
+      enterprise_id: request.enterprise_id,
+      role: "org_admin",
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error: roleGrantError } = await (supabase as any)
+      .from("user_enterprise_roles")
+      .upsert(enterpriseRoleRows, { onConflict: "user_id,enterprise_id" });
+
+    if (roleGrantError) {
+      console.error("[acceptAdoptionRequest] Failed to grant enterprise roles to org admins:", roleGrantError);
+      // Non-fatal: adoption still succeeds, admins can be added manually
+    }
+  }
+
+  // Step 4: Mark request as accepted
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { error: markAcceptedError } = await (supabase as any)
     .from("enterprise_adoption_requests")

--- a/supabase/migrations/20261010000000_fix_enterprise_invite_role_cast.sql
+++ b/supabase/migrations/20261010000000_fix_enterprise_invite_role_cast.sql
@@ -1,0 +1,282 @@
+-- Fix: enterprise invite redemption fails with
+-- "column 'role' is of type user_role but expression is of type text"
+--
+-- Root cause: enterprise_invites.role is text, user_organization_roles.role is
+-- user_role enum. The INSERT/UPDATE in both redeem_enterprise_invite and
+-- complete_enterprise_invite_redemption omitted the ::public.user_role cast.
+--
+-- Both functions are recreated with search_path = '' (matching the hardening
+-- from 20261008000001) and all references fully qualified.
+
+-- =====================================================
+-- Part 1: Fix redeem_enterprise_invite
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.redeem_enterprise_invite(p_code_or_token text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_invite public.enterprise_invites;
+  v_user_id uuid;
+  v_org_name text;
+  v_org_slug text;
+  v_existing_status text;
+  v_orgs jsonb;
+  v_admin_count integer;
+BEGIN
+  -- Get current user
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Must be authenticated';
+  END IF;
+
+  -- Find the invite by code or token (lock row to prevent race conditions)
+  SELECT * INTO v_invite
+  FROM public.enterprise_invites
+  WHERE (code = upper(p_code_or_token) OR token = p_code_or_token)
+    AND revoked_at IS NULL
+    AND (expires_at IS NULL OR expires_at > now())
+    AND (uses_remaining IS NULL OR uses_remaining > 0)
+  FOR UPDATE;
+
+  IF v_invite IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Invalid, expired, or fully used invite code'
+    );
+  END IF;
+
+  -- If invite has no specific org, return available orgs for user to choose
+  IF v_invite.organization_id IS NULL THEN
+    SELECT jsonb_agg(jsonb_build_object(
+      'id', o.id,
+      'name', o.name,
+      'slug', o.slug,
+      'description', o.description
+    ) ORDER BY o.name)
+    INTO v_orgs
+    FROM public.organizations o
+    WHERE o.enterprise_id = v_invite.enterprise_id
+      AND NOT EXISTS (
+        SELECT 1 FROM public.user_organization_roles ur
+        WHERE ur.user_id = v_user_id
+          AND ur.organization_id = o.id
+          AND ur.status IN ('active', 'pending')
+      );
+
+    RETURN jsonb_build_object(
+      'success', true,
+      'status', 'choose_org',
+      'enterprise_id', v_invite.enterprise_id,
+      'role', v_invite.role,
+      'organizations', COALESCE(v_orgs, '[]'::jsonb),
+      'invite_token', v_invite.token
+    );
+  END IF;
+
+  -- Org-specific invite: enforce admin cap at redemption time
+  IF v_invite.role = 'admin' THEN
+    SELECT count(*) INTO v_admin_count
+    FROM public.user_organization_roles uor
+    JOIN public.organizations o ON o.id = uor.organization_id
+    WHERE o.enterprise_id = v_invite.enterprise_id
+      AND uor.role = 'admin'::public.user_role
+      AND uor.status = 'active';
+
+    IF v_admin_count >= 12 THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'Enterprise admin limit reached (maximum 12 admins across all organizations)'
+      );
+    END IF;
+  END IF;
+
+  -- Check existing membership status
+  SELECT status INTO v_existing_status
+  FROM public.user_organization_roles
+  WHERE user_id = v_user_id AND organization_id = v_invite.organization_id;
+
+  IF v_existing_status = 'revoked' THEN
+    -- Restore revoked user with new role from invite
+    UPDATE public.user_organization_roles
+    SET status = 'active', role = v_invite.role::public.user_role
+    WHERE user_id = v_user_id AND organization_id = v_invite.organization_id;
+  ELSIF v_existing_status IS NOT NULL THEN
+    -- User already has active or pending role
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'You already have a role in this organization'
+    );
+  ELSE
+    -- Respect alumni quota for alumni invites
+    IF v_invite.role = 'alumni' THEN
+      PERFORM public.assert_alumni_quota(v_invite.organization_id);
+    END IF;
+
+    -- Create new membership with active status (auto-approved for enterprise invites)
+    INSERT INTO public.user_organization_roles (
+      user_id,
+      organization_id,
+      role,
+      status
+    ) VALUES (
+      v_user_id,
+      v_invite.organization_id,
+      v_invite.role::public.user_role,
+      'active'
+    );
+  END IF;
+
+  -- Get org details
+  SELECT name, slug INTO v_org_name, v_org_slug
+  FROM public.organizations
+  WHERE id = v_invite.organization_id;
+
+  -- Decrement uses if applicable
+  IF v_invite.uses_remaining IS NOT NULL THEN
+    UPDATE public.enterprise_invites
+    SET uses_remaining = uses_remaining - 1
+    WHERE id = v_invite.id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'organization_id', v_invite.organization_id,
+    'organization_name', v_org_name,
+    'organization_slug', v_org_slug,
+    'role', v_invite.role
+  );
+END;
+$$;
+
+-- =====================================================
+-- Part 2: Fix complete_enterprise_invite_redemption
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.complete_enterprise_invite_redemption(
+  p_token text,
+  p_organization_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_invite public.enterprise_invites;
+  v_user_id uuid;
+  v_org_name text;
+  v_org_slug text;
+  v_existing_status text;
+  v_admin_count integer;
+BEGIN
+  -- Get current user
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Must be authenticated';
+  END IF;
+
+  -- Find the invite by token (must be enterprise-wide: organization_id IS NULL)
+  -- Lock row to prevent race conditions on uses_remaining
+  SELECT * INTO v_invite
+  FROM public.enterprise_invites
+  WHERE token = p_token
+    AND organization_id IS NULL
+    AND revoked_at IS NULL
+    AND (expires_at IS NULL OR expires_at > now())
+    AND (uses_remaining IS NULL OR uses_remaining > 0)
+  FOR UPDATE;
+
+  IF v_invite IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Invalid, expired, or fully used invite'
+    );
+  END IF;
+
+  -- Verify the chosen organization belongs to this enterprise
+  IF NOT EXISTS (
+    SELECT 1 FROM public.organizations
+    WHERE id = p_organization_id
+      AND enterprise_id = v_invite.enterprise_id
+  ) THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Organization does not belong to this enterprise'
+    );
+  END IF;
+
+  -- Enforce admin cap at redemption time
+  IF v_invite.role = 'admin' THEN
+    SELECT count(*) INTO v_admin_count
+    FROM public.user_organization_roles uor
+    JOIN public.organizations o ON o.id = uor.organization_id
+    WHERE o.enterprise_id = v_invite.enterprise_id
+      AND uor.role = 'admin'::public.user_role
+      AND uor.status = 'active';
+
+    IF v_admin_count >= 12 THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'Enterprise admin limit reached (maximum 12 admins across all organizations)'
+      );
+    END IF;
+  END IF;
+
+  -- Check existing membership status
+  SELECT status INTO v_existing_status
+  FROM public.user_organization_roles
+  WHERE user_id = v_user_id AND organization_id = p_organization_id;
+
+  IF v_existing_status = 'revoked' THEN
+    UPDATE public.user_organization_roles
+    SET status = 'active', role = v_invite.role::public.user_role
+    WHERE user_id = v_user_id AND organization_id = p_organization_id;
+  ELSIF v_existing_status IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'You already have a role in this organization'
+    );
+  ELSE
+    -- Respect alumni quota for alumni invites
+    IF v_invite.role = 'alumni' THEN
+      PERFORM public.assert_alumni_quota(p_organization_id);
+    END IF;
+
+    INSERT INTO public.user_organization_roles (
+      user_id,
+      organization_id,
+      role,
+      status
+    ) VALUES (
+      v_user_id,
+      p_organization_id,
+      v_invite.role::public.user_role,
+      'active'
+    );
+  END IF;
+
+  -- Get org details
+  SELECT name, slug INTO v_org_name, v_org_slug
+  FROM public.organizations
+  WHERE id = p_organization_id;
+
+  -- Decrement uses if applicable
+  IF v_invite.uses_remaining IS NOT NULL THEN
+    UPDATE public.enterprise_invites
+    SET uses_remaining = uses_remaining - 1
+    WHERE id = v_invite.id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'organization_id', p_organization_id,
+    'organization_name', v_org_name,
+    'organization_slug', v_org_slug,
+    'role', v_invite.role
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary

- **Fix enterprise invite role cast** — `redeem_enterprise_invite` and `complete_enterprise_invite_redemption` RPCs were inserting text into a `user_role` enum column without casting, causing `column "role" is of type user_role but expression is of type text` error when joining via enterprise invite
- **Fix dashboard org visibility** — Enterprise sub-orgs were invisible on the `/app` dashboard when the user had no enterprise-level role (e.g., joined via enterprise invite). Now shown in the main org grid with a purple "Enterprise" badge
- **Fix adoption role grant** — When an org admin accepts an enterprise adoption request, all active org admins now receive an `org_admin` enterprise role so they can access the enterprise dashboard

## DB migration

`20261010000000_fix_enterprise_invite_role_cast.sql` — already applied to production via SQL Editor (urgent fix for live enterprise customer demo). Recreates both RPCs with `::public.user_role` casts and `SET search_path = ''`.

## Test plan

- [x] All 1407 route tests pass
- [x] Production build succeeds
- [x] DB migration applied and verified in production
- [ ] Verify enterprise invite join works (admin, active_member, alumni roles)
- [ ] Verify joined enterprise org appears on `/app` dashboard with Enterprise badge
- [ ] Verify adoption flow grants `org_admin` enterprise role to accepting org admins