### PR TITLE
feat(blog): add blog section + org branding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1109,7 +1108,6 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -1144,7 +1142,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -1319,7 +1316,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.2.tgz",
       "integrity": "sha512-GlC5me7/WlyS1ZCpwLoCm7ezggRWxyMxfckDhtnJvGanoVZAOnCKSqrNkjmDF8aufdh/kOoXRc/P3zJ/eUKMTg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.103.2",
         "@supabase/functions-js": "2.103.2",
@@ -1651,7 +1647,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1727,7 +1722,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -2246,7 +2240,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3638,7 +3631,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4455,7 +4447,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5659,7 +5650,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7057,17 +7047,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -7737,7 +7716,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8020,7 +7998,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8033,7 +8010,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8047,7 +8023,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9345,7 +9320,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9953,7 +9927,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/[orgSlug]/customization/page.tsx
+++ b/src/app/[orgSlug]/customization/page.tsx
@@ -68,6 +68,7 @@ function OrgSettingsContent() {
 
   // Initial data for child components
   const [initialLogoUrl, setInitialLogoUrl] = useState<string | null>(null);
+  const [initialBaseColor, setInitialBaseColor] = useState("primary");
   const [initialPrimaryColor, setInitialPrimaryColor] = useState("#1e3a5f");
   const [initialSecondaryColor, setInitialSecondaryColor] = useState("#10b981");
   const [initialPrefs, setInitialPrefs] = useState<{
@@ -125,7 +126,7 @@ function OrgSettingsContent() {
 
       const { data: org, error: orgError } = await supabase
         .from("organizations")
-        .select("id, name, logo_url, primary_color, secondary_color, feed_post_roles, job_post_roles, discussion_post_roles, media_upload_roles, linkedin_resync_enabled, timezone, default_language")
+        .select("id, name, logo_url, base_color, primary_color, secondary_color, feed_post_roles, job_post_roles, discussion_post_roles, media_upload_roles, linkedin_resync_enabled, timezone, default_language")
         .eq("slug", orgSlug)
         .maybeSingle();
 
@@ -138,6 +139,7 @@ function OrgSettingsContent() {
       setOrgId(org.id);
       setOrgName(org.name || tCustom("fallbackOrgName"));
       setInitialLogoUrl(org.logo_url);
+      setInitialBaseColor((org as Record<string, unknown>).base_color as string || "primary");
       setInitialPrimaryColor(org.primary_color || "#1e3a5f");
       setInitialSecondaryColor(org.secondary_color || "#10b981");
       setFeedPostRoles((org as Record<string, unknown>).feed_post_roles as string[] || ["admin", "active_member", "alumni"]);
@@ -443,8 +445,9 @@ function OrgSettingsContent() {
             orgName={orgName}
             isAdmin={isAdmin}
             initialLogoUrl={initialLogoUrl}
-            initialPrimaryColor={initialPrimaryColor}
-            initialSecondaryColor={initialSecondaryColor}
+            initialBaseColor={initialBaseColor}
+            initialSidebarColor={initialPrimaryColor}
+            initialButtonColor={initialSecondaryColor}
           />
 
           {isAdmin && (

--- a/src/app/[orgSlug]/layout.tsx
+++ b/src/app/[orgSlug]/layout.tsx
@@ -267,12 +267,13 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
         .eq("organization_id", organization.id)
         .maybeSingle()
     : { data: null };
-  const primary = safeHexColor(organization.primary_color, "#1e3a5f");
-  const secondary = safeHexColor(organization.secondary_color, "#10b981");
+  const rawBase = (organization as Record<string, unknown>).base_color as string | null;
+  const baseColor = rawBase === "primary" ? "primary" : safeHexColor(rawBase, "primary");
+  const sidebarColor = safeHexColor(organization.primary_color, "#1e3a5f");
+  const buttonColor = safeHexColor(organization.secondary_color, "#10b981");
 
-  // Compute theme variables for both light and dark modes
-  const lightModeVars = computeOrgThemeVariables(primary, secondary, false);
-  const darkModeVars = computeOrgThemeVariables(primary, secondary, true);
+  // Compute theme variables — base color determines light/dark, no separate modes
+  const themeVars = computeOrgThemeVariables(baseColor, sidebarColor, buttonColor);
 
   return (
     <OrgAnalyticsProvider orgId={organization.id} orgType={(organization as Record<string, unknown>).org_type as string || "general"}>
@@ -281,27 +282,18 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
     <div data-org-shell className="min-h-screen">
       <style
         dangerouslySetInnerHTML={{
-          __html: `
-            :root {
-              ${Object.entries(lightModeVars)
-                .map(([key, value]) => `${key}: ${value};`)
-                .join("\n              ")}
-            }
-
-            :root.dark {
-              ${Object.entries(darkModeVars)
-                .map(([key, value]) => `${key}: ${value};`)
-                .join("\n              ")}
-            }
-
-            @media (prefers-color-scheme: dark) {
-              :root:not(.light) {
-                ${Object.entries(darkModeVars)
-                  .map(([key, value]) => `${key}: ${value};`)
-                  .join("\n                ")}
-              }
-            }
-          `,
+          __html: (() => {
+            const vars = Object.entries(themeVars)
+              .map(([key, value]) => `${key}: ${value};`)
+              .join("\n              ");
+            // Inject into :root, .dark, AND prefers-color-scheme so org theme
+            // always wins over globals.css dark mode overrides
+            return `
+            :root { ${vars} }
+            :root.dark { ${vars} }
+            @media (prefers-color-scheme: dark) { :root:not(.light) { ${vars} } }
+            `;
+          })(),
         }}
       />
 

--- a/src/app/api/organizations/[organizationId]/branding/route.ts
+++ b/src/app/api/organizations/[organizationId]/branding/route.ts
@@ -111,21 +111,34 @@ export async function POST(req: Request, { params }: RouteParams) {
   }
 
   const formData = await req.formData();
+  const rawBaseColor = formData.get("baseColor");
   const rawPrimary = formData.get("primaryColor");
   const rawSecondary = formData.get("secondaryColor");
+
+  // Validate base color: "primary", #ffffff, or #222326
+  const VALID_BASE_COLORS = new Set(["primary", "#ffffff", "#222326"]);
+  let baseColor: string | null = null;
+  if (rawBaseColor && typeof rawBaseColor === "string" && rawBaseColor.trim()) {
+    const normalized = rawBaseColor.trim().toLowerCase();
+    if (!VALID_BASE_COLORS.has(normalized)) {
+      return respond({ error: "Base color must be 'primary', #ffffff, or #222326." }, 400);
+    }
+    baseColor = normalized;
+  }
+
   const primary = normalizeHexColor(rawPrimary);
   const secondary = normalizeHexColor(rawSecondary);
   const file = formData.get("logo");
 
   if (primary.invalid) {
-    return respond({ error: "Primary color must be a 6-digit hex value like #1e3a5f." }, 400);
+    return respond({ error: "Sidebar color must be a 6-digit hex value like #1e3a5f." }, 400);
   }
   if (secondary.invalid) {
-    return respond({ error: "Secondary color must be a 6-digit hex value like #10b981." }, 400);
+    return respond({ error: "Button color must be a 6-digit hex value like #10b981." }, 400);
   }
 
   const uploadFile = file instanceof File ? file : null;
-  if (!uploadFile && !primary.color && !secondary.color) {
+  if (!uploadFile && !primary.color && !secondary.color && !baseColor) {
     return respond({ error: "Provide a logo or updated colors to save." }, 400);
   }
 
@@ -156,11 +169,15 @@ export async function POST(req: Request, { params }: RouteParams) {
 
   const serviceSupabase = createServiceClient();
   const updates: {
+    base_color?: string;
     primary_color?: string;
     secondary_color?: string;
     logo_url?: string;
   } = {};
 
+  if (baseColor) {
+    updates.base_color = baseColor;
+  }
   if (primary.color) {
     updates.primary_color = primary.color;
   }
@@ -195,7 +212,7 @@ export async function POST(req: Request, { params }: RouteParams) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .update(updates as any)
     .eq("id", organizationId)
-    .select("id, name, slug, logo_url, primary_color, secondary_color")
+    .select("id, name, slug, logo_url, base_color, primary_color, secondary_color")
     .maybeSingle();
 
   if (updateError) {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,243 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ButtonLink } from "@/components/ui";
+import { getPostBySlug, getAllSlugs } from "@/lib/blog/posts";
+import "../../landing-styles.css";
+
+export const revalidate = 3600;
+
+export function generateStaticParams() {
+  return getAllSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+  if (!post) return { title: "Post Not Found | TeamNetwork" };
+  return {
+    title: `${post.title} | TeamNetwork Blog`,
+    description: post.excerpt,
+  };
+}
+
+function formatDate(iso: string) {
+  return new Date(iso + "T00:00:00").toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default async function BlogPostPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+  if (!post) notFound();
+
+  return (
+    <div
+      id="top"
+      className="landing-page min-h-screen text-landing-cream relative noise-overlay bg-landing-navy"
+    >
+      {/* Background */}
+      <div className="fixed inset-0 stripe-pattern pointer-events-none" />
+      <div className="fixed inset-0 bg-gradient-to-b from-landing-navy via-landing-navy to-landing-navy/95 pointer-events-none" />
+
+      {/* Header */}
+      <header className="relative z-20 sticky top-0 bg-landing-navy/95 backdrop-blur-md border-b border-landing-cream/10">
+        <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link href="/" className="group flex items-center gap-2">
+            <Image
+              src="/TeamNetwor.png"
+              alt=""
+              width={541}
+              height={303}
+              sizes="28px"
+              className="h-8 w-auto shrink-0 object-contain sm:h-7"
+              aria-hidden="true"
+            />
+            <span className="font-display hidden text-base font-bold tracking-tight text-landing-cream sm:inline sm:text-xl">
+              <span className="text-landing-green">Team</span>
+              <span className="text-landing-cream">Network</span>
+            </span>
+            <span className="sr-only">TeamNetwork</span>
+          </Link>
+          <nav className="hidden md:flex items-center gap-8 text-sm">
+            <Link
+              href="/blog"
+              className="text-landing-cream/70 hover:text-landing-cream transition-colors flex items-center gap-1.5"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M15.75 19.5 8.25 12l7.5-7.5"
+                />
+              </svg>
+              All Posts
+            </Link>
+          </nav>
+          <div className="flex items-center gap-3">
+            <ButtonLink
+              href="/auth/login"
+              variant="custom"
+              className="text-landing-cream/80 hover:text-landing-cream hover:bg-landing-cream/10"
+            >
+              Sign In
+            </ButtonLink>
+            <ButtonLink
+              href="/auth/signup"
+              variant="custom"
+              className="bg-landing-green-dark hover:bg-[#059669] text-white font-semibold px-5"
+            >
+              Get Started
+            </ButtonLink>
+          </div>
+        </div>
+      </header>
+
+      <main className="relative z-10">
+        <article className="max-w-3xl mx-auto px-6 pt-16 lg:pt-24 pb-24">
+          {/* Meta */}
+          <div className="mb-10">
+            <Link
+              href="/blog"
+              className="md:hidden inline-flex items-center gap-1.5 text-sm text-landing-cream/50 hover:text-landing-cream transition-colors mb-6"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M15.75 19.5 8.25 12l7.5-7.5"
+                />
+              </svg>
+              All Posts
+            </Link>
+
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-landing-green/10 text-landing-green text-xs font-medium mb-5">
+              {post.category}
+            </span>
+
+            <h1 className="font-display text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight leading-[1.15] mb-5">
+              {post.title}
+            </h1>
+
+            <div className="flex items-center gap-4 text-sm text-landing-cream/40">
+              <time dateTime={post.date}>{formatDate(post.date)}</time>
+              <span className="w-1 h-1 rounded-full bg-landing-cream/20" />
+              <span>{post.readingTime}</span>
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="h-px bg-landing-cream/10 mb-10" />
+
+          {/* Content */}
+          <div className="blog-prose">
+            {post.sections.map((section, i) => (
+              <section key={i}>
+                {section.heading && (
+                  <h2 className="font-display">{section.heading}</h2>
+                )}
+                {section.paragraphs.map((p, j) => (
+                  <p key={j}>{p}</p>
+                ))}
+              </section>
+            ))}
+          </div>
+
+          {/* CTA */}
+          <div className="mt-16 pt-10 border-t border-landing-cream/10 text-center">
+            <p className="text-landing-cream/50 text-sm mb-5">
+              Ready to build your alumni network?
+            </p>
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+              <ButtonLink
+                href="/auth/signup"
+                variant="custom"
+                className="bg-landing-green-dark hover:bg-[#059669] text-white font-semibold px-8 py-3"
+              >
+                Get Started Free
+              </ButtonLink>
+              <ButtonLink
+                href="/demos"
+                variant="custom"
+                className="bg-landing-cream/10 text-landing-cream hover:bg-landing-cream/20 border border-landing-cream/20 px-8 py-3"
+              >
+                See a Demo
+              </ButtonLink>
+            </div>
+          </div>
+        </article>
+      </main>
+
+      {/* Footer */}
+      <footer className="relative z-10 border-t border-landing-cream/10 py-12 bg-landing-navy">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="flex flex-col md:flex-row items-center justify-between gap-6">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded bg-landing-green-dark flex items-center justify-center">
+                <span className="font-display font-bold text-white text-sm">
+                  TN
+                </span>
+              </div>
+              <span className="font-display font-bold">TeamNetwork</span>
+            </div>
+
+            <div className="flex items-center gap-8 text-sm text-landing-cream/50">
+              <Link
+                href="/terms"
+                className="hover:text-landing-cream transition-colors"
+              >
+                Terms
+              </Link>
+              <Link
+                href="/privacy"
+                className="hover:text-landing-cream transition-colors"
+              >
+                Privacy
+              </Link>
+              <Link
+                href="/#pricing"
+                className="hover:text-landing-cream transition-colors"
+              >
+                Pricing
+              </Link>
+              <a
+                href="mailto:support@myteamnetwork.com"
+                className="hover:text-landing-cream transition-colors"
+              >
+                Contact
+              </a>
+            </div>
+
+            <p className="text-sm text-landing-cream/30">
+              &copy; {new Date().getFullYear()} TeamNetwork
+            </p>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,215 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { ButtonLink } from "@/components/ui";
+import { blogPosts } from "@/lib/blog/posts";
+import "../landing-styles.css";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "Blog | TeamNetwork",
+  description:
+    "Insights on alumni engagement, mentorship, and building lasting communities.",
+};
+
+function formatDate(iso: string) {
+  return new Date(iso + "T00:00:00").toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function BlogPage() {
+  return (
+    <div
+      id="top"
+      className="landing-page min-h-screen text-landing-cream relative noise-overlay bg-landing-navy"
+    >
+      {/* Background */}
+      <div className="fixed inset-0 stripe-pattern pointer-events-none" />
+      <div className="fixed inset-0 bg-gradient-to-b from-landing-navy via-landing-navy to-landing-navy/95 pointer-events-none" />
+
+      {/* Header */}
+      <header className="relative z-20 sticky top-0 bg-landing-navy/95 backdrop-blur-md border-b border-landing-cream/10">
+        <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link href="/" className="group flex items-center gap-2">
+            <Image
+              src="/TeamNetwor.png"
+              alt=""
+              width={541}
+              height={303}
+              sizes="28px"
+              className="h-8 w-auto shrink-0 object-contain sm:h-7"
+              aria-hidden="true"
+            />
+            <span className="font-display hidden text-base font-bold tracking-tight text-landing-cream sm:inline sm:text-xl">
+              <span className="text-landing-green">Team</span>
+              <span className="text-landing-cream">Network</span>
+            </span>
+            <span className="sr-only">TeamNetwork</span>
+          </Link>
+          <nav className="hidden md:flex items-center gap-8 text-sm">
+            <Link
+              href="/#features"
+              className="text-landing-cream/70 hover:text-landing-cream transition-colors"
+            >
+              Features
+            </Link>
+            <Link
+              href="/#pricing"
+              className="text-landing-cream/70 hover:text-landing-cream transition-colors"
+            >
+              Pricing
+            </Link>
+            <Link
+              href="/demos"
+              className="text-landing-cream/70 hover:text-landing-cream transition-colors"
+            >
+              Demo
+            </Link>
+            <Link
+              href="/#faq"
+              className="text-landing-cream/70 hover:text-landing-cream transition-colors"
+            >
+              FAQ
+            </Link>
+            <Link
+              href="/blog"
+              className="text-landing-cream transition-colors"
+            >
+              Blog
+            </Link>
+            <Link
+              href="/terms"
+              className="text-landing-cream/70 hover:text-landing-cream transition-colors"
+            >
+              Terms
+            </Link>
+          </nav>
+          <div className="flex items-center gap-3">
+            <ButtonLink
+              href="/auth/login"
+              variant="custom"
+              className="text-landing-cream/80 hover:text-landing-cream hover:bg-landing-cream/10"
+            >
+              Sign In
+            </ButtonLink>
+            <ButtonLink
+              href="/auth/signup"
+              variant="custom"
+              className="bg-landing-green-dark hover:bg-[#059669] text-white font-semibold px-5"
+            >
+              Get Started
+            </ButtonLink>
+          </div>
+        </div>
+      </header>
+
+      <main className="relative z-10">
+        {/* Hero */}
+        <section className="relative z-10 pt-20 lg:pt-28 pb-16 px-6">
+          <div className="max-w-6xl mx-auto">
+            <div className="hero-animate inline-flex items-center gap-2 px-4 py-2 rounded-full bg-landing-cream/10 border border-landing-cream/20 mb-6">
+              <span className="w-2 h-2 rounded-full bg-landing-green" />
+              <span className="text-landing-cream/80 text-sm font-medium">
+                Blog
+              </span>
+            </div>
+            <h1 className="hero-animate font-display text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight leading-[1.1] mb-5 max-w-3xl">
+              Insights &amp; Research
+            </h1>
+            <p className="hero-animate text-lg text-landing-cream/50 max-w-2xl leading-relaxed">
+              Data-driven perspectives on alumni engagement, mentorship, and
+              building communities that last beyond graduation.
+            </p>
+          </div>
+        </section>
+
+        {/* Post grid */}
+        <section className="relative z-10 px-6 pb-24">
+          <div className="max-w-6xl mx-auto">
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {blogPosts.map((post) => (
+                <Link
+                  key={post.slug}
+                  href={`/blog/${post.slug}`}
+                  className="blog-card group rounded-2xl border border-landing-cream/10 bg-landing-navy-light/40 p-7 flex flex-col"
+                >
+                  {/* Category */}
+                  <span className="inline-flex self-start items-center gap-1.5 px-3 py-1 rounded-full bg-landing-green/10 text-landing-green text-xs font-medium mb-5">
+                    {post.category}
+                  </span>
+
+                  {/* Title */}
+                  <h2 className="font-display text-xl font-bold leading-snug mb-3 group-hover:text-landing-green transition-colors">
+                    {post.title}
+                  </h2>
+
+                  {/* Excerpt */}
+                  <p className="text-sm text-landing-cream/50 leading-relaxed mb-6 flex-1">
+                    {post.excerpt}
+                  </p>
+
+                  {/* Footer */}
+                  <div className="flex items-center justify-between text-xs text-landing-cream/35 pt-4 border-t border-landing-cream/5">
+                    <time dateTime={post.date}>{formatDate(post.date)}</time>
+                    <span>{post.readingTime}</span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+
+      {/* Footer */}
+      <footer className="relative z-10 border-t border-landing-cream/10 py-12 bg-landing-navy">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="flex flex-col md:flex-row items-center justify-between gap-6">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded bg-landing-green-dark flex items-center justify-center">
+                <span className="font-display font-bold text-white text-sm">
+                  TN
+                </span>
+              </div>
+              <span className="font-display font-bold">TeamNetwork</span>
+            </div>
+
+            <div className="flex items-center gap-8 text-sm text-landing-cream/50">
+              <Link
+                href="/terms"
+                className="hover:text-landing-cream transition-colors"
+              >
+                Terms
+              </Link>
+              <Link
+                href="/privacy"
+                className="hover:text-landing-cream transition-colors"
+              >
+                Privacy
+              </Link>
+              <Link
+                href="/#pricing"
+                className="hover:text-landing-cream transition-colors"
+              >
+                Pricing
+              </Link>
+              <a
+                href="mailto:support@myteamnetwork.com"
+                className="hover:text-landing-cream transition-colors"
+              >
+                Contact
+              </a>
+            </div>
+
+            <p className="text-sm text-landing-cream/30">
+              &copy; {new Date().getFullYear()} TeamNetwork
+            </p>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
   --font-display: "Bitter";
   --font-mono: "Space Mono";
 
-  /* Dynamic org color - will be overridden per-org */
+  /* Dynamic org colors - overridden per-org via layout <style> */
   --color-org-primary: #1e3a5f;
   --color-org-primary-light: #2d4a6f;
   --color-org-primary-dark: #0f2a4f;
@@ -16,6 +16,12 @@
   --color-org-secondary-light: #34d399;
   --color-org-secondary-dark: #047857;
   --color-org-secondary-foreground: #ffffff;
+
+  /* Sidebar */
+  --sidebar-bg: #1e3a5f;
+  --sidebar-foreground: #f8fafc;
+  --sidebar-muted: #2d4a6f;
+  --sidebar-muted-foreground: #94a3b8;
 
   /* Base theme */
   --background: #fafbfc;
@@ -151,12 +157,13 @@ body {
 }
 
 .badge-primary {
-  background: var(--color-org-primary);
-  @apply text-white;
+  background: var(--color-org-secondary);
+  color: var(--color-org-secondary-foreground);
 }
 
 .badge-success {
-  @apply bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400;
+  background: color-mix(in srgb, var(--color-org-secondary) 15%, var(--card));
+  color: var(--color-org-secondary);
 }
 
 .badge-success-muted {
@@ -165,11 +172,12 @@ body {
 }
 
 .badge-warning {
-  @apply bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400;
+  background: color-mix(in srgb, var(--color-org-primary) 15%, var(--card));
+  color: var(--color-org-primary);
 }
 
 .badge-error {
-  @apply bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400;
+  @apply bg-red-100 text-red-800;
 }
 
 .badge-muted {

--- a/src/app/landing-styles.css
+++ b/src/app/landing-styles.css
@@ -863,3 +863,37 @@ noscript~.scroll-reveal {
     transition: none;
   }
 }
+
+/* ── Blog ─────────────────────────────────────────────────────── */
+
+.blog-prose p {
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 1.85;
+  font-size: 1.125rem;
+  margin-bottom: 1.5rem;
+}
+
+.blog-prose h2 {
+  color: var(--landing-cream);
+  font-weight: 700;
+  font-size: 1.625rem;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  letter-spacing: -0.01em;
+}
+
+.blog-prose blockquote {
+  border-left: 3px solid var(--landing-green);
+  padding-left: 1.5rem;
+  margin: 2rem 0;
+  color: rgba(255, 255, 255, 0.85);
+  font-style: italic;
+}
+
+.blog-card {
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+.blog-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(34, 197, 94, 0.3);
+}

--- a/src/components/layout/HoverSidebar.tsx
+++ b/src/components/layout/HoverSidebar.tsx
@@ -87,6 +87,16 @@ useEffect(() => {
     ? "w-64"
     : "w-14 data-[expanded=true]:w-64";
 
+  // Scope base CSS vars within sidebar so child components (NavGroupSection, etc.)
+  // get sidebar-appropriate text/muted colors instead of page-level ones
+  const sidebarScopeStyle = {
+    "--foreground": "var(--sidebar-foreground)",
+    "--muted": "var(--sidebar-muted)",
+    "--muted-foreground": "var(--sidebar-muted-foreground)",
+    "--card": "var(--sidebar-bg)",
+    "--card-foreground": "var(--sidebar-foreground)",
+  } as React.CSSProperties;
+
   return (
     <aside
       data-expanded={isExpanded}
@@ -102,7 +112,8 @@ useEffect(() => {
               }
             }
       }
-      className={`flex flex-col bg-card border-r border-border overflow-hidden transition-[width] duration-300 ease-in-out motion-reduce:transition-none ${positionClass} ${widthClass} ${className}`}
+      style={sidebarScopeStyle}
+      className={`flex flex-col bg-[var(--sidebar-bg)] text-[var(--sidebar-foreground)] border-r border-border overflow-hidden transition-[width] duration-300 ease-in-out motion-reduce:transition-none ${positionClass} ${widthClass} ${className}`}
     >
       {children({ isExpanded, isPinned, togglePin })}
     </aside>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -101,7 +101,14 @@ export function MobileNav({ organization, role, isDevAdmin = false, hasAlumniAcc
 
       {/* Slide-out Drawer */}
       <div
-        className={`fixed top-0 bottom-0 left-0 w-64 bg-card z-50 transform transition-transform duration-300 ease-in-out lg:hidden overscroll-contain ${
+        style={{
+          "--foreground": "var(--sidebar-foreground)",
+          "--muted": "var(--sidebar-muted)",
+          "--muted-foreground": "var(--sidebar-muted-foreground)",
+          "--card": "var(--sidebar-bg)",
+          "--card-foreground": "var(--sidebar-foreground)",
+        } as React.CSSProperties}
+        className={`fixed top-0 bottom-0 left-0 w-64 bg-[var(--sidebar-bg)] text-[var(--sidebar-foreground)] z-50 transform transition-transform duration-300 ease-in-out lg:hidden overscroll-contain ${
           isOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >

--- a/src/components/marketing/LandingHeader.tsx
+++ b/src/components/marketing/LandingHeader.tsx
@@ -10,6 +10,7 @@ const NAV_LINKS = [
   { href: "#pricing", label: "Pricing" },
   { href: "/demos", label: "Demos" },
   { href: "#faq", label: "FAQ" },
+  { href: "/blog", label: "Blog" },
   { href: "/terms", label: "Terms" },
 ] as const;
 

--- a/src/components/settings/BrandingCard.tsx
+++ b/src/components/settings/BrandingCard.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { animate } from "animejs";
 import { useTranslations } from "next-intl";
 import { Badge, Button, Card, Input } from "@/components/ui";
-import { computeOrgThemeVariables } from "@/lib/theming/org-colors";
+import { computeOrgThemeVariables, isColorDark } from "@/lib/theming/org-colors";
 import { hexColorSchema } from "@/lib/schemas/common";
 
 interface BrandingCardProps {
@@ -15,9 +15,14 @@ interface BrandingCardProps {
   orgName: string;
   isAdmin: boolean;
   initialLogoUrl: string | null;
-  initialPrimaryColor: string;
-  initialSecondaryColor: string;
+  initialBaseColor: string;
+  initialSidebarColor: string;
+  initialButtonColor: string;
 }
+
+const BASE_PRIMARY = "primary";
+const BASE_WHITE = "#ffffff";
+const BASE_DARK = "#222326";
 
 export function BrandingCard({
   orgId,
@@ -25,16 +30,22 @@ export function BrandingCard({
   orgName,
   isAdmin,
   initialLogoUrl,
-  initialPrimaryColor,
-  initialSecondaryColor,
+  initialBaseColor,
+  initialSidebarColor,
+  initialButtonColor,
 }: BrandingCardProps) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const tSettings = useTranslations("settings");
   const tCommon = useTranslations("common");
 
-  const [primaryColor, setPrimaryColor] = useState(initialPrimaryColor);
-  const [secondaryColor, setSecondaryColor] = useState(initialSecondaryColor);
+  const [baseColor, setBaseColor] = useState(
+    initialBaseColor === BASE_DARK ? BASE_DARK
+    : initialBaseColor === BASE_WHITE ? BASE_WHITE
+    : BASE_PRIMARY
+  );
+  const [sidebarColor, setSidebarColor] = useState(initialSidebarColor);
+  const [buttonColor, setButtonColor] = useState(initialButtonColor);
   const [logoUrl, setLogoUrl] = useState(initialLogoUrl);
   const [selectedLogo, setSelectedLogo] = useState<File | null>(null);
   const [logoPreview, setLogoPreview] = useState<string | null>(null);
@@ -66,32 +77,31 @@ export function BrandingCard({
       duration: 480,
       easing: "easeOutQuad",
     });
-  }, [primaryColor, secondaryColor, logoPreview, logoUrl]);
+  }, [baseColor, sidebarColor, buttonColor, logoPreview, logoUrl]);
 
-  const applyThemeLocally = (nextPrimary: string, nextSecondary: string) => {
-    const lightVars = computeOrgThemeVariables(nextPrimary, nextSecondary, false);
-    const darkVars = computeOrgThemeVariables(nextPrimary, nextSecondary, true);
+  const applyThemeLocally = (nextBase: string, nextSidebar: string, nextButton: string) => {
+    const vars = computeOrgThemeVariables(nextBase, nextSidebar, nextButton);
 
     const existingStyle = document.getElementById("org-theme-preview");
     if (existingStyle) existingStyle.remove();
 
+    const cssVars = Object.entries(vars).map(([k, v]) => `${k}: ${v};`).join("\n        ");
     const style = document.createElement("style");
     style.id = "org-theme-preview";
+    // Override :root, .dark, and prefers-color-scheme so base color always wins
     style.textContent = `
-      :root {
-        ${Object.entries(lightVars).map(([k, v]) => `${k}: ${v};`).join("\n        ")}
-      }
-      :root.dark {
-        ${Object.entries(darkVars).map(([k, v]) => `${k}: ${v};`).join("\n        ")}
-      }
-      @media (prefers-color-scheme: dark) {
-        :root:not(.light) {
-          ${Object.entries(darkVars).map(([k, v]) => `${k}: ${v};`).join("\n          ")}
-        }
-      }
+      :root { ${cssVars} }
+      :root.dark { ${cssVars} }
+      @media (prefers-color-scheme: dark) { :root:not(.light) { ${cssVars} } }
     `;
     document.head.appendChild(style);
   };
+
+  // Live preview on any color change
+  useEffect(() => {
+    applyThemeLocally(baseColor, sidebarColor, buttonColor);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baseColor, sidebarColor, buttonColor]);
 
   const handleBrandingSave = async () => {
     if (!isAdmin) {
@@ -99,7 +109,7 @@ export function BrandingCard({
       return;
     }
 
-    if (!hexColorSchema.safeParse(primaryColor).success || !hexColorSchema.safeParse(secondaryColor).success) {
+    if (!hexColorSchema.safeParse(sidebarColor).success || !hexColorSchema.safeParse(buttonColor).success) {
       setBrandError(tSettings("branding.hexError"));
       return;
     }
@@ -109,8 +119,9 @@ export function BrandingCard({
     setBrandSuccess(null);
 
     const formData = new FormData();
-    formData.append("primaryColor", primaryColor);
-    formData.append("secondaryColor", secondaryColor);
+    formData.append("baseColor", baseColor);
+    formData.append("primaryColor", sidebarColor);
+    formData.append("secondaryColor", buttonColor);
     if (selectedLogo) {
       formData.append("logo", selectedLogo);
     }
@@ -128,20 +139,23 @@ export function BrandingCard({
 
       const updatedOrg = (data?.organization || null) as {
         logo_url?: string | null;
+        base_color?: string | null;
         primary_color?: string | null;
         secondary_color?: string | null;
       } | null;
 
-      const nextPrimary = updatedOrg?.primary_color || primaryColor;
-      const nextSecondary = updatedOrg?.secondary_color || secondaryColor;
+      const nextBase = updatedOrg?.base_color || baseColor;
+      const nextSidebar = updatedOrg?.primary_color || sidebarColor;
+      const nextButton = updatedOrg?.secondary_color || buttonColor;
 
       setLogoUrl(updatedOrg?.logo_url ?? logoUrl);
-      setPrimaryColor(nextPrimary);
-      setSecondaryColor(nextSecondary);
+      setBaseColor(nextBase === BASE_DARK ? BASE_DARK : nextBase === BASE_WHITE ? BASE_WHITE : BASE_PRIMARY);
+      setSidebarColor(nextSidebar);
+      setButtonColor(nextButton);
       setBrandSuccess(tSettings("branding.saved"));
       setSelectedLogo(null);
       setLogoPreview(null);
-      applyThemeLocally(nextPrimary, nextSecondary);
+      applyThemeLocally(nextBase, nextSidebar, nextButton);
       router.refresh();
     } catch (err) {
       setBrandError(err instanceof Error ? err.message : tSettings("branding.unableToSave"));
@@ -151,6 +165,16 @@ export function BrandingCard({
   };
 
   const displayLogo = logoPreview || logoUrl;
+  const isPrimaryBase = baseColor === BASE_PRIMARY;
+  const isDarkBase = baseColor === BASE_DARK;
+  // Resolve the actual background color for previews
+  const resolvedBg = isPrimaryBase ? sidebarColor : isDarkBase ? BASE_DARK : "#fafbfc";
+  const resolvedFg = isPrimaryBase
+    ? (isColorDark(sidebarColor) ? "#ffffff" : "#000000")
+    : isDarkBase ? "#ffffff" : "#000000";
+  const resolvedMuted = isPrimaryBase
+    ? (isColorDark(sidebarColor) ? "#a0aec0" : "#4a5568")
+    : isDarkBase ? "#a0aec0" : "#4a5568";
 
   return (
     <Card className="org-settings-card p-5 space-y-4 opacity-0 translate-y-2">
@@ -164,35 +188,54 @@ export function BrandingCard({
         <Badge variant={isAdmin ? "muted" : "warning"}>{isAdmin ? tCommon("admin") : tCommon("viewOnly")}</Badge>
       </div>
 
+      {/* Live preview showing all 3 colors */}
       <div
-        className="org-brand-preview relative overflow-hidden rounded-2xl border border-border p-5 shadow-soft"
-        style={{ backgroundColor: primaryColor }}
+        className="org-brand-preview relative overflow-hidden rounded-2xl border border-border shadow-soft flex"
+        style={{ backgroundColor: resolvedBg, minHeight: 88 }}
       >
-        <div className="absolute inset-0 bg-black/5 dark:bg-black/20" />
-        <div className="relative flex items-center gap-4">
+        {/* Sidebar strip */}
+        <div
+          className="w-14 shrink-0 flex items-center justify-center"
+          style={{ backgroundColor: sidebarColor }}
+        >
           {displayLogo ? (
-            <div className="relative h-14 w-14 rounded-2xl overflow-hidden border border-white/40 shadow-lg">
+            <div className="relative h-8 w-8 rounded-lg overflow-hidden border border-white/30">
               <Image
                 src={displayLogo}
                 alt={orgName}
                 fill
                 className="object-cover"
-                sizes="56px"
+                sizes="32px"
               />
             </div>
           ) : (
-            <div className="h-14 w-14 rounded-2xl flex items-center justify-center text-white font-bold text-lg bg-white/20 shadow-lg">
+            <div className="h-8 w-8 rounded-lg flex items-center justify-center text-white/90 font-bold text-xs bg-white/20">
               {orgName.charAt(0)}
             </div>
           )}
+        </div>
+        {/* Content area */}
+        <div className="flex-1 p-4 flex items-center justify-between gap-3">
           <div>
-            <p className="font-semibold text-white">{orgName}</p>
-            <p className="text-sm text-white/80 truncate">/{orgSlug}</p>
+            <p className="font-semibold text-sm" style={{ color: resolvedFg }}>
+              {orgName}
+            </p>
+            <p className="text-xs mt-0.5" style={{ color: resolvedMuted }}>
+              /{orgSlug}
+            </p>
           </div>
+          <button
+            type="button"
+            className="px-3 py-1.5 rounded-lg text-xs font-medium"
+            style={{ backgroundColor: buttonColor, color: "#fff" }}
+          >
+            Button
+          </button>
         </div>
       </div>
 
       <div className="space-y-4">
+        {/* Logo upload */}
         <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
           <input
             ref={fileInputRef}
@@ -223,15 +266,65 @@ export function BrandingCard({
           )}
         </div>
 
+        {/* Base Color Toggle */}
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-foreground">Base Color</p>
+          <div className="flex gap-3 flex-wrap">
+            <button
+              type="button"
+              onClick={() => { setBaseColor(BASE_PRIMARY); setBrandSuccess(null); }}
+              disabled={!isAdmin}
+              className={`flex items-center gap-2 px-4 py-2.5 rounded-xl border-2 transition-all duration-200 ${
+                isPrimaryBase
+                  ? "border-[var(--color-org-secondary)] shadow-sm"
+                  : "border-border hover:border-muted-foreground"
+              } ${!isAdmin ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+            >
+              <div className="w-6 h-6 rounded-full border border-white/30" style={{ backgroundColor: sidebarColor }} />
+              <span className="text-sm font-medium text-foreground">Primary</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => { setBaseColor(BASE_WHITE); setBrandSuccess(null); }}
+              disabled={!isAdmin}
+              className={`flex items-center gap-2 px-4 py-2.5 rounded-xl border-2 transition-all duration-200 ${
+                baseColor === BASE_WHITE
+                  ? "border-[var(--color-org-secondary)] shadow-sm"
+                  : "border-border hover:border-muted-foreground"
+              } ${!isAdmin ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+            >
+              <div className="w-6 h-6 rounded-full border border-gray-200 bg-white" />
+              <span className="text-sm font-medium text-foreground">White</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => { setBaseColor(BASE_DARK); setBrandSuccess(null); }}
+              disabled={!isAdmin}
+              className={`flex items-center gap-2 px-4 py-2.5 rounded-xl border-2 transition-all duration-200 ${
+                isDarkBase
+                  ? "border-[var(--color-org-secondary)] shadow-sm"
+                  : "border-border hover:border-muted-foreground"
+              } ${!isAdmin ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+            >
+              <div className="w-6 h-6 rounded-full border border-gray-600" style={{ backgroundColor: BASE_DARK }} />
+              <span className="text-sm font-medium text-foreground">Dark Grey</span>
+            </button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Sets the page background and text contrast
+          </p>
+        </div>
+
+        {/* Sidebar & Button Color Pickers */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div className="space-y-2">
-            <p className="text-sm font-medium text-foreground">{tSettings("branding.primaryColor")}</p>
+            <p className="text-sm font-medium text-foreground">Sidebar Color</p>
             <div className="flex items-center gap-3">
               <input
                 type="color"
-                value={primaryColor}
+                value={sidebarColor}
                 onChange={(e) => {
-                  setPrimaryColor(e.target.value);
+                  setSidebarColor(e.target.value);
                   setBrandSuccess(null);
                 }}
                 disabled={!isAdmin}
@@ -239,9 +332,9 @@ export function BrandingCard({
               />
               <Input
                 type="text"
-                value={primaryColor}
+                value={sidebarColor}
                 onChange={(e) => {
-                  setPrimaryColor(e.target.value);
+                  setSidebarColor(e.target.value);
                   setBrandSuccess(null);
                 }}
                 disabled={!isAdmin}
@@ -249,18 +342,18 @@ export function BrandingCard({
               />
             </div>
             <p className="text-xs text-muted-foreground">
-              {tSettings("branding.primaryHint")}
+              Background color of the navigation sidebar
             </p>
           </div>
 
           <div className="space-y-2">
-            <p className="text-sm font-medium text-foreground">{tSettings("branding.secondaryColor")}</p>
+            <p className="text-sm font-medium text-foreground">Button Color</p>
             <div className="flex items-center gap-3">
               <input
                 type="color"
-                value={secondaryColor}
+                value={buttonColor}
                 onChange={(e) => {
-                  setSecondaryColor(e.target.value);
+                  setButtonColor(e.target.value);
                   setBrandSuccess(null);
                 }}
                 disabled={!isAdmin}
@@ -268,9 +361,9 @@ export function BrandingCard({
               />
               <Input
                 type="text"
-                value={secondaryColor}
+                value={buttonColor}
                 onChange={(e) => {
-                  setSecondaryColor(e.target.value);
+                  setButtonColor(e.target.value);
                   setBrandSuccess(null);
                 }}
                 disabled={!isAdmin}
@@ -278,7 +371,7 @@ export function BrandingCard({
               />
             </div>
             <p className="text-xs text-muted-foreground">
-              {tSettings("branding.secondaryHint")}
+              Color used for buttons and active navigation items
             </p>
           </div>
         </div>

--- a/src/lib/auth/roles.ts
+++ b/src/lib/auth/roles.ts
@@ -108,7 +108,7 @@ export const getOrgContext = cache(async (orgSlug: string): Promise<OrgContextRe
     supabase
       .from("organizations")
       .select(
-        "id, name, slug, logo_url, primary_color, secondary_color, nav_config, stripe_connect_account_id, org_type, donation_embed_url, created_at, feed_post_roles, job_post_roles, discussion_post_roles, media_upload_roles, timezone, hide_donor_names"
+        "id, name, slug, logo_url, base_color, primary_color, secondary_color, nav_config, stripe_connect_account_id, org_type, donation_embed_url, created_at, feed_post_roles, job_post_roles, discussion_post_roles, media_upload_roles, timezone, hide_donor_names"
       )
       .eq("slug", orgSlug)
       .maybeSingle(),

--- a/src/lib/blog/posts.ts
+++ b/src/lib/blog/posts.ts
@@ -1,0 +1,89 @@
+export interface BlogSection {
+  heading?: string;
+  paragraphs: string[];
+}
+
+export interface BlogPost {
+  slug: string;
+  title: string;
+  date: string;
+  category: string;
+  excerpt: string;
+  readingTime: string;
+  sections: BlogSection[];
+}
+
+export const blogPosts: BlogPost[] = [
+  {
+    slug: "alumni-network-broken",
+    title: "Your Alumni Network Is Broken. Here's the Data — and the Fix.",
+    date: "2026-04-10",
+    category: "Research",
+    excerpt:
+      "According to a Strada-Gallup survey, just 9% of graduates say their alumni network has been helpful to their career. The problem isn't willingness — it's infrastructure.",
+    readingTime: "8 min read",
+    sections: [
+      {
+        paragraphs: [
+          "Every program, team, and school tells its members the same thing at some point: the network will open doors for you. It's one of the most enduring promises in education and organized community life. Stay connected. Give back. Look out for each other.",
+          "The problem is that for most programs, the infrastructure to actually deliver on that promise simply does not exist.",
+          "The research makes this uncomfortably clear.",
+        ],
+      },
+      {
+        heading: "The Gap Between Promise and Reality",
+        paragraphs: [
+          "According to a Strada-Gallup Alumni Survey of more than 5,100 respondents, just 9% of graduates say their alumni network has been helpful or very helpful to their career. Read that again. Nine percent. At institutions that spend considerable resources recruiting students in part on the strength of their alumni communities, fewer than one in ten graduates say those communities actually delivered.",
+          "More than two-thirds of respondents — 69% — said their networks were neither helpful nor unhelpful. Another 22% said they had been unhelpful or very unhelpful.",
+          "These aren't the numbers of a system that's slightly underperforming. They're the numbers of a system that has largely failed to bridge the gap between the people who graduated and the people still in the program.",
+          "The failure is not for lack of willing alumni. When institutions actually organize their graduates around a shared purpose, the results speak for themselves. At the University of Chicago, 550 alumni volunteered through career services in a single academic year during the economic crisis of 2009, helping provide 25% of all job and internship opportunities for graduating students that year. The alumni were there. They wanted to help. The difference was infrastructure — someone had organized the connection.",
+          "That's the core of the problem. It is not a willingness problem. It is a systems problem.",
+        ],
+      },
+      {
+        heading: "Social Capital Is Lying Dormant",
+        paragraphs: [
+          "The Clayton Christensen Institute, one of the leading research organizations studying innovation in education, identified this gap clearly in its landmark report on alumni networks. Alumni bases hold a critical stock of social capital, currently lying dormant across much of the system.",
+          "Endowment-supported institutions have long-held, elaborate strategies in place to \"engage\" alumni to mine their financial capital. But they — and their peer institutions with smaller or no endowments — could be doing more to successfully activate alumni's social capital.",
+          "This is the distinction that most organizations miss entirely. Programs know how to ask alumni for donations. They send newsletters. They plan reunions. They measure giving rates. What they rarely do is build structured, scalable pathways for alumni to become mentors, advisors, connectors, and advocates for the people still in the program.",
+          "The Christensen Institute report found that alumni hold potential across four distinct functions that most programs leave untapped: mentors to drive persistence and student success; sources of career advice, inspiration, and referrals; providers of experiential learning and internships; and part-time staff for program delivery.",
+          "Nearly every program has alumni who could fulfill one or more of these roles today. The gap is not the people. It is the platform to connect them.",
+        ],
+      },
+      {
+        heading: "The Mentorship Gap Is Especially Urgent",
+        paragraphs: [
+          "Gallup's research found that many institutions know how to mobilize their alumni for donations, but few throw that same energy behind alumni-student mentorship programs.",
+          "This matters because the consequences are measurable. Students who have mentors in college demonstrate greater academic achievement and career development, yet they are lacking in higher education. Only one-quarter of college students said they \"strongly agree\" they had a mentor who encouraged them to go after their goals.",
+          "For youth sports programs, after-school organizations, and community programs, this problem is even more acute. These communities often lack the formal career services infrastructure that universities — however imperfectly — at least attempt to provide. A young person who went through a program, found their confidence there, and now needs guidance as they navigate their next steps has no formal mechanism to connect with the adults who came before them through that same program.",
+          "The alumni who could mentor them exist. They graduated from the same program. They know what it means to be there. They often want to give back. But there is no system to find them, no directory to search, no platform to facilitate the introduction — and no way to keep that relationship alive over time.",
+        ],
+      },
+      {
+        heading: "The Infrastructure Has Never Existed — Until Now",
+        paragraphs: [
+          "A range of technology tools and new alumni engagement models are starting to emerge that could help institutions change course, taking the chance out of chance encounters between students and alumni.",
+          "That is precisely what TeamNetwork was built to do.",
+          "We believe the relationship between a program and its members should never end at graduation. The problem the research identifies — dormant social capital, disorganized alumni, no structured mentorship pathways, communities that go dark the moment someone leaves — is the exact problem TeamNetwork solves.",
+          "TeamNetwork gives every program, team, and organization a living alumni platform: a searchable directory that grows over time, structured mentorship matching that connects alumni to current members, fundraising and donation tools, event management for reunions and giving days, and long-term communication infrastructure that keeps the community active not just during the season but for years after graduation.",
+          "The difference between the 9% who found their alumni network genuinely helpful and the 91% who didn't is not luck. It is infrastructure. It is whether someone built a system to make the connection easy, consistent, and ongoing — rather than leaving it to chance.",
+          "Every program deserves that system. Every alumnus who wants to give back deserves a simple way to do it. Every current member deserves access to the people who walked the same path before them.",
+          "That is what TeamNetwork makes possible.",
+        ],
+      },
+      {
+        paragraphs: [
+          "TeamNetwork is the alumni engagement platform built for every program, team, and community. Learn more at myteamnetwork.com.",
+        ],
+      },
+    ],
+  },
+];
+
+export function getPostBySlug(slug: string): BlogPost | undefined {
+  return blogPosts.find((p) => p.slug === slug);
+}
+
+export function getAllSlugs(): string[] {
+  return blogPosts.map((p) => p.slug);
+}

--- a/src/lib/cached-queries.ts
+++ b/src/lib/cached-queries.ts
@@ -49,7 +49,7 @@ export function getCachedOrgSettings(orgId: string) {
       const supabase = createServiceClient();
       const { data, error } = await supabase
         .from("organizations")
-        .select("id, name, slug, primary_color, secondary_color, logo_url, org_type, nav_config, stripe_connect_account_id")
+        .select("id, name, slug, base_color, primary_color, secondary_color, logo_url, org_type, nav_config, stripe_connect_account_id")
         .eq("id", id)
         .single();
       if (error) throw new Error(`Org settings query failed: ${error.message}`);

--- a/src/lib/middleware/routing-decisions.ts
+++ b/src/lib/middleware/routing-decisions.ts
@@ -32,6 +32,7 @@ const NON_ORG_TOP_LEVEL_SEGMENTS = [
   "app",
   "auth",
   "api",
+  "blog",
   "settings",
   "enterprise",
   "_next",
@@ -60,7 +61,7 @@ export function isPublicApiPattern(pathname: string): boolean {
  * Includes all /auth/* sub-paths.
  */
 export function isPublicRoute(pathname: string): boolean {
-  return PUBLIC_ROUTES.some((route) => pathname === route) || pathname.startsWith("/auth/");
+  return PUBLIC_ROUTES.some((route) => pathname === route) || pathname.startsWith("/auth/") || pathname.startsWith("/blog");
 }
 
 /**

--- a/src/lib/theming/org-colors.ts
+++ b/src/lib/theming/org-colors.ts
@@ -1,6 +1,6 @@
 /**
  * Organization color theming utilities
- * Provides centralized color manipulation and CSS variable generation for org branding
+ * 3-color system: base (white/dark toggle), sidebar (free hex), button (free hex)
  */
 
 const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
@@ -59,112 +59,106 @@ export function isColorDark(hex: string): boolean {
   return luminance < 0.6;
 }
 
-/**
- * Derives dark mode variants of org colors
- * Adjusts brightness to ensure proper contrast in dark mode
- */
-export function deriveOrgDarkModeColors(
-  primaryColor: string,
-  secondaryColor: string
-): {
-  primary: string;
-  primaryLight: string;
-  primaryDark: string;
-  secondary: string;
-  secondaryLight: string;
-  secondaryDark: string;
-  secondaryForeground: string;
-} {
-  const isPrimaryDark = isColorDark(primaryColor);
-  const isSecondaryDark = isColorDark(secondaryColor);
+/** Hardcoded light palette — stable, hand-picked values */
+const LIGHT_PALETTE = {
+  "--background": "#fafbfc",
+  "--foreground": "#000000",
+  "--card": "#ffffff",
+  "--card-foreground": "#000000",
+  "--muted": "#f1f5f9",
+  "--muted-foreground": "#4a5568",
+  "--border": "#e2e8f0",
+} as const;
 
-  // In dark mode, brighten dark colors and darken light colors for proper contrast
-  const primary = isPrimaryDark ? adjustColor(primaryColor, 15) : adjustColor(primaryColor, -30);
-  const secondary = isSecondaryDark
-    ? adjustColor(secondaryColor, 15)
-    : adjustColor(secondaryColor, -30);
+/** Hardcoded dark palette — stable, hand-picked values */
+const DARK_PALETTE = {
+  "--background": "#222326",
+  "--foreground": "#ffffff",
+  "--card": "#2a2d31",
+  "--card-foreground": "#ffffff",
+  "--muted": "#33363b",
+  "--muted-foreground": "#a0aec0",
+  "--border": "#3d4147",
+} as const;
+
+const BASE_DARK = "#222326";
+const BASE_PRIMARY = "primary";
+
+/** Compute a dynamic palette from an arbitrary hex color */
+function computeDynamicPalette(hex: string): Record<string, string> {
+  const dark = isColorDark(hex);
+  const foreground = dark ? "#ffffff" : "#000000";
+  const card = dark ? adjustColor(hex, 18) : adjustColor(hex, -12);
+  const muted = dark ? adjustColor(hex, 28) : adjustColor(hex, -25);
+  const mutedForeground = dark ? "#a0aec0" : "#4a5568";
+  const border = dark ? adjustColor(hex, 35) : adjustColor(hex, -35);
 
   return {
-    primary,
-    primaryLight: adjustColor(primary, 20),
-    primaryDark: adjustColor(primary, -20),
-    secondary,
-    secondaryLight: adjustColor(secondary, 20),
-    secondaryDark: adjustColor(secondary, -20),
-    secondaryForeground: isColorDark(secondary) ? "#ffffff" : "#0f172a",
+    "--background": hex,
+    "--foreground": foreground,
+    "--card": card,
+    "--card-foreground": foreground,
+    "--muted": muted,
+    "--muted-foreground": mutedForeground,
+    "--border": border,
   };
 }
 
 /**
- * Computes complete CSS variable object for org theming
- * Supports both light and dark modes
+ * Computes complete CSS variable object for org theming.
+ * Base color: "primary" (use sidebar color), "#ffffff" (light), or "#222326" (dark).
  */
 export function computeOrgThemeVariables(
-  primaryColor: string,
-  secondaryColor: string,
-  isDarkMode: boolean
+  baseColor: string,
+  sidebarColor: string,
+  buttonColor: string,
 ): Record<string, string> {
-  if (isDarkMode) {
-    const darkColors = deriveOrgDarkModeColors(primaryColor, secondaryColor);
-    const cardColor = adjustColor(darkColors.primary, 18);
-    const muted = adjustColor(darkColors.primary, 28);
-    const borderColor = adjustColor(darkColors.primary, 35);
-    const primaryForeground = isColorDark(darkColors.primary) ? "#f8fafc" : "#0f172a";
+  const basePalette =
+    baseColor === BASE_PRIMARY ? computeDynamicPalette(sidebarColor)
+    : baseColor === BASE_DARK ? DARK_PALETTE
+    : LIGHT_PALETTE;
 
-    return {
-      "--color-org-primary": darkColors.primary,
-      "--color-org-primary-light": darkColors.primaryLight,
-      "--color-org-primary-dark": darkColors.primaryDark,
-      "--color-org-primary-foreground": primaryForeground,
-      "--color-org-secondary": darkColors.secondary,
-      "--color-org-secondary-light": darkColors.secondaryLight,
-      "--color-org-secondary-dark": darkColors.secondaryDark,
-      "--color-org-secondary-foreground": darkColors.secondaryForeground,
-      "--background": darkColors.primary,
-      "--foreground": "#f8fafc",
-      "--card": cardColor,
-      "--card-foreground": "#f8fafc",
-      "--muted": muted,
-      "--muted-foreground": "#e2e8f0",
-      "--border": borderColor,
-      "--ring": darkColors.secondary,
-    };
-  }
+  // Sidebar: auto-derive foreground + muted variants from sidebar color darkness
+  const sidebarDark = isColorDark(sidebarColor);
+  const sidebarForeground = sidebarDark ? "#f8fafc" : "#1A1F36";
+  const sidebarMuted = sidebarDark ? adjustColor(sidebarColor, 25) : adjustColor(sidebarColor, -20);
+  const sidebarMutedForeground = sidebarDark ? "#94a3b8" : "#64748b";
 
-  // Light mode
-  const primaryLight = adjustColor(primaryColor, 20);
-  const primaryDark = adjustColor(primaryColor, -20);
-  const secondaryLight = adjustColor(secondaryColor, 20);
-  const secondaryDark = adjustColor(secondaryColor, -20);
-  const isPrimaryDark = isColorDark(primaryColor);
-  const isSecondaryDark = isColorDark(secondaryColor);
-  const baseForeground = isPrimaryDark ? "#f8fafc" : "#0f172a";
-  const primaryForeground = isPrimaryDark ? "#ffffff" : "#0f172a";
-  const secondaryForeground = isSecondaryDark ? "#ffffff" : "#0f172a";
-  const cardColor = isPrimaryDark ? adjustColor(primaryColor, 18) : adjustColor(primaryColor, -12);
-  const cardForeground = isColorDark(cardColor) ? "#f8fafc" : "#0f172a";
-  const muted = isPrimaryDark ? adjustColor(primaryColor, 28) : adjustColor(primaryColor, -35);
-  const mutedForeground = isColorDark(muted) ? "#e2e8f0" : "#475569";
-  const borderColor = isPrimaryDark
-    ? adjustColor(primaryColor, 35)
-    : adjustColor(primaryColor, -45);
+  // Button: derive light/dark variants + foreground
+  const buttonDark = isColorDark(buttonColor);
+  const buttonLight = adjustColor(buttonColor, 20);
+  const buttonDarkVariant = adjustColor(buttonColor, -20);
+  const buttonForeground = buttonDark ? "#ffffff" : "#0f172a";
+
+  // Map org-primary vars → sidebar color (30+ components reference these)
+  const sidebarLight = adjustColor(sidebarColor, 20);
+  const sidebarDarkVariant = adjustColor(sidebarColor, -20);
+  const sidebarPrimaryForeground = sidebarDark ? "#ffffff" : "#0f172a";
 
   return {
-    "--color-org-primary": primaryColor,
-    "--color-org-primary-light": primaryLight,
-    "--color-org-primary-dark": primaryDark,
-    "--color-org-primary-foreground": primaryForeground,
-    "--color-org-secondary": secondaryColor,
-    "--color-org-secondary-light": secondaryLight,
-    "--color-org-secondary-dark": secondaryDark,
-    "--color-org-secondary-foreground": secondaryForeground,
-    "--background": primaryColor,
-    "--foreground": baseForeground,
-    "--card": cardColor,
-    "--card-foreground": cardForeground,
-    "--muted": muted,
-    "--muted-foreground": mutedForeground,
-    "--border": borderColor,
-    "--ring": secondaryColor,
+    // Base palette (hardcoded, no computation)
+    ...basePalette,
+
+    // Sidebar (scoped vars — applied on sidebar element to override base vars)
+    "--sidebar-bg": sidebarColor,
+    "--sidebar-foreground": sidebarForeground,
+    "--sidebar-muted": sidebarMuted,
+    "--sidebar-muted-foreground": sidebarMutedForeground,
+
+    // org-primary → maps to sidebar color (preserves existing component references)
+    "--color-org-primary": sidebarColor,
+    "--color-org-primary-light": sidebarLight,
+    "--color-org-primary-dark": sidebarDarkVariant,
+    "--color-org-primary-foreground": sidebarPrimaryForeground,
+
+    // org-secondary → maps to button color
+    "--color-org-secondary": buttonColor,
+    "--color-org-secondary-light": buttonLight,
+    "--color-org-secondary-dark": buttonDarkVariant,
+    "--color-org-secondary-foreground": buttonForeground,
+
+    // Ring & selection
+    "--ring": sidebarColor,
+    "--selection": buttonLight,
   };
 }

--- a/supabase/migrations/20261015120000_org_base_color.sql
+++ b/supabase/migrations/20261015120000_org_base_color.sql
@@ -1,0 +1,3 @@
+-- Add base_color column for 3-color branding system
+-- base_color: 'primary' (sidebar color), '#ffffff' (light), or '#222326' (dark)
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS base_color VARCHAR(20) DEFAULT 'primary';


### PR DESCRIPTION
## Summary
- Adds `/blog` listing page and `/blog/[slug]` article pages inspired by Cursor's blog design, matching the dark landing page aesthetic
- First blog post: "Your Alumni Network Is Broken. Here's the Data — and the Fix."
- Adds "Blog" tab to landing page navigation between FAQ and Terms
- Makes `/blog` routes public in middleware (no auth required)
- Includes org base_color branding changes (customization page, layout, sidebar, API, migration)
- Fixes pre-existing build failure by installing missing `pdf-parse` dependency

## Test plan
- [ ] Visit `/blog` — listing page renders with the first post card
- [ ] Click card → `/blog/alumni-network-broken` — full article renders with proper typography
- [ ] Landing page nav shows "Blog" tab between FAQ and Terms
- [ ] Unauthenticated access to `/blog` and `/blog/alumni-network-broken` works (not redirected to login)
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)