### PR TITLE
fix(landing): trial copy requires credit card

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -382,7 +382,7 @@ export default async function LandingPage() {
           </p>
 
           <p className="scroll-reveal text-sm text-landing-cream/40 mb-10">
-            Free to get started. No credit card required.
+            Start with a free trial. Credit card required.
           </p>
 
           <div className="scroll-reveal flex flex-col sm:flex-row gap-4 justify-center">

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -71,7 +71,7 @@ export const FAQ_ITEMS = [
   },
   {
     question: "Is there a free trial?",
-    answer: "Every organization starts with a free trial — no credit card required. You can explore the full platform, invite members, and set up your community before committing to a paid plan.",
+    answer: "Every organization can start with a free trial. A credit card is required up front, and billing begins when the trial ends unless you cancel.",
   },
   {
     question: "What happens to my data if I cancel?",


### PR DESCRIPTION
Aligns marketing copy with billing: trial messaging now states a credit card is required.

**Files:** `src/app/page.tsx`, `src/lib/pricing.ts`

Quality: `npx tsc --noEmit`, `npm run lint` (clean).