### PR TITLE
fix(approvals): show real names and restore profiles on re-approval

### DIFF
--- a/src/app/[orgSlug]/settings/approvals/page.tsx
+++ b/src/app/[orgSlug]/settings/approvals/page.tsx
@@ -57,17 +57,47 @@ export default function ApprovalsPage() {
           .order("created_at", { ascending: false })
           .range(offset, offset + PAGE_SIZE - 1);
 
+        const pendingUserIds = (memberships ?? []).map((m) => m.user_id);
+
+        const [{ data: memberRows }, { data: alumniRows }] = pendingUserIds.length
+          ? await Promise.all([
+              supabase
+                .from("members")
+                .select("user_id, first_name, last_name, email")
+                .eq("organization_id", org.id)
+                .in("user_id", pendingUserIds),
+              supabase
+                .from("alumni")
+                .select("user_id, first_name, last_name, email")
+                .eq("organization_id", org.id)
+                .in("user_id", pendingUserIds),
+            ])
+          : [{ data: [] }, { data: [] }];
+
+        const profileByUserId = new Map<string, { name: string | null; email: string | null }>();
+        for (const row of [...(alumniRows ?? []), ...(memberRows ?? [])]) {
+          if (!row.user_id) continue;
+          const fullName = [row.first_name, row.last_name].filter(Boolean).join(" ").trim();
+          if (!profileByUserId.has(row.user_id)) {
+            profileByUserId.set(row.user_id, {
+              name: fullName || null,
+              email: row.email ?? null,
+            });
+          }
+        }
+
         const normalizedMemberships: PendingMember[] =
           memberships?.map((m) => {
             const user = Array.isArray(m.users) ? m.users[0] : m.users;
+            const profile = profileByUserId.get(m.user_id);
             return {
               user_id: m.user_id,
               role: m.role,
               status: m.status,
               created_at: m.created_at,
               users: {
-                name: user?.name ?? null,
-                email: user?.email ?? null,
+                name: user?.name ?? profile?.name ?? null,
+                email: user?.email ?? profile?.email ?? null,
               },
             };
           }) || [];

--- a/supabase/migrations/20261015100000_sync_member_restore_on_reapproval.sql
+++ b/supabase/migrations/20261015100000_sync_member_restore_on_reapproval.sql
@@ -1,0 +1,108 @@
+-- Update sync trigger to restore soft-deleted member/alumni rows when UOR re-activates.
+-- Prevents "ghost approved" state where user's UOR is active but profile stays hidden
+-- because alumni/members row still has deleted_at set from prior admin delete.
+
+CREATE OR REPLACE FUNCTION public.handle_org_member_sync()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_email text;
+  v_first_name text;
+  v_last_name text;
+  v_avatar_url text;
+  v_member_id uuid;
+  v_alumni_id uuid;
+BEGIN
+  SELECT
+    email,
+    COALESCE(raw_user_meta_data->>'first_name', split_part(COALESCE(raw_user_meta_data->>'full_name', 'Member'), ' ', 1)),
+    COALESCE(raw_user_meta_data->>'last_name', split_part(COALESCE(raw_user_meta_data->>'full_name', ''), ' ', 2)),
+    raw_user_meta_data->>'avatar_url'
+  INTO v_user_email, v_first_name, v_last_name, v_avatar_url
+  FROM auth.users
+  WHERE id = NEW.user_id;
+
+  v_first_name := COALESCE(v_first_name, 'Member');
+  v_last_name := COALESCE(v_last_name, '');
+
+  -- 1. Sync to public.members (prefer live row; fall back to soft-deleted to restore)
+  SELECT id INTO v_member_id
+  FROM public.members
+  WHERE organization_id = NEW.organization_id
+    AND (user_id = NEW.user_id OR (email IS NOT NULL AND email = v_user_email))
+  ORDER BY deleted_at NULLS FIRST, created_at DESC
+  LIMIT 1;
+
+  IF v_member_id IS NOT NULL THEN
+    UPDATE public.members
+    SET
+      user_id = NEW.user_id,
+      role = NEW.role,
+      status = NEW.status::text::public.member_status,
+      deleted_at = CASE WHEN NEW.status = 'active' THEN NULL ELSE deleted_at END,
+      updated_at = now()
+    WHERE id = v_member_id;
+  ELSE
+    INSERT INTO public.members (
+      organization_id,
+      user_id,
+      first_name,
+      last_name,
+      email,
+      photo_url,
+      role,
+      status
+    )
+    VALUES (
+      NEW.organization_id,
+      NEW.user_id,
+      v_first_name,
+      v_last_name,
+      v_user_email,
+      v_avatar_url,
+      NEW.role,
+      NEW.status::text::public.member_status
+    );
+  END IF;
+
+  -- 2. Sync to public.alumni if role is ALUMNI (prefer live row; fall back to soft-deleted)
+  IF NEW.role = 'alumni' THEN
+    SELECT id INTO v_alumni_id
+    FROM public.alumni
+    WHERE organization_id = NEW.organization_id
+      AND (user_id = NEW.user_id OR (email IS NOT NULL AND email = v_user_email))
+    ORDER BY deleted_at NULLS FIRST, created_at DESC
+    LIMIT 1;
+
+    IF v_alumni_id IS NOT NULL THEN
+       UPDATE public.alumni
+       SET
+         user_id = NEW.user_id,
+         deleted_at = CASE WHEN NEW.status = 'active' THEN NULL ELSE deleted_at END,
+         updated_at = now()
+       WHERE id = v_alumni_id;
+    ELSE
+       INSERT INTO public.alumni (
+         organization_id,
+         user_id,
+         first_name,
+         last_name,
+         email,
+         photo_url
+       )
+       VALUES (
+         NEW.organization_id,
+         NEW.user_id,
+         v_first_name,
+         v_last_name,
+         v_user_email,
+         v_avatar_url
+       );
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary

- Approval page falls back to `members` / `alumni` profile data when the `public.users` join returns null, so pending users render with their real name instead of "Unknown User".
- `handle_org_member_sync` trigger now clears `deleted_at` on the matching member/alumni row when a `user_organization_roles` row transitions to `active`, so re-approving a previously deleted user restores their profile in place.

## Why

Reported by a user on AIM General: admin soft-deleted her own test alumni entry to try the approve/reject flow, saw the pending request show "Unknown User" instead of her name, and could no longer find her profile after re-approval because the alumni row kept `deleted_at` set.

## Changes

- `src/app/[orgSlug]/settings/approvals/page.tsx` — batch-fetch `members` and `alumni` rows for the pending `user_id`s and use them as a name/email fallback.
- `supabase/migrations/20261015100000_sync_member_restore_on_reapproval.sql` — update the sync trigger to un-soft-delete member/alumni rows when the UOR becomes active; also widens the existing-row lookup to consider soft-deleted rows so we restore in place instead of creating a duplicate.

## Test plan

- [ ] As an admin, soft-delete an alumni, then re-invite / re-approve the same user and confirm: (a) the approvals list shows their real name, (b) the alumni row becomes visible again with original data (phone, grad year, etc.), (c) the user can self-edit their profile.
- [ ] Fresh pending invite (no prior profile) still shows the name from `public.users` as before.
- [ ] Reject flow unchanged.