### PR TITLE
chore(logging): drop debug console.log noise, promote ops logs to console.info

### DIFF
--- a/src/app/api/cron/error-baselines/route.ts
+++ b/src/app/api/cron/error-baselines/route.ts
@@ -40,7 +40,7 @@ export async function GET(request: Request) {
           throw resetError;
         }
 
-        console.log("[cron/error-baselines] Baseline update completed (fallback mode)");
+        console.info("[cron/error-baselines] Baseline update completed (fallback mode)");
 
         return NextResponse.json({
           success: true,
@@ -51,7 +51,7 @@ export async function GET(request: Request) {
       throw error;
     }
 
-    console.log("[cron/error-baselines] Baseline update completed");
+    console.info("[cron/error-baselines] Baseline update completed");
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/cron/graduation-check/route.ts
+++ b/src/app/api/cron/graduation-check/route.ts
@@ -93,7 +93,7 @@ export async function GET(request: Request) {
 
     // Step 1: Send 30-day warnings
     const nearingGraduation = await getMembersNearingGraduation(supabase, 30);
-    console.log(`[cron/graduation-check] Found ${nearingGraduation.length} members nearing graduation`);
+    console.info(`[cron/graduation-check] Found ${nearingGraduation.length} members nearing graduation`);
 
     // Group by organization
     const byOrgWarning = new Map<string, typeof nearingGraduation>();
@@ -154,7 +154,7 @@ export async function GET(request: Request) {
 
     // Step 2: Process graduations
     const pastGraduation = await getMembersPastGraduation(supabase);
-    console.log(`[cron/graduation-check] Found ${pastGraduation.length} members past graduation`);
+    console.info(`[cron/graduation-check] Found ${pastGraduation.length} members past graduation`);
 
     // Group by organization
     const byOrgGrad = new Map<string, typeof pastGraduation>();
@@ -198,7 +198,7 @@ export async function GET(request: Request) {
           for (const member of members) {
             // Skip members without a user account (can't transition roles)
             if (!member.user_id) {
-              console.log(`[cron/graduation-check] Skipping member ${member.id} - no user_id`);
+              console.info(`[cron/graduation-check] Skipping member ${member.id} - no user_id`);
               continue;
             }
 
@@ -291,7 +291,7 @@ export async function GET(request: Request) {
 
     // Step 3: Reverse flow — reinstate members whose graduation date was moved forward
     const membersToReinstate = await getMembersToReinstate(supabase);
-    console.log(`[cron/graduation-check] Found ${membersToReinstate.length} members to reinstate`);
+    console.info(`[cron/graduation-check] Found ${membersToReinstate.length} members to reinstate`);
 
     const byOrgReinstate = new Map<string, typeof membersToReinstate>();
     for (const member of membersToReinstate) {
@@ -318,7 +318,7 @@ export async function GET(request: Request) {
 
         for (const member of members) {
           if (!member.user_id) {
-            console.log(`[cron/graduation-check] Skipping reinstate for member ${member.id} - no user_id`);
+            console.info(`[cron/graduation-check] Skipping reinstate for member ${member.id} - no user_id`);
             continue;
           }
 
@@ -349,7 +349,7 @@ export async function GET(request: Request) {
       }
     }
 
-    console.log("[cron/graduation-check] Completed:", results);
+    console.info("[cron/graduation-check] Completed:", results);
     debugLog("graduation-cron", "batch summary", {
       totalProcessed: pastGraduation.length,
       transitioned: results.transitionsToAlumni,

--- a/src/app/api/cron/linkedin-bulk-sync/route.ts
+++ b/src/app/api/cron/linkedin-bulk-sync/route.ts
@@ -143,7 +143,7 @@ export async function GET(request: Request) {
   }
 
   const summary = { processed, orgs: orgs.length, ok, not_found: notFound, errors, skipped };
-  console.log("[linkedin-bulk-sync] Complete:", JSON.stringify(summary));
+  console.info("[linkedin-bulk-sync] Complete:", JSON.stringify(summary));
 
   return NextResponse.json(summary);
 }

--- a/src/app/api/dev/seed-enterprise/route.ts
+++ b/src/app/api/dev/seed-enterprise/route.ts
@@ -114,13 +114,6 @@ export async function POST() {
       `)
       .eq("user_id", user.id);
 
-    console.log("[seed-enterprise] Verification:", {
-      verifyEnterprise,
-      verifyRole,
-      rlsTest,
-      rlsError: rlsError?.message,
-    });
-
     return NextResponse.json({
       success: true,
       message: "Mock enterprise created successfully",

--- a/src/app/api/feedback/submit/route.ts
+++ b/src/app/api/feedback/submit/route.ts
@@ -82,7 +82,7 @@ User Agent: ${responses.user_agent}
   }
 
   // Stub for development
-  console.log("[STUB] Would send admin notification:", {
+  console.info("[STUB] Would send admin notification:", {
     to: ADMIN_EMAIL,
     subject,
     body: body.substring(0, 200) + "...",

--- a/src/app/api/media/[mediaId]/finalize/route.ts
+++ b/src/app/api/media/[mediaId]/finalize/route.ts
@@ -221,8 +221,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "Failed to finalize upload" }, { status: 500 });
     }
 
-    console.log("[media/gallery] Finalize success", { mediaId });
-
     return NextResponse.json(
       { mediaId: updated.id, status: updated.status },
       { headers: rateLimit.headers },

--- a/src/app/api/media/[mediaId]/moderate/route.ts
+++ b/src/app/api/media/[mediaId]/moderate/route.ts
@@ -100,8 +100,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    console.log("[media/gallery] Moderated", { mediaId, action: newStatus });
-
     return NextResponse.json(updated, { headers: rateLimit.headers });
   } catch (error) {
     if (error instanceof ValidationError) {

--- a/src/app/api/media/[mediaId]/route.ts
+++ b/src/app/api/media/[mediaId]/route.ts
@@ -273,8 +273,6 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: deletion.error }, { status: deletion.status });
     }
 
-    console.log("[media/gallery] Deleted", { mediaId, deletedIds: deletion.deletedIds });
-
     return NextResponse.json({ success: true }, { headers: rateLimit.headers });
   } catch {
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -336,10 +336,9 @@ export async function POST(request: NextRequest) {
     const initialStatus = "uploading";
 
     let mediaId: string;
-    let creationPath: "rpc" | "fallback";
 
     try {
-      ({ mediaId, creationPath } = await createMediaGalleryUploadRecord(
+      ({ mediaId } = await createMediaGalleryUploadRecord(
         serviceClient as unknown as GalleryUploadRecordClient,
         {
           orgId,
@@ -424,15 +423,6 @@ export async function POST(request: NextRequest) {
       await serviceClient.from("media_items").delete().eq("id", mediaId);
       return NextResponse.json({ error: "Failed to generate preview upload URL" }, { status: 500 });
     }
-
-    console.log("[media/gallery] Upload intent created", {
-      orgId,
-      mediaId,
-      mimeType,
-      fileSizeBytes,
-      creationPath,
-      hasPreviewUpload: Boolean(previewStoragePath),
-    });
 
     return NextResponse.json(
       {

--- a/src/app/api/user/linkedin/connect/route.ts
+++ b/src/app/api/user/linkedin/connect/route.ts
@@ -51,7 +51,6 @@ export async function POST(request: Request) {
     });
 
     const redirectUrl = getLinkedInAuthUrl(oauthState.state);
-    console.log("[linkedin-connect] redirect_uri used in OAuth URL:", redirectUrl.split("redirect_uri=")[1]?.split("&")[0]);
     const response = NextResponse.json({ redirectUrl });
     response.cookies.set(
       oauthState.cookie.name,

--- a/src/components/dev/SeedEnterpriseButton.tsx
+++ b/src/components/dev/SeedEnterpriseButton.tsx
@@ -18,7 +18,6 @@ export function SeedEnterpriseButton() {
         method: "POST",
       });
       const data = await response.json();
-      console.log("[SeedEnterpriseButton] Response:", data);
 
       if (!response.ok) {
         throw new Error(data.error || "Failed to seed enterprise");

--- a/src/hooks/useGalleryUpload.ts
+++ b/src/hooks/useGalleryUpload.ts
@@ -271,11 +271,6 @@ export async function prepareGalleryUploadEntries(
         previewFileSize = prepared.previewFile?.size ?? 0;
         if (previewUrl) revokeObjectUrl(previewUrl);
         previewUrl = prepared.previewUrl;
-        console.log("[media/upload] prepared gallery image", {
-          fileName: file.name,
-          originalBytes: prepared.originalBytes,
-          normalizedBytes: prepared.normalizedBytes,
-        });
       } catch (error) {
         if (previewUrl) revokeObjectUrl(previewUrl);
         rejected.push({

--- a/src/lib/linkedin/bright-data.ts
+++ b/src/lib/linkedin/bright-data.ts
@@ -123,7 +123,7 @@ export async function fetchBrightDataProfile(
   const fetchFn = options.fetchFn ?? fetch;
 
   if (!apiKey) {
-    console.log("[bright-data] Skipping enrichment — BRIGHT_DATA_API_KEY not configured");
+    console.info("[bright-data] Skipping enrichment — BRIGHT_DATA_API_KEY not configured");
     return {
       ok: false,
       kind: "not_configured",

--- a/src/lib/linkedin/oauth.ts
+++ b/src/lib/linkedin/oauth.ts
@@ -597,14 +597,6 @@ export async function runBrightDataEnrichment(
     const profile = fetchResult.profile;
     const fields = mapBrightDataToFields(profile);
 
-    console.log("[bright-data-enrichment] Profile fetched:", {
-      experienceCount: profile.experience?.length ?? 0,
-      educationCount: profile.education?.length ?? 0,
-      hasAbout: !!profile.about,
-      hasPosition: !!profile.position,
-      currentCompany: profile.current_company || profile.current_company_name || null,
-    });
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { error } = await (supabase as any).rpc("sync_user_linkedin_enrichment", {
       p_user_id: userId,

--- a/src/lib/media/feed-composer-prep.ts
+++ b/src/lib/media/feed-composer-prep.ts
@@ -142,11 +142,6 @@ export async function prepareFeedImageEntries(
     let preparedImage: PreparedImageUpload;
     try {
       preparedImage = await prepareImage(file);
-      console.log("[media/upload] prepared feed image", {
-        fileName: file.name,
-        originalBytes: preparedImage.originalBytes,
-        normalizedBytes: preparedImage.normalizedBytes,
-      });
     } catch (err) {
       skipped.push(
         `${file.name}: ${err instanceof Error ? err.message : "failed to prepare image upload"}`,

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -108,7 +108,7 @@ async function runWithConcurrency<T extends { success: boolean; error?: string }
 export async function sendEmail(params: EmailParams): Promise<NotificationResult> {
   if (!resend) {
     // Fallback to stub behavior when Resend is not configured (e.g., local development)
-    console.log("[STUB] Sending email (RESEND_API_KEY not configured):", {
+    console.info("[STUB] Sending email (RESEND_API_KEY not configured):", {
       to: params.to,
       subject: params.subject,
       body: params.body.substring(0, 100) + "...",
@@ -143,7 +143,7 @@ export async function sendEmail(params: EmailParams): Promise<NotificationResult
 // gate on an SMS_PROVIDER env var. The stub safely returns success so callers
 // can be written against the final interface today.
 export async function sendSMS(params: SMSParams): Promise<NotificationResult> {
-  console.log("[STUB] Sending SMS (provider not configured):", {
+  console.info("[STUB] Sending SMS (provider not configured):", {
     to: params.to,
     message: params.message.substring(0, 100) + "...",
   });


### PR DESCRIPTION
## Summary
- Tech-debt cleanup pass 1: strip leftover debug `console.log` calls and normalize operational logs to `console.info` so they survive structured-log filtering.
- No behavior change. Hot paths (media upload/finalize/moderate/delete, feed image prep, LinkedIn OAuth, graduation cron) lose success-path noise; cron + stub-mode notices keep visibility.
- Drops now-unused `creationPath` destructure in `src/app/api/media/route.ts` (only consumer was a deleted debug log).

## Changes
- `src/app/api/media/{route,[mediaId]/{route,finalize/route,moderate/route}}.ts` — remove success-path `console.log`
- `src/app/api/user/linkedin/connect/route.ts` — drop redirect_uri trace (avoids leaking URI fragments into server logs)
- `src/app/api/dev/seed-enterprise/route.ts`, `src/components/dev/SeedEnterpriseButton.tsx` — drop dev verification dumps
- `src/hooks/useGalleryUpload.ts`, `src/lib/media/feed-composer-prep.ts` — drop prepared-image debug
- `src/lib/linkedin/oauth.ts` — drop bright-data profile-fetched trace
- `src/app/api/cron/{graduation-check,linkedin-bulk-sync,error-baselines}/route.ts`, `src/lib/{linkedin/bright-data,notifications}.ts`, `src/app/api/feedback/submit/route.ts` — `console.log` → `console.info`

Net: 16 files changed, +14 / -57.

## Risk
- Low. No runtime branching changed; only log-level + removals on success paths.
- Stub-mode notices (`[STUB] Sending email …`, bright-data missing-key) intentionally retained at `console.info` so dev fallback stays visible.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:fast` — 4832/4832 pass
- [x] `npm run build` — succeeds