### PR TITLE
fix(calendar): preserve view state when navigating to/from event details

### DIFF
--- a/src/app/[orgSlug]/calendar/events/[eventId]/page.tsx
+++ b/src/app/[orgSlug]/calendar/events/[eventId]/page.tsx
@@ -13,10 +13,17 @@ import { resolveOrgTimezone } from "@/lib/utils/timezone";
 
 interface EventDetailPageProps {
   params: Promise<{ orgSlug: string; eventId: string }>;
+  searchParams: Promise<{ from?: string }>;
 }
 
-export default async function CalendarEventDetailPage({ params }: EventDetailPageProps) {
+export default async function CalendarEventDetailPage({ params, searchParams }: EventDetailPageProps) {
   const { orgSlug, eventId } = await params;
+  const { from } = await searchParams;
+
+  const isRelative = (s: string) => s.startsWith("/") && !s.startsWith("//");
+  const backHref = (from && isRelative(decodeURIComponent(from)))
+    ? decodeURIComponent(from)
+    : calendarEventsPath(orgSlug);
 
   const { organization: org, isAdmin } = await getOrgContext(orgSlug);
   if (!org) return notFound();
@@ -79,7 +86,7 @@ export default async function CalendarEventDetailPage({ params }: EventDetailPag
       <EventOpenTracker organizationId={org.id} eventId={eventId} />
       <PageHeader
         title={event.title}
-        backHref={calendarEventsPath(orgSlug)}
+        backHref={backHref}
         actions={
           isAdmin && (
             <div className="flex items-center gap-2">

--- a/src/components/calendar/CalendarMonthView.tsx
+++ b/src/components/calendar/CalendarMonthView.tsx
@@ -18,6 +18,7 @@ type CalendarMonthViewProps = {
   initialEvents?: UnifiedEvent[];
   timeZone?: string;
   rightSlot?: React.ReactNode;
+  returnTo?: string;
 };
 
 const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -109,7 +110,7 @@ function getSourceColors(sourceType: string): { dot: string; text: string } {
   }
 }
 
-export function CalendarMonthView({ orgId, orgSlug, initialEvents, timeZone, rightSlot }: CalendarMonthViewProps) {
+export function CalendarMonthView({ orgId, orgSlug, initialEvents, timeZone, rightSlot, returnTo }: CalendarMonthViewProps) {
   const resolvedTimeZone = resolveOrgTimezone(timeZone);
   const mounted = useHasMounted();
   const [displayMonth, setDisplayMonth] = useState<CalendarMonthCursor>(() => getCalendarMonthCursor(new Date(), resolvedTimeZone));
@@ -320,7 +321,7 @@ export function CalendarMonthView({ orgId, orgSlug, initialEvents, timeZone, rig
               <div className="flex-1 overflow-hidden space-y-0.5">
                 {visibleEvents.map((event) => {
                   const { dot, text } = getSourceColors(event.sourceType);
-                  const href = getUnifiedEventHref(orgSlug, event);
+                  const href = getUnifiedEventHref(orgSlug, event, returnTo);
 
                   if (href) {
                     return (

--- a/src/components/calendar/CalendarTab.tsx
+++ b/src/components/calendar/CalendarTab.tsx
@@ -82,6 +82,9 @@ export function CalendarTab({
   const isGridActive = subview === "grid";
   const isListActive = subview === "list";
 
+  const currentParams = searchParams.toString();
+  const returnTo = `/${orgSlug}/calendar${currentParams ? `?${currentParams}` : ""}`;
+
   const viewToggleButtonClass =
     "p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
   const activeViewToggleButtonClass =
@@ -151,6 +154,7 @@ export function CalendarTab({
           initialEvents={initialEvents}
           timeZone={timeZone}
           timeframe={timeframe}
+          returnTo={returnTo}
         />
       </div>
     );
@@ -164,6 +168,7 @@ export function CalendarTab({
       initialEvents={initialEvents}
       timeZone={timeZone}
       rightSlot={rightSlot}
+      returnTo={returnTo}
     />
   );
 }

--- a/src/components/calendar/UnifiedEventFeed.tsx
+++ b/src/components/calendar/UnifiedEventFeed.tsx
@@ -19,6 +19,7 @@ type UnifiedEventFeedProps = {
   initialEvents?: UnifiedEvent[];
   timeZone?: string;
   timeframe?: CalendarEventTimeframe;
+  returnTo?: string;
 };
 
 type SourceFilterKey = "events" | "schedules" | "feeds" | "classes";
@@ -122,7 +123,7 @@ function getBadgeColor(badgeText: string): string {
   return "bg-muted text-muted-foreground";
 }
 
-export function UnifiedEventFeed({ orgId, orgSlug, initialEvents, timeZone, timeframe = "upcoming" }: UnifiedEventFeedProps) {
+export function UnifiedEventFeed({ orgId, orgSlug, initialEvents, timeZone, timeframe = "upcoming", returnTo }: UnifiedEventFeedProps) {
   const hasInitialData = initialEvents !== undefined;
   const [events, setEvents] = useState<UnifiedEvent[]>(initialEvents ?? []);
   const [loading, setLoading] = useState(!hasInitialData);
@@ -262,7 +263,7 @@ export function UnifiedEventFeed({ orgId, orgSlug, initialEvents, timeZone, time
     );
 
     const className = "flex items-start gap-3 py-3.5";
-    const href = getUnifiedEventHref(orgSlug, event);
+    const href = getUnifiedEventHref(orgSlug, event, returnTo);
 
     if (href) {
       return (

--- a/src/lib/calendar/navigation.ts
+++ b/src/lib/calendar/navigation.ts
@@ -1,3 +1,5 @@
+import { calendarEventDetailPath } from "@/lib/calendar/routes";
+
 type UnifiedEventLinkTarget = {
   sourceType: "event" | "schedule" | "feed" | "class";
   id?: string;
@@ -29,6 +31,7 @@ function parsePrefixedId(value: string | undefined, prefix: "event" | "class"): 
 export function getUnifiedEventHref(
   orgSlug: string,
   event: UnifiedEventLinkTarget,
+  returnTo?: string,
 ): string | null {
   if (
     event.sourceType === "event"
@@ -42,7 +45,8 @@ export function getUnifiedEventHref(
   if (event.sourceType === "event") {
     const eventId = event.eventId ?? parsePrefixedId(event.id, "event");
     if (eventId) {
-      return `/${orgSlug}/events/${eventId}`;
+      const base = calendarEventDetailPath(orgSlug, eventId);
+      return returnTo ? `${base}?from=${encodeURIComponent(returnTo)}` : base;
     }
   }
 

--- a/tests/calendar-navigation.test.ts
+++ b/tests/calendar-navigation.test.ts
@@ -8,14 +8,14 @@ describe("calendar navigation helpers", () => {
   it("routes team events to the event detail page", () => {
     assert.equal(
       getUnifiedEventHref("acme", { sourceType: "event", eventId: "event-1" }),
-      "/acme/events/event-1",
+      "/acme/calendar/events/event-1",
     );
   });
 
   it("falls back to the unified event id when the explicit eventId is missing", () => {
     assert.equal(
       getUnifiedEventHref("acme", { sourceType: "event", id: "event:event-1" }),
-      "/acme/events/event-1",
+      "/acme/calendar/events/event-1",
     );
   });
 
@@ -48,5 +48,19 @@ describe("calendar navigation helpers", () => {
   it("does not create bogus edit links for imported schedule rows", () => {
     assert.equal(getUnifiedEventHref("acme", { sourceType: "schedule" }), null);
     assert.equal(getUnifiedEventHref("acme", { sourceType: "feed" }), null);
+  });
+
+  it("appends from param when returnTo is provided", () => {
+    assert.equal(
+      getUnifiedEventHref("acme", { sourceType: "event", eventId: "event-1" }, "/acme/calendar?subview=list"),
+      "/acme/calendar/events/event-1?from=%2Facme%2Fcalendar%3Fsubview%3Dlist",
+    );
+  });
+
+  it("encodes returnTo parameter safely", () => {
+    assert.equal(
+      getUnifiedEventHref("acme", { sourceType: "event", eventId: "event-1" }, "/acme/calendar"),
+      "/acme/calendar/events/event-1?from=%2Facme%2Fcalendar",
+    );
   });
 });


### PR DESCRIPTION
## Summary

When users click an event from the calendar grid or list view, the app now preserves their current view preference. Users can navigate back to the exact view they came from.

## Implementation

- Pass current calendar URL as `?from=` query param when navigating to event details
- Event detail page reads `?from=` and uses it as the back button destination
- Validate `?from=` is a relative URL to prevent open redirects
- Changed event link target to canonical `/calendar/events/{id}` instead of legacy `/events/{id}` redirect

## Test Plan

- [ ] Grid view: click event → back returns to grid (no `?subview` param)
- [ ] List view: click event → back returns to list (`?subview=list`)
- [ ] Direct link to event (no `?from=`): back defaults to list view
- [ ] Invalid `?from=` (absolute URL): ignored, fallback applied
- [ ] All unit tests pass (2554 pass)

## Notes

- Changed event link paths from `/events/{id}` to `/calendar/events/{id}` to bypass legacy redirect and preserve `?from=` param
- Updated 2 test cases to expect new canonical path
- Added 2 new test cases for `returnTo` parameter encoding