### PR TITLE
feat: new-user onboarding — welcome modal + checklist + guided tour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "animejs": "^4.2.2",
         "cheerio": "^1.2.0",
         "cmdk": "^1.0.4",
+        "driver.js": "^1.4.0",
         "falkordb": "^6.6.2",
         "falkordblite": "^0.2.0",
         "framer-motion": "^12.38.0",
@@ -3731,6 +3732,12 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/driver.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -7414,16 +7421,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-themes": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "animejs": "^4.2.2",
     "cheerio": "^1.2.0",
     "cmdk": "^1.0.4",
+    "driver.js": "^1.4.0",
     "falkordb": "^6.6.2",
     "falkordblite": "^0.2.0",
     "framer-motion": "^12.38.0",

--- a/src/app/[orgSlug]/layout.tsx
+++ b/src/app/[orgSlug]/layout.tsx
@@ -19,6 +19,7 @@ import { AIPanelProvider } from "@/components/ai-assistant";
 import { JoinOrgGate } from "@/components/join/JoinOrgGate";
 import { MediaUploadManagerProvider } from "@/components/media/MediaUploadManagerContext";
 import { pickCurrentOrgProfile } from "@/lib/auth/current-org-profile";
+import { getProgress } from "@/lib/onboarding/progress";
 import dynamic from "next/dynamic";
 const AIPanel = dynamic(
   () => import("@/components/ai-assistant/AIPanel").then((m) => m.AIPanel),
@@ -30,6 +31,10 @@ const AIEdgeTab = dynamic(
 );
 const OrgGlobalSearch = dynamic(
   () => import("@/components/search/OrgGlobalSearch").then((m) => m.OrgGlobalSearch),
+  { ssr: false },
+);
+const OnboardingShell = dynamic(
+  () => import("@/components/onboarding/OnboardingShell").then((m) => m.OnboardingShell),
   { ssr: false },
 );
 import { computeOrgThemeVariables, safeCssValue, safeHexColor } from "@/lib/theming/org-colors";
@@ -196,6 +201,15 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
   let currentProfileName: string | undefined;
   let currentProfileAvatar: string | undefined;
   let pendingApprovalsCount = 0;
+  let onboardingProgress = {
+    id: null as string | null,
+    completedItems: [] as import("@/lib/schemas/onboarding").OnboardingItemId[],
+    visitedItems: [] as import("@/lib/schemas/onboarding").OnboardingItemId[],
+    welcomeSeenAt: null as string | null,
+    tourCompletedAt: null as string | null,
+    dismissedAt: null as string | null,
+  };
+  let currentMemberId: string | null = null;
   if (orgContext.userId) {
     const supabase = await createClient();
     const [{ data: memberRow }, { data: alumniRow }, { data: parentRow }] = await Promise.all([
@@ -244,6 +258,21 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
         .eq("status", "pending");
       pendingApprovalsCount = count ?? 0;
     }
+
+    // Onboarding progress (non-blocking — zero-state on error)
+    [onboardingProgress] = await Promise.all([
+      getProgress(orgContext.userId, organization.id),
+    ]);
+
+    // Capture current member ID for onboarding deep-links (complete_profile)
+    const memberRowForOnboarding = await supabase
+      .from("members")
+      .select("id")
+      .eq("organization_id", organization.id)
+      .eq("user_id", orgContext.userId)
+      .is("deleted_at", null)
+      .maybeSingle();
+    currentMemberId = memberRowForOnboarding.data?.id ?? null;
   }
 
   let serviceSupabase = null;
@@ -336,6 +365,19 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
       <MobileNav organization={organization} role={orgContext.role} isDevAdmin={isDevAdmin} hasAlumniAccess={orgContext.hasAlumniAccess} hasParentsAccess={orgContext.hasParentsAccess} currentProfileHref={currentProfileHref} currentProfileName={currentProfileName} currentProfileAvatar={currentProfileAvatar} pendingApprovalsCount={pendingApprovalsCount} />
       {!isDevAdmin && <ConsentModal />}
       {!isDevAdmin && <LinkedInUrlPrompt />}
+      {!isDevAdmin && orgContext.userId && (
+        <OnboardingShell
+          userId={orgContext.userId}
+          orgId={organization.id}
+          orgSlug={orgSlug}
+          orgName={organization.name}
+          memberId={currentMemberId}
+          role={orgContext.role}
+          hasAlumniAccess={orgContext.hasAlumniAccess}
+          hasParentsAccess={orgContext.hasParentsAccess}
+          initialProgress={onboardingProgress}
+        />
+      )}
 
       <MediaUploadManagerProvider orgId={organization.id}>
         <OrgMainContent hasTopBanner={orgContext.gracePeriod.isInGracePeriod || orgContext.gracePeriod.isCanceling}>

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { getProgress } from "@/lib/onboarding/progress";
+import { detectCompletedItems } from "@/lib/onboarding/detect";
+import type { OnboardingItemId } from "@/lib/schemas/onboarding";
+
+const querySchema = z.object({
+  orgId: z.string().uuid(),
+  memberId: z.string().uuid().optional(),
+});
+
+/**
+ * GET /api/onboarding/status?orgId=<uuid>&memberId=<uuid>
+ *
+ * Returns the current onboarding progress merged with auto-detected completions.
+ * Auto-detected items are persisted on each call so the checklist stays in sync.
+ *
+ * Security:
+ * - Caller must be authenticated.
+ * - Caller must be an active member of `orgId` — prevents cross-org writes /
+ *   existence probing against orgs the user doesn't belong to.
+ */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(request.url);
+  let params: z.infer<typeof querySchema>;
+  try {
+    params = querySchema.parse({
+      orgId: url.searchParams.get("orgId") ?? undefined,
+      memberId: url.searchParams.get("memberId") ?? undefined,
+    });
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid parameters", details: e.flatten() },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json({ error: "Bad request" }, { status: 400 });
+  }
+
+  const { orgId, memberId } = params;
+
+  // Verify the caller is a member of this org before doing any work.
+  // Mirrors the pattern in src/app/api/calendar/preferences/route.ts.
+  const { data: membership, error: membershipError } = await supabase
+    .from("user_organization_roles")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("organization_id", orgId)
+    .eq("status", "active")
+    .maybeSingle();
+
+  if (membershipError || !membership) {
+    return NextResponse.json(
+      { error: "Forbidden", message: "You are not a member of this organization." },
+      { status: 403 }
+    );
+  }
+
+  // Fetch stored progress and auto-detect in parallel
+  const [stored, autoCompleted] = await Promise.all([
+    getProgress(user.id, orgId),
+    detectCompletedItems({ userId: user.id, orgId, memberId }),
+  ]);
+
+  // Persist any newly auto-detected items that weren't already in completed_items
+  const newAutoCompleted = autoCompleted.filter(
+    (id) => !stored.completedItems.includes(id)
+  );
+
+  if (newAutoCompleted.length > 0) {
+    const allCompleted: OnboardingItemId[] = [
+      ...stored.completedItems,
+      ...newAutoCompleted,
+    ];
+
+    // Upsert the merged set. Errors don't block the response — client can retry.
+    const { error: upsertError } = await supabase
+      .from("user_onboarding_progress")
+      .upsert(
+        {
+          user_id: user.id,
+          organization_id: orgId,
+          completed_items: allCompleted,
+        },
+        { onConflict: "user_id,organization_id" }
+      );
+
+    if (upsertError) {
+      console.error("[onboarding/status] upsert failed:", upsertError);
+    }
+  }
+
+  return NextResponse.json({
+    completedItems: [
+      ...new Set([...stored.completedItems, ...autoCompleted]),
+    ],
+    visitedItems: stored.visitedItems,
+    welcomeSeenAt: stored.welcomeSeenAt,
+    tourCompletedAt: stored.tourCompletedAt,
+    dismissedAt: stored.dismissedAt,
+    autoCompleted,
+  });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Driver.js guided tour styles */
+@import "driver.js/dist/driver.css";
+
 :root {
   --font-sans: "Plus Jakarta Sans";
   --font-display: "Bitter";

--- a/src/components/layout/NavGroupSection.tsx
+++ b/src/components/layout/NavGroupSection.tsx
@@ -152,6 +152,7 @@ export function NavItemLink({
         href={href}
         title={isCollapsed ? item.label : undefined}
         aria-label={isCollapsed ? item.label : undefined}
+        data-tour={item.tourId ?? undefined}
         onClick={() => {
           trackBehavioralEvent(
             "nav_click",

--- a/src/components/layout/OrgSidebar.tsx
+++ b/src/components/layout/OrgSidebar.tsx
@@ -17,6 +17,8 @@ import { Avatar } from "@/components/ui/Avatar";
 import { Badge } from "@/components/ui/Badge";
 import { getRoleLabel } from "@/lib/auth/role-display";
 import { Search } from "lucide-react";
+import { ChecklistTrigger } from "@/components/onboarding/ChecklistTrigger";
+import { getVisibleOnboardingItems } from "@/lib/onboarding/visible-items";
 
 
 interface OrgSidebarProps {
@@ -45,6 +47,33 @@ export function OrgSidebar({ organization, role, isDevAdmin = false, hasAlumniAc
   const tAuth = useTranslations("auth");
 
   const [openGroups, setOpenGroups] = useState<Set<NavGroupId>>(new Set());
+
+  // Onboarding checklist progress — updated via tn:onboarding-progress CustomEvent from OnboardingShell
+  const onboardingItems = useMemo(
+    () => getVisibleOnboardingItems({ role, hasAlumniAccess, hasParentsAccess }),
+    [role, hasAlumniAccess, hasParentsAccess]
+  );
+  const [onboardingCompleted, setOnboardingCompleted] = useState(0);
+  const [onboardingDismissed, setOnboardingDismissed] = useState(false);
+
+  useEffect(() => {
+    function handleProgress(e: Event) {
+      const detail = (e as CustomEvent<{ completedCount: number; totalCount: number }>).detail;
+      setOnboardingCompleted(detail.completedCount);
+      if (detail.completedCount >= detail.totalCount && detail.totalCount > 0) {
+        // Keep visible until user explicitly dismisses
+      }
+    }
+    function handleDismissed() {
+      setOnboardingDismissed(true);
+    }
+    window.addEventListener("tn:onboarding-progress", handleProgress);
+    window.addEventListener("tn:onboarding-dismissed", handleDismissed);
+    return () => {
+      window.removeEventListener("tn:onboarding-progress", handleProgress);
+      window.removeEventListener("tn:onboarding-dismissed", handleDismissed);
+    };
+  }, []);
 
   const navConfig = useMemo<NavConfig>(() => {
     if (
@@ -297,6 +326,14 @@ export function OrgSidebar({ organization, role, isDevAdmin = false, hasAlumniAc
 
             {/* User Section */}
             <div className={`border-t border-border ${isCollapsed ? "flex flex-col items-center gap-1 px-2 py-2" : "space-y-1 p-2"}`}>
+              {/* Onboarding checklist trigger — hidden when collapsed, dismissed, or all done */}
+              {!isCollapsed && !onboardingDismissed && onboardingItems.length > 0 && (
+                <ChecklistTrigger
+                  completedCount={onboardingCompleted}
+                  totalCount={onboardingItems.length}
+                />
+              )}
+
               <Link
                 href="/app"
                 title={isCollapsed ? tSidebar("switchOrg") : undefined}

--- a/src/components/onboarding/ChecklistCard.tsx
+++ b/src/components/onboarding/ChecklistCard.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Card, Button } from "@/components/ui";
+import { ProgressBar } from "@/components/ui/ProgressBar";
+import { ChecklistItem } from "./ChecklistItem";
+import {
+  markItemComplete,
+  dismissChecklist,
+} from "@/lib/onboarding/progress";
+import { getVisibleOnboardingItems } from "@/lib/onboarding/visible-items";
+import type { OrgRole } from "@/lib/auth/role-utils";
+import type { OnboardingItemId } from "@/lib/schemas/onboarding";
+import type { OnboardingProgress } from "@/lib/onboarding/progress";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface ChecklistCardProps {
+  userId: string;
+  orgId: string;
+  orgSlug: string;
+  memberId?: string | null;
+  role: OrgRole | null;
+  hasAlumniAccess: boolean;
+  hasParentsAccess?: boolean;
+  initialProgress: OnboardingProgress;
+  onDismiss?: () => void;
+  /** Fired when the user clicks a checklist item link — lets the shell close the panel. */
+  onItemClick?: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ChecklistCard({
+  userId,
+  orgId,
+  orgSlug,
+  memberId,
+  role,
+  hasAlumniAccess,
+  hasParentsAccess = false,
+  initialProgress,
+  onDismiss,
+  onItemClick,
+}: ChecklistCardProps) {
+  const visibleItems = getVisibleOnboardingItems({
+    role,
+    hasAlumniAccess,
+    hasParentsAccess,
+  });
+
+  const [completedItems, setCompletedItems] = useState<OnboardingItemId[]>(
+    initialProgress.completedItems
+  );
+  const [markingDone, setMarkingDone] = useState<OnboardingItemId | null>(null);
+  const [dismissing, setDismissing] = useState(false);
+
+  const completedCount = visibleItems.filter((item) =>
+    completedItems.includes(item.id)
+  ).length;
+  const totalCount = visibleItems.length;
+  const progressPct =
+    totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+
+  const handleMarkDone = useCallback(
+    async (itemId: OnboardingItemId) => {
+      if (completedItems.includes(itemId)) return;
+      setMarkingDone(itemId);
+      try {
+        await markItemComplete(userId, orgId, itemId, completedItems);
+        setCompletedItems((prev) => [...prev, itemId]);
+      } catch (err) {
+        console.error("Failed to mark item complete:", err);
+      } finally {
+        setMarkingDone(null);
+      }
+    },
+    [userId, orgId, completedItems]
+  );
+
+  const handleDismiss = useCallback(async () => {
+    setDismissing(true);
+    try {
+      await dismissChecklist(userId, orgId);
+      onDismiss?.();
+    } catch (err) {
+      console.error("Failed to dismiss checklist:", err);
+    } finally {
+      setDismissing(false);
+    }
+  }, [userId, orgId, onDismiss]);
+
+  return (
+    <Card padding="sm" className="w-full">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">
+            Getting started
+          </h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {completedCount} of {totalCount} completed
+          </p>
+        </div>
+        <button
+          onClick={handleDismiss}
+          disabled={dismissing}
+          className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded-md hover:bg-muted"
+          aria-label="Dismiss getting started checklist"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Progress bar */}
+      <ProgressBar
+        value={progressPct}
+        variant={progressPct === 100 ? "success" : "default"}
+        size="sm"
+        label={`${progressPct}% complete`}
+        className="mb-3"
+      />
+
+      {/* Items */}
+      <div className="divide-y divide-border">
+        {visibleItems.map((item) => (
+          <ChecklistItem
+            key={item.id}
+            item={item}
+            orgSlug={orgSlug}
+            memberId={memberId ?? undefined}
+            completed={completedItems.includes(item.id)}
+            onMarkDone={handleMarkDone}
+            isMarkingDone={markingDone === item.id}
+            onNavigate={onItemClick}
+          />
+        ))}
+      </div>
+
+      {/* All done state */}
+      {progressPct === 100 && (
+        <div className="mt-3 text-center">
+          <p className="text-xs text-green-600 dark:text-green-400 font-medium">
+            🎉 You&apos;re all set! Feel free to dismiss this.
+          </p>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleDismiss}
+            disabled={dismissing}
+            className="mt-1 text-xs"
+          >
+            Dismiss
+          </Button>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/components/onboarding/ChecklistItem.tsx
+++ b/src/components/onboarding/ChecklistItem.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui";
+import type { OnboardingItem } from "@/lib/onboarding/items";
+import type { OnboardingItemId } from "@/lib/schemas/onboarding";
+
+// ─── Inline icons ─────────────────────────────────────────────────────────────
+
+function CheckCircleIcon() {
+  return (
+    <svg
+      className="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
+function EmptyCircleIcon() {
+  return (
+    <svg
+      className="w-5 h-5 text-muted-foreground flex-shrink-0"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <circle cx="12" cy="12" r="9" />
+    </svg>
+  );
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface ChecklistItemProps {
+  item: OnboardingItem;
+  orgSlug: string;
+  memberId?: string;
+  completed: boolean;
+  onMarkDone: (id: OnboardingItemId) => void;
+  isMarkingDone: boolean;
+  /** Fired when user clicks the item's link — lets parent close the panel. */
+  onNavigate?: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ChecklistItem({
+  item,
+  orgSlug,
+  memberId,
+  completed,
+  onMarkDone,
+  isMarkingDone,
+  onNavigate,
+}: ChecklistItemProps) {
+  const href = item.href(orgSlug, memberId);
+
+  return (
+    <div className="flex items-start gap-3 py-2.5 group">
+      {/* Check indicator */}
+      <div className="mt-0.5">
+        {completed ? <CheckCircleIcon /> : <EmptyCircleIcon />}
+      </div>
+
+      {/* Text */}
+      <div className="flex-1 min-w-0">
+        <Link
+          href={href}
+          onClick={onNavigate}
+          className={`block text-sm font-medium leading-snug hover:underline ${
+            completed
+              ? "line-through text-muted-foreground"
+              : "text-foreground"
+          }`}
+        >
+          {item.title}
+        </Link>
+        {!completed && (
+          <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+            {item.description}
+          </p>
+        )}
+      </div>
+
+      {/* Manual "Mark done" — only shown when not auto-detectable or not yet complete.
+          Uses group-focus-within so keyboard users can actually reach it. */}
+      {!completed && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onMarkDone(item.id)}
+          disabled={isMarkingDone}
+          className="text-xs opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 transition-opacity shrink-0"
+          aria-label={`Mark ${item.title} as done`}
+        >
+          Done
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/onboarding/ChecklistTrigger.tsx
+++ b/src/components/onboarding/ChecklistTrigger.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useCallback } from "react";
+
+interface ChecklistTriggerProps {
+  completedCount: number;
+  totalCount: number;
+}
+
+/**
+ * Sidebar footer button. Dispatches a CustomEvent `tn:open-onboarding`
+ * that OnboardingShell listens for to open the checklist panel.
+ */
+export function ChecklistTrigger({
+  completedCount,
+  totalCount,
+}: ChecklistTriggerProps) {
+  const handleClick = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("tn:open-onboarding"));
+  }, []);
+
+  const pct =
+    totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+
+  return (
+    <button
+      onClick={handleClick}
+      className="w-full flex items-center gap-2.5 px-3 py-2 rounded-xl text-left hover:bg-muted transition-colors group"
+      aria-label={`Getting started — ${completedCount} of ${totalCount} complete`}
+    >
+      {/* Progress ring */}
+      <div className="relative w-5 h-5 flex-shrink-0">
+        <svg viewBox="0 0 20 20" className="w-5 h-5 -rotate-90">
+          <circle
+            cx="10"
+            cy="10"
+            r="8"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            className="text-muted"
+          />
+          <circle
+            cx="10"
+            cy="10"
+            r="8"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeDasharray={`${2 * Math.PI * 8}`}
+            strokeDashoffset={`${2 * Math.PI * 8 * (1 - pct / 100)}`}
+            className="text-[var(--color-org-secondary)] transition-[stroke-dashoffset] duration-300"
+            strokeLinecap="round"
+          />
+        </svg>
+        {pct === 100 && (
+          <svg
+            className="absolute inset-0 w-5 h-5 text-green-500"
+            fill="none"
+            viewBox="0 0 20 20"
+            stroke="currentColor"
+            strokeWidth={2.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 10l3 3 5-5"
+            />
+          </svg>
+        )}
+      </div>
+
+      {/* Label */}
+      <span className="text-xs font-medium text-muted-foreground group-hover:text-foreground transition-colors truncate">
+        Getting started
+      </span>
+
+      {/* Badge */}
+      {pct < 100 && (
+        <span className="ml-auto text-xs font-medium text-muted-foreground bg-muted rounded-full px-1.5 py-0.5 shrink-0">
+          {completedCount}/{totalCount}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/components/onboarding/GuidedTour.tsx
+++ b/src/components/onboarding/GuidedTour.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { markTourCompleted } from "@/lib/onboarding/progress";
+
+// ─── Tour step definitions ────────────────────────────────────────────────────
+
+const TOUR_STEPS = [
+  {
+    element: '[data-tour="feed"]',
+    popover: {
+      title: "Feed",
+      description:
+        "Share updates, photos, and polls with your org. Start by posting your intro!",
+      side: "right" as const,
+    },
+  },
+  {
+    element: '[data-tour="calendar"]',
+    popover: {
+      title: "Calendar & Events",
+      description:
+        "See upcoming events and RSVP. Never miss a practice, meeting, or social.",
+      side: "right" as const,
+    },
+  },
+  {
+    element: '[data-tour="messages"]',
+    popover: {
+      title: "Messages",
+      description:
+        "Chat with teammates in channels or direct messages. Conversations happen here.",
+      side: "right" as const,
+    },
+  },
+  {
+    element: '[data-tour="announcements"]',
+    popover: {
+      title: "Announcements",
+      description:
+        "Important org-wide updates from leadership. Check here for the latest news.",
+      side: "right" as const,
+    },
+  },
+  {
+    element: '[data-tour="members"]',
+    popover: {
+      title: "Members Directory",
+      description:
+        "Find teammates, explore profiles, and connect with your community.",
+      side: "right" as const,
+    },
+  },
+] as const;
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface GuidedTourProps {
+  active: boolean;
+  userId: string;
+  orgId: string;
+  onComplete: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function GuidedTour({
+  active,
+  userId,
+  orgId,
+  onComplete,
+}: GuidedTourProps) {
+  const driverRef = useRef<ReturnType<
+    typeof import("driver.js")["driver"]
+  > | null>(null);
+
+  const handleTourEnd = useCallback(
+    async (opts: { completed: boolean }) => {
+      // Only persist tour_completed_at when user actually reached the last step.
+      // Abandonment (ESC / close mid-tour) should leave the flag unset so the
+      // user can be re-prompted next time.
+      if (opts.completed) {
+        try {
+          await markTourCompleted(userId, orgId);
+        } catch (err) {
+          console.error("Failed to persist tour completion:", err);
+        }
+      }
+      onComplete();
+    },
+    [userId, orgId, onComplete]
+  );
+
+  const startTour = useCallback(async () => {
+    // Lazy-load driver.js to avoid adding to initial bundle
+    // driver.js CSS is imported globally in globals.css
+    const { driver } = await import("driver.js");
+
+    // Filter steps to only those whose target element exists in the DOM
+    const availableSteps = TOUR_STEPS.filter(
+      (step) => !!document.querySelector(step.element)
+    );
+
+    if (availableSteps.length === 0) {
+      onComplete();
+      return;
+    }
+
+    const d = driver({
+      animate: true,
+      showProgress: true,
+      showButtons: ["next", "previous", "close"],
+      nextBtnText: "Next →",
+      prevBtnText: "← Back",
+      doneBtnText: "Finish",
+      steps: availableSteps.map((step) => ({
+        element: step.element,
+        popover: {
+          ...step.popover,
+          align: "start",
+        },
+      })),
+      onDestroyStarted: () => {
+        // Reached the last step before destroy? Then it's a Finish, not abandon.
+        const activeIndex = d.getActiveIndex?.() ?? -1;
+        const completed = activeIndex === availableSteps.length - 1;
+        d.destroy();
+        handleTourEnd({ completed });
+      },
+    });
+
+    driverRef.current = d;
+    d.drive();
+  }, [onComplete, handleTourEnd]);
+
+  useEffect(() => {
+    if (active) {
+      startTour();
+    }
+
+    return () => {
+      // Teardown on unmount — driver.js is idempotent re: destroy().
+      driverRef.current?.destroy();
+      driverRef.current = null;
+    };
+  }, [active, startTour]);
+
+  // Pure effect — no DOM output
+  return null;
+}

--- a/src/components/onboarding/OnboardingShell.tsx
+++ b/src/components/onboarding/OnboardingShell.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { WelcomeModal } from "./WelcomeModal";
+import { ChecklistCard } from "./ChecklistCard";
+import { GuidedTour } from "./GuidedTour";
+import { getVisibleOnboardingItems } from "@/lib/onboarding/visible-items";
+import type { OrgRole } from "@/lib/auth/role-utils";
+import type { OnboardingProgress } from "@/lib/onboarding/progress";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface OnboardingShellProps {
+  userId: string;
+  orgId: string;
+  orgSlug: string;
+  orgName: string;
+  memberId?: string | null;
+  role: OrgRole | null;
+  hasAlumniAccess: boolean;
+  hasParentsAccess?: boolean;
+  initialProgress: OnboardingProgress;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function OnboardingShell({
+  userId,
+  orgId,
+  orgSlug,
+  orgName,
+  memberId,
+  role,
+  hasAlumniAccess,
+  hasParentsAccess = false,
+  initialProgress,
+}: OnboardingShellProps) {
+  const [welcomeOpen, setWelcomeOpen] = useState(
+    !initialProgress.welcomeSeenAt
+  );
+  const [checklistOpen, setChecklistOpen] = useState(false);
+  const [tourActive, setTourActive] = useState(false);
+  const [dismissed, setDismissed] = useState(
+    !!initialProgress.dismissedAt
+  );
+
+  // Sync progress from /api/onboarding/status on mount (hydrates auto-completions)
+  const [progress, setProgress] = useState<OnboardingProgress>(initialProgress);
+  const fetchedRef = useRef(false);
+
+  useEffect(() => {
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
+
+    let cancelled = false;
+    const params = new URLSearchParams({ orgId });
+    if (memberId) params.set("memberId", memberId);
+
+    fetch(`/api/onboarding/status?${params}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (data.completedItems) {
+          setProgress((prev) => ({
+            ...prev,
+            completedItems: data.completedItems,
+            visitedItems: data.visitedItems ?? prev.visitedItems,
+            welcomeSeenAt: data.welcomeSeenAt ?? prev.welcomeSeenAt,
+            tourCompletedAt: data.tourCompletedAt ?? prev.tourCompletedAt,
+            dismissedAt: data.dismissedAt ?? prev.dismissedAt,
+          }));
+          if (data.dismissedAt) setDismissed(true);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) console.error("Failed to fetch onboarding status:", err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, memberId]);
+
+  // Listen for ChecklistTrigger's CustomEvent to reopen the panel
+  useEffect(() => {
+    function handleOpenEvent() {
+      setChecklistOpen(true);
+    }
+    window.addEventListener("tn:open-onboarding", handleOpenEvent);
+    return () => {
+      window.removeEventListener("tn:open-onboarding", handleOpenEvent);
+    };
+  }, []);
+
+  // Dispatch progress updates so ChecklistTrigger can reflect current state
+  // via a shared event bus (count synced via window event)
+  const visibleItems = getVisibleOnboardingItems({
+    role,
+    hasAlumniAccess,
+    hasParentsAccess,
+  });
+  const completedCount = visibleItems.filter((item) =>
+    progress.completedItems.includes(item.id)
+  ).length;
+
+  useEffect(() => {
+    window.dispatchEvent(
+      new CustomEvent("tn:onboarding-progress", {
+        detail: { completedCount, totalCount: visibleItems.length },
+      })
+    );
+  }, [completedCount, visibleItems.length]);
+
+  // ── Handlers ────────────────────────────────────────────────────────────────
+
+  const handleWelcomeTakeTour = useCallback(() => {
+    setWelcomeOpen(false);
+    setTourActive(true);
+  }, []);
+
+  const handleWelcomeShowChecklist = useCallback(() => {
+    setWelcomeOpen(false);
+    setChecklistOpen(true);
+  }, []);
+
+  const handleWelcomeDismiss = useCallback(() => {
+    setWelcomeOpen(false);
+  }, []);
+
+  const handleTourComplete = useCallback(() => {
+    setTourActive(false);
+    setChecklistOpen(true);
+  }, []);
+
+  const handleChecklistDismiss = useCallback(() => {
+    setChecklistOpen(false);
+    setDismissed(true);
+    // Notify the sidebar trigger to hide itself (OrgSidebar listens for this).
+    window.dispatchEvent(new CustomEvent("tn:onboarding-dismissed"));
+  }, []);
+
+  // Close the floating checklist panel when the user clicks through to an item.
+  const handleChecklistClose = useCallback(() => {
+    setChecklistOpen(false);
+  }, []);
+
+  // Don't render if dismissed and not reopened via trigger
+  if (dismissed && !checklistOpen) return null;
+
+  return (
+    <>
+      {/* Welcome modal — one-time on first org visit */}
+      <WelcomeModal
+        open={welcomeOpen}
+        userId={userId}
+        orgId={orgId}
+        orgName={orgName}
+        onTakeTour={handleWelcomeTakeTour}
+        onShowChecklist={handleWelcomeShowChecklist}
+        onDismiss={handleWelcomeDismiss}
+      />
+
+      {/* Checklist side panel */}
+      {checklistOpen && (
+        <div
+          className="fixed bottom-6 right-6 z-[60] w-80 shadow-2xl rounded-2xl"
+          role="complementary"
+          aria-label="Getting started checklist"
+        >
+          <ChecklistCard
+            userId={userId}
+            orgId={orgId}
+            orgSlug={orgSlug}
+            memberId={memberId}
+            role={role}
+            hasAlumniAccess={hasAlumniAccess}
+            hasParentsAccess={hasParentsAccess}
+            initialProgress={progress}
+            onDismiss={handleChecklistDismiss}
+            onItemClick={handleChecklistClose}
+          />
+        </div>
+      )}
+
+      {/* Guided tour — effect-only, no DOM */}
+      <GuidedTour
+        active={tourActive}
+        userId={userId}
+        orgId={orgId}
+        onComplete={handleTourComplete}
+      />
+    </>
+  );
+}

--- a/src/components/onboarding/WelcomeModal.tsx
+++ b/src/components/onboarding/WelcomeModal.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { Button } from "@/components/ui";
+import { markWelcomeSeen } from "@/lib/onboarding/progress";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface WelcomeModalProps {
+  open: boolean;
+  userId: string;
+  orgId: string;
+  orgName: string;
+  onTakeTour: () => void;
+  onShowChecklist: () => void;
+  onDismiss: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function WelcomeModal({
+  open,
+  userId,
+  orgId,
+  orgName,
+  onTakeTour,
+  onShowChecklist,
+  onDismiss,
+}: WelcomeModalProps) {
+  async function persistAndClose(action: () => void) {
+    try {
+      await markWelcomeSeen(userId, orgId);
+    } catch (err) {
+      console.error("Failed to mark welcome seen:", err);
+    }
+    action();
+  }
+
+  // Radix calls this whenever the dialog wants to close (ESC, outside click
+  // if allowed, programmatic). We funnel all close paths through dismiss so
+  // welcome_seen_at always persists — otherwise the modal reopens next reload.
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      persistAndClose(onDismiss);
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[100] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[101] w-full max-w-md bg-card border border-border rounded-2xl shadow-2xl p-8 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+          aria-describedby="welcome-modal-description"
+        >
+          {/* Illustration */}
+          <div className="flex justify-center mb-6">
+            <div className="w-16 h-16 rounded-2xl bg-[var(--color-org-secondary)]/10 flex items-center justify-center">
+              <svg
+                className="w-8 h-8 text-[var(--color-org-secondary)]"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
+                />
+              </svg>
+            </div>
+          </div>
+
+          {/* Heading */}
+          <Dialog.Title className="text-xl font-bold text-center text-foreground mb-2">
+            Welcome to {orgName}!
+          </Dialog.Title>
+          <Dialog.Description
+            id="welcome-modal-description"
+            className="text-sm text-muted-foreground text-center mb-8 leading-relaxed"
+          >
+            Let&apos;s help you get the most out of your membership. What would
+            you like to do first?
+          </Dialog.Description>
+
+          {/* CTAs */}
+          <div className="space-y-3">
+            <Button
+              variant="primary"
+              className="w-full"
+              onClick={() => persistAndClose(onTakeTour)}
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z"
+                />
+              </svg>
+              Take the guided tour
+            </Button>
+
+            <Button
+              variant="secondary"
+              className="w-full"
+              onClick={() => persistAndClose(onShowChecklist)}
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              Show me the checklist
+            </Button>
+
+            <button
+              onClick={() => persistAndClose(onDismiss)}
+              className="w-full text-sm text-muted-foreground hover:text-foreground transition-colors py-2 rounded-xl hover:bg-muted"
+            >
+              I&apos;ll explore on my own
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/lib/navigation/nav-items.tsx
+++ b/src/lib/navigation/nav-items.tsx
@@ -55,6 +55,8 @@ export type OrgNavItem = {
   requiresAlumni?: boolean;
   requiresParents?: boolean;
   group?: NavGroupId;
+  /** Identifier used by the guided onboarding tour (sets data-tour attribute on the nav link). */
+  tourId?: string;
 };
 
 export type NavConfigEntry = {
@@ -70,20 +72,20 @@ export type NavConfig = Record<string, NavConfigEntry>;
 export const getConfigKey = (href: string): string => href === "" ? "dashboard" : href;
 
 export const ORG_NAV_ITEMS: OrgNavItem[] = [
-  { href: "", label: "Home", i18nKey: "home", icon: HomeIcon, roles: ["admin", "active_member", "alumni", "parent"] },
-  { href: "/members", label: "Members", i18nKey: "members", icon: UsersIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "people" },
-  { href: "/messages", label: "Messages", i18nKey: "messages", icon: ChatIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community" },
+  { href: "", label: "Home", i18nKey: "home", icon: HomeIcon, roles: ["admin", "active_member", "alumni", "parent"], tourId: "feed" },
+  { href: "/members", label: "Members", i18nKey: "members", icon: UsersIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "people", tourId: "members" },
+  { href: "/messages", label: "Messages", i18nKey: "messages", icon: ChatIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community", tourId: "messages" },
   { href: "/alumni", label: "Alumni", i18nKey: "alumni", icon: GraduationCapIcon, roles: ["admin", "active_member", "alumni", "parent"], requiresAlumni: true, group: "people" },
   { href: "/parents", label: "Parents", i18nKey: "parents", icon: ParentsIcon, roles: ["admin", "active_member", "parent"], requiresParents: true, group: "people" },
   { href: "/mentorship", label: "Mentorship", i18nKey: "mentorship", icon: HandshakeIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "people" },
   { href: "/workouts", label: "Workouts", i18nKey: "workouts", icon: DumbbellIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "activity" },
   { href: "/competition", label: "Competition", i18nKey: "competition", icon: AwardIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "activity" },
-  { href: "/announcements", label: "Announcements", i18nKey: "announcements", icon: MegaphoneIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community" },
+  { href: "/announcements", label: "Announcements", i18nKey: "announcements", icon: MegaphoneIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community", tourId: "announcements" },
   { href: "/philanthropy", label: "Philanthropy", i18nKey: "philanthropy", icon: HeartIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "finance" },
   { href: "/donations", label: "Donations", i18nKey: "donations", icon: DollarIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "finance" },
   { href: "/expenses", label: "Expenses", i18nKey: "expenses", icon: ReceiptIcon, roles: ["admin", "active_member"], group: "finance" },
   { href: "/records", label: "Records", i18nKey: "records", icon: TrophyIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "activity" },
-  { href: "/calendar", label: "Calendar", i18nKey: "calendar", icon: BookOpenIcon, roles: ["admin", "active_member", "alumni", "parent"] },
+  { href: "/calendar", label: "Calendar", i18nKey: "calendar", icon: BookOpenIcon, roles: ["admin", "active_member", "alumni", "parent"], tourId: "calendar" },
   { href: "/jobs", label: "Jobs", i18nKey: "jobs", icon: BriefcaseIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community" },
   { href: "/forms", label: "Forms", i18nKey: "forms", icon: ClipboardIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community" },
   { href: "/media", label: "Media", i18nKey: "media", icon: GridIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community" },

--- a/src/lib/onboarding/detect.ts
+++ b/src/lib/onboarding/detect.ts
@@ -1,0 +1,142 @@
+import type { OnboardingItemId } from "@/lib/schemas/onboarding";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface DetectionContext {
+  userId: string;
+  orgId: string;
+  memberId?: string | null;
+}
+
+// ─── Detection helpers ────────────────────────────────────────────────────────
+
+/**
+ * Runs parallel Supabase queries to determine which onboarding items
+ * the user has already completed. Returns an array of auto-completed item IDs.
+ *
+ * Must be called from a server context (Route Handler or Server Action)
+ * as it uses the server Supabase client.
+ *
+ * Column references verified against src/types/database.ts:
+ * - feed_posts.author_id
+ * - chat_messages.author_id
+ * - workout_logs.user_id (NOT workouts — workouts is a prescription catalog)
+ * - event_rsvps.user_id
+ * - notification_preferences.user_id
+ * - members.photo_url / linkedin_url / bio
+ */
+export async function detectCompletedItems(
+  ctx: DetectionContext
+): Promise<OnboardingItemId[]> {
+  const { createClient } = await import("@/lib/supabase/server");
+  const supabase = await createClient();
+
+  const { userId, orgId, memberId } = ctx;
+
+  // Run all detection queries in parallel — same idiom as pendingApprovalsCount
+  const [
+    profileResult,
+    feedPostResult,
+    rsvpResult,
+    messageResult,
+    notifPrefsResult,
+    linkedInResult,
+    workoutResult,
+  ] = await Promise.all([
+    // has_profile_photo + bio: member row has BOTH non-null photo_url and
+    // a non-empty bio. Returned data.bio is checked in JS since we can't
+    // trivially express "length > 0" with the Supabase query builder.
+    memberId
+      ? supabase
+          .from("members")
+          .select("photo_url, bio")
+          .eq("id", memberId)
+          .not("photo_url", "is", null)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+
+    // has_feed_post: user has posted at least one feed post in this org
+    supabase
+      .from("feed_posts")
+      .select("id", { count: "exact", head: true })
+      .eq("organization_id", orgId)
+      .eq("author_id", userId)
+      .is("deleted_at", null),
+
+    // has_rsvp: user has RSVPed to at least one event in this org
+    supabase
+      .from("event_rsvps")
+      .select("id", { count: "exact", head: true })
+      .eq("organization_id", orgId)
+      .eq("user_id", userId),
+
+    // has_sent_message: user has sent at least one chat message in this org
+    supabase
+      .from("chat_messages")
+      .select("id", { count: "exact", head: true })
+      .eq("organization_id", orgId)
+      .eq("author_id", userId)
+      .is("deleted_at", null),
+
+    // has_notification_prefs: user has a notification_preferences row for this org
+    supabase
+      .from("notification_preferences")
+      .select("id", { count: "exact", head: true })
+      .eq("organization_id", orgId)
+      .eq("user_id", userId),
+
+    // has_linkedin: member has a linkedin_url set
+    memberId
+      ? supabase
+          .from("members")
+          .select("linkedin_url")
+          .eq("id", memberId)
+          .not("linkedin_url", "is", null)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+
+    // has_logged_workout: user has logged at least one workout log in this org
+    supabase
+      .from("workout_logs")
+      .select("id", { count: "exact", head: true })
+      .eq("organization_id", orgId)
+      .eq("user_id", userId),
+  ]);
+
+  const autoCompleted: OnboardingItemId[] = [];
+
+  // complete_profile: photo present AND bio has content
+  if (!profileResult.error && profileResult.data) {
+    const row = profileResult.data as { photo_url: string | null; bio: string | null };
+    if (row.photo_url && row.bio && row.bio.trim().length > 0) {
+      autoCompleted.push("complete_profile");
+    }
+  }
+
+  // Count-based checks
+  if (!feedPostResult.error && (feedPostResult.count ?? 0) > 0) {
+    autoCompleted.push("post_feed");
+  }
+
+  if (!rsvpResult.error && (rsvpResult.count ?? 0) > 0) {
+    autoCompleted.push("rsvp_event");
+  }
+
+  if (!messageResult.error && (messageResult.count ?? 0) > 0) {
+    autoCompleted.push("send_message");
+  }
+
+  if (!notifPrefsResult.error && (notifPrefsResult.count ?? 0) > 0) {
+    autoCompleted.push("configure_notifications");
+  }
+
+  if (!linkedInResult.error && linkedInResult.data) {
+    autoCompleted.push("update_linkedin");
+  }
+
+  if (!workoutResult.error && (workoutResult.count ?? 0) > 0) {
+    autoCompleted.push("log_workout");
+  }
+
+  return autoCompleted;
+}

--- a/src/lib/onboarding/items.ts
+++ b/src/lib/onboarding/items.ts
@@ -1,0 +1,106 @@
+import type { OrgRole } from "@/lib/auth/role-utils";
+import type { OnboardingItemId } from "@/lib/schemas/onboarding";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface OnboardingItem {
+  readonly id: OnboardingItemId;
+  readonly title: string;
+  readonly description: string;
+  /** Generates the deep-link URL. Receives the org slug. */
+  readonly href: (orgSlug: string, memberId?: string) => string;
+  /** Empty array = visible to all roles. */
+  readonly roles: readonly OrgRole[];
+  readonly requiresAlumniAccess?: boolean;
+  readonly requiresParentsAccess?: boolean;
+  /**
+   * Name of the auto-detection key returned by the /api/onboarding/status
+   * endpoint. When present, the item auto-checks on detection.
+   * When absent, only manual "Mark done" completes the item.
+   */
+  readonly detectKey?: string;
+}
+
+// ─── Registry ────────────────────────────────────────────────────────────────
+
+export const ONBOARDING_ITEMS: readonly OnboardingItem[] = [
+  // ── Universal ──────────────────────────────────────────────────────────────
+  {
+    id: "complete_profile",
+    title: "Complete your profile",
+    description: "Add a photo and bio so teammates know who you are.",
+    href: (orgSlug, memberId) =>
+      memberId ? `/${orgSlug}/members/${memberId}/edit` : `/${orgSlug}/members`,
+    roles: [],
+    detectKey: "has_profile_photo",
+  },
+  {
+    id: "post_feed",
+    title: "Post in the feed",
+    description: "Share an update, photo, or poll with your org.",
+    href: (orgSlug) => `/${orgSlug}/feed`,
+    roles: [],
+    detectKey: "has_feed_post",
+  },
+  {
+    id: "rsvp_event",
+    title: "RSVP to an event",
+    description: "Find an upcoming event on the calendar and RSVP.",
+    href: (orgSlug) => `/${orgSlug}/calendar`,
+    roles: [],
+    detectKey: "has_rsvp",
+  },
+  {
+    id: "send_message",
+    title: "Send a message",
+    description: "Start or join a conversation in Messages.",
+    href: (orgSlug) => `/${orgSlug}/messages`,
+    roles: [],
+    detectKey: "has_sent_message",
+  },
+  {
+    id: "read_announcement",
+    title: "Read an announcement",
+    description: "Check the latest announcements from your org.",
+    href: (orgSlug) => `/${orgSlug}/announcements`,
+    roles: [],
+    // Detected via client-side visit flag, persisted as visitedItem
+    detectKey: "visited_announcements",
+  },
+  {
+    id: "configure_notifications",
+    title: "Configure notifications",
+    description: "Choose which emails you want to receive.",
+    href: () => "/settings/notifications",
+    roles: [],
+    detectKey: "has_notification_prefs",
+  },
+  // ── Alumni-only ─────────────────────────────────────────────────────────────
+  {
+    id: "update_linkedin",
+    title: "Add your LinkedIn",
+    description: "Connect your LinkedIn profile for the alumni directory.",
+    href: () => "/settings/linkedin",
+    roles: ["alumni"],
+    requiresAlumniAccess: true,
+    detectKey: "has_linkedin",
+  },
+  {
+    id: "browse_alumni_directory",
+    title: "Browse the alumni directory",
+    description: "Filter by industry, class year, or location.",
+    href: (orgSlug) => `/${orgSlug}/alumni`,
+    roles: ["alumni"],
+    requiresAlumniAccess: true,
+    detectKey: "visited_alumni_directory",
+  },
+  // ── Active-member-only ──────────────────────────────────────────────────────
+  {
+    id: "log_workout",
+    title: "Log a workout",
+    description: "Record or view today's workout results.",
+    href: (orgSlug) => `/${orgSlug}/workouts`,
+    roles: ["active_member", "admin"],
+    detectKey: "has_logged_workout",
+  },
+] as const;

--- a/src/lib/onboarding/progress.ts
+++ b/src/lib/onboarding/progress.ts
@@ -1,0 +1,159 @@
+import type { OnboardingItemId } from "@/lib/schemas/onboarding";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface OnboardingProgress {
+  id: string | null;
+  completedItems: OnboardingItemId[];
+  visitedItems: OnboardingItemId[];
+  welcomeSeenAt: string | null;
+  tourCompletedAt: string | null;
+  dismissedAt: string | null;
+}
+
+const EMPTY_PROGRESS: OnboardingProgress = {
+  id: null,
+  completedItems: [],
+  visitedItems: [],
+  welcomeSeenAt: null,
+  tourCompletedAt: null,
+  dismissedAt: null,
+};
+
+// ─── Server reads (Server Components / Route Handlers) ────────────────────────
+
+/**
+ * Fetch the onboarding progress row for (userId, orgId).
+ * Returns a zero-state object when no row exists yet.
+ * Uses the server-side Supabase client (cookie-based auth).
+ */
+export async function getProgress(
+  userId: string,
+  orgId: string
+): Promise<OnboardingProgress> {
+  // Dynamic import so this module is safe to import from both server and client
+  const { createClient } = await import("@/lib/supabase/server");
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("user_onboarding_progress")
+    .select(
+      "id, completed_items, visited_items, welcome_seen_at, tour_completed_at, dismissed_at"
+    )
+    .eq("user_id", userId)
+    .eq("organization_id", orgId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("getProgress error:", error);
+    return EMPTY_PROGRESS;
+  }
+
+  if (!data) return EMPTY_PROGRESS;
+
+  return {
+    id: data.id,
+    completedItems: (data.completed_items as OnboardingItemId[]) ?? [],
+    visitedItems: (data.visited_items as OnboardingItemId[]) ?? [],
+    welcomeSeenAt: data.welcome_seen_at ?? null,
+    tourCompletedAt: data.tour_completed_at ?? null,
+    dismissedAt: data.dismissed_at ?? null,
+  };
+}
+
+// ─── Client mutations (Client Components) ────────────────────────────────────
+// All mutations use createClient from @/lib/supabase/client (browser client)
+// and follow the upsert pattern from NotificationPrefsCard.tsx.
+
+async function upsertProgress(
+  userId: string,
+  orgId: string,
+  patch: Record<string, unknown>
+): Promise<void> {
+  const { createClient } = await import("@/lib/supabase/client");
+  const supabase = createClient();
+
+  const { error } = await supabase
+    .from("user_onboarding_progress")
+    .upsert(
+      {
+        user_id: userId,
+        organization_id: orgId,
+        ...patch,
+      },
+      { onConflict: "user_id,organization_id" }
+    );
+
+  if (error) {
+    console.error("upsertProgress error:", error);
+    throw new Error(`Onboarding progress update failed: ${error.message}`);
+  }
+}
+
+/** Add an item to completed_items (idempotent via jsonb array union). */
+export async function markItemComplete(
+  userId: string,
+  orgId: string,
+  itemId: OnboardingItemId,
+  currentCompleted: OnboardingItemId[]
+): Promise<void> {
+  if (currentCompleted.includes(itemId)) return;
+
+  await upsertProgress(userId, orgId, {
+    completed_items: [...currentCompleted, itemId],
+  });
+}
+
+/** Add an item to visited_items (idempotent). */
+export async function markVisited(
+  userId: string,
+  orgId: string,
+  itemId: OnboardingItemId,
+  currentVisited: OnboardingItemId[]
+): Promise<void> {
+  if (currentVisited.includes(itemId)) return;
+
+  await upsertProgress(userId, orgId, {
+    visited_items: [...currentVisited, itemId],
+  });
+}
+
+/** Set welcome_seen_at to now (first-login modal shown). */
+export async function markWelcomeSeen(
+  userId: string,
+  orgId: string
+): Promise<void> {
+  await upsertProgress(userId, orgId, {
+    welcome_seen_at: new Date().toISOString(),
+  });
+}
+
+/** Set tour_completed_at to now. */
+export async function markTourCompleted(
+  userId: string,
+  orgId: string
+): Promise<void> {
+  await upsertProgress(userId, orgId, {
+    tour_completed_at: new Date().toISOString(),
+  });
+}
+
+/** Set dismissed_at to now — hides the sidebar trigger. */
+export async function dismissChecklist(
+  userId: string,
+  orgId: string
+): Promise<void> {
+  await upsertProgress(userId, orgId, {
+    dismissed_at: new Date().toISOString(),
+  });
+}
+
+/** Clear dismissed_at — re-opens the checklist. */
+export async function reopenChecklist(
+  userId: string,
+  orgId: string
+): Promise<void> {
+  await upsertProgress(userId, orgId, {
+    dismissed_at: null,
+  });
+}

--- a/src/lib/onboarding/visible-items.ts
+++ b/src/lib/onboarding/visible-items.ts
@@ -1,0 +1,40 @@
+import type { OrgRole } from "@/lib/auth/role-utils";
+import { ONBOARDING_ITEMS, type OnboardingItem } from "./items";
+
+interface GetVisibleOnboardingItemsInput {
+  role: OrgRole | null;
+  hasAlumniAccess?: boolean;
+  hasParentsAccess?: boolean;
+}
+
+/** Max items shown in the checklist at once. */
+const MAX_CHECKLIST_ITEMS = 8;
+
+/**
+ * Returns the subset of ONBOARDING_ITEMS visible to a given user,
+ * capped at MAX_CHECKLIST_ITEMS. Mirrors getVisibleOrgNavItems logic.
+ */
+export function getVisibleOnboardingItems({
+  role,
+  hasAlumniAccess = false,
+  hasParentsAccess = false,
+}: GetVisibleOnboardingItemsInput): readonly OnboardingItem[] {
+  const filtered = ONBOARDING_ITEMS.filter((item) => {
+    // Universal items (empty roles array) are always included when role is known
+    if (item.roles.length > 0 && role && !item.roles.includes(role)) {
+      return false;
+    }
+
+    if (item.requiresAlumniAccess && !hasAlumniAccess) {
+      return false;
+    }
+
+    if (item.requiresParentsAccess && !hasParentsAccess) {
+      return false;
+    }
+
+    return true;
+  });
+
+  return filtered.slice(0, MAX_CHECKLIST_ITEMS);
+}

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -83,3 +83,6 @@ export * from "./global-search";
 
 // AI feedback schemas
 export * from "./ai-feedback";
+
+// Onboarding checklist schemas
+export * from "./onboarding";

--- a/src/lib/schemas/onboarding.ts
+++ b/src/lib/schemas/onboarding.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+// ─── Item IDs ────────────────────────────────────────────────────────────────
+
+export const ONBOARDING_ITEM_IDS = [
+  "complete_profile",
+  "post_feed",
+  "rsvp_event",
+  "send_message",
+  "read_announcement",
+  "configure_notifications",
+  "update_linkedin",
+  "browse_alumni_directory",
+  "log_workout",
+] as const;
+
+export type OnboardingItemId = (typeof ONBOARDING_ITEM_IDS)[number];
+
+export const onboardingItemIdSchema = z.enum(ONBOARDING_ITEM_IDS);
+
+// ─── DB row shape ────────────────────────────────────────────────────────────
+
+export const onboardingProgressRowSchema = z.object({
+  id: z.string().uuid(),
+  user_id: z.string().uuid(),
+  organization_id: z.string().uuid(),
+  completed_items: z.array(onboardingItemIdSchema),
+  visited_items: z.array(onboardingItemIdSchema),
+  welcome_seen_at: z.string().datetime().nullable(),
+  tour_completed_at: z.string().datetime().nullable(),
+  dismissed_at: z.string().datetime().nullable(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+});
+
+export type OnboardingProgressRow = z.infer<typeof onboardingProgressRowSchema>;
+
+// ─── Mutation payloads ────────────────────────────────────────────────────────
+
+export const markItemCompleteSchema = z.object({
+  orgId: z.string().uuid(),
+  itemId: onboardingItemIdSchema,
+});
+
+export const markVisitedSchema = z.object({
+  orgId: z.string().uuid(),
+  itemId: onboardingItemIdSchema,
+});
+
+export const dismissChecklistSchema = z.object({
+  orgId: z.string().uuid(),
+});
+
+export const markWelcomeSeenSchema = z.object({
+  orgId: z.string().uuid(),
+});
+
+export const markTourCompletedSchema = z.object({
+  orgId: z.string().uuid(),
+});
+
+// ─── API response ─────────────────────────────────────────────────────────────
+
+export const onboardingStatusResponseSchema = z.object({
+  completedItems: z.array(onboardingItemIdSchema),
+  visitedItems: z.array(onboardingItemIdSchema),
+  welcomeSeenAt: z.string().datetime().nullable(),
+  tourCompletedAt: z.string().datetime().nullable(),
+  dismissedAt: z.string().datetime().nullable(),
+  autoCompleted: z.array(onboardingItemIdSchema),
+});
+
+export type OnboardingStatusResponse = z.infer<typeof onboardingStatusResponseSchema>;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -5883,6 +5883,10 @@ export type Database = {
         }
         Returns: boolean
       }
+      can_view_event: {
+        Args: { e: Database["public"]["Tables"]["events"]["Row"] }
+        Returns: boolean
+      }
       cancel_ai_pending_action: {
         Args: { p_action_id: string; p_user_id: string }
         Returns: Json
@@ -6091,7 +6095,7 @@ export type Database = {
         Returns: Json
       }
       filter_announcement_ids_for_user: {
-        Args: { p_org_id: string; p_announcement_ids: string[] }
+        Args: { p_announcement_ids: string[]; p_org_id: string }
         Returns: string[]
       }
       get_alumni_quota: { Args: { p_org_id: string }; Returns: Json }
@@ -6180,12 +6184,20 @@ export type Database = {
         }
         Returns: Json
       }
+      is_alumni_directory_visible: {
+        Args: { p_alumni_id: string; p_org_id: string }
+        Returns: boolean
+      }
       is_chat_group_creator: { Args: { group_id: string }; Returns: boolean }
       is_chat_group_member: { Args: { group_id: string }; Returns: boolean }
       is_chat_group_moderator: { Args: { group_id: string }; Returns: boolean }
       is_enterprise_admin: { Args: { ent_id: string }; Returns: boolean }
       is_enterprise_member: { Args: { ent_id: string }; Returns: boolean }
       is_enterprise_owner: { Args: { ent_id: string }; Returns: boolean }
+      is_member_directory_visible: {
+        Args: { p_member_id: string; p_org_id: string }
+        Returns: boolean
+      }
       is_org_admin: { Args: { org_id: string }; Returns: boolean }
       is_org_member: { Args: { org_id: string }; Returns: boolean }
       log_analytics_event: {
@@ -6334,6 +6346,8 @@ export type Database = {
         Args: { p_org_id: string }
         Returns: undefined
       }
+      show_limit: { Args: never; Returns: number }
+      show_trgm: { Args: { "": string }; Returns: string[] }
       sync_enterprise_nav_to_org: {
         Args: { p_enterprise_id: string; p_organization_id: string }
         Returns: boolean

--- a/supabase/migrations/20261018000000_user_onboarding_progress.sql
+++ b/supabase/migrations/20261018000000_user_onboarding_progress.sql
@@ -1,0 +1,49 @@
+-- User onboarding progress table.
+-- Tracks per-(user, org) checklist state: which items completed, which visited,
+-- whether the welcome modal has been shown, and whether the checklist is dismissed.
+-- One row per (user_id, organization_id) pair.
+
+CREATE TABLE user_onboarding_progress (
+  id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  organization_id  uuid        NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  -- JSON arrays of onboarding item IDs (string[])
+  completed_items  jsonb       NOT NULL DEFAULT '[]'::jsonb,
+  visited_items    jsonb       NOT NULL DEFAULT '[]'::jsonb,
+  -- Timestamps for modal / tour completion
+  welcome_seen_at     timestamptz,
+  tour_completed_at   timestamptz,
+  -- When the user dismissed the sidebar checklist (NULL = not dismissed)
+  dismissed_at     timestamptz,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, organization_id)
+);
+
+COMMENT ON TABLE user_onboarding_progress IS 'Per-(user, org) onboarding checklist state — completed items, visit tracking, modal/tour flags';
+COMMENT ON COLUMN user_onboarding_progress.completed_items IS 'JSON array of completed onboarding item IDs';
+COMMENT ON COLUMN user_onboarding_progress.visited_items   IS 'JSON array of visited (client-side) onboarding item IDs';
+COMMENT ON COLUMN user_onboarding_progress.dismissed_at    IS 'NULL = checklist visible; non-NULL = user dismissed it';
+
+-- Indexes
+CREATE INDEX idx_onboarding_progress_user_org
+  ON user_onboarding_progress(user_id, organization_id);
+
+-- Row Level Security
+ALTER TABLE user_onboarding_progress ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY onboarding_progress_select ON user_onboarding_progress
+  FOR SELECT USING (user_id = auth.uid());
+
+CREATE POLICY onboarding_progress_insert ON user_onboarding_progress
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY onboarding_progress_update ON user_onboarding_progress
+  FOR UPDATE USING (user_id = auth.uid());
+
+-- updated_at auto-maintenance (reuses existing function defined in 20251215000000_embeds_fix_and_approvals.sql)
+DROP TRIGGER IF EXISTS user_onboarding_progress_updated_at ON public.user_onboarding_progress;
+CREATE TRIGGER user_onboarding_progress_updated_at
+  BEFORE UPDATE ON public.user_onboarding_progress
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();

--- a/supabase/migrations/20261018000001_user_onboarding_progress_rls_hardening.sql
+++ b/supabase/migrations/20261018000001_user_onboarding_progress_rls_hardening.sql
@@ -1,0 +1,17 @@
+-- Harden RLS on user_onboarding_progress.
+-- Fixes review finding: UPDATE policy lacked WITH CHECK, so an authenticated
+-- user could UPDATE their own row and set user_id to another user's UUID.
+-- Also adds a DELETE policy for user-owned rows (GDPR / reset support).
+
+-- Recreate UPDATE policy with WITH CHECK to prevent user_id hijack.
+DROP POLICY IF EXISTS onboarding_progress_update ON user_onboarding_progress;
+CREATE POLICY onboarding_progress_update ON user_onboarding_progress
+  FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- Allow users to delete their own onboarding row (reset flow / GDPR).
+DROP POLICY IF EXISTS onboarding_progress_delete ON user_onboarding_progress;
+CREATE POLICY onboarding_progress_delete ON user_onboarding_progress
+  FOR DELETE
+  USING (user_id = auth.uid());

--- a/tests/onboarding-items-registry.test.ts
+++ b/tests/onboarding-items-registry.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getVisibleOnboardingItems } from "@/lib/onboarding/visible-items";
+import { ONBOARDING_ITEMS } from "@/lib/onboarding/items";
+import { ONBOARDING_ITEM_IDS } from "@/lib/schemas/onboarding";
+
+describe("ONBOARDING_ITEMS registry", () => {
+  it("has items with unique IDs", () => {
+    const ids = ONBOARDING_ITEMS.map((i) => i.id);
+    const unique = new Set(ids);
+    assert.equal(ids.length, unique.size, "All item IDs must be unique");
+  });
+
+  it("all items have title, description, href function", () => {
+    for (const item of ONBOARDING_ITEMS) {
+      assert.ok(item.title.length > 0, `${item.id} must have a title`);
+      assert.ok(item.description.length > 0, `${item.id} must have a description`);
+      assert.ok(typeof item.href === "function", `${item.id} href must be a function`);
+    }
+  });
+
+  it("href function produces a URL string", () => {
+    for (const item of ONBOARDING_ITEMS) {
+      const href = item.href("test-org", "member-123");
+      assert.ok(typeof href === "string" && href.length > 0, `${item.id} href must produce a string`);
+    }
+  });
+
+  it("ONBOARDING_ITEMS ids match ONBOARDING_ITEM_IDS (no drift)", () => {
+    const registryIds = ONBOARDING_ITEMS.map((i) => i.id).sort();
+    const schemaIds = [...ONBOARDING_ITEM_IDS].sort();
+    assert.deepEqual(
+      registryIds,
+      schemaIds,
+      "items.ts registry and schemas/onboarding.ts ONBOARDING_ITEM_IDS must stay in sync"
+    );
+  });
+});
+
+describe("getVisibleOnboardingItems", () => {
+  it("returns universal items for active_member", () => {
+    const items = getVisibleOnboardingItems({ role: "active_member" });
+    const ids = items.map((i) => i.id);
+
+    assert.ok(ids.includes("complete_profile"));
+    assert.ok(ids.includes("post_feed"));
+    assert.ok(ids.includes("rsvp_event"));
+    assert.ok(ids.includes("send_message"));
+    assert.ok(ids.includes("read_announcement"));
+    assert.ok(ids.includes("configure_notifications"));
+  });
+
+  it("includes log_workout for active_member", () => {
+    const items = getVisibleOnboardingItems({ role: "active_member" });
+    const ids = items.map((i) => i.id);
+    assert.ok(ids.includes("log_workout"), "active_member should see log_workout");
+  });
+
+  it("excludes alumni-only items when hasAlumniAccess=false", () => {
+    const items = getVisibleOnboardingItems({ role: "alumni", hasAlumniAccess: false });
+    const ids = items.map((i) => i.id);
+    assert.ok(!ids.includes("update_linkedin"), "update_linkedin requires alumni access");
+    assert.ok(!ids.includes("browse_alumni_directory"), "browse_alumni_directory requires alumni access");
+  });
+
+  it("includes alumni items when hasAlumniAccess=true and role=alumni", () => {
+    const items = getVisibleOnboardingItems({ role: "alumni", hasAlumniAccess: true });
+    const ids = items.map((i) => i.id);
+    assert.ok(ids.includes("update_linkedin"), "alumni with access should see update_linkedin");
+    assert.ok(ids.includes("browse_alumni_directory"), "alumni with access should see browse_alumni_directory");
+  });
+
+  it("excludes alumni-specific items for active_member even with access", () => {
+    const items = getVisibleOnboardingItems({ role: "active_member", hasAlumniAccess: true });
+    const ids = items.map((i) => i.id);
+    // update_linkedin is alumni role only
+    assert.ok(!ids.includes("update_linkedin"), "update_linkedin is alumni role only");
+  });
+
+  it("excludes log_workout for alumni role", () => {
+    const items = getVisibleOnboardingItems({ role: "alumni", hasAlumniAccess: true });
+    const ids = items.map((i) => i.id);
+    assert.ok(!ids.includes("log_workout"), "log_workout is not for alumni role");
+  });
+
+  it("returns at most 8 items", () => {
+    const items = getVisibleOnboardingItems({ role: "admin", hasAlumniAccess: true });
+    assert.ok(items.length <= 8, `Should return at most 8 items, got ${items.length}`);
+  });
+
+  it("returns items for null role (not yet assigned)", () => {
+    const items = getVisibleOnboardingItems({ role: null });
+    // With null role, role filter is bypassed so universal + role-scoped items may appear
+    // (but alumni-gated items still require hasAlumniAccess, which defaults to false).
+    assert.ok(items.length > 0, "Should return at least some items for null role");
+    const ids = items.map((i) => i.id);
+    assert.ok(ids.includes("complete_profile"), "Universal item complete_profile must appear");
+    assert.ok(ids.includes("post_feed"), "Universal item post_feed must appear");
+    // Alumni-gated items should NOT appear without hasAlumniAccess
+    assert.ok(!ids.includes("update_linkedin"), "update_linkedin requires alumni access");
+    assert.ok(!ids.includes("browse_alumni_directory"), "browse_alumni_directory requires alumni access");
+  });
+
+  it("returns items for parent role", () => {
+    const items = getVisibleOnboardingItems({ role: "parent" });
+    const ids = items.map((i) => i.id);
+    // Universal items visible
+    assert.ok(ids.includes("complete_profile"));
+    // log_workout not for parent
+    assert.ok(!ids.includes("log_workout"), "parent should not see log_workout");
+  });
+});

--- a/tests/onboarding-migration-contract.test.ts
+++ b/tests/onboarding-migration-contract.test.ts
@@ -1,0 +1,133 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const MIGRATIONS_DIR = join(__dirname, "..", "supabase", "migrations");
+
+function readMigration(filename: string): string {
+  return readFileSync(join(MIGRATIONS_DIR, filename), "utf-8");
+}
+
+describe("user_onboarding_progress migration contract", () => {
+  const MIGRATION_FILE = "20261018000000_user_onboarding_progress.sql";
+  // Read at describe scope so all it() blocks have access
+  const sql = readMigration(MIGRATION_FILE);
+
+  it("migration file exists and is non-empty", () => {
+    assert.ok(sql.length > 0, "Migration file must be non-empty");
+  });
+
+  it("creates user_onboarding_progress table", () => {
+    assert.ok(
+      sql.includes("CREATE TABLE user_onboarding_progress"),
+      "Must create user_onboarding_progress table"
+    );
+  });
+
+  it("has user_id referencing auth.users", () => {
+    assert.ok(
+      sql.includes("user_id") && sql.includes("auth.users"),
+      "Must reference auth.users for user_id"
+    );
+  });
+
+  it("has organization_id with cascade delete", () => {
+    assert.ok(
+      sql.includes("organization_id") && sql.includes("ON DELETE CASCADE"),
+      "Must have organization_id with ON DELETE CASCADE"
+    );
+  });
+
+  it("has completed_items jsonb column with default empty array", () => {
+    assert.ok(
+      sql.includes("completed_items") && sql.includes("jsonb"),
+      "Must have completed_items jsonb column"
+    );
+    assert.ok(
+      sql.includes("'[]'::jsonb"),
+      "Must default to empty JSON array"
+    );
+  });
+
+  it("has visited_items jsonb column", () => {
+    assert.ok(
+      sql.includes("visited_items"),
+      "Must have visited_items column"
+    );
+  });
+
+  it("has welcome_seen_at column", () => {
+    assert.ok(
+      sql.includes("welcome_seen_at"),
+      "Must have welcome_seen_at timestamptz column"
+    );
+  });
+
+  it("has tour_completed_at column", () => {
+    assert.ok(
+      sql.includes("tour_completed_at"),
+      "Must have tour_completed_at timestamptz column"
+    );
+  });
+
+  it("has dismissed_at column", () => {
+    assert.ok(
+      sql.includes("dismissed_at"),
+      "Must have dismissed_at timestamptz column"
+    );
+  });
+
+  it("has unique constraint on (user_id, organization_id)", () => {
+    assert.ok(
+      sql.includes("UNIQUE(user_id, organization_id)"),
+      "Must have unique constraint on (user_id, organization_id)"
+    );
+  });
+
+  it("enables row level security", () => {
+    assert.ok(
+      sql.includes("ENABLE ROW LEVEL SECURITY"),
+      "Must enable RLS"
+    );
+  });
+
+  it("has select policy for auth.uid()", () => {
+    assert.ok(
+      sql.includes("onboarding_progress_select") && sql.includes("auth.uid()"),
+      "Must have a select RLS policy checking auth.uid()"
+    );
+  });
+
+  it("has insert policy with check", () => {
+    assert.ok(
+      sql.includes("onboarding_progress_insert"),
+      "Must have insert RLS policy"
+    );
+  });
+
+  it("has update policy", () => {
+    assert.ok(
+      sql.includes("onboarding_progress_update"),
+      "Must have update RLS policy"
+    );
+  });
+
+  it("attaches updated_at trigger", () => {
+    assert.ok(
+      sql.includes("user_onboarding_progress_updated_at") &&
+        sql.includes("update_updated_at_column"),
+      "Must attach updated_at trigger using existing update_updated_at_column()"
+    );
+  });
+
+  it("creates index on user_id, organization_id", () => {
+    assert.ok(
+      sql.includes("idx_onboarding_progress_user_org"),
+      "Must create index idx_onboarding_progress_user_org"
+    );
+  });
+});

--- a/tests/onboarding-progress-schema.test.ts
+++ b/tests/onboarding-progress-schema.test.ts
@@ -1,0 +1,147 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  onboardingItemIdSchema,
+  markItemCompleteSchema,
+  dismissChecklistSchema,
+  markVisitedSchema,
+  markWelcomeSeenSchema,
+  markTourCompletedSchema,
+  onboardingProgressRowSchema,
+  ONBOARDING_ITEM_IDS,
+} from "@/lib/schemas/onboarding";
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("onboardingItemIdSchema", () => {
+  it("accepts all valid item IDs", () => {
+    for (const id of ONBOARDING_ITEM_IDS) {
+      const result = onboardingItemIdSchema.safeParse(id);
+      assert.equal(result.success, true, `Should accept ${id}`);
+    }
+  });
+
+  it("rejects unknown item ID", () => {
+    const result = onboardingItemIdSchema.safeParse("nonexistent_item");
+    assert.equal(result.success, false);
+  });
+
+  it("rejects empty string", () => {
+    const result = onboardingItemIdSchema.safeParse("");
+    assert.equal(result.success, false);
+  });
+});
+
+describe("markItemCompleteSchema", () => {
+  it("accepts valid payload", () => {
+    const result = markItemCompleteSchema.safeParse({
+      orgId: VALID_UUID,
+      itemId: "post_feed",
+    });
+    assert.equal(result.success, true);
+    if (result.success) {
+      assert.equal(result.data.itemId, "post_feed");
+    }
+  });
+
+  it("rejects invalid orgId (not uuid)", () => {
+    const result = markItemCompleteSchema.safeParse({
+      orgId: "not-a-uuid",
+      itemId: "post_feed",
+    });
+    assert.equal(result.success, false);
+  });
+
+  it("rejects invalid itemId", () => {
+    const result = markItemCompleteSchema.safeParse({
+      orgId: VALID_UUID,
+      itemId: "hack_the_planet",
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("dismissChecklistSchema", () => {
+  it("accepts valid payload", () => {
+    const result = dismissChecklistSchema.safeParse({ orgId: VALID_UUID });
+    assert.equal(result.success, true);
+  });
+
+  it("rejects missing orgId", () => {
+    const result = dismissChecklistSchema.safeParse({});
+    assert.equal(result.success, false);
+  });
+});
+
+describe("markVisitedSchema", () => {
+  it("accepts valid payload", () => {
+    const result = markVisitedSchema.safeParse({ orgId: VALID_UUID, itemId: "rsvp_event" });
+    assert.equal(result.success, true);
+  });
+});
+
+describe("markWelcomeSeenSchema", () => {
+  it("accepts valid payload", () => {
+    const result = markWelcomeSeenSchema.safeParse({ orgId: VALID_UUID });
+    assert.equal(result.success, true);
+  });
+});
+
+describe("markTourCompletedSchema", () => {
+  it("accepts valid payload", () => {
+    const result = markTourCompletedSchema.safeParse({ orgId: VALID_UUID });
+    assert.equal(result.success, true);
+  });
+});
+
+describe("onboardingProgressRowSchema", () => {
+  const validRow = {
+    id: VALID_UUID,
+    user_id: VALID_UUID,
+    organization_id: VALID_UUID,
+    completed_items: ["post_feed", "rsvp_event"],
+    visited_items: ["read_announcement"],
+    welcome_seen_at: "2026-04-01T12:00:00.000Z",
+    tour_completed_at: null,
+    dismissed_at: null,
+    created_at: "2026-04-01T00:00:00.000Z",
+    updated_at: "2026-04-01T00:00:00.000Z",
+  };
+
+  it("accepts a valid progress row", () => {
+    const result = onboardingProgressRowSchema.safeParse(validRow);
+    assert.equal(result.success, true);
+    if (result.success) {
+      assert.equal(result.data.completed_items.length, 2);
+      assert.equal(result.data.dismissed_at, null);
+    }
+  });
+
+  it("rejects row with invalid completed item", () => {
+    const result = onboardingProgressRowSchema.safeParse({
+      ...validRow,
+      completed_items: ["invalid_item_xyz"],
+    });
+    assert.equal(result.success, false);
+  });
+
+  it("accepts row with empty arrays", () => {
+    const result = onboardingProgressRowSchema.safeParse({
+      ...validRow,
+      completed_items: [],
+      visited_items: [],
+    });
+    assert.equal(result.success, true);
+  });
+
+  it("accepts row with dismissed_at timestamp", () => {
+    const result = onboardingProgressRowSchema.safeParse({
+      ...validRow,
+      dismissed_at: "2026-04-02T09:00:00.000Z",
+    });
+    assert.equal(result.success, true);
+    if (result.success) {
+      assert.ok(result.data.dismissed_at !== null);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Layered onboarding for new members landing in an org:
- **First-login WelcomeModal** (one-time, ESC-dismissible) with three CTAs
- **Persistent sidebar ChecklistCard** with 6–8 role-tailored items, progress bar, auto-detection + manual "Mark done" fallback
- **On-demand GuidedTour** via lazy-loaded driver.js highlighting feed / calendar / messages / announcements / members

Opus review uncovered 5 CRITICAL issues — all fixed before this PR:
1. `detect.ts` used 3 non-existent columns (`feed_posts.author_user_id`, `chat_messages.sender_user_id`, `workouts.user_id`) — now correctly queries `author_id`, `author_id`, `workout_logs.user_id`
2. RLS UPDATE policy lacked `WITH CHECK` — follow-up migration adds it + a DELETE policy
3. `/api/onboarding/status` accepted any `orgId` with no membership check — now verifies `user_organization_roles` status=active
4. WelcomeModal had no ESC escape hatch — now uses `onOpenChange` and persists `welcome_seen_at` on any close path
5. Profile auto-detection only checked photo — now requires photo AND non-empty bio

Also fixes HIGH issues: missing `tn:onboarding-dismissed` event dispatch, missing `hasParentsAccess` filter in `getVisibleOnboardingItems`, OnboardingShell fetch race on unmount, GuidedTour confusing abandonment with completion, ChecklistItem "Done" button keyboard-invisible, checklist panel not closing on item navigation.

## What's included

- `user_onboarding_progress` table + RLS hardening migrations
- `src/lib/onboarding/{items,visible-items,progress,detect}.ts` + `src/lib/schemas/onboarding.ts`
- `src/app/api/onboarding/status/route.ts`
- Six client components under `src/components/onboarding/`
- Wired into `[orgSlug]/layout.tsx` and `OrgSidebar.tsx` via CustomEvent bus
- 44 new tests (items registry + Zod schemas + migration contract + drift guard)

## Test plan

- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run lint` — clean
- [ ] `node --test --loader ./tests/ts-loader.js tests/onboarding-*.test.ts` — 44/44 passing
- [ ] Apply migrations to dev Supabase
- [ ] Run `npm run gen:types` to pick up `user_onboarding_progress` types
- [ ] Manual: sign up new user, join org, confirm welcome modal appears once
- [ ] Manual: post in feed, reload, confirm `post_feed` auto-checks
- [ ] Manual: click "Mark done" on an item, verify persistence across devices
- [ ] Manual: launch guided tour, finish → `tour_completed_at` persists; launch again, hit ESC mid-tour → flag stays NULL
- [ ] Manual: dismiss checklist from card → sidebar trigger hides immediately
- [ ] Manual: ESC the welcome modal → `welcome_seen_at` persists, modal does not reopen on reload

## Out of scope / follow-ups

- Admin + parent role item sets
- Org-level admin customization of items
- Playwright E2E coverage (`tests/e2e/onboarding.spec.ts`)
- i18n for item strings
- Server-side `pendingApprovalsCount`-style initial progress pass-through to OrgSidebar (currently hydrates from CustomEvent)