### PR TITLE
fix(search): use server-driven searchParams for album deep-link

### DIFF
--- a/src/app/[orgSlug]/media/page.tsx
+++ b/src/app/[orgSlug]/media/page.tsx
@@ -12,10 +12,13 @@ const MediaGallery = dynamic(
 
 export default async function MediaArchivePage({
   params,
+  searchParams,
 }: {
   params: Promise<{ orgSlug: string }>;
+  searchParams: Promise<{ album?: string; _t?: string }>;
 }) {
   const { orgSlug } = await params;
+  const { album: deepLinkAlbumId, _t: deepLinkKey } = await searchParams;
   const orgCtx = await getOrgContext(orgSlug);
 
   if (!orgCtx.organization) {
@@ -38,6 +41,8 @@ export default async function MediaArchivePage({
         canUpload={canUpload}
         isAdmin={isAdmin}
         currentUserId={orgCtx.userId || undefined}
+        deepLinkAlbumId={deepLinkAlbumId}
+        deepLinkKey={deepLinkKey}
       />
     </div>
   );

--- a/src/components/media/MediaGallery.tsx
+++ b/src/components/media/MediaGallery.tsx
@@ -52,6 +52,8 @@ interface MediaGalleryProps {
   canUpload: boolean;
   isAdmin: boolean;
   currentUserId?: string;
+  deepLinkAlbumId?: string;
+  deepLinkKey?: string;
 }
 
 type MediaType = "all" | "image" | "video";
@@ -118,42 +120,33 @@ function SortableMediaRow({
   );
 }
 
-export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId }: MediaGalleryProps) {
+export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId, deepLinkAlbumId, deepLinkKey }: MediaGalleryProps) {
   const tMedia = useTranslations("media");
   const tCommon = useTranslations("common");
   const { dismissImportAlbum, importingAlbum } = useMediaUploadManager();
 
-  // Deep-link: capture ?album=<id> from URL on mount (e.g. from global search)
-  const [autoSelectAlbumId, setAutoSelectAlbumId] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    const url = new URL(window.location.href);
-    const id = url.searchParams.get("album");
-    if (id) {
-      url.searchParams.delete("album");
-      window.history.replaceState(null, "", url.pathname + url.search);
-    }
-    return id;
-  });
+  // Deep-link: album ID passed from server via searchParams (e.g. from global search)
+  const [autoSelectAlbumId, setAutoSelectAlbumId] = useState<string | null>(deepLinkAlbumId ?? null);
   // Sequence counter so repeated searches for the same album still trigger auto-select
   const [autoSelectSeq, setAutoSelectSeq] = useState(0);
 
-  // Listen for same-page album deep-links from global search (custom event
-  // dispatched by GlobalSearchPalette when the user is already on /media).
+  // React to server-provided deep-link album ID changes (e.g. navigating
+  // from global search while already on the media page — router.push triggers
+  // a server re-render that flows new searchParams down as props).
   useEffect(() => {
-    const handler = (e: Event) => {
-      const { albumId } = (e as CustomEvent<{ albumId: string }>).detail;
-      setSelectedAlbum(null);
-      setView("albums");
-      setAutoSelectAlbumId(albumId);
-      setAutoSelectSeq((s) => s + 1);
-      // Clean URL
-      const url = new URL(window.location.href);
+    if (!deepLinkAlbumId) return;
+    setSelectedAlbum(null);
+    setView("albums");
+    setAutoSelectAlbumId(deepLinkAlbumId);
+    setAutoSelectSeq((s) => s + 1);
+    // Clean URL so refresh doesn't replay the deep-link
+    const url = new URL(window.location.href);
+    if (url.searchParams.has("album")) {
       url.searchParams.delete("album");
+      url.searchParams.delete("_t");
       window.history.replaceState(null, "", url.pathname + url.search);
-    };
-    window.addEventListener("media:select-album", handler);
-    return () => window.removeEventListener("media:select-album", handler);
-  }, []);
+    }
+  }, [deepLinkAlbumId, deepLinkKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // View tab state
   const [view, setView] = useState<GalleryView>("albums");

--- a/src/components/search/GlobalSearchPalette.tsx
+++ b/src/components/search/GlobalSearchPalette.tsx
@@ -246,17 +246,15 @@ export function GlobalSearchPalette() {
       );
       setOpen(false);
 
-      // If targeting an album on the media page, fire a custom event so an
-      // already-mounted MediaGallery can react (router.push won't re-run
-      // useState initialisers on a soft navigation).
-      const albumMatch = url.match(/\/media\?album=([^&]+)/);
-      if (albumMatch) {
-        window.dispatchEvent(
-          new CustomEvent("media:select-album", { detail: { albumId: albumMatch[1] } }),
-        );
+      // Add cache-bust param for album deep-links so repeated clicks for
+      // the same album always produce a fresh searchParams prop on the
+      // server-rendered media page.
+      let navUrl = url;
+      if (/\/media\?album=/.test(url)) {
+        navUrl = `${url}&_t=${Date.now()}`;
       }
 
-      router.push(url);
+      router.push(navUrl);
     },
     [orgId, mode, orgSlug, query, router, setOpen],
   );


### PR DESCRIPTION
## Summary
- Replace fragile client-side `window.location` URL parsing and custom `media:select-album` DOM events with Next.js `searchParams` page prop
- Album ID now flows from server component → client component as a React prop, eliminating race conditions with App Router soft navigation
- Add `_t` cache-bust param so repeated same-album searches always trigger a fresh server render

## Test plan
- [ ] From a non-media page, Cmd+K search for an album, click it → opens inside the album
- [ ] While on the media page (album grid), search for an album, click it → opens inside that album
- [ ] While viewing album A, search for album B, click it → switches to album B
- [ ] Search for the same album twice in a row → works both times
- [ ] After opening an album via search, refresh the page → shows album grid (URL cleaned)