### PR TITLE
fix(search): album deep-link via AlbumGrid auto-select

### DIFF
--- a/src/components/media/AlbumGrid.tsx
+++ b/src/components/media/AlbumGrid.tsx
@@ -37,6 +37,8 @@ interface AlbumGridProps {
    * from a stale browser cache.
    */
   refreshToken?: number;
+  /** When set, auto-select this album after the initial fetch (deep-link from global search). */
+  autoSelectAlbumId?: string;
 }
 
 function usePrefersReducedMotion(): boolean {
@@ -92,7 +94,7 @@ function SortableAlbumRow({
   );
 }
 
-export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, refreshToken }: AlbumGridProps) {
+export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, refreshToken, autoSelectAlbumId }: AlbumGridProps) {
   const tMedia = useTranslations("media");
   const tCommon = useTranslations("common");
   const { importingAlbum } = useMediaUploadManager();
@@ -137,9 +139,21 @@ export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, ref
     }
   }, [orgId, tMedia]);
 
+  const didAutoSelect = useRef(false);
+
   useEffect(() => {
     fetchAlbums();
   }, [fetchAlbums, refreshToken]);
+
+  // Auto-select album from deep-link (e.g. global search)
+  useEffect(() => {
+    if (!autoSelectAlbumId || didAutoSelect.current || albums.length === 0) return;
+    const match = albums.find((a) => a.id === autoSelectAlbumId);
+    if (match) {
+      didAutoSelect.current = true;
+      onSelectAlbum(match);
+    }
+  }, [albums, autoSelectAlbumId, onSelectAlbum]);
 
   const albumIds = useMemo(() => visibleAlbums.map((a) => a.id), [visibleAlbums]);
 

--- a/src/components/media/MediaGallery.tsx
+++ b/src/components/media/MediaGallery.tsx
@@ -122,35 +122,23 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
   const tMedia = useTranslations("media");
   const tCommon = useTranslations("common");
   const { dismissImportAlbum, importingAlbum } = useMediaUploadManager();
+
+  // Deep-link: capture ?album=<id> from URL on mount (e.g. from global search)
+  const [autoSelectAlbumId] = useState(() => {
+    if (typeof window === "undefined") return null;
+    const url = new URL(window.location.href);
+    const id = url.searchParams.get("album");
+    if (id) {
+      url.searchParams.delete("album");
+      window.history.replaceState(null, "", url.pathname + url.search);
+    }
+    return id;
+  });
+
   // View tab state
   const [view, setView] = useState<GalleryView>("albums");
   const [selectedAlbum, setSelectedAlbum] = useState<MediaAlbum | null>(null);
   const [hiddenAlbumIds, setHiddenAlbumIds] = useState<Set<string>>(new Set());
-
-  // Deep-link: open album from ?album=<id> (e.g. from global search)
-  useEffect(() => {
-    const url = new URL(window.location.href);
-    const albumId = url.searchParams.get("album");
-    if (!albumId) return;
-
-    // Clear the query param without triggering a React re-render
-    url.searchParams.delete("album");
-    window.history.replaceState(null, "", url.pathname + url.search);
-
-    // Fetch albums and select the matching one
-    fetch(`/api/media/albums?orgId=${encodeURIComponent(orgId)}`, { cache: "no-store" })
-      .then((res) => (res.ok ? res.json() : Promise.reject(new Error("Failed to load album"))))
-      .then((result) => {
-        const album = (result.data as MediaAlbum[])?.find((a) => a.id === albumId);
-        if (album) {
-          setView("albums");
-          setSelectedAlbum(album);
-        }
-      })
-      .catch(() => {
-        // Silently fail — user lands on the gallery
-      });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Photos state
   const [items, setItems] = useState<MediaItem[]>([]);
@@ -717,6 +705,7 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
           hiddenAlbumIds={hiddenAlbumIds}
           onSelectAlbum={setSelectedAlbum}
           refreshToken={albumRefreshToken}
+          autoSelectAlbumId={autoSelectAlbumId ?? undefined}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Previous deep-link attempts raced with AlbumGrid's own album fetch and got wiped by re-renders
- Now `MediaGallery` captures `?album=<id>` synchronously in a `useState` initializer and passes it to `AlbumGrid` as `autoSelectAlbumId`
- `AlbumGrid` auto-selects the matching album after its own fetch completes — no duplicate request, no race condition

## Test plan
- [ ] Cmd+K → search album name → click result → album detail view opens
- [ ] Direct URL `/org/media?album=<id>` → album detail view opens
- [ ] Normal album grid navigation still works (no auto-select without param)