### PR TITLE
fix(search): handle album deep-link when already on media page

### DIFF
--- a/src/components/media/AlbumGrid.tsx
+++ b/src/components/media/AlbumGrid.tsx
@@ -39,6 +39,8 @@ interface AlbumGridProps {
   refreshToken?: number;
   /** When set, auto-select this album after the initial fetch (deep-link from global search). */
   autoSelectAlbumId?: string;
+  /** Bumped to allow re-selecting the same album (e.g. repeated searches). */
+  autoSelectSeq?: number;
 }
 
 function usePrefersReducedMotion(): boolean {
@@ -94,7 +96,7 @@ function SortableAlbumRow({
   );
 }
 
-export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, refreshToken, autoSelectAlbumId }: AlbumGridProps) {
+export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, refreshToken, autoSelectAlbumId, autoSelectSeq }: AlbumGridProps) {
   const tMedia = useTranslations("media");
   const tCommon = useTranslations("common");
   const { importingAlbum } = useMediaUploadManager();
@@ -140,6 +142,13 @@ export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, ref
   }, [orgId, tMedia]);
 
   const didAutoSelect = useRef(false);
+
+  // Reset auto-select guard when the target album changes (or seq bumps for same album)
+  useEffect(() => {
+    if (autoSelectAlbumId) {
+      didAutoSelect.current = false;
+    }
+  }, [autoSelectAlbumId, autoSelectSeq]);
 
   useEffect(() => {
     fetchAlbums();

--- a/src/components/media/MediaGallery.tsx
+++ b/src/components/media/MediaGallery.tsx
@@ -124,7 +124,7 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
   const { dismissImportAlbum, importingAlbum } = useMediaUploadManager();
 
   // Deep-link: capture ?album=<id> from URL on mount (e.g. from global search)
-  const [autoSelectAlbumId] = useState(() => {
+  const [autoSelectAlbumId, setAutoSelectAlbumId] = useState<string | null>(() => {
     if (typeof window === "undefined") return null;
     const url = new URL(window.location.href);
     const id = url.searchParams.get("album");
@@ -134,6 +134,26 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
     }
     return id;
   });
+  // Sequence counter so repeated searches for the same album still trigger auto-select
+  const [autoSelectSeq, setAutoSelectSeq] = useState(0);
+
+  // Listen for same-page album deep-links from global search (custom event
+  // dispatched by GlobalSearchPalette when the user is already on /media).
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { albumId } = (e as CustomEvent<{ albumId: string }>).detail;
+      setSelectedAlbum(null);
+      setView("albums");
+      setAutoSelectAlbumId(albumId);
+      setAutoSelectSeq((s) => s + 1);
+      // Clean URL
+      const url = new URL(window.location.href);
+      url.searchParams.delete("album");
+      window.history.replaceState(null, "", url.pathname + url.search);
+    };
+    window.addEventListener("media:select-album", handler);
+    return () => window.removeEventListener("media:select-album", handler);
+  }, []);
 
   // View tab state
   const [view, setView] = useState<GalleryView>("albums");
@@ -706,6 +726,7 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: Media
           onSelectAlbum={setSelectedAlbum}
           refreshToken={albumRefreshToken}
           autoSelectAlbumId={autoSelectAlbumId ?? undefined}
+          autoSelectSeq={autoSelectSeq}
         />
       )}
 

--- a/src/components/search/GlobalSearchPalette.tsx
+++ b/src/components/search/GlobalSearchPalette.tsx
@@ -245,6 +245,17 @@ export function GlobalSearchPalette() {
         orgId,
       );
       setOpen(false);
+
+      // If targeting an album on the media page, fire a custom event so an
+      // already-mounted MediaGallery can react (router.push won't re-run
+      // useState initialisers on a soft navigation).
+      const albumMatch = url.match(/\/media\?album=([^&]+)/);
+      if (albumMatch) {
+        window.dispatchEvent(
+          new CustomEvent("media:select-album", { detail: { albumId: albumMatch[1] } }),
+        );
+      }
+
       router.push(url);
     },
     [orgId, mode, orgSlug, query, router, setOpen],


### PR DESCRIPTION
## Summary
- When searching for an album via Cmd+K while already on the media page, clicking the result now opens the album instead of doing nothing
- Dispatches a `media:select-album` custom event from `GlobalSearchPalette` so an already-mounted `MediaGallery` can react to same-page navigations
- Handles edge cases: switching from photos tab, closing a currently-open album, repeated searches for the same album

## Test plan
- [ ] On media page (albums tab), Cmd+K search for an album → should open it
- [ ] On media page (photos tab), search for an album → should switch to albums tab and open it
- [ ] Viewing album A, search for album B → should close A and open B
- [ ] From a different page, search for an album → should navigate to media and open it (existing behavior preserved)
- [ ] URL should be clean after navigation (no lingering `?album=` param)