### PR TITLE
fix(enterprise): treat enterprise-managed orgs as pooled in billing UI

### DIFF
--- a/src/app/api/organizations/[organizationId]/subscription/route.ts
+++ b/src/app/api/organizations/[organizationId]/subscription/route.ts
@@ -3,6 +3,7 @@ import type Stripe from "stripe";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { getAlumniLimit, normalizeBucket } from "@/lib/alumni-quota";
+import { getAlumniCapacitySnapshot } from "@/lib/alumni/capacity";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import {
   baseSchemas,
@@ -271,6 +272,7 @@ function buildQuotaResponse(params: {
   alumniLimit: number | null;
   alumniCount: number;
   status: string;
+  isEnterpriseManaged?: boolean;
   stripeSubscriptionId: string | null;
   stripeCustomerId: string | null;
   currentPeriodEnd: string | null;
@@ -283,6 +285,7 @@ function buildQuotaResponse(params: {
     alumniCount: params.alumniCount,
     remaining,
     status: params.status,
+    isEnterpriseManaged: params.isEnterpriseManaged ?? false,
   };
   if (params.includeStripeDetails === true) {
     payload.stripeSubscriptionId = params.stripeSubscriptionId;
@@ -331,6 +334,29 @@ export async function GET(req: Request, { params }: RouteParams) {
   );
   const baseInterval: SubscriptionInterval =
     sub?.base_plan_interval === "year" ? "year" : "month";
+
+  // Enterprise-managed orgs pool capacity across the enterprise. Their
+  // organization_subscriptions.alumni_bucket is "none" (billing lives on the
+  // enterprise subscription), so return pooled limit + pooled count instead.
+  if ((sub?.status as string | undefined) === "enterprise_managed") {
+    try {
+      const snap = await getAlumniCapacitySnapshot(organizationId, serviceSupabase);
+      return buildQuotaResponse({
+        bucket,
+        alumniLimit: snap.alumniLimit,
+        alumniCount: snap.currentAlumniCount,
+        status: "enterprise_managed",
+        isEnterpriseManaged: true,
+        stripeSubscriptionId: null,
+        stripeCustomerId: null,
+        currentPeriodEnd: null,
+        includeStripeDetails: false,
+      }, respond);
+    } catch (e) {
+      console.error("[subscription] enterprise capacity snapshot failed", e);
+      return respond({ error: "Unable to load enterprise capacity" }, 500);
+    }
+  }
 
   // Non-admin callers: return cached DB state only (no Stripe API calls or backfill writes)
   if (!isAdmin) {

--- a/src/components/settings/SubscriptionCard.tsx
+++ b/src/components/settings/SubscriptionCard.tsx
@@ -31,13 +31,20 @@ export function SubscriptionCard({ orgId, quota, isLoadingQuota, onQuotaRefresh 
   const [isUpdatingPlan, setIsUpdatingPlan] = useState(false);
   const [planError, setPlanError] = useState<string | null>(null);
   const [planSuccess, setPlanSuccess] = useState<string | null>(null);
+  const isEnterpriseManaged = quota?.isEnterpriseManaged === true || quota?.status === "enterprise_managed";
+  const currentPlanLabel = isEnterpriseManaged ? "Enterprise pooled quota" : (quota?.bucket || "none");
 
   // Sync bucket when quota loads
   useEffect(() => {
-    if (quota?.bucket) setSelectedBucket(quota.bucket);
-  }, [quota?.bucket]);
+    if (quota?.bucket && !isEnterpriseManaged) setSelectedBucket(quota.bucket);
+  }, [isEnterpriseManaged, quota?.bucket]);
 
   const handleUpdatePlan = async () => {
+    if (isEnterpriseManaged) {
+      setPlanError("This organization uses enterprise-managed billing. Update alumni capacity from the enterprise billing page.");
+      return;
+    }
+
     const targetLimit = ALUMNI_LIMITS[selectedBucket];
     if (
       quota &&
@@ -110,9 +117,9 @@ export function SubscriptionCard({ orgId, quota, isLoadingQuota, onQuotaRefresh 
         <div>
           <p className="text-sm text-muted-foreground">{tSettings("subscription.currentPlan")}</p>
           <p className="text-lg font-semibold text-foreground">
-            {isLoadingQuota ? tCommon("loading") : quota?.bucket || "none"}
+            {isLoadingQuota ? tCommon("loading") : currentPlanLabel}
           </p>
-          {!quota?.stripeSubscriptionId && (
+          {!isEnterpriseManaged && !quota?.stripeSubscriptionId && (
             <p className="text-xs text-amber-600">{tSettings("subscription.billingNotConnected")}</p>
           )}
         </div>
@@ -144,13 +151,19 @@ export function SubscriptionCard({ orgId, quota, isLoadingQuota, onQuotaRefresh 
         </div>
       )}
 
+      {isEnterpriseManaged && (
+        <div className="mt-4 p-3 rounded-xl bg-muted/60 text-sm text-muted-foreground">
+          Alumni capacity is pooled across the enterprise. Manage billing and bucket changes from the enterprise dashboard.
+        </div>
+      )}
+
       <div className="mt-4 grid gap-4 sm:grid-cols-[2fr_1fr_1fr]">
         <div className="space-y-2">
           <Select
             label={tSettings("subscription.alumniPlan")}
             value={selectedBucket}
             onChange={(e) => setSelectedBucket(e.target.value as AlumniBucket)}
-            disabled={isLoadingQuota}
+            disabled={isLoadingQuota || isEnterpriseManaged}
             options={BUCKET_OPTIONS.map((option) => ({
               ...option,
               disabled:
@@ -161,7 +174,9 @@ export function SubscriptionCard({ orgId, quota, isLoadingQuota, onQuotaRefresh 
             }))}
           />
           <p className="text-xs text-muted-foreground">
-            {quota?.stripeSubscriptionId && quota?.stripeCustomerId
+            {isEnterpriseManaged
+              ? "Enterprise-managed organizations inherit pooled alumni capacity."
+              : quota?.stripeSubscriptionId && quota?.stripeCustomerId
               ? tSettings("subscription.downgradeDisabled")
               : tSettings("subscription.selectPlan")}
           </p>
@@ -171,7 +186,7 @@ export function SubscriptionCard({ orgId, quota, isLoadingQuota, onQuotaRefresh 
             label={tSettings("subscription.billingInterval")}
             value={selectedInterval}
             onChange={(e) => setSelectedInterval(e.target.value as "month" | "year")}
-            disabled={isLoadingQuota}
+            disabled={isLoadingQuota || isEnterpriseManaged}
             options={[
               { value: "month", label: tSettings("subscription.monthly") },
               { value: "year", label: tSettings("subscription.yearly") },
@@ -182,7 +197,7 @@ export function SubscriptionCard({ orgId, quota, isLoadingQuota, onQuotaRefresh 
           <Button
             onClick={handleUpdatePlan}
             isLoading={isUpdatingPlan}
-            disabled={isLoadingQuota || !quota || (selectedBucket === quota.bucket && !!quota.stripeSubscriptionId)}
+            disabled={isLoadingQuota || !quota || isEnterpriseManaged || (selectedBucket === quota.bucket && !!quota.stripeSubscriptionId)}
           >
             {tSettings("subscription.updatePlan")}
           </Button>

--- a/src/lib/alumni-quota.ts
+++ b/src/lib/alumni-quota.ts
@@ -27,9 +27,21 @@ interface OrgWithEnterprise {
   enterprise_id: string | null;
 }
 
+interface OrgSubscriptionRow {
+  alumni_bucket: string | null;
+  status: string | null;
+}
+
 // Type for enterprise subscription (until types are regenerated)
 interface EnterpriseSubscriptionRow {
   alumni_bucket_quantity: number;
+}
+
+export function shouldUseEnterpriseAlumniQuota(
+  enterpriseId: string | null | undefined,
+  subscriptionStatus: string | null | undefined,
+) {
+  return Boolean(enterpriseId && subscriptionStatus === "enterprise_managed");
 }
 
 /**
@@ -40,14 +52,24 @@ interface EnterpriseSubscriptionRow {
 export async function isOrgEnterpriseManaged(orgId: string): Promise<boolean> {
   const supabase = createServiceClient();
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: org } = await (supabase as any)
-    .from("organizations")
-    .select("enterprise_id")
-    .eq("id", orgId)
-    .single() as { data: OrgWithEnterprise | null };
+  const [{ data: org }, { data: orgSub }] = await Promise.all([
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (supabase as any)
+      .from("organizations")
+      .select("enterprise_id")
+      .eq("id", orgId)
+      .single() as Promise<{ data: OrgWithEnterprise | null }>,
+    supabase
+      .from("organization_subscriptions")
+      .select("status")
+      .eq("organization_id", orgId)
+      .maybeSingle() as Promise<{ data: Pick<OrgSubscriptionRow, "status"> | null }>,
+  ]);
 
-  return org?.enterprise_id != null;
+  return shouldUseEnterpriseAlumniQuota(
+    org?.enterprise_id ?? null,
+    orgSub?.status ?? null,
+  );
 }
 
 /**
@@ -60,20 +82,26 @@ export async function isOrgEnterpriseManaged(orgId: string): Promise<boolean> {
 export async function getAlumniLimitForOrg(orgId: string): Promise<number | null> {
   const supabase = createServiceClient();
 
-  // Get org with enterprise info
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: org } = await (supabase as any)
-    .from("organizations")
-    .select("enterprise_id")
-    .eq("id", orgId)
-    .single() as { data: OrgWithEnterprise | null };
+  const [{ data: org }, { data: orgSub }] = await Promise.all([
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (supabase as any)
+      .from("organizations")
+      .select("enterprise_id")
+      .eq("id", orgId)
+      .single() as Promise<{ data: OrgWithEnterprise | null }>,
+    supabase
+      .from("organization_subscriptions")
+      .select("alumni_bucket, status")
+      .eq("organization_id", orgId)
+      .maybeSingle() as Promise<{ data: OrgSubscriptionRow | null }>,
+  ]);
 
   if (!org) {
     return 0;
   }
 
-  // If org belongs to an enterprise, use enterprise pooled limit
-  if (org.enterprise_id) {
+  // If org is enterprise-managed, use enterprise pooled limit.
+  if (shouldUseEnterpriseAlumniQuota(org.enterprise_id, orgSub?.status ?? null)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data: subscription } = await (supabase as any)
       .from("enterprise_subscriptions")
@@ -90,12 +118,6 @@ export async function getAlumniLimitForOrg(orgId: string): Promise<number | null
   }
 
   // Otherwise, use org's individual subscription
-  const { data: orgSub } = await supabase
-    .from("organization_subscriptions")
-    .select("alumni_bucket")
-    .eq("organization_id", orgId)
-    .maybeSingle() as { data: { alumni_bucket: string | null } | null };
-
   if (!orgSub) {
     return 0;
   }

--- a/src/lib/alumni/capacity.ts
+++ b/src/lib/alumni/capacity.ts
@@ -1,5 +1,5 @@
 import { createServiceClient } from "@/lib/supabase/service";
-import { getAlumniLimitForOrg } from "@/lib/alumni-quota";
+import { getAlumniLimitForOrg, shouldUseEnterpriseAlumniQuota } from "@/lib/alumni-quota";
 import { getLinkedInImportCapacitySnapshot } from "@/lib/alumni/linkedin-import";
 
 interface EnterpriseAlumniCountsQuery {
@@ -24,17 +24,33 @@ export async function getAlumniCapacitySnapshot(
   return getLinkedInImportCapacitySnapshot(organizationId, {
     getAlumniLimitForOrg,
     async getEnterpriseIdForOrg(orgId) {
-      const { data: organization, error } = await serviceSupabase
-        .from("organizations")
-        .select("enterprise_id")
-        .eq("id", orgId)
-        .maybeSingle();
+      const [{ data: organization, error: orgError }, { data: subscription, error: subError }] = await Promise.all([
+        serviceSupabase
+          .from("organizations")
+          .select("enterprise_id")
+          .eq("id", orgId)
+          .maybeSingle(),
+        serviceSupabase
+          .from("organization_subscriptions")
+          .select("status")
+          .eq("organization_id", orgId)
+          .maybeSingle(),
+      ]);
 
-      if (error) {
-        throw error;
+      if (orgError) {
+        throw orgError;
       }
 
-      return organization?.enterprise_id ?? null;
+      if (subError) {
+        throw subError;
+      }
+
+      return shouldUseEnterpriseAlumniQuota(
+        organization?.enterprise_id ?? null,
+        subscription?.status ?? null,
+      )
+        ? (organization?.enterprise_id ?? null)
+        : null;
     },
     async countAlumniForOrg(orgId) {
       const { count, error } = await serviceSupabase

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -6,6 +6,7 @@ export interface SubscriptionInfo {
   alumniCount: number;
   remaining: number | null;
   status: string;
+  isEnterpriseManaged: boolean;
   stripeSubscriptionId: string | null;
   stripeCustomerId: string | null;
   currentPeriodEnd: string | null;

--- a/tests/enterprise/enterprise-managed-alumni-quota-migration.test.ts
+++ b/tests/enterprise/enterprise-managed-alumni-quota-migration.test.ts
@@ -4,6 +4,8 @@ import { readFileSync } from "node:fs";
 
 const migrationFile = "../../supabase/migrations/20261014000000_fix_enterprise_managed_alumni_quota.sql";
 const migration = readFileSync(new URL(migrationFile, import.meta.url), "utf8");
+const alumniQuotaSource = readFileSync(new URL("../../src/lib/alumni-quota.ts", import.meta.url), "utf8");
+const alumniCapacitySource = readFileSync(new URL("../../src/lib/alumni/capacity.ts", import.meta.url), "utf8");
 
 test("enterprise-managed alumni quota migration uses pooled enterprise limit", () => {
   assert.match(
@@ -32,5 +34,16 @@ test("enterprise-managed alumni quota migration keeps security-definer hardening
   assert.equal(
     (migration.match(/SET search_path = ''/g) ?? []).length >= 3,
     true
+  );
+});
+
+test("app-side alumni quota readers require enterprise_managed status before using pooled enterprise quota", () => {
+  assert.match(
+    alumniQuotaSource,
+    /subscriptionStatus === "enterprise_managed"/
+  );
+  assert.match(
+    alumniCapacitySource,
+    /shouldUseEnterpriseAlumniQuota\(\s*organization\?\.enterprise_id \?\? null,\s*subscription\?\.status \?\? null,\s*\)/
   );
 });

--- a/tests/routes/enterprise/invites.test.ts
+++ b/tests/routes/enterprise/invites.test.ts
@@ -243,6 +243,31 @@ test("RPC 'Alumni quota reached' error is forwarded to client", () => {
   assert.strictEqual(result.body.error, "Alumni quota reached for this enterprise");
 });
 
+test("org-specific alumni invite succeeds for an enterprise-managed organization", () => {
+  const organizationId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+  const result = simulateCreateInvite({
+    organizationId,
+    role: "alumni",
+    orgBelongsToEnterprise: true,
+    rpcResult: {
+      data: {
+        id: "invite-1",
+        code: "AIM123",
+        token: "token-1",
+        organization_id: organizationId,
+        role: "alumni",
+      },
+      error: null,
+    },
+  });
+
+  assert.strictEqual(result.status, 200);
+  assert.strictEqual(result.body.role, "alumni");
+  assert.strictEqual(result.body.organization_id, organizationId);
+  assert.strictEqual(result.body.organization_name, "Test Org");
+  assert.strictEqual(result.body.is_enterprise_wide, false);
+});
+
 test("RPC 'Enterprise admin limit reached' error is forwarded to client", () => {
   const result = simulateCreateInvite({
     role: "admin",


### PR DESCRIPTION
## Summary
- **API**: `GET /api/organizations/[organizationId]/subscription` now returns an explicit `isEnterpriseManaged` flag and pooled enterprise capacity (via `getAlumniCapacitySnapshot`) when the org's subscription status is `enterprise_managed`.
- **UI**: `SubscriptionCard` treats enterprise-managed orgs as read-only pooled billing — shows "Enterprise pooled quota", hides the "billing not connected" warning, disables plan/interval controls, and blocks the Update Plan path so admins aren't routed into org-level checkout.
- **Hardening**: `isOrgEnterpriseManaged` and `getAlumniCapacitySnapshot` now require `organization_subscriptions.status = 'enterprise_managed'` in addition to `organizations.enterprise_id` before pooling capacity. Orgs with an `enterprise_id` but a non-managed status (pending, transitioning) stay on per-org quota.
- **Tests**: Adds regression coverage for creating an org-specific alumni invite under an enterprise-managed org, plus a guard asserting the app-side readers check the status flag.

## Context
Follow-up to #71, which fixed the SQL quota helpers (`can_add_alumni`, `assert_alumni_quota`, `get_alumni_quota`). That unblocked invites but the org settings subscription card still displayed misleading "bucket: none" / "billing not connected" copy and pushed enterprise-managed admins toward org checkout. This PR makes the UI and app-side quota readers consistent with the DB fix.

## Test plan
- [x] `node --test tests/routes/enterprise/invites.test.ts` — 25/25 pass (includes new success-path assertion)
- [x] `node --test tests/enterprise/enterprise-managed-alumni-quota-migration.test.ts` — 4/4 pass
- [x] `npm run test` — 4145/4146 pass (1 pre-existing flake in `tests/middleware-routing.test.ts` unrelated to this change; passes standalone)
- [x] `npx eslint` clean on all modified files
- [ ] Manual verify on AIM: org settings shows "Enterprise pooled quota", controls disabled, invite creation still works