### PR TITLE
feat(search): quick-action nav items in global search palette

### DIFF
--- a/src/app/[orgSlug]/layout.tsx
+++ b/src/app/[orgSlug]/layout.tsx
@@ -283,7 +283,7 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
     <OrgAnalyticsProvider orgId={organization.id} orgType={(organization as Record<string, unknown>).org_type as string || "general"}>
     <AnalyticsProvider>
     <AIPanelProvider autoOpen={isAdmin}>
-    <OrgGlobalSearch orgSlug={orgSlug} orgId={organization.id}>
+    <OrgGlobalSearch orgSlug={orgSlug} orgId={organization.id} currentProfileHref={currentProfileHref}>
     <div data-org-shell className="min-h-screen">
       <style
         dangerouslySetInnerHTML={{

--- a/src/components/search/GlobalSearchPalette.tsx
+++ b/src/components/search/GlobalSearchPalette.tsx
@@ -11,9 +11,12 @@ import {
   Megaphone,
   MessageSquare,
   Search,
+  Settings,
+  User,
   Users,
   X,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useGlobalSearch, type GlobalSearchMode } from "./GlobalSearchProvider";
 import { trackBehavioralEvent } from "@/lib/analytics/events";
 import { detectIntent } from "@/lib/search/intent-fallback";
@@ -104,7 +107,7 @@ function entityLabel(entityType: string) {
 }
 
 export function GlobalSearchPalette() {
-  const { orgSlug, orgId, open, setOpen } = useGlobalSearch();
+  const { orgSlug, orgId, currentProfileHref, open, setOpen } = useGlobalSearch();
   const router = useRouter();
   const [query, setQuery] = useState("");
   const [mode, setMode] = useState<GlobalSearchMode>("fast");
@@ -242,6 +245,25 @@ export function GlobalSearchPalette() {
     [orgId, mode, orgSlug, query, router, setOpen],
   );
 
+  const runAction = useCallback(
+    (id: string, href: string) => {
+      trackBehavioralEvent("search_action_click", { action: id }, orgId);
+      setOpen(false);
+      router.push(href);
+    },
+    [orgId, router, setOpen],
+  );
+
+  const actions = useMemo(() => {
+    const items: { id: string; label: string; href: string; icon: LucideIcon }[] = [];
+    if (currentProfileHref) {
+      items.push({ id: "profile", label: "Profile", href: currentProfileHref, icon: User });
+    }
+    items.push({ id: "calendar", label: "Calendar", href: `/${orgSlug}/calendar`, icon: CalendarDays });
+    items.push({ id: "settings", label: "Settings", href: `/${orgSlug}/settings/invites`, icon: Settings });
+    return items;
+  }, [currentProfileHref, orgSlug]);
+
   const announcementHint = mode === "ai" && /\bannouncement\b/i.test(query.trim());
 
   const dialogOverlay = isMobile
@@ -300,6 +322,27 @@ export function GlobalSearchPalette() {
       </div>
 
       <Command.List className="flex-1 min-h-0 overflow-y-auto p-2">
+        {actions.length > 0 && (
+          <Command.Group heading="Actions">
+            {actions.map((a) => {
+              const Icon = a.icon;
+              return (
+                <Command.Item
+                  key={a.id}
+                  value={`action:${a.id}`}
+                  onSelect={() => runAction(a.id, a.href)}
+                  className="flex cursor-pointer gap-3 rounded-lg px-2 py-2 text-left aria-selected:bg-muted aria-selected:text-org-secondary"
+                >
+                  <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+                  <div className="min-w-0 flex-1">
+                    <div className="line-clamp-1 text-sm font-medium text-foreground">{a.label}</div>
+                  </div>
+                </Command.Item>
+              );
+            })}
+          </Command.Group>
+        )}
+
         {query.trim().length === 0 && (
           <Command.Group heading="Recent">
             {recents.length === 0 ? (

--- a/src/components/search/GlobalSearchProvider.tsx
+++ b/src/components/search/GlobalSearchProvider.tsx
@@ -16,6 +16,7 @@ export type GlobalSearchMode = "fast" | "ai";
 type GlobalSearchContextValue = {
   orgSlug: string;
   orgId: string;
+  currentProfileHref?: string;
   open: boolean;
   setOpen: (open: boolean) => void;
   openSearch: () => void;
@@ -34,10 +35,12 @@ export function useGlobalSearch() {
 export function GlobalSearchProvider({
   orgSlug,
   orgId,
+  currentProfileHref,
   children,
 }: {
   orgSlug: string;
   orgId: string;
+  currentProfileHref?: string;
   children: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
@@ -80,8 +83,8 @@ export function GlobalSearchProvider({
   const openSearch = useCallback(() => setOpen(true), []);
 
   const value = useMemo(
-    () => ({ orgSlug, orgId, open, setOpen, openSearch }),
-    [orgSlug, orgId, open, openSearch],
+    () => ({ orgSlug, orgId, currentProfileHref, open, setOpen, openSearch }),
+    [orgSlug, orgId, currentProfileHref, open, openSearch],
   );
 
   return <GlobalSearchContext.Provider value={value}>{children}</GlobalSearchContext.Provider>;

--- a/src/components/search/OrgGlobalSearch.tsx
+++ b/src/components/search/OrgGlobalSearch.tsx
@@ -7,14 +7,16 @@ import { GlobalSearchPalette } from "./GlobalSearchPalette";
 export function OrgGlobalSearch({
   orgSlug,
   orgId,
+  currentProfileHref,
   children,
 }: {
   orgSlug: string;
   orgId: string;
+  currentProfileHref?: string;
   children: ReactNode;
 }) {
   return (
-    <GlobalSearchProvider orgSlug={orgSlug} orgId={orgId}>
+    <GlobalSearchProvider orgSlug={orgSlug} orgId={orgId} currentProfileHref={currentProfileHref}>
       {children}
       <GlobalSearchPalette />
     </GlobalSearchProvider>

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -23,6 +23,7 @@ export const BEHAVIORAL_EVENT_NAMES = [
   "chat_participants_change",
   "search_used",
   "search_result_click",
+  "search_action_click",
 ] as const;
 
 export type AnalyticsEventName = (typeof BEHAVIORAL_EVENT_NAMES)[number];


### PR DESCRIPTION
## Summary
- Pin Profile, Calendar, Settings as an Actions group at top of the ⌘K command palette
- Thread `currentProfileHref` through `GlobalSearchProvider` so Profile routes to user's member detail page (omitted for parent role with no member record)
- Add `search_action_click` behavioral analytics event

## Test plan
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run lint` clean
- [ ] Open ⌘K on `/{orgSlug}/feed`: Actions group renders first with Profile, Calendar, Settings
- [ ] Each item routes correctly and closes modal
- [ ] Type 1 char: Actions stay, entity results begin at 2 chars
- [ ] Sign in as parent role: Profile entry hidden, Calendar + Settings visible
- [ ] Mobile viewport: Actions render in full-screen palette