### PR TITLE
fix(enterprise): treat enterprise_managed as active subscription status

### DIFF
--- a/src/app/[orgSlug]/layout.tsx
+++ b/src/app/[orgSlug]/layout.tsx
@@ -168,7 +168,7 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
     }
   }
   
-  const activeStatuses = ["active", "trialing", "canceling"];
+  const activeStatuses = ["active", "trialing", "canceling", "enterprise_managed"];
   const shouldShowBillingGate = 
     subscriptionStatus && 
     !activeStatuses.includes(subscriptionStatus) && 

--- a/src/lib/subscription/grace-period.ts
+++ b/src/lib/subscription/grace-period.ts
@@ -118,7 +118,7 @@ export function formatGracePeriodDate(date: Date | string | null): string {
 export function shouldBlockAccess(subscription: SubscriptionStatus | null): boolean {
   if (!subscription) return true;
   
-  const activeStatuses = ["active", "trialing", "canceling"];
+  const activeStatuses = ["active", "trialing", "canceling", "enterprise_managed"];
   if (activeStatuses.includes(subscription.status || "")) {
     return false;
   }


### PR DESCRIPTION
## Summary
- Enterprise sub-orgs have `subscription_status = "enterprise_managed"` but the billing gate only recognized `active`, `trialing`, and `canceling` as valid statuses
- This caused all enterprise org members to hit a "Billing Required / Activate your organization" wall with no way past it (clicking "Manage Billing" fails since there's no Stripe subscription)
- Adds `"enterprise_managed"` to `activeStatuses` in both the org layout gate and the `shouldBlockAccess()` utility

## Test plan
- [ ] Enterprise sub-org member can access org pages without hitting billing gate
- [ ] Non-enterprise orgs with `active`/`trialing`/`canceling` still work as before
- [ ] Orgs with `pending`/`past_due`/etc. still show the billing gate correctly