### PR TITLE
fix(ci): sync lockfile, regenerate db types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -7045,6 +7045,16 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-themes": {

--- a/src/app/api/organizations/[organizationId]/route.ts
+++ b/src/app/api/organizations/[organizationId]/route.ts
@@ -249,6 +249,7 @@ export async function PATCH(req: Request, { params }: RouteParams) {
       media_upload_roles: string[];
       linkedin_resync_enabled?: boolean;
       require_invite_approval?: boolean;
+      hide_donor_names?: boolean;
       timezone?: string;
       default_language?: string;
     } | null;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -349,6 +349,41 @@ export type Database = {
           },
         ]
       }
+      ai_feedback: {
+        Row: {
+          comment: string | null
+          created_at: string
+          id: string
+          message_id: string
+          rating: string
+          user_id: string
+        }
+        Insert: {
+          comment?: string | null
+          created_at?: string
+          id?: string
+          message_id: string
+          rating: string
+          user_id: string
+        }
+        Update: {
+          comment?: string | null
+          created_at?: string
+          id?: string
+          message_id?: string
+          rating?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "ai_feedback_message_id_fkey"
+            columns: ["message_id"]
+            isOneToOne: false
+            referencedRelation: "ai_messages"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       ai_indexing_exclusions: {
         Row: {
           created_at: string
@@ -616,6 +651,7 @@ export type Database = {
       alumni: {
         Row: {
           address_summary: string | null
+          birth_year: number | null
           created_at: string | null
           current_city: string | null
           current_company: string | null
@@ -650,6 +686,7 @@ export type Database = {
         }
         Insert: {
           address_summary?: string | null
+          birth_year?: number | null
           created_at?: string | null
           current_city?: string | null
           current_company?: string | null
@@ -684,6 +721,7 @@ export type Database = {
         }
         Update: {
           address_summary?: string | null
+          birth_year?: number | null
           created_at?: string | null
           current_city?: string | null
           current_company?: string | null
@@ -3743,6 +3781,75 @@ export type Database = {
           },
         ]
       }
+      mentorship_meetings: {
+        Row: {
+          calendar_event_id: string | null
+          calendar_sync_status: string
+          created_at: string
+          created_by: string
+          deleted_at: string | null
+          duration_minutes: number
+          id: string
+          meeting_link: string | null
+          organization_id: string
+          pair_id: string
+          platform: string
+          scheduled_at: string
+          scheduled_end_at: string | null
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          calendar_event_id?: string | null
+          calendar_sync_status?: string
+          created_at?: string
+          created_by: string
+          deleted_at?: string | null
+          duration_minutes?: number
+          id?: string
+          meeting_link?: string | null
+          organization_id: string
+          pair_id: string
+          platform: string
+          scheduled_at: string
+          scheduled_end_at?: string | null
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          calendar_event_id?: string | null
+          calendar_sync_status?: string
+          created_at?: string
+          created_by?: string
+          deleted_at?: string | null
+          duration_minutes?: number
+          id?: string
+          meeting_link?: string | null
+          organization_id?: string
+          pair_id?: string
+          platform?: string
+          scheduled_at?: string
+          scheduled_end_at?: string | null
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "mentorship_meetings_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "mentorship_meetings_pair_id_fkey"
+            columns: ["pair_id"]
+            isOneToOne: false
+            referencedRelation: "mentorship_pairs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       mentorship_pairs: {
         Row: {
           created_at: string
@@ -3780,6 +3887,63 @@ export type Database = {
             columns: ["organization_id"]
             isOneToOne: false
             referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      mentorship_tasks: {
+        Row: {
+          created_at: string
+          created_by: string
+          deleted_at: string | null
+          description: string | null
+          due_date: string | null
+          id: string
+          organization_id: string
+          pair_id: string
+          status: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          deleted_at?: string | null
+          description?: string | null
+          due_date?: string | null
+          id?: string
+          organization_id: string
+          pair_id: string
+          status?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          deleted_at?: string | null
+          description?: string | null
+          due_date?: string | null
+          id?: string
+          organization_id?: string
+          pair_id?: string
+          status?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "mentorship_tasks_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "mentorship_tasks_pair_id_fkey"
+            columns: ["pair_id"]
+            isOneToOne: false
+            referencedRelation: "mentorship_pairs"
             referencedColumns: ["id"]
           },
         ]
@@ -4181,6 +4345,7 @@ export type Database = {
           stripe_checkout_session_id: string | null
           stripe_payment_intent_id: string | null
           updated_at: string
+          visibility: string
         }
         Insert: {
           amount_cents: number
@@ -4199,6 +4364,7 @@ export type Database = {
           stripe_checkout_session_id?: string | null
           stripe_payment_intent_id?: string | null
           updated_at?: string
+          visibility?: string
         }
         Update: {
           amount_cents?: number
@@ -4217,6 +4383,7 @@ export type Database = {
           stripe_checkout_session_id?: string | null
           stripe_payment_intent_id?: string | null
           updated_at?: string
+          visibility?: string
         }
         Relationships: [
           {
@@ -4349,6 +4516,7 @@ export type Database = {
       }
       organizations: {
         Row: {
+          base_color: string | null
           created_at: string | null
           default_language: string
           description: string | null
@@ -4359,6 +4527,7 @@ export type Database = {
           enterprise_nav_synced_at: string | null
           enterprise_relationship_type: string | null
           feed_post_roles: string[]
+          hide_donor_names: boolean
           id: string
           job_post_roles: string[]
           linkedin_resync_enabled: boolean
@@ -4377,6 +4546,7 @@ export type Database = {
           timezone: string
         }
         Insert: {
+          base_color?: string | null
           created_at?: string | null
           default_language?: string
           description?: string | null
@@ -4387,6 +4557,7 @@ export type Database = {
           enterprise_nav_synced_at?: string | null
           enterprise_relationship_type?: string | null
           feed_post_roles?: string[]
+          hide_donor_names?: boolean
           id?: string
           job_post_roles?: string[]
           linkedin_resync_enabled?: boolean
@@ -4405,6 +4576,7 @@ export type Database = {
           timezone?: string
         }
         Update: {
+          base_color?: string | null
           created_at?: string | null
           default_language?: string
           description?: string | null
@@ -4415,6 +4587,7 @@ export type Database = {
           enterprise_nav_synced_at?: string | null
           enterprise_relationship_type?: string | null
           feed_post_roles?: string[]
+          hide_donor_names?: boolean
           id?: string
           job_post_roles?: string[]
           linkedin_resync_enabled?: boolean
@@ -5919,6 +6092,10 @@ export type Database = {
       }
       get_alumni_quota: { Args: { p_org_id: string }; Returns: Json }
       get_dropdown_options: { Args: { p_org_id: string }; Returns: Json }
+      get_enterprise_alumni_stats: {
+        Args: { p_enterprise_id: string }
+        Returns: Json
+      }
       get_enterprise_member_counts: {
         Args: { enterprise_ids: string[] }
         Returns: {


### PR DESCRIPTION
## Summary
Fixes all CI failures on main:
- **Lockfile sync** — `npm ci` was failing because `@swc/helpers@0.5.21` was missing from the lockfile. Regenerated `package-lock.json`.
- **Database types** — `src/types/database.ts` was out of sync with the schema (missing `birth_year`, `hide_donor_names`, `visibility` columns and `mentorship_tasks` table, all added via migrations that were applied remotely but not regenerated into types during the AI branch merge). Ran `npm run gen:types`.
- **hide_donor_names type cast** — added the missing field to the inline `updatedOrg` type in the organizations PATCH route.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes (was failing with 50+ errors)
- [x] `npm test` passes (4510 tests)
- [x] `npm run build` passes
- [x] `npm ci` succeeds from clean lockfile