### PR TITLE
fix(enterprise): critical batch org wizard fixes (C1, H4, H5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1110,6 +1111,7 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -1475,6 +1477,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -1649,6 +1652,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.2.tgz",
       "integrity": "sha512-GlC5me7/WlyS1ZCpwLoCm7ezggRWxyMxfckDhtnJvGanoVZAOnCKSqrNkjmDF8aufdh/kOoXRc/P3zJ/eUKMTg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.103.2",
         "@supabase/functions-js": "2.103.2",
@@ -1980,6 +1984,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1991,6 +1996,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2055,6 +2061,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -2573,6 +2580,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3998,6 +4006,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4167,6 +4176,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4814,6 +4824,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6026,6 +6037,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8092,6 +8104,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8374,6 +8387,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8386,6 +8400,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8399,6 +8414,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9765,6 +9781,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10415,6 +10432,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1566,9 +1566,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.2.tgz",
-      "integrity": "sha512-gHCp8J7TJ3ZrNsT5NiJt8Sa5SK7QnotUtxkBEaJ/vuimZ6MsWn6p4JWoDc01uZBmJTiISH3gQqTF2/S+kglDIw==",
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.104.0.tgz",
+      "integrity": "sha512-Vs0ndL+s5an7rOmXtS/nbYnGXL8m+KXlCSrPIcw9bR96ma6qyLYILnE6syuM+rpDnf+Tg4PVNxNB2+oDwoy6mA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1578,9 +1578,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.2.tgz",
-      "integrity": "sha512-VescBNuZPVcoFpH3R44YbLDDFPZnMtzBHuY1cNyL75h8Vlw9YBHv9qztVgDalKRoeA9wNQhuHqawXdTgCobhIQ==",
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.104.0.tgz",
+      "integrity": "sha512-O8EyEz/RT1kfWhyJNpVc/VbLeBsohHGBVif/CI83zoMB+Iul/t/NIekH1/7RsH6kuO+b2D4wJhfiaW8Qr47sRg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1596,9 +1596,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.2.tgz",
-      "integrity": "sha512-Qi9Dn0azoI/RhaVnZsggeQg6MY+7jg3jHVPt2vlh9nojMjOBniTbBeSrdSSEdufpbwXxPne3Z13OPva1VmC9CA==",
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.104.0.tgz",
+      "integrity": "sha512-ynylEq6wduQEycj6pL3P+/yIfDQ+CTnBC5I6p+PzcAO2ybj9coAITVtMfboi+g/dacgMslN5MH73rXsRMB29+Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1608,9 +1608,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.2.tgz",
-      "integrity": "sha512-zj/JruFaSJScdtq0W2cI+WbLuQmwYBD8i++0YFlzwyAeeZy9RwEAfjT1mkvhBNHPCy2V4LIsE4F0rAHSGR8AOg==",
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.104.0.tgz",
+      "integrity": "sha512-9fUVDoTVAhn7a79+AmEx+asUlRtf2yBrji7TQckcKn/WK4hvAA9Lia9er+lnhuz3WNiF1x6kkA4x7bRCJrU+KA==",
       "license": "MIT",
       "dependencies": {
         "@supabase/phoenix": "^0.4.0",
@@ -1635,9 +1635,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.2.tgz",
-      "integrity": "sha512-d40lZ29EyWJ4cOTtSBH4myaRuYSa9kOdt+NFkUmR+a3SAy2VpbdI1/nE3QWIrdifOa4pxTo8RXGC3BngPMVhRw==",
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.104.0.tgz",
+      "integrity": "sha512-s2NHtuAWb9nldJ/fS62WnJE6edvCWn31rrO+FJKlAohs99qdVgtLegUReTU2H9WnZiQlVqaBtu386wt6/6lrRw==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -1648,26 +1648,26 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.2.tgz",
-      "integrity": "sha512-GlC5me7/WlyS1ZCpwLoCm7ezggRWxyMxfckDhtnJvGanoVZAOnCKSqrNkjmDF8aufdh/kOoXRc/P3zJ/eUKMTg==",
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.104.0.tgz",
+      "integrity": "sha512-hILwhIjCB53G31jlHUe73NDEmrXudcjcYlVRuvNfEhzf0gyFQaFf7j6rd1UGmYZkFMOg//DFE8Iy9ZbNEgosVw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@supabase/auth-js": "2.103.2",
-        "@supabase/functions-js": "2.103.2",
-        "@supabase/postgrest-js": "2.103.2",
-        "@supabase/realtime-js": "2.103.2",
-        "@supabase/storage-js": "2.103.2"
+        "@supabase/auth-js": "2.104.0",
+        "@supabase/functions-js": "2.104.0",
+        "@supabase/postgrest-js": "2.104.0",
+        "@supabase/realtime-js": "2.104.0",
+        "@supabase/storage-js": "2.104.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.26.tgz",
-      "integrity": "sha512-OmcP96CFsNOwa65tamQayRcfqhNlcQ3YCWOq+0Wb+CAM4uB7kOMrXY41Gj4atthxrGhLQ9pg7Vk26iApb88idA==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.30.tgz",
+      "integrity": "sha512-VvpP+vq08HmGYewMWvrdsxh9s2lthz/808zXm8Yu5kaqeR8Yia2b0eYXleHQ3VAjoStUDk6LzTheBW9KXYQdMA==",
       "cpu": [
         "arm64"
       ],
@@ -1681,9 +1681,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.26.tgz",
-      "integrity": "sha512-liTTTpKSv89ivIxcZ+iU1cRige9Y7JkOjVnJ2Ystzl+DsWNHqt7wLTTgm/u7gEqmmAS2JKryODLQn3q1UtFNPQ==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.30.tgz",
+      "integrity": "sha512-WiJA0hiZI3nwQAO6mu5RqigtWGDtth4Hiq6rbZxAaQyhIcqKIg5IoMRc1Y071lrNJn29eEDMC86Rq58xgUxlDg==",
       "cpu": [
         "x64"
       ],
@@ -1697,9 +1697,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.26.tgz",
-      "integrity": "sha512-Y/g+m3I8CeBof5A3kWWOS6QA2HOIUytF5EeTgfwcAK+GKT/tGe7Xqo5svBtaqflU5od2zzbMTWqkinPXgRWGgA==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.30.tgz",
+      "integrity": "sha512-YANuFUo48kIT6plJgCD0keae9HFXfjxsbvsgevqc0hr/07X/p7sAWTFOGYEc2SXcASaK7UvuQqzlbW8pr7R79g==",
       "cpu": [
         "arm"
       ],
@@ -1713,9 +1713,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.26.tgz",
-      "integrity": "sha512-19IvwyPfBN/rz9s7qXhOTQmW0922+pjpRUUvIebu+CMM75nX6YuDzHsGx8hSmn5dS89SNaMCh1lgUuXqm++6jg==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.30.tgz",
+      "integrity": "sha512-VndG8jaR4ugY6u+iVOT0Q+d2fZd7sLgjPgN8W/Le+3EbZKl+cRfFxV7Eoz4gfLqhmneZPdcIzf9T3LkgkmqNLg==",
       "cpu": [
         "arm64"
       ],
@@ -1729,9 +1729,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.26.tgz",
-      "integrity": "sha512-iNlbvTIo425rkKzDLLWFJGnFXr3myETUdIDHcjuiPNZE8b0ogmcAuilC4yEJX7FSHGbnlsoJcCT2xf4b3VJmmQ==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.30.tgz",
+      "integrity": "sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA==",
       "cpu": [
         "arm64"
       ],
@@ -1745,9 +1745,9 @@
       }
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.26.tgz",
-      "integrity": "sha512-AuuEOtG+YXKIjIUup4RsxYNklx6XVB3WKWfhxG6hnfPrn7vp89RNOLbbyyprgj6Sk7k9ulwGVTJElEvmBNPSCA==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.30.tgz",
+      "integrity": "sha512-TXREtiXeRhbfDFbmhnkIsXpKfzbfT73YkV2ZF6w0sfxgjC5zI2ZAbaCOq25qxvegofj2K93DtOpm9RLaBgqR2g==",
       "cpu": [
         "ppc64"
       ],
@@ -1761,9 +1761,9 @@
       }
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.26.tgz",
-      "integrity": "sha512-JcMDWQvW1BchUyRg8E0jHiTx7CQYpUr5uDEL1dnPDECrEjBEGG2ynmJ3XX70sWXql0JagqR1t3VpANYFWdUnqA==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.30.tgz",
+      "integrity": "sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g==",
       "cpu": [
         "s390x"
       ],
@@ -1777,9 +1777,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.26.tgz",
-      "integrity": "sha512-FW7V7Mbpq4+PA7BiAq76LJs8MdNuUSylyuRVfQRkhIyeWadFroZ+KOPgjku8Z/fXzngxBRvsk+PGGB0t8mGcjA==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.30.tgz",
+      "integrity": "sha512-5Pizw3NgfOJ5BJOBK8TIRa59xFW2avESTOBDPTAYwZYa1JNDs+KMF9lUfjJiJLM5HiMs/wPheA9eiT0q9m2AoA==",
       "cpu": [
         "x64"
       ],
@@ -1793,9 +1793,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.26.tgz",
-      "integrity": "sha512-w8erqMHsVcdGwUfJxF6LaiTuPoKnyLOcUbhLcxiXrlLt5MLjtlgcIeUY/NWK/oPoyqkgH+/i8pOJnMTxvl83ZQ==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.30.tgz",
+      "integrity": "sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA==",
       "cpu": [
         "x64"
       ],
@@ -1809,9 +1809,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.26.tgz",
-      "integrity": "sha512-uDCWCNpUiqkbvPmsuPUTn/P7ag9SqNXD2JT/W3dUu7yZ2krzN+nmmoQ2xRX63/J6RYiHI7aT4jo7Z++lsljlPA==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.30.tgz",
+      "integrity": "sha512-CaQENgDHVGOg1mSF5sQVgvfFHG9kjMor2rkLMLeLOkfZYNj13ppnJ9+lfaBZLZUMMbnlGQnavCJb8PVBUOso7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1825,9 +1825,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.26.tgz",
-      "integrity": "sha512-2k1ax1QmmqLEnpC0uRCw7OXhBfyvdPqERBXupDasjYbChT6ZSO/uha28Bp38cw0viKIG79L27aTDkbkABsMW3w==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.30.tgz",
+      "integrity": "sha512-30VdLeGk6fugiUs/kUdJ/pAg7z/zpvVbR11RH60jZ0Z42WIeIniYx0rLEWN7h/pKJ3CopqsQ3RsogCAkRKiA2g==",
       "cpu": [
         "ia32"
       ],
@@ -1841,9 +1841,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.26.tgz",
-      "integrity": "sha512-aUuYecSEGa4SUSdyCWaI/vk8jdseifYnsF1GZQx2+piL8GIuT/5QrVcFfmes4Iwy7FIVXxtzD063z/FfpZ7K7w==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.30.tgz",
+      "integrity": "sha512-4iObHPR+Q4oDY110EF5SF5eIaaVJNpMdG9C0q3Q92BsJ5y467uHz7sYQhP60WYlLFsLQ1el2YrIPUItUAQGOKg==",
       "cpu": [
         "x64"
       ],
@@ -2017,17 +2017,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/type-utils": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2040,7 +2040,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.2",
+        "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2056,17 +2056,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2082,14 +2082,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2104,14 +2104,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2122,9 +2122,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2139,15 +2139,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2164,9 +2164,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2178,16 +2178,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2245,16 +2245,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2269,13 +2269,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.59.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4176,7 +4176,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4570,9 +4569,9 @@
       "optional": true
     },
     "node_modules/fast-check": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
-      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
       "dev": true,
       "funding": [
         {
@@ -5285,9 +5284,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7396,9 +7395,9 @@
       "license": "MIT"
     },
     "node_modules/next-intl/node_modules/@swc/core": {
-      "version": "1.15.26",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.26.tgz",
-      "integrity": "sha512-tglZGyx8N5PC+x1Nd/JrZxqpqlcZoSuG9gTDKO6AuFToFiVB3uS8HvbKFuO7g3lJzvFf9riAb94xs9HU2UhAHQ==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.30.tgz",
+      "integrity": "sha512-R8VQbQY1BZcbIF2p3gjlTCwAQzx1A194ugWfwld5y+WgVVWqVKm7eURGGOVbQVubgKWzidP2agomBbg96rZilQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7413,18 +7412,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.26",
-        "@swc/core-darwin-x64": "1.15.26",
-        "@swc/core-linux-arm-gnueabihf": "1.15.26",
-        "@swc/core-linux-arm64-gnu": "1.15.26",
-        "@swc/core-linux-arm64-musl": "1.15.26",
-        "@swc/core-linux-ppc64-gnu": "1.15.26",
-        "@swc/core-linux-s390x-gnu": "1.15.26",
-        "@swc/core-linux-x64-gnu": "1.15.26",
-        "@swc/core-linux-x64-musl": "1.15.26",
-        "@swc/core-win32-arm64-msvc": "1.15.26",
-        "@swc/core-win32-ia32-msvc": "1.15.26",
-        "@swc/core-win32-x64-msvc": "1.15.26"
+        "@swc/core-darwin-arm64": "1.15.30",
+        "@swc/core-darwin-x64": "1.15.30",
+        "@swc/core-linux-arm-gnueabihf": "1.15.30",
+        "@swc/core-linux-arm64-gnu": "1.15.30",
+        "@swc/core-linux-arm64-musl": "1.15.30",
+        "@swc/core-linux-ppc64-gnu": "1.15.30",
+        "@swc/core-linux-s390x-gnu": "1.15.30",
+        "@swc/core-linux-x64-gnu": "1.15.30",
+        "@swc/core-linux-x64-musl": "1.15.30",
+        "@swc/core-win32-arm64-msvc": "1.15.30",
+        "@swc/core-win32-ia32-msvc": "1.15.30",
+        "@swc/core-win32-x64-msvc": "1.15.30"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -7433,6 +7432,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-themes": {
@@ -8410,9 +8420,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.72.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
-      "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
+      "version": "7.73.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.73.1.tgz",
+      "integrity": "sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -8707,9 +8717,9 @@
       "license": "ISC"
     },
     "node_modules/resend": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.0.tgz",
-      "integrity": "sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
       "license": "MIT",
       "dependencies": {
         "postal-mime": "2.7.4",
@@ -8833,15 +8843,15 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },

--- a/src/app/api/enterprise/[enterpriseId]/members/route.ts
+++ b/src/app/api/enterprise/[enterpriseId]/members/route.ts
@@ -87,7 +87,7 @@ export async function GET(req: Request, { params }: RouteParams) {
     .order("id", { ascending: true });
 
   if (after) {
-    userQuery = userQuery.gte("id", after);
+    userQuery = userQuery.gt("id", after);
   }
 
   const { data: usersPage, error: usersPageError } = await userQuery.limit(limit + 1) as {

--- a/src/app/api/enterprise/[enterpriseId]/organizations/create-with-upgrade/route.ts
+++ b/src/app/api/enterprise/[enterpriseId]/organizations/create-with-upgrade/route.ts
@@ -52,6 +52,11 @@ const createOrgWithUpgradeSchema = z
     primary_color: baseSchemas.hexColor.optional(),
     expectedCurrentQuantity: z.number().int().min(1).max(1000).optional(),
     billingType: z.literal("enterprise_managed").default("enterprise_managed"),
+    // Hard block: client must explicitly confirm the upgrade before we bump
+    // the seat quantity and charge. Absence returns 402 with a cost preview
+    // so the frontend can surface a confirmation modal. See requirements doc:
+    // docs/brainstorms/2026-04-20-enterprise-bulk-org-wizard-requirements.md
+    confirmUpgrade: z.boolean().optional(),
   })
   .strict();
 
@@ -87,6 +92,7 @@ export async function POST(req: Request, { params }: RouteParams) {
       purpose,
       primary_color,
       expectedCurrentQuantity,
+      confirmUpgrade,
     } = body;
 
     const slugAvailability = await ensureEnterpriseSlugAvailable(
@@ -147,6 +153,60 @@ export async function POST(req: Request, { params }: RouteParams) {
       counts?.enterprise_managed_org_count ?? 0,
       getFreeSubOrgCount(bucketQuantity)
     );
+    const requestedQuantity = currentQuantity + 1;
+
+    // Hard block: this route bumps the paid seat quantity by +1. Per the
+    // bulk-org-wizard requirements, admins must explicitly confirm before we
+    // charge. Mirrors the 402 needsUpgrade convention from batch-create so the
+    // frontend can render a confirm modal with cost preview, then retry with
+    // confirmUpgrade: true.
+    if (confirmUpgrade !== true) {
+      const currentPricing = getSubOrgPricing(
+        currentQuantity,
+        subscription.billing_interval,
+        bucketQuantity
+      );
+      const projectedPricing = getSubOrgPricing(
+        requestedQuantity,
+        subscription.billing_interval,
+        bucketQuantity
+      );
+
+      return respond(
+        {
+          error: "Upgrade confirmation required to add another organization",
+          needsUpgrade: true,
+          currentCount: counts?.enterprise_managed_org_count ?? 0,
+          maxAllowed: subscription.sub_org_quantity,
+          remaining:
+            subscription.sub_org_quantity != null
+              ? Math.max(
+                  subscription.sub_org_quantity -
+                    (counts?.enterprise_managed_org_count ?? 0),
+                  0
+                )
+              : null,
+          currentQuantity,
+          requestedQuantity,
+          billingInterval: subscription.billing_interval,
+          costPreview: {
+            current: {
+              freeOrgs: currentPricing.freeOrgs,
+              billableOrgs: currentPricing.billableOrgs,
+              totalCents: currentPricing.totalCents,
+            },
+            projected: {
+              freeOrgs: projectedPricing.freeOrgs,
+              billableOrgs: projectedPricing.billableOrgs,
+              totalCents: projectedPricing.totalCents,
+            },
+            additionalCents: projectedPricing.totalCents - currentPricing.totalCents,
+            unitCents: projectedPricing.unitCents,
+          },
+        },
+        402
+      );
+    }
 
     const adjustment = await adjustEnterpriseSubOrgQuantity({
       serviceSupabase: ctx.serviceSupabase,
@@ -154,7 +214,7 @@ export async function POST(req: Request, { params }: RouteParams) {
       userId: ctx.userId,
       userEmail: ctx.userEmail,
       req,
-      newQuantity: currentQuantity + 1,
+      newQuantity: requestedQuantity,
       expectedCurrentQuantity,
     });
 

--- a/src/components/enterprise/CreateSubOrgForm.tsx
+++ b/src/components/enterprise/CreateSubOrgForm.tsx
@@ -150,6 +150,9 @@ export function CreateSubOrgForm({
           primary_color: pendingFormData.primaryColor,
           expectedCurrentQuantity: upgradeInfo?.maxAllowed,
           billingType: pendingFormData.billingType,
+          // Hard-block protocol: server requires this flag before bumping the
+          // seat quantity. The user has just confirmed in OrgLimitUpgradeModal.
+          confirmUpgrade: true,
         }),
       });
 

--- a/src/lib/enterprise/member-list.ts
+++ b/src/lib/enterprise/member-list.ts
@@ -63,9 +63,10 @@ export function paginateEnterpriseMemberUsers(
   nextCursor: string | null;
 } {
   const hasMore = users.length > limit;
+  const trimmed = users.slice(0, limit);
   return {
-    users: users.slice(0, limit),
-    nextCursor: hasMore ? users[limit].id : null,
+    users: trimmed,
+    nextCursor: hasMore && trimmed.length > 0 ? trimmed[trimmed.length - 1].id : null,
   };
 }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1957,6 +1957,112 @@ export type Database = {
           },
         ]
       }
+      dsr_requests: {
+        Row: {
+          ack_due_at: string
+          acknowledged_at: string | null
+          acknowledgement_method: string | null
+          created_at: string
+          deleted_at: string | null
+          id: string
+          linked_access_log_id: string | null
+          linked_deletion_request_id: string | null
+          organization_id: string | null
+          received_at: string
+          request_type: string
+          requester_email: string | null
+          requester_name: string | null
+          requester_relationship: string
+          resolution_method: string | null
+          resolution_notes: string | null
+          resolve_due_at: string
+          resolved_at: string | null
+          school_owner_user_id: string | null
+          source: string
+          status: string
+          subject_identifier: string | null
+          subject_identifier_type: string | null
+          subject_user_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          ack_due_at?: string
+          acknowledged_at?: string | null
+          acknowledgement_method?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          linked_access_log_id?: string | null
+          linked_deletion_request_id?: string | null
+          organization_id?: string | null
+          received_at?: string
+          request_type: string
+          requester_email?: string | null
+          requester_name?: string | null
+          requester_relationship: string
+          resolution_method?: string | null
+          resolution_notes?: string | null
+          resolve_due_at?: string
+          resolved_at?: string | null
+          school_owner_user_id?: string | null
+          source: string
+          status?: string
+          subject_identifier?: string | null
+          subject_identifier_type?: string | null
+          subject_user_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          ack_due_at?: string
+          acknowledged_at?: string | null
+          acknowledgement_method?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          linked_access_log_id?: string | null
+          linked_deletion_request_id?: string | null
+          organization_id?: string | null
+          received_at?: string
+          request_type?: string
+          requester_email?: string | null
+          requester_name?: string | null
+          requester_relationship?: string
+          resolution_method?: string | null
+          resolution_notes?: string | null
+          resolve_due_at?: string
+          resolved_at?: string | null
+          school_owner_user_id?: string | null
+          source?: string
+          status?: string
+          subject_identifier?: string | null
+          subject_identifier_type?: string | null
+          subject_user_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "dsr_requests_linked_access_log_id_fkey"
+            columns: ["linked_access_log_id"]
+            isOneToOne: false
+            referencedRelation: "data_access_log"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "dsr_requests_linked_deletion_request_id_fkey"
+            columns: ["linked_deletion_request_id"]
+            isOneToOne: false
+            referencedRelation: "user_deletion_requests"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "dsr_requests_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       enterprise_adoption_requests: {
         Row: {
           enterprise_id: string
@@ -3676,6 +3782,122 @@ export type Database = {
           },
         ]
       }
+      mentee_preferences: {
+        Row: {
+          communication_prefs: string[]
+          created_at: string
+          geographic_pref: string | null
+          goals: string | null
+          id: string
+          nice_to_have_attributes: string[]
+          organization_id: string
+          preferred_industries: string[]
+          preferred_positions: string[]
+          preferred_role_families: string[]
+          preferred_sports: string[]
+          preferred_topics: string[]
+          required_attributes: string[]
+          seeking_mentorship: boolean
+          time_availability: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          communication_prefs?: string[]
+          created_at?: string
+          geographic_pref?: string | null
+          goals?: string | null
+          id?: string
+          nice_to_have_attributes?: string[]
+          organization_id: string
+          preferred_industries?: string[]
+          preferred_positions?: string[]
+          preferred_role_families?: string[]
+          preferred_sports?: string[]
+          preferred_topics?: string[]
+          required_attributes?: string[]
+          seeking_mentorship?: boolean
+          time_availability?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          communication_prefs?: string[]
+          created_at?: string
+          geographic_pref?: string | null
+          goals?: string | null
+          id?: string
+          nice_to_have_attributes?: string[]
+          organization_id?: string
+          preferred_industries?: string[]
+          preferred_positions?: string[]
+          preferred_role_families?: string[]
+          preferred_sports?: string[]
+          preferred_topics?: string[]
+          required_attributes?: string[]
+          seeking_mentorship?: boolean
+          time_availability?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "mentee_preferences_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      mentor_bio_backfill_queue: {
+        Row: {
+          attempts: number
+          created_at: string
+          error: string | null
+          id: string
+          mentor_profile_id: string
+          organization_id: string
+          processed_at: string | null
+          updated_at: string
+        }
+        Insert: {
+          attempts?: number
+          created_at?: string
+          error?: string | null
+          id?: string
+          mentor_profile_id: string
+          organization_id: string
+          processed_at?: string | null
+          updated_at?: string
+        }
+        Update: {
+          attempts?: number
+          created_at?: string
+          error?: string | null
+          id?: string
+          mentor_profile_id?: string
+          organization_id?: string
+          processed_at?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "mentor_bio_backfill_queue_mentor_profile_id_fkey"
+            columns: ["mentor_profile_id"]
+            isOneToOne: false
+            referencedRelation: "mentor_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "mentor_bio_backfill_queue_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       mentor_profiles: {
         Row: {
           accepting_new: boolean
@@ -3691,10 +3913,14 @@ export type Database = {
           custom_attributes: Json
           expertise_areas: string[]
           id: string
+          industries: string[]
           is_active: boolean
           max_mentees: number
           meeting_preferences: string[]
           organization_id: string
+          positions: string[]
+          role_families: string[]
+          sports: string[]
           time_commitment: string | null
           topics: string[]
           updated_at: string
@@ -3715,10 +3941,14 @@ export type Database = {
           custom_attributes?: Json
           expertise_areas?: string[]
           id?: string
+          industries?: string[]
           is_active?: boolean
           max_mentees?: number
           meeting_preferences?: string[]
           organization_id: string
+          positions?: string[]
+          role_families?: string[]
+          sports?: string[]
           time_commitment?: string | null
           topics?: string[]
           updated_at?: string
@@ -3739,10 +3969,14 @@ export type Database = {
           custom_attributes?: Json
           expertise_areas?: string[]
           id?: string
+          industries?: string[]
           is_active?: boolean
           max_mentees?: number
           meeting_preferences?: string[]
           organization_id?: string
+          positions?: string[]
+          role_families?: string[]
+          sports?: string[]
           time_commitment?: string | null
           topics?: string[]
           updated_at?: string
@@ -3807,54 +4041,6 @@ export type Database = {
             columns: ["pair_id"]
             isOneToOne: false
             referencedRelation: "mentorship_pairs"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      mentor_bio_backfill_queue: {
-        Row: {
-          attempts: number
-          created_at: string
-          error: string | null
-          id: string
-          mentor_profile_id: string
-          organization_id: string
-          processed_at: string | null
-          updated_at: string
-        }
-        Insert: {
-          attempts?: number
-          created_at?: string
-          error?: string | null
-          id?: string
-          mentor_profile_id: string
-          organization_id: string
-          processed_at?: string | null
-          updated_at?: string
-        }
-        Update: {
-          attempts?: number
-          created_at?: string
-          error?: string | null
-          id?: string
-          mentor_profile_id?: string
-          organization_id?: string
-          processed_at?: string | null
-          updated_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "mentor_bio_backfill_queue_mentor_profile_id_fkey"
-            columns: ["mentor_profile_id"]
-            isOneToOne: false
-            referencedRelation: "mentor_profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "mentor_bio_backfill_queue_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organizations"
             referencedColumns: ["id"]
           },
         ]
@@ -4037,6 +4223,41 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "mentorship_pairs_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      mentorship_reminders: {
+        Row: {
+          created_at: string
+          id: string
+          mentor_user_id: string
+          organization_id: string
+          pending_count: number
+          sent_by: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          mentor_user_id: string
+          organization_id: string
+          pending_count: number
+          sent_by: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          mentor_user_id?: string
+          organization_id?: string
+          pending_count?: number
+          sent_by?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "mentorship_reminders_organization_id_fkey"
             columns: ["organization_id"]
             isOneToOne: false
             referencedRelation: "organizations"
@@ -4695,6 +4916,7 @@ export type Database = {
           original_subscription_id: string | null
           original_subscription_status: string | null
           primary_color: string | null
+          purpose: string | null
           require_invite_approval: boolean
           secondary_color: string | null
           settings: Json
@@ -4726,6 +4948,7 @@ export type Database = {
           original_subscription_id?: string | null
           original_subscription_status?: string | null
           primary_color?: string | null
+          purpose?: string | null
           require_invite_approval?: boolean
           secondary_color?: string | null
           settings?: Json
@@ -4757,6 +4980,7 @@ export type Database = {
           original_subscription_id?: string | null
           original_subscription_status?: string | null
           primary_color?: string | null
+          purpose?: string | null
           require_invite_approval?: boolean
           secondary_color?: string | null
           settings?: Json
@@ -6073,6 +6297,10 @@ export type Database = {
       }
     }
     Functions: {
+      _donation_is_settled: {
+        Args: { p_deleted_at: string; p_status: string }
+        Returns: boolean
+      }
       accept_mentorship_proposal: {
         Args: { admin_override?: boolean; pair_id: string }
         Returns: {
@@ -6110,7 +6338,6 @@ export type Database = {
       assert_parents_quota: { Args: { p_org_id: string }; Returns: undefined }
       backfill_ai_embedding_queue: { Args: { p_org_id: string }; Returns: Json }
       backfill_graph_sync_queue: { Args: { p_org_id: string }; Returns: Json }
-      backfill_mentor_bio_queue: { Args: { p_org_id: string }; Returns: Json }
       backfill_ip_hashes: {
         Args: { salt: string }
         Returns: {
@@ -6118,17 +6345,13 @@ export type Database = {
           updated_count: number
         }[]
       }
-      dequeue_mentor_bio_backfill_queue: {
-        Args: { p_batch_size?: number }
+      backfill_mentor_bio_queue: { Args: { p_org_id: string }; Returns: Json }
+      batch_create_enterprise_orgs: {
+        Args: { p_enterprise_id: string; p_orgs: Json; p_user_id: string }
         Returns: {
-          attempts: number
-          created_at: string
-          error: string | null
-          id: string
-          mentor_profile_id: string
-          organization_id: string
-          processed_at: string | null
-          updated_at: string
+          out_org_id: string
+          out_slug: string
+          out_status: string
         }[]
       }
       bulk_import_alumni_rich: {
@@ -6358,6 +6581,25 @@ export type Database = {
           isSetofReturn: true
         }
       }
+      dequeue_mentor_bio_backfill_queue: {
+        Args: { p_batch_size?: number }
+        Returns: {
+          attempts: number
+          created_at: string
+          error: string | null
+          id: string
+          mentor_profile_id: string
+          organization_id: string
+          processed_at: string | null
+          updated_at: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "mentor_bio_backfill_queue"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
       enrich_alumni_by_id: {
         Args: {
           p_alumni_id: string
@@ -6380,8 +6622,41 @@ export type Database = {
         Returns: string[]
       }
       get_alumni_quota: { Args: { p_org_id: string }; Returns: Json }
+      get_donation_analytics: {
+        Args: {
+          p_bucket: string
+          p_org_id: string
+          p_top_purposes_limit: number
+          p_window_days: number
+        }
+        Returns: Json
+      }
       get_dropdown_options: { Args: { p_org_id: string }; Returns: Json }
+      get_dsr_requests_due_soon: {
+        Args: { p_org_id: string; p_window_days?: number }
+        Returns: {
+          ack_due_at: string
+          acknowledged_at: string
+          due_at: string
+          due_phase: string
+          id: string
+          organization_id: string
+          received_at: string
+          request_type: string
+          requester_email: string
+          requester_name: string
+          requester_relationship: string
+          resolve_due_at: string
+          school_owner_user_id: string
+          source: string
+          status: string
+        }[]
+      }
       get_enterprise_alumni_stats: {
+        Args: { p_enterprise_id: string }
+        Returns: Json
+      }
+      get_enterprise_counts: {
         Args: { p_enterprise_id: string }
         Returns: Json
       }
@@ -6425,6 +6700,7 @@ export type Database = {
         Args: { allowed_roles: string[]; org: string }
         Returns: boolean
       }
+      has_dsr_compliance_role: { Args: never; Returns: boolean }
       increment_ai_queue_attempts: {
         Args: { p_error: string; p_id: string }
         Returns: undefined

--- a/supabase/migrations/20261020199000_organizations_add_purpose.sql
+++ b/supabase/migrations/20261020199000_organizations_add_purpose.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.organizations ADD COLUMN IF NOT EXISTS purpose text;
+COMMENT ON COLUMN public.organizations.purpose IS 'Why this organization exists (visible to members). Distinct from description, which covers what the org does.';

--- a/tests/routes/enterprise/create-with-upgrade-confirm.test.ts
+++ b/tests/routes/enterprise/create-with-upgrade-confirm.test.ts
@@ -1,0 +1,182 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { resolveCurrentQuantity } from "@/lib/enterprise/quota-logic";
+import { getSubOrgPricing, getFreeSubOrgCount } from "@/lib/enterprise/pricing";
+
+interface SimulationParams {
+  rawQuantity: number | null;
+  currentManagedOrgCount: number;
+  bucketQuantity: number;
+  billingInterval: "month" | "year";
+  confirmUpgrade?: boolean;
+}
+
+interface AdjustmentInvocation {
+  newQuantity: number;
+  expectedCurrentQuantity?: number;
+}
+
+/**
+ * Mirrors the route's hard-block branch: if confirmUpgrade !== true, return
+ * 402 needsUpgrade with cost preview and never invoke the seat adjuster.
+ */
+function simulateHardBlock(params: SimulationParams) {
+  const currentQuantity = resolveCurrentQuantity(
+    params.rawQuantity,
+    params.currentManagedOrgCount,
+    getFreeSubOrgCount(params.bucketQuantity)
+  );
+  const requestedQuantity = currentQuantity + 1;
+
+  let adjustmentCalledWith: AdjustmentInvocation | null = null;
+
+  if (params.confirmUpgrade !== true) {
+    const currentPricing = getSubOrgPricing(
+      currentQuantity,
+      params.billingInterval,
+      params.bucketQuantity
+    );
+    const projectedPricing = getSubOrgPricing(
+      requestedQuantity,
+      params.billingInterval,
+      params.bucketQuantity
+    );
+
+    return {
+      status: 402,
+      body: {
+        error: "Upgrade confirmation required to add another organization",
+        needsUpgrade: true,
+        currentCount: params.currentManagedOrgCount,
+        maxAllowed: params.rawQuantity,
+        currentQuantity,
+        requestedQuantity,
+        billingInterval: params.billingInterval,
+        costPreview: {
+          current: {
+            freeOrgs: currentPricing.freeOrgs,
+            billableOrgs: currentPricing.billableOrgs,
+            totalCents: currentPricing.totalCents,
+          },
+          projected: {
+            freeOrgs: projectedPricing.freeOrgs,
+            billableOrgs: projectedPricing.billableOrgs,
+            totalCents: projectedPricing.totalCents,
+          },
+          additionalCents: projectedPricing.totalCents - currentPricing.totalCents,
+          unitCents: projectedPricing.unitCents,
+        },
+      },
+      adjustmentCalledWith,
+    };
+  }
+
+  // Confirmed path: invoke seat adjuster.
+  adjustmentCalledWith = {
+    newQuantity: requestedQuantity,
+    expectedCurrentQuantity: params.rawQuantity ?? undefined,
+  };
+
+  return {
+    status: 201,
+    body: { ok: true },
+    adjustmentCalledWith,
+  };
+}
+
+test("create-with-upgrade returns 402 needsUpgrade when confirmUpgrade is omitted", () => {
+  const result = simulateHardBlock({
+    rawQuantity: 4,
+    currentManagedOrgCount: 4,
+    bucketQuantity: 1,
+    billingInterval: "month",
+  });
+
+  assert.equal(result.status, 402);
+  assert.equal(result.body.needsUpgrade, true);
+  assert.equal(result.adjustmentCalledWith, null, "must not bump seat quantity without explicit confirmation");
+  assert.equal(result.body.currentQuantity, 4);
+  assert.equal(result.body.requestedQuantity, 5);
+  // Cost preview present so frontend can render confirm modal.
+  assert.ok(result.body.costPreview, "402 must include costPreview");
+});
+
+test("create-with-upgrade returns 402 when confirmUpgrade is explicitly false", () => {
+  const result = simulateHardBlock({
+    rawQuantity: 3,
+    currentManagedOrgCount: 3,
+    bucketQuantity: 1,
+    billingInterval: "month",
+    confirmUpgrade: false,
+  });
+
+  assert.equal(result.status, 402);
+  assert.equal(result.adjustmentCalledWith, null);
+});
+
+test("create-with-upgrade proceeds when confirmUpgrade is true", () => {
+  const result = simulateHardBlock({
+    rawQuantity: 4,
+    currentManagedOrgCount: 4,
+    bucketQuantity: 1,
+    billingInterval: "month",
+    confirmUpgrade: true,
+  });
+
+  assert.equal(result.status, 201);
+  assert.deepEqual(result.adjustmentCalledWith, {
+    newQuantity: 5,
+    expectedCurrentQuantity: 4,
+  });
+});
+
+test("create-with-upgrade cost preview reports non-zero additional charge when crossing free tier", () => {
+  // Bucket=1 → freeSubOrgs=3. Going from 3 → 4 orgs adds first billable org.
+  const result = simulateHardBlock({
+    rawQuantity: 3,
+    currentManagedOrgCount: 3,
+    bucketQuantity: 1,
+    billingInterval: "month",
+  });
+
+  assert.equal(result.status, 402);
+  const preview = result.body.costPreview as {
+    current: { billableOrgs: number; totalCents: number };
+    projected: { billableOrgs: number; totalCents: number };
+    additionalCents: number;
+  };
+  assert.equal(preview.current.billableOrgs, 0);
+  assert.equal(preview.projected.billableOrgs, 1);
+  assert.ok(preview.additionalCents > 0, "crossing free tier must report a positive additionalCents");
+});
+
+test("create-with-upgrade route source enforces confirmUpgrade hard block", () => {
+  const routePath = path.join(
+    process.cwd(),
+    "src/app/api/enterprise/[enterpriseId]/organizations/create-with-upgrade/route.ts"
+  );
+  const source = readFileSync(routePath, "utf8");
+
+  // Schema must accept the optional flag.
+  assert.match(source, /confirmUpgrade:\s*z\.boolean\(\)\.optional\(\)/);
+  // Route must short-circuit when the flag is missing.
+  assert.match(source, /confirmUpgrade\s*!==\s*true/);
+  // Hard-block response must be 402 with needsUpgrade payload (matches batch-create convention).
+  assert.match(source, /needsUpgrade:\s*true/);
+  assert.match(source, /402/);
+  // Cost preview must be returned so the frontend can render a confirm modal.
+  assert.match(source, /costPreview/);
+});
+
+test("create-with-upgrade frontend caller passes confirmUpgrade: true after modal confirm", () => {
+  const formPath = path.join(
+    process.cwd(),
+    "src/components/enterprise/CreateSubOrgForm.tsx"
+  );
+  const source = readFileSync(formPath, "utf8");
+
+  // The retry path (handleUpgradeConfirm) must include confirmUpgrade: true.
+  assert.match(source, /confirmUpgrade:\s*true/);
+});

--- a/tests/routes/enterprise/create-with-upgrade-quota.test.ts
+++ b/tests/routes/enterprise/create-with-upgrade-quota.test.ts
@@ -128,5 +128,6 @@ test("create-with-upgrade route uses resolveCurrentQuantity and the shared billi
 
   assert.match(source, /resolveCurrentQuantity\(/);
   assert.match(source, /adjustEnterpriseSubOrgQuantity\(/);
-  assert.match(source, /newQuantity:\s*currentQuantity\s*\+\s*1/);
+  assert.match(source, /requestedQuantity\s*=\s*currentQuantity\s*\+\s*1/);
+  assert.match(source, /newQuantity:\s*requestedQuantity/);
 });

--- a/tests/routes/enterprise/members-list.test.ts
+++ b/tests/routes/enterprise/members-list.test.ts
@@ -6,6 +6,7 @@ import {
   buildEnterpriseMembers,
   getActiveAdminOrgIds,
   paginateEnterpriseMemberUsers,
+  type EnterpriseMemberUserRow,
 } from "@/lib/enterprise/member-list";
 
 async function fetchAllEnterpriseMembers<T extends { userId: string }>(
@@ -42,7 +43,7 @@ test("member list scoping dedupes repeated active admin rows", () => {
   assert.deepEqual(scopedOrgIds, ["org-1", "org-2"]);
 });
 
-test("member pagination slices by unique users and advances with the extra user cursor", () => {
+test("member pagination slices by unique users and uses the last returned user id as cursor", () => {
   const page = paginateEnterpriseMemberUsers(
     [
       { id: "user-1", email: "one@example.com", name: "One" },
@@ -56,7 +57,72 @@ test("member pagination slices by unique users and advances with the extra user 
     page.users.map((user) => user.id),
     ["user-1", "user-2"]
   );
-  assert.equal(page.nextCursor, "user-3");
+  // Cursor MUST be the last id of the returned page (used with `.gt(cursor)` in the
+  // query), not the id of the extra peeked row. Returning the extra row's id paired
+  // with `.gte(cursor)` would duplicate that row on the next page.
+  assert.equal(page.nextCursor, "user-2");
+});
+
+test("member pagination returns null cursor when there is no next page", () => {
+  const page = paginateEnterpriseMemberUsers(
+    [
+      { id: "user-1", email: "one@example.com", name: "One" },
+      { id: "user-2", email: "two@example.com", name: "Two" },
+    ],
+    2
+  );
+
+  assert.deepEqual(
+    page.users.map((user) => user.id),
+    ["user-1", "user-2"]
+  );
+  assert.equal(page.nextCursor, null);
+});
+
+test("member pagination across consecutive pages yields no duplicates and no skips", () => {
+  // Simulate the DB layer: stable order by id, fetch limit+1, apply `.gt(after)`
+  // when a cursor is supplied. This mirrors the behavior of the route.
+  const allUsers: EnterpriseMemberUserRow[] = Array.from({ length: 5 }, (_, index) => ({
+    id: `user-${index + 1}`,
+    email: `user${index + 1}@example.com`,
+    name: `User ${index + 1}`,
+  }));
+
+  const limit = 2;
+
+  const fetchPeek = (after: string | null) => {
+    const filtered = after === null ? allUsers : allUsers.filter((user) => user.id > after);
+    return filtered.slice(0, limit + 1);
+  };
+
+  const firstPage = paginateEnterpriseMemberUsers(fetchPeek(null), limit);
+  assert.deepEqual(
+    firstPage.users.map((user) => user.id),
+    ["user-1", "user-2"]
+  );
+  assert.equal(firstPage.nextCursor, "user-2");
+
+  const secondPage = paginateEnterpriseMemberUsers(fetchPeek(firstPage.nextCursor), limit);
+  assert.deepEqual(
+    secondPage.users.map((user) => user.id),
+    ["user-3", "user-4"]
+  );
+  assert.equal(secondPage.nextCursor, "user-4");
+
+  const thirdPage = paginateEnterpriseMemberUsers(fetchPeek(secondPage.nextCursor), limit);
+  assert.deepEqual(
+    thirdPage.users.map((user) => user.id),
+    ["user-5"]
+  );
+  assert.equal(thirdPage.nextCursor, null);
+
+  const seenIds = [
+    ...firstPage.users.map((user) => user.id),
+    ...secondPage.users.map((user) => user.id),
+    ...thirdPage.users.map((user) => user.id),
+  ];
+  assert.deepEqual(seenIds, ["user-1", "user-2", "user-3", "user-4", "user-5"]);
+  assert.equal(new Set(seenIds).size, seenIds.length, "no duplicate user ids across pages");
 });
 
 test("member building keeps later users reachable even when one user has many org-role rows", () => {
@@ -90,7 +156,7 @@ test("member building keeps later users reachable even when one user has many or
   );
 });
 
-test("fetchAllEnterpriseMembers reaches later pages when nextCursor is the next unique user id", async () => {
+test("fetchAllEnterpriseMembers reaches later pages when nextCursor is the last returned user id", async () => {
   const seenCursors: Array<string | null> = [];
 
   const members = await fetchAllEnterpriseMembers(async (after) => {
@@ -116,7 +182,7 @@ test("fetchAllEnterpriseMembers reaches later pages when nextCursor is the next 
             ],
           },
         ],
-        nextCursor: "user-3",
+        nextCursor: "user-2",
       };
     }
 
@@ -135,7 +201,7 @@ test("fetchAllEnterpriseMembers reaches later pages when nextCursor is the next 
     };
   });
 
-  assert.deepEqual(seenCursors, [null, "user-3"]);
+  assert.deepEqual(seenCursors, [null, "user-2"]);
   assert.deepEqual(
     members.map((member) => member.userId),
     ["user-1", "user-2", "user-3"]
@@ -151,7 +217,10 @@ test("members route pages distinct users instead of truncating on raw role rows"
 
   assert.match(source, /\.from\("users"\)/);
   assert.match(source, /user_organization_roles!inner/);
-  assert.match(source, /\.gte\("id", after\)/);
+  // Cursor pagination MUST use `.gt` (strict) to avoid duplicating the boundary
+  // row on the next page; `.gte` would cause repeated rows.
+  assert.match(source, /\.gt\("id", after\)/);
+  assert.doesNotMatch(source, /\.gte\("id", after\)/);
   assert.match(source, /\.limit\(limit \+ 1\)/);
   assert.doesNotMatch(source, /\.limit\(limit \* 5\)/);
 });


### PR DESCRIPTION
## Summary

Three issues surfaced by 3-lens code review on the enterprise batch org wizard (merged in b07cfa59..11d7cad1).

- **C1 (critical):** missing migration for `organizations.purpose` column. `batch_create_enterprise_orgs` RPC inserts `purpose` but no DDL existed, so fresh deploys would 500 on every batch + single org create.
- **H4 (high):** `create-with-upgrade` auto-bumped `sub_org_quantity` silently, bypassing the "hard block over soft warning" key decision. Now requires `confirmUpgrade: true` or returns 402 `needsUpgrade` with cost preview.
- **H5 (high):** `paginateEnterpriseMemberUsers` duplicated the boundary row (`.gte` + `users[limit].id`). Fixed to `.gt` + last id of trimmed page.

## Changes

- `supabase/migrations/20261020199000_organizations_add_purpose.sql` — new, adds `organizations.purpose text` before the batch RPC migration. Already applied to production via `mcp apply_migration`.
- `src/app/api/enterprise/[enterpriseId]/organizations/create-with-upgrade/route.ts` — adds `confirmUpgrade?: boolean` to Zod schema, returns 402 with cost preview when upgrade needed without flag.
- `src/components/enterprise/CreateSubOrgForm.tsx` — retry path sends `confirmUpgrade: true` after user confirms in existing modal.
- `src/app/api/enterprise/[enterpriseId]/members/route.ts` + `src/lib/enterprise/member-list.ts` — pagination cursor fix.
- `src/types/database.ts` — regenerated via `npm run gen:types`, `purpose: string | null` added to `organizations` Row/Insert/Update.
- `tests/routes/enterprise/create-with-upgrade-confirm.test.ts` — new, 6 tests covering hard-block contract + cost preview shape.
- `tests/routes/enterprise/members-list.test.ts` — new walk test covering three consecutive pages with no duplicates/skips.
- `tests/routes/enterprise/create-with-upgrade-quota.test.ts` — source-grep updates for renamed `requestedQuantity`.

## Risk

- **Backwards-incompatible:** API callers of `create-with-upgrade` that omit `confirmUpgrade` now get 402 instead of a silent charge. Intended. Only in-repo caller (`CreateSubOrgForm`) is updated. No known external callers.
- Migration is `IF NOT EXISTS` safe — already applied to prod, idempotent on re-run.
- Pagination change is a correctness fix; existing clients will see correct pages instead of duplicated boundary rows.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `members-list.test.ts` — 8/8 pass (incl. new boundary walk test)
- [x] `create-with-upgrade-confirm.test.ts` — 6/6 pass
- [x] `create-with-upgrade-quota.test.ts` — pass after source-grep update
- [x] Migration applied to prod (`rytsziwekhtjdqzzpdso`)
- [ ] Manual: admin hits create-with-upgrade without flag → sees confirm modal → submits with flag → org created + seat charged
- [ ] Manual: paginate enterprise members past the limit boundary → no duplicate rows

## Follow-up (not in this PR)

Remaining from 3-lens review still to ship: H1 (purpose read-side surface), H2 (billing ordering in create-with-upgrade), H3 (error detail leak), H6/H7 (duplicate Stripe helpers), H8/H9/H10 (transfer N+1, non-atomic move, audit fire-and-forget), plus Important tier items.