### PR TITLE
feat(sidebar): hover-expand with pin, shared shell for org + enterprise

### DIFF
--- a/src/app/[orgSlug]/layout.tsx
+++ b/src/app/[orgSlug]/layout.tsx
@@ -307,7 +307,7 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
 
       {/* Canceling banner - shown when subscription is scheduled to cancel at period end */}
       {orgContext.gracePeriod.isCanceling && orgContext.subscription?.currentPeriodEnd && (
-        <div className="fixed top-0 left-0 right-0 z-50 lg:left-64">
+        <div className="fixed top-0 left-0 right-0 z-50 lg:left-[var(--sidebar-offset,3.5rem)] transition-[left] duration-300 ease-in-out motion-reduce:transition-none">
           <CancelingBanner
             periodEndDate={orgContext.subscription.currentPeriodEnd}
             orgSlug={orgSlug}
@@ -319,7 +319,7 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
 
       {/* Grace period banner - shown when subscription is canceled but within 30-day grace */}
       {orgContext.gracePeriod.isInGracePeriod && (
-        <div className="fixed top-0 left-0 right-0 z-50 lg:left-64">
+        <div className="fixed top-0 left-0 right-0 z-50 lg:left-[var(--sidebar-offset,3.5rem)] transition-[left] duration-300 ease-in-out motion-reduce:transition-none">
           <GracePeriodBanner
             daysRemaining={orgContext.gracePeriod.daysRemaining}
             orgSlug={orgSlug}
@@ -329,7 +329,7 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
         </div>
       )}
 
-      <div className="hidden lg:block fixed left-0 top-0 h-screen w-64 z-40">
+      <div className="hidden lg:block">
         <OrgSidebar organization={organization} role={orgContext.role} isDevAdmin={isDevAdmin} hasAlumniAccess={orgContext.hasAlumniAccess} hasParentsAccess={orgContext.hasParentsAccess} currentProfileHref={currentProfileHref} currentProfileName={currentProfileName} currentProfileAvatar={currentProfileAvatar} pendingApprovalsCount={pendingApprovalsCount} />
       </div>
 

--- a/src/app/enterprise/[enterpriseSlug]/layout.tsx
+++ b/src/app/enterprise/[enterpriseSlug]/layout.tsx
@@ -20,7 +20,7 @@ export default async function EnterpriseLayout({ children, params }: EnterpriseL
   return (
     <div className="min-h-screen bg-background">
       {/* Desktop Sidebar */}
-      <div className="hidden lg:block fixed left-0 top-0 h-screen w-64 z-40">
+      <div className="hidden lg:block">
         <EnterpriseSidebar
           enterpriseSlug={enterprise.slug}
           enterpriseName={enterprise.name}
@@ -55,7 +55,7 @@ export default async function EnterpriseLayout({ children, params }: EnterpriseL
       </div>
 
       {/* Main Content */}
-      <main className="lg:ml-64 p-4 lg:p-8 pt-20 lg:pt-8">
+      <main className="lg:ml-[var(--sidebar-offset,3.5rem)] p-4 lg:p-8 pt-20 lg:pt-8 transition-[margin-left] duration-300 ease-in-out motion-reduce:transition-none">
         {children}
       </main>
     </div>

--- a/src/components/enterprise/EnterpriseSidebar.tsx
+++ b/src/components/enterprise/EnterpriseSidebar.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { usePathname } from "next/navigation";
 import type { EnterpriseRole } from "@/types/enterprise";
 import { getEnterprisePermissions } from "@/types/enterprise";
+import { HoverSidebar, PinButton } from "@/components/layout/HoverSidebar";
 
 function HomeIcon({ className }: { className?: string }) {
   return (
@@ -123,6 +124,8 @@ interface EnterpriseSidebarProps {
   role: EnterpriseRole;
   className?: string;
   onClose?: () => void;
+  forceExpanded?: boolean;
+  layout?: "fixed" | "static";
 }
 
 interface NavItem {
@@ -150,6 +153,8 @@ export function EnterpriseSidebar({
   role,
   className = "",
   onClose,
+  forceExpanded = false,
+  layout = "fixed",
 }: EnterpriseSidebarProps) {
   const pathname = usePathname();
   const basePath = `/enterprise/${enterpriseSlug}`;
@@ -163,99 +168,152 @@ export function EnterpriseSidebar({
   });
 
   return (
-    <aside className={`flex flex-col bg-card border-r border-border h-full ${className}`}>
-      {/* Logo/Enterprise Header */}
-      <div className="p-6 border-b border-border">
-        <Link href={basePath} className="flex items-center gap-3">
-          {logoUrl ? (
-            <div className="relative h-10 w-10 rounded-xl overflow-hidden">
-              <Image
-                src={logoUrl}
-                alt={enterpriseName}
-                fill
-                className="object-cover"
-                sizes="40px"
-              />
-            </div>
-          ) : (
-            <div
-              className="h-10 w-10 rounded-xl flex items-center justify-center text-white font-bold text-lg"
-              style={{ backgroundColor: primaryColor || "#6B21A8" }}
-            >
-              {enterpriseName.charAt(0)}
-            </div>
-          )}
-          <div className="flex-1 min-w-0">
-            <h2 className="font-semibold text-foreground truncate">{enterpriseName}</h2>
-            <p className="text-xs text-muted-foreground">Enterprise</p>
-          </div>
-        </Link>
-      </div>
-
-      {/* Navigation */}
-      <nav className="flex-1 overflow-y-auto p-4">
-        <ul className="space-y-1">
-          {visibleNav.map((item) => {
-            const href = `${basePath}${item.href}`;
-            let isActive = pathname === href;
-            if (!isActive && item.href !== "") {
-              const isPathMatch = pathname.startsWith(href + "/") || pathname === href;
-              const hasMoreSpecificMatch = visibleNav.some(
-                (other) =>
-                  other.href !== item.href &&
-                  other.href.startsWith(item.href + "/") &&
-                  pathname.startsWith(`${basePath}${other.href}`)
-              );
-              isActive = isPathMatch && !hasMoreSpecificMatch;
-            }
-            const Icon = item.icon;
-
-            return (
-              <li key={item.href || "dashboard"}>
-                <Link
-                  href={href}
-                  onClick={onClose}
-                  className={`flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 ${
-                    isActive ? "shadow-soft" : "text-muted-foreground hover:bg-muted hover:text-foreground"
+    <HoverSidebar
+      storageKey="sidebar-pinned-enterprise"
+      forceExpanded={forceExpanded}
+      layout={layout}
+      className={className}
+    >
+      {({ isExpanded, isPinned, togglePin }) => {
+        const isCollapsed = !isExpanded;
+        return (
+          <>
+            {/* Logo/Enterprise Header */}
+            <div className="flex items-stretch border-b border-border">
+              <Link href={basePath} className="flex flex-1 min-w-0 items-center gap-3 py-4 pl-4">
+                {logoUrl ? (
+                  <div className="relative h-8 w-8 flex-shrink-0 rounded-xl overflow-hidden">
+                    <Image
+                      src={logoUrl}
+                      alt={enterpriseName}
+                      fill
+                      className="object-cover"
+                      sizes="32px"
+                    />
+                  </div>
+                ) : (
+                  <div
+                    className="h-8 w-8 flex-shrink-0 rounded-xl flex items-center justify-center text-white font-bold"
+                    style={{ backgroundColor: primaryColor || "#6B21A8" }}
+                  >
+                    {enterpriseName.charAt(0)}
+                  </div>
+                )}
+                <div
+                  className={`flex-1 min-w-0 transition-opacity duration-200 motion-reduce:transition-none ${
+                    isCollapsed ? "opacity-0" : "opacity-100"
                   }`}
-                  style={
-                    isActive
-                      ? {
-                          backgroundColor: `${primaryColor || "#6B21A8"}1F`,
-                          color: primaryColor || "#6B21A8",
-                        }
-                      : {}
-                  }
+                  aria-hidden={isCollapsed || undefined}
                 >
-                  <Icon className="h-5 w-5 flex-shrink-0" />
-                  {item.label}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </nav>
+                  <h2 className="font-semibold text-foreground text-sm leading-tight break-words">{enterpriseName}</h2>
+                  <p className="text-xs text-muted-foreground">Enterprise</p>
+                </div>
+              </Link>
+              {!forceExpanded && (
+                <div className="flex items-start pt-2 pr-2 flex-shrink-0">
+                  <PinButton
+                    isPinned={isPinned}
+                    isExpanded={isExpanded}
+                    onToggle={togglePin}
+                  />
+                </div>
+              )}
+            </div>
 
-      {/* User Section */}
-      <div className="p-4 border-t border-border space-y-1">
-        <Link
-          href="/app"
-          className="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-all duration-200"
-        >
-          <GridIcon className="h-5 w-5" />
-          Back to App
-        </Link>
+            {/* Navigation */}
+            <nav className="flex-1 overflow-y-auto overflow-x-hidden p-2">
+              <ul className="space-y-1">
+                {visibleNav.map((item) => {
+                  const href = `${basePath}${item.href}`;
+                  let isActive = pathname === href;
+                  if (!isActive && item.href !== "") {
+                    const isPathMatch = pathname.startsWith(href + "/") || pathname === href;
+                    const hasMoreSpecificMatch = visibleNav.some(
+                      (other) =>
+                        other.href !== item.href &&
+                        other.href.startsWith(item.href + "/") &&
+                        pathname.startsWith(`${basePath}${other.href}`)
+                    );
+                    isActive = isPathMatch && !hasMoreSpecificMatch;
+                  }
+                  const Icon = item.icon;
 
-        <form action="/auth/signout" method="POST">
-          <button
-            type="submit"
-            className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-all duration-200"
-          >
-            <LogOutIcon className="h-5 w-5" />
-            Sign Out
-          </button>
-        </form>
-      </div>
-    </aside>
+                  return (
+                    <li key={item.href || "dashboard"}>
+                      <Link
+                        href={href}
+                        onClick={onClose}
+                        title={isCollapsed ? item.label : undefined}
+                        aria-label={isCollapsed ? item.label : undefined}
+                        className={`flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-[background-color,color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${
+                          isActive ? "shadow-soft" : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                        }`}
+                        style={
+                          isActive
+                            ? {
+                                backgroundColor: `${primaryColor || "#6B21A8"}1F`,
+                                color: primaryColor || "#6B21A8",
+                              }
+                            : {}
+                        }
+                      >
+                        <Icon className="h-5 w-5 flex-shrink-0" />
+                        <span
+                          aria-hidden={isCollapsed || undefined}
+                          className={`whitespace-nowrap transition-opacity duration-200 motion-reduce:transition-none ${
+                            isCollapsed ? "opacity-0" : "opacity-100"
+                          }`}
+                        >
+                          {item.label}
+                        </span>
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </nav>
+
+            {/* User Section */}
+            <div className="p-2 border-t border-border space-y-1">
+              <Link
+                href="/app"
+                title={isCollapsed ? "Back to App" : undefined}
+                aria-label={isCollapsed ? "Back to App" : undefined}
+                className="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-[background-color,color] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+              >
+                <GridIcon className="h-5 w-5 flex-shrink-0" />
+                <span
+                  aria-hidden={isCollapsed || undefined}
+                  className={`whitespace-nowrap transition-opacity duration-200 motion-reduce:transition-none ${
+                    isCollapsed ? "opacity-0" : "opacity-100"
+                  }`}
+                >
+                  Back to App
+                </span>
+              </Link>
+
+              <form action="/auth/signout" method="POST">
+                <button
+                  type="submit"
+                  title={isCollapsed ? "Sign Out" : undefined}
+                  aria-label={isCollapsed ? "Sign Out" : undefined}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-[background-color,color] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                >
+                  <LogOutIcon className="h-5 w-5 flex-shrink-0" />
+                  <span
+                    aria-hidden={isCollapsed || undefined}
+                    className={`whitespace-nowrap transition-opacity duration-200 motion-reduce:transition-none ${
+                      isCollapsed ? "opacity-0" : "opacity-100"
+                    }`}
+                  >
+                    Sign Out
+                  </span>
+                </button>
+              </form>
+            </div>
+          </>
+        );
+      }}
+    </HoverSidebar>
   );
 }

--- a/src/components/layout/HoverSidebar.tsx
+++ b/src/components/layout/HoverSidebar.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+
+interface HoverSidebarContext {
+  isExpanded: boolean;
+  isPinned: boolean;
+  togglePin: () => void;
+}
+
+interface HoverSidebarProps {
+  storageKey: string;
+  forceExpanded?: boolean;
+  layout?: "fixed" | "static";
+  className?: string;
+  children: (ctx: HoverSidebarContext) => ReactNode;
+}
+
+const COLLAPSED_OFFSET = "3.5rem";
+const EXPANDED_OFFSET = "16rem";
+
+function writeOffset(pinned: boolean) {
+  if (typeof document === "undefined") return;
+  if (pinned) {
+    document.documentElement.style.setProperty("--sidebar-offset", EXPANDED_OFFSET);
+  } else {
+    document.documentElement.style.setProperty("--sidebar-offset", COLLAPSED_OFFSET);
+  }
+}
+
+function clearOffset() {
+  if (typeof document === "undefined") return;
+  document.documentElement.style.removeProperty("--sidebar-offset");
+}
+
+export function HoverSidebar({
+  storageKey,
+  forceExpanded = false,
+  layout = "fixed",
+  className = "",
+  children,
+}: HoverSidebarProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const [isPinned, setIsPinned] = useState(false);
+
+  useEffect(() => {
+    if (forceExpanded) return;
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (stored === "1") {
+        setIsPinned(true);
+        writeOffset(true);
+      } else {
+        writeOffset(false);
+      }
+    } catch {
+      writeOffset(false);
+    }
+    return () => {
+      clearOffset();
+    };
+  }, [storageKey, forceExpanded]);
+
+  const togglePin = useCallback(() => {
+    setIsPinned((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(storageKey, next ? "1" : "0");
+      } catch {
+        // ignore quota / privacy errors
+      }
+      writeOffset(next);
+      if (!next) {
+        setIsHovered(false);
+        setIsFocused(false);
+      }
+      return next;
+    });
+  }, [storageKey]);
+
+  const isExpanded = forceExpanded || isPinned || isHovered || isFocused;
+
+  const positionClass =
+    layout === "fixed" ? "fixed left-0 top-0 h-screen z-40" : "relative h-full";
+  const widthClass = forceExpanded
+    ? "w-64"
+    : "w-14 data-[expanded=true]:w-64";
+
+  return (
+    <aside
+      data-expanded={isExpanded}
+      onMouseEnter={forceExpanded ? undefined : () => setIsHovered(true)}
+      onMouseLeave={forceExpanded ? undefined : () => setIsHovered(false)}
+      onFocusCapture={forceExpanded ? undefined : () => setIsFocused(true)}
+      onBlurCapture={
+        forceExpanded
+          ? undefined
+          : (e) => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+                setIsFocused(false);
+              }
+            }
+      }
+      className={`flex flex-col bg-card border-r border-border overflow-hidden transition-[width] duration-300 ease-in-out motion-reduce:transition-none ${positionClass} ${widthClass} ${className}`}
+    >
+      {children({ isExpanded, isPinned, togglePin })}
+    </aside>
+  );
+}
+
+interface PinButtonProps {
+  isPinned: boolean;
+  isExpanded: boolean;
+  onToggle: () => void;
+  className?: string;
+}
+
+export function PinButton({ isPinned, isExpanded, onToggle, className = "" }: PinButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={isPinned ? "Unpin sidebar" : "Pin sidebar"}
+      aria-pressed={isPinned}
+      className={`inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-[opacity,color,background-color] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${
+        isExpanded ? "opacity-100" : "opacity-0 pointer-events-none"
+      } ${className}`}
+      tabIndex={isExpanded ? 0 : -1}
+    >
+      <svg
+        className="h-4 w-4"
+        viewBox="0 0 24 24"
+        fill={isPinned ? "currentColor" : "none"}
+        stroke="currentColor"
+        strokeWidth={1.75}
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M15 4.5l4.5 4.5-4.95 1.65-3.3 3.3-1.2 4.05L5.25 12 9.3 10.8l3.3-3.3L15 4.5zM9.75 14.25L4.5 19.5"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -116,8 +116,10 @@ export function MobileNav({ organization, role, isDevAdmin = false, hasAlumniAcc
             currentProfileName={currentProfileName}
             currentProfileAvatar={currentProfileAvatar}
             pendingApprovalsCount={pendingApprovalsCount}
-            className="h-full border-r border-border"
+            className="h-full"
             onClose={closeMenu}
+            forceExpanded
+            layout="static"
           />
         )}
       </div>

--- a/src/components/layout/NavGroupSection.tsx
+++ b/src/components/layout/NavGroupSection.tsx
@@ -17,6 +17,7 @@ interface NavGroupSectionProps {
   globalIndexMap: Map<string, number>;
   onClose?: () => void;
   badgeCounts?: Record<string, number>;
+  isCollapsed?: boolean;
 }
 
 export function NavGroupSection({
@@ -31,8 +32,30 @@ export function NavGroupSection({
   globalIndexMap,
   onClose,
   badgeCounts,
+  isCollapsed = false,
 }: NavGroupSectionProps) {
   const panelId = `nav-group-${group.id}`;
+
+  if (isCollapsed) {
+    return (
+      <ul className="space-y-0.5">
+        {items.map((item) => (
+          <NavItemLink
+            key={item.href}
+            item={item}
+            basePath={basePath}
+            pathname={pathname}
+            visibleNav={visibleNav}
+            organizationId={organizationId}
+            globalIndex={globalIndexMap.get(item.href) ?? 0}
+            onClose={onClose}
+            badgeCounts={badgeCounts}
+            isCollapsed
+          />
+        ))}
+      </ul>
+    );
+  }
 
   return (
     <div>
@@ -93,6 +116,7 @@ interface NavItemLinkProps {
   globalIndex: number;
   onClose?: () => void;
   badgeCounts?: Record<string, number>;
+  isCollapsed?: boolean;
 }
 
 export function NavItemLink({
@@ -104,6 +128,7 @@ export function NavItemLink({
   globalIndex,
   onClose,
   badgeCounts,
+  isCollapsed = false,
 }: NavItemLinkProps) {
   const href = `${basePath}${item.href}`;
   let isActive = pathname === href;
@@ -118,11 +143,15 @@ export function NavItemLink({
     isActive = isPathMatch && !hasMoreSpecificMatch;
   }
   const Icon = item.icon;
+  const badgeCount = badgeCounts?.[item.href];
+  const hasBadge = badgeCount != null && badgeCount > 0;
 
   return (
     <li>
       <Link
         href={href}
+        title={isCollapsed ? item.label : undefined}
+        aria-label={isCollapsed ? item.label : undefined}
         onClick={() => {
           trackBehavioralEvent(
             "nav_click",
@@ -142,10 +171,21 @@ export function NavItemLink({
         }`}
       >
         <Icon className="h-5 w-5 flex-shrink-0" />
-        {item.label}
-        {badgeCounts?.[item.href] != null && badgeCounts[item.href] > 0 && (
-          <span className="ml-auto inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[10px] font-bold rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
-            {badgeCounts[item.href]}
+        <span
+          aria-hidden={isCollapsed || undefined}
+          className={`whitespace-nowrap transition-opacity duration-200 motion-reduce:transition-none ${
+            isCollapsed ? "opacity-0" : "opacity-100"
+          }`}
+        >
+          {item.label}
+        </span>
+        {hasBadge && (
+          <span
+            className={`ml-auto inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[10px] font-bold rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300 transition-opacity duration-200 motion-reduce:transition-none ${
+              isCollapsed ? "opacity-0" : "opacity-100"
+            }`}
+          >
+            {badgeCount}
           </span>
         )}
       </Link>

--- a/src/components/layout/OrgMainContent.tsx
+++ b/src/components/layout/OrgMainContent.tsx
@@ -12,7 +12,9 @@ export function OrgMainContent({ children, hasTopBanner }: OrgMainContentProps) 
   const isMessages = pathname.includes("/messages");
 
   return (
-    <main className={`lg:ml-64 ${isMessages ? "h-[calc(100dvh-4rem)] lg:h-dvh overflow-hidden pt-16 lg:pt-0" : "p-4 lg:p-8 pt-20 lg:pt-8"} ${hasTopBanner ? "mt-12" : ""}`}>
+    <main
+      className={`lg:ml-[var(--sidebar-offset,3.5rem)] transition-[margin-left] duration-300 ease-in-out motion-reduce:transition-none ${isMessages ? "h-[calc(100dvh-4rem)] lg:h-dvh overflow-hidden pt-16 lg:pt-0" : "p-4 lg:p-8 pt-20 lg:pt-8"} ${hasTopBanner ? "mt-12" : ""}`}
+    >
       {children}
     </main>
   );

--- a/src/components/layout/OrgSidebar.tsx
+++ b/src/components/layout/OrgSidebar.tsx
@@ -10,6 +10,7 @@ import type { OrgRole } from "@/lib/auth/role-utils";
 import { ORG_NAV_ITEMS, ORG_NAV_GROUPS, type NavConfig, type NavGroupId, GridIcon, LogOutIcon, getConfigKey } from "@/lib/navigation/nav-items";
 import { bucketItemsByGroup, buildSectionOrder, buildGlobalIndexMap, getActiveGroup, type VisibleNavItem } from "@/lib/navigation/sidebar-groups";
 import { NavGroupSection, NavItemLink } from "@/components/layout/NavGroupSection";
+import { HoverSidebar, PinButton } from "@/components/layout/HoverSidebar";
 import { useUIProfile } from "@/lib/analytics/use-ui-profile";
 import { Avatar } from "@/components/ui/Avatar";
 import { Badge } from "@/components/ui/Badge";
@@ -28,9 +29,11 @@ interface OrgSidebarProps {
   pendingApprovalsCount?: number;
   className?: string;
   onClose?: () => void;
+  forceExpanded?: boolean;
+  layout?: "fixed" | "static";
 }
 
-export function OrgSidebar({ organization, role, isDevAdmin = false, hasAlumniAccess = false, hasParentsAccess = false, currentProfileHref, currentProfileName, currentProfileAvatar, pendingApprovalsCount, className = "", onClose }: OrgSidebarProps) {
+export function OrgSidebar({ organization, role, isDevAdmin = false, hasAlumniAccess = false, hasParentsAccess = false, currentProfileHref, currentProfileName, currentProfileAvatar, pendingApprovalsCount, className = "", onClose, forceExpanded = false, layout = "fixed" }: OrgSidebarProps) {
   const pathname = usePathname();
   const basePath = `/${organization.slug}`;
   const { profile } = useUIProfile();
@@ -41,7 +44,6 @@ export function OrgSidebar({ organization, role, isDevAdmin = false, hasAlumniAc
 
   const [openGroups, setOpenGroups] = useState<Set<NavGroupId>>(new Set());
 
-  // Parse nav_config with stable identity for hook dependencies
   const navConfig = useMemo<NavConfig>(() => {
     if (
       organization.nav_config &&
@@ -68,8 +70,6 @@ export function OrgSidebar({ organization, role, isDevAdmin = false, hasAlumniAc
       const configKey = getConfigKey(item.href);
       const config = navConfig[configKey];
       const translatedLabel = tNav(`items.${item.i18nKey}`);
-      // For non-English locales, prefer the i18n translation over custom labels
-      // (which are typically set in English by admins). For English, custom labels win.
       const customLabel = config?.label?.trim();
       const effectiveLabel = locale === "en"
         ? (customLabel || translatedLabel)
@@ -96,7 +96,6 @@ export function OrgSidebar({ organization, role, isDevAdmin = false, hasAlumniAc
       return ORG_NAV_ITEMS.findIndex(i => i.href === a.href) - ORG_NAV_ITEMS.findIndex(i => i.href === b.href);
     }), [role, hasAlumniAccess, hasParentsAccess, navConfig, profile, tNav, locale]);
 
-  // Auto-expand active group on navigation
   useEffect(() => {
     const activeGroupId = getActiveGroup(pathname, basePath, visibleNav);
     if (activeGroupId) {
@@ -116,7 +115,6 @@ export function OrgSidebar({ organization, role, isDevAdmin = false, hasAlumniAc
     });
   }, []);
 
-  // Sort-then-bucket: bucket already-sorted items, translate group labels
   const { sections, globalIndexMap } = useMemo(() => {
     const translatedGroups = ORG_NAV_GROUPS.map(g => ({
       ...g,
@@ -137,157 +135,206 @@ export function OrgSidebar({ organization, role, isDevAdmin = false, hasAlumniAc
   }, [pendingApprovalsCount]);
 
   return (
-    <aside className={`flex flex-col bg-card border-r border-border h-full ${className}`}>
-      {/* Logo/Org Header */}
-      <div className="p-6 border-b border-border">
-        <Link href={basePath} className="flex items-center gap-3">
-          {organization.logo_url ? (
-            <div className="relative h-10 w-10 rounded-xl overflow-hidden">
-              <Image
-                src={organization.logo_url}
-                alt={organization.name}
-                fill
-                className="object-cover"
-                sizes="40px"
-              />
-            </div>
-          ) : (
-            <div
-              className="h-10 w-10 rounded-xl flex items-center justify-center text-white font-bold text-lg"
-              style={{ backgroundColor: "var(--color-org-primary)" }}
-            >
-              {organization.name.charAt(0)}
-            </div>
-          )}
-          <div className="flex-1 min-w-0">
-            <h2 className="font-semibold text-foreground truncate">{organization.name}</h2>
-            <p className="text-xs text-muted-foreground">TeamNetwork</p>
-            {isDevAdmin && (
-              <p className="text-[10px] uppercase tracking-wide text-purple-300 mt-1">Dev Admin</p>
-            )}
-          </div>
-        </Link>
-      </div>
-
-      {/* Profile Card */}
-      {currentProfileHref && currentProfileName && (
-        <div className="px-4 pt-3 pb-3 border-b border-border">
-          <Link
-            href={currentProfileHref}
-            className="flex items-center gap-3 p-2.5 rounded-xl hover:bg-muted/50 transition-all duration-200"
-          >
-            <Avatar src={currentProfileAvatar} name={currentProfileName} size="md" />
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-semibold text-foreground truncate">{currentProfileName}</p>
-              <Badge variant="muted" className="text-[11px] capitalize mt-0.5">
-                {role ? getRoleLabel(role) : "Profile"}
-              </Badge>
-            </div>
-          </Link>
-        </div>
-      )}
-
-      {/* Navigation */}
-      <nav className="flex-1 overflow-y-auto p-4">
-        <div className="space-y-3">
-          {sections.map((section, sectionIndex) => {
-            if (section.type === "dashboard") {
-              return (
-                <ul key="dashboard">
-                  <NavItemLink
-                    item={section.item}
-                    basePath={basePath}
-                    pathname={pathname}
-                    visibleNav={visibleNav}
-                    organizationId={organization.id}
-                    globalIndex={globalIndexMap.get(section.item.href) ?? 0}
-                    onClose={onClose}
-                    badgeCounts={badgeCounts}
-                  />
-                </ul>
-              );
-            }
-            if (section.type === "group") {
-              return (
-                <NavGroupSection
-                  key={section.group.id}
-                  group={section.group}
-                  items={section.items}
-                  isOpen={openGroups.has(section.group.id)}
-                  onToggle={() => toggleGroup(section.group.id)}
-                  basePath={basePath}
-                  pathname={pathname}
-                  visibleNav={visibleNav}
-                  organizationId={organization.id}
-                  globalIndexMap={globalIndexMap}
-                  onClose={onClose}
-                  badgeCounts={badgeCounts}
-                />
-              );
-            }
-            if (section.type === "standalone") {
-              return (
-                <ul key="standalone" className="space-y-0.5">
-                  {section.items.map((item) => (
-                    <NavItemLink
-                      key={item.href}
-                      item={item}
-                      basePath={basePath}
-                      pathname={pathname}
-                      visibleNav={visibleNav}
-                      organizationId={organization.id}
-                      globalIndex={globalIndexMap.get(item.href) ?? 0}
-                      onClose={onClose}
-                      badgeCounts={badgeCounts}
+    <HoverSidebar
+      storageKey="sidebar-pinned-org"
+      forceExpanded={forceExpanded}
+      layout={layout}
+      className={className}
+    >
+      {({ isExpanded, isPinned, togglePin }) => {
+        const isCollapsed = !isExpanded;
+        return (
+          <>
+            {/* Logo/Org Header */}
+            <div className="flex items-stretch border-b border-border">
+              <Link href={basePath} className="flex flex-1 min-w-0 items-center gap-3 py-4 pl-4">
+                {organization.logo_url ? (
+                  <div className="relative h-8 w-8 flex-shrink-0 rounded-xl overflow-hidden">
+                    <Image
+                      src={organization.logo_url}
+                      alt={organization.name}
+                      fill
+                      className="object-cover"
+                      sizes="32px"
                     />
-                  ))}
-                </ul>
-              );
-            }
-            if (section.type === "divider") {
-              return <hr key={`divider-${sectionIndex}`} className="border-border" />;
-            }
-            return null;
-          })}
-        </div>
-      </nav>
+                  </div>
+                ) : (
+                  <div
+                    className="h-8 w-8 flex-shrink-0 rounded-xl flex items-center justify-center text-white font-bold"
+                    style={{ backgroundColor: "var(--color-org-primary)" }}
+                  >
+                    {organization.name.charAt(0)}
+                  </div>
+                )}
+                <div
+                  className={`flex-1 min-w-0 transition-opacity duration-200 motion-reduce:transition-none ${
+                    isCollapsed ? "opacity-0" : "opacity-100"
+                  }`}
+                  aria-hidden={isCollapsed || undefined}
+                >
+                  <h2 className="font-semibold text-foreground text-sm leading-tight break-words">{organization.name}</h2>
+                  <p className="text-xs text-muted-foreground">TeamNetwork</p>
+                  {isDevAdmin && (
+                    <p className="text-[10px] uppercase tracking-wide text-purple-300 mt-1">Dev Admin</p>
+                  )}
+                </div>
+              </Link>
+              {!forceExpanded && (
+                <div className="flex items-start pt-2 pr-2 flex-shrink-0">
+                  <PinButton
+                    isPinned={isPinned}
+                    isExpanded={isExpanded}
+                    onToggle={togglePin}
+                  />
+                </div>
+              )}
+            </div>
 
-      {/* User Section */}
-      <div className="p-4 border-t border-border space-y-1">
-        <Link
-          href="/app"
-          className="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-[background-color,color] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-        >
-          <GridIcon className="h-5 w-5" />
-          {tSidebar("switchOrg")}
-        </Link>
+            {/* Profile Card — hidden when collapsed */}
+            {currentProfileHref && currentProfileName && !isCollapsed && (
+              <div className="px-4 pt-3 pb-3 border-b border-border">
+                <Link
+                  href={currentProfileHref}
+                  className="flex items-center gap-3 p-2.5 rounded-xl hover:bg-muted/50 transition-all duration-200"
+                >
+                  <Avatar src={currentProfileAvatar} name={currentProfileName} size="md" />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-semibold text-foreground truncate">{currentProfileName}</p>
+                    <Badge variant="muted" className="text-[11px] capitalize mt-0.5">
+                      {role ? getRoleLabel(role) : "Profile"}
+                    </Badge>
+                  </div>
+                </Link>
+              </div>
+            )}
 
-        <form action="/auth/signout" method="POST">
-          <button
-            type="submit"
-            className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-[background-color,color] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-          >
-            <LogOutIcon className="h-5 w-5" />
-            {tAuth("signOut")}
-          </button>
-        </form>
-      </div>
+            {/* Navigation */}
+            <nav className="flex-1 overflow-y-auto overflow-x-hidden p-2">
+              <div className="space-y-3">
+                {sections.map((section, sectionIndex) => {
+                  if (section.type === "dashboard") {
+                    return (
+                      <ul key="dashboard">
+                        <NavItemLink
+                          item={section.item}
+                          basePath={basePath}
+                          pathname={pathname}
+                          visibleNav={visibleNav}
+                          organizationId={organization.id}
+                          globalIndex={globalIndexMap.get(section.item.href) ?? 0}
+                          onClose={onClose}
+                          badgeCounts={badgeCounts}
+                          isCollapsed={isCollapsed}
+                        />
+                      </ul>
+                    );
+                  }
+                  if (section.type === "group") {
+                    return (
+                      <NavGroupSection
+                        key={section.group.id}
+                        group={section.group}
+                        items={section.items}
+                        isOpen={openGroups.has(section.group.id)}
+                        onToggle={() => toggleGroup(section.group.id)}
+                        basePath={basePath}
+                        pathname={pathname}
+                        visibleNav={visibleNav}
+                        organizationId={organization.id}
+                        globalIndexMap={globalIndexMap}
+                        onClose={onClose}
+                        badgeCounts={badgeCounts}
+                        isCollapsed={isCollapsed}
+                      />
+                    );
+                  }
+                  if (section.type === "standalone") {
+                    return (
+                      <ul key="standalone" className="space-y-0.5">
+                        {section.items.map((item) => (
+                          <NavItemLink
+                            key={item.href}
+                            item={item}
+                            basePath={basePath}
+                            pathname={pathname}
+                            visibleNav={visibleNav}
+                            organizationId={organization.id}
+                            globalIndex={globalIndexMap.get(item.href) ?? 0}
+                            onClose={onClose}
+                            badgeCounts={badgeCounts}
+                            isCollapsed={isCollapsed}
+                          />
+                        ))}
+                      </ul>
+                    );
+                  }
+                  if (section.type === "divider") {
+                    return <hr key={`divider-${sectionIndex}`} className="border-border" />;
+                  }
+                  return null;
+                })}
+              </div>
+            </nav>
 
-      {/* Platform Branding */}
-      <div className="px-4 py-4 border-t border-border">
-        <Link href="/" className="flex flex-col items-start gap-1 group">
-          <span className="text-[10px] uppercase tracking-widest text-muted-foreground/50 group-hover:text-muted-foreground/80 transition-colors">
-            {tSidebar("poweredBy")}
-          </span>
-          <Image
-            src="/TeamNetwor.png"
-            alt="TeamNetwork"
-            width={541}
-            height={303}
-            className="w-full max-w-[200px] h-auto object-contain opacity-50 group-hover:opacity-80 transition-opacity"
-          />
-        </Link>
-      </div>
-    </aside>
+            {/* User Section */}
+            <div className="p-2 border-t border-border space-y-1">
+              <Link
+                href="/app"
+                title={isCollapsed ? tSidebar("switchOrg") : undefined}
+                aria-label={isCollapsed ? tSidebar("switchOrg") : undefined}
+                className="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-[background-color,color] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+              >
+                <GridIcon className="h-5 w-5 flex-shrink-0" />
+                <span
+                  aria-hidden={isCollapsed || undefined}
+                  className={`whitespace-nowrap transition-opacity duration-200 motion-reduce:transition-none ${
+                    isCollapsed ? "opacity-0" : "opacity-100"
+                  }`}
+                >
+                  {tSidebar("switchOrg")}
+                </span>
+              </Link>
+
+              <form action="/auth/signout" method="POST">
+                <button
+                  type="submit"
+                  title={isCollapsed ? tAuth("signOut") : undefined}
+                  aria-label={isCollapsed ? tAuth("signOut") : undefined}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-[background-color,color] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                >
+                  <LogOutIcon className="h-5 w-5 flex-shrink-0" />
+                  <span
+                    aria-hidden={isCollapsed || undefined}
+                    className={`whitespace-nowrap transition-opacity duration-200 motion-reduce:transition-none ${
+                      isCollapsed ? "opacity-0" : "opacity-100"
+                    }`}
+                  >
+                    {tAuth("signOut")}
+                  </span>
+                </button>
+              </form>
+            </div>
+
+            {/* Platform Branding — hidden when collapsed */}
+            {!isCollapsed && (
+              <div className="px-4 py-4 border-t border-border">
+                <Link href="/" className="flex flex-col items-start gap-1 group">
+                  <span className="text-[10px] uppercase tracking-widest text-muted-foreground/50 group-hover:text-muted-foreground/80 transition-colors">
+                    {tSidebar("poweredBy")}
+                  </span>
+                  <Image
+                    src="/TeamNetwor.png"
+                    alt="TeamNetwork"
+                    width={541}
+                    height={303}
+                    className="w-full max-w-[200px] h-auto object-contain opacity-50 group-hover:opacity-80 transition-opacity"
+                  />
+                </Link>
+              </div>
+            )}
+          </>
+        );
+      }}
+    </HoverSidebar>
   );
 }


### PR DESCRIPTION
## Summary
- Sidebar collapses to 56px (icons only) by default, expands to 256px on hover/focus. Pin button (top-right of header) persists the expanded state to localStorage per surface (org and enterprise use separate keys).
- Pinned = content reflows (margin shifts); hover-only = sidebar overlays content without reflow (peek).
- New shared `HoverSidebar` shell owns hover/focus/pin state + writes `--sidebar-offset` CSS var on `<html>` when pinned. Render-prop keeps each sidebar's logic (i18n, nav_config, role filtering, theming) untouched.
- Long org/enterprise names wrap (not truncate) in `text-sm` so full name remains visible next to the pin button.
- MobileNav drawer passes `forceExpanded` + `layout="static"` — full-width sidebar inside drawer unchanged.

## Files
- New: `src/components/layout/HoverSidebar.tsx`
- Modified: `NavGroupSection`, `OrgSidebar`, `EnterpriseSidebar`, `OrgMainContent`, `MobileNav`, `[orgSlug]/layout.tsx`, `enterprise/[enterpriseSlug]/layout.tsx`

## Test plan
- [ ] Desktop org route: sidebar collapsed to 56px; hover expands; labels fade; pin persists across reload; unpin collapses immediately
- [ ] Desktop enterprise route: same hover/pin behavior; pin state independent from org pin
- [ ] Long enterprise name ("American Institute of Monterrey") wraps to 2 lines without truncation
- [ ] Canceling + grace-period banners align to sidebar offset when pinned
- [ ] Messages route (`/[orgSlug]/messages`) content offset still correct
- [ ] Mobile (<1024px): hamburger drawer opens full-width sidebar, no hover-collapse, no pin button
- [ ] Keyboard: tab into sidebar expands via focus; tab out collapses
- [ ] `npm run lint` clean
- [ ] `npm run build` clean