### PR TITLE
fix(search): drive album deep-link from URL as single source of truth

### DIFF
--- a/src/app/[orgSlug]/media/page.tsx
+++ b/src/app/[orgSlug]/media/page.tsx
@@ -12,13 +12,10 @@ const MediaGallery = dynamic(
 
 export default async function MediaArchivePage({
   params,
-  searchParams,
 }: {
   params: Promise<{ orgSlug: string }>;
-  searchParams: Promise<{ album?: string; _t?: string }>;
 }) {
   const { orgSlug } = await params;
-  const { album: deepLinkAlbumId, _t: deepLinkKey } = await searchParams;
   const orgCtx = await getOrgContext(orgSlug);
 
   if (!orgCtx.organization) {
@@ -38,11 +35,10 @@ export default async function MediaArchivePage({
       <MediaStorageUsageBar orgId={orgCtx.organization.id} isAdmin={isAdmin} />
       <MediaGallery
         orgId={orgCtx.organization.id}
+        orgSlug={orgSlug}
         canUpload={canUpload}
         isAdmin={isAdmin}
         currentUserId={orgCtx.userId || undefined}
-        deepLinkAlbumId={deepLinkAlbumId}
-        deepLinkKey={deepLinkKey}
       />
     </div>
   );

--- a/src/components/media/AlbumGrid.tsx
+++ b/src/components/media/AlbumGrid.tsx
@@ -30,17 +30,13 @@ interface AlbumGridProps {
   orgId: string;
   canCreate: boolean;
   hiddenAlbumIds?: Iterable<string>;
+  albums: MediaAlbum[];
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+  onAlbumsChange: (next: MediaAlbum[]) => void;
   onSelectAlbum: (album: MediaAlbum) => void;
-  /**
-   * Bumping this value triggers a fresh, cache-busting refetch of albums.
-   * Used by parents after a delete so the gallery doesn't show ghost albums
-   * from a stale browser cache.
-   */
-  refreshToken?: number;
-  /** When set, auto-select this album after the initial fetch (deep-link from global search). */
-  autoSelectAlbumId?: string;
-  /** Bumped to allow re-selecting the same album (e.g. repeated searches). */
-  autoSelectSeq?: number;
+  onAlbumCreated: (album: MediaAlbum) => void;
 }
 
 function usePrefersReducedMotion(): boolean {
@@ -96,14 +92,22 @@ function SortableAlbumRow({
   );
 }
 
-export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, refreshToken, autoSelectAlbumId, autoSelectSeq }: AlbumGridProps) {
+export function AlbumGrid({
+  orgId,
+  canCreate,
+  hiddenAlbumIds,
+  albums,
+  loading,
+  error,
+  onRetry,
+  onAlbumsChange,
+  onSelectAlbum,
+  onAlbumCreated,
+}: AlbumGridProps) {
   const tMedia = useTranslations("media");
   const tCommon = useTranslations("common");
   const { importingAlbum } = useMediaUploadManager();
 
-  const [albums, setAlbums] = useState<MediaAlbum[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [reorderMode, setReorderMode] = useState(false);
   const reducedMotion = usePrefersReducedMotion();
@@ -117,52 +121,6 @@ export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, ref
   sourceAlbumsRef.current = albums;
 
   const canReorder = canCreate;
-
-  const fetchAlbums = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      // cache: "no-store" — belt-and-braces guard against any intermediate
-      // browser cache so deletes are reflected immediately. The server now
-      // also returns max-age=0 for this endpoint.
-      const res = await fetch(`/api/media/albums?orgId=${encodeURIComponent(orgId)}`, {
-        cache: "no-store",
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => null);
-        throw new Error(data?.error || tMedia("failedToLoadAlbums"));
-      }
-      const result = await res.json();
-      setAlbums(result.data || []);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : tMedia("failedToLoadAlbums"));
-    } finally {
-      setLoading(false);
-    }
-  }, [orgId, tMedia]);
-
-  const didAutoSelect = useRef(false);
-
-  // Reset auto-select guard when the target album changes (or seq bumps for same album)
-  useEffect(() => {
-    if (autoSelectAlbumId) {
-      didAutoSelect.current = false;
-    }
-  }, [autoSelectAlbumId, autoSelectSeq]);
-
-  useEffect(() => {
-    fetchAlbums();
-  }, [fetchAlbums, refreshToken]);
-
-  // Auto-select album from deep-link (e.g. global search)
-  useEffect(() => {
-    if (!autoSelectAlbumId || didAutoSelect.current || albums.length === 0) return;
-    const match = albums.find((a) => a.id === autoSelectAlbumId);
-    if (match) {
-      didAutoSelect.current = true;
-      onSelectAlbum(match);
-    }
-  }, [albums, autoSelectAlbumId, onSelectAlbum]);
 
   const albumIds = useMemo(() => visibleAlbums.map((a) => a.id), [visibleAlbums]);
 
@@ -184,10 +142,10 @@ export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, ref
       }
       showFeedback("Album order saved", "success", { duration: 2500 });
     } catch (err) {
-      setAlbums(previous);
+      onAlbumsChange(previous);
       showFeedback(err instanceof Error ? err.message : "Could not save order", "error", { duration: 4000 });
     }
-  }, [orgId]);
+  }, [orgId, onAlbumsChange]);
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
@@ -209,15 +167,16 @@ export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, ref
         .map((a) => a.id);
       const fullAlbumIds = [...reorderedIds, ...hiddenIds];
 
-      // Update local state with the reordered source albums
+      // Update source list with the reordered source albums
       const orderMap = new Map(fullAlbumIds.map((id, i) => [id, i]));
       const reorderedAlbums = [...sourceAlbumsRef.current].sort(
         (a, b) => (orderMap.get(a.id) ?? 0) - (orderMap.get(b.id) ?? 0),
       );
-      setAlbums(reorderedAlbums);
-      void persistReorder(fullAlbumIds, sourceAlbumsRef.current);
+      const previous = sourceAlbumsRef.current;
+      onAlbumsChange(reorderedAlbums);
+      void persistReorder(fullAlbumIds, previous);
     },
-    [persistReorder],
+    [onAlbumsChange, persistReorder],
   );
 
   if (loading) {
@@ -236,7 +195,7 @@ export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, ref
     return (
       <div className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950/20 rounded-lg p-3">
         {error}
-        <button type="button" onClick={fetchAlbums} className="ml-2 underline">{tCommon("retry")}</button>
+        <button type="button" onClick={onRetry} className="ml-2 underline">{tCommon("retry")}</button>
       </div>
     );
   }
@@ -319,7 +278,7 @@ export function AlbumGrid({ orgId, canCreate, hiddenAlbumIds, onSelectAlbum, ref
           onClose={() => setShowCreate(false)}
           onCreated={(album) => {
             setShowCreate(false);
-            void fetchAlbums().then(() => onSelectAlbum(album));
+            onAlbumCreated(album);
           }}
         />
       )}

--- a/src/components/media/MediaGallery.tsx
+++ b/src/components/media/MediaGallery.tsx
@@ -18,6 +18,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { showFeedback } from "@/lib/feedback/show-feedback";
 import {
@@ -49,11 +50,10 @@ import { useMediaUploadManager } from "./MediaUploadManagerContext";
 
 interface MediaGalleryProps {
   orgId: string;
+  orgSlug: string;
   canUpload: boolean;
   isAdmin: boolean;
   currentUserId?: string;
-  deepLinkAlbumId?: string;
-  deepLinkKey?: string;
 }
 
 type MediaType = "all" | "image" | "video";
@@ -120,38 +120,71 @@ function SortableMediaRow({
   );
 }
 
-export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId, deepLinkAlbumId, deepLinkKey }: MediaGalleryProps) {
+export function MediaGallery({ orgId, orgSlug, canUpload, isAdmin, currentUserId }: MediaGalleryProps) {
   const tMedia = useTranslations("media");
   const tCommon = useTranslations("common");
   const { dismissImportAlbum, importingAlbum } = useMediaUploadManager();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const selectedAlbumId = searchParams.get("album");
 
-  // Deep-link: album ID passed from server via searchParams (e.g. from global search)
-  const [autoSelectAlbumId, setAutoSelectAlbumId] = useState<string | null>(deepLinkAlbumId ?? null);
-  // Sequence counter so repeated searches for the same album still trigger auto-select
-  const [autoSelectSeq, setAutoSelectSeq] = useState(0);
+  const navigateToAlbum = useCallback(
+    (albumId: string | null) => {
+      const target = albumId
+        ? `/${orgSlug}/media?album=${encodeURIComponent(albumId)}`
+        : `/${orgSlug}/media`;
+      router.push(target);
+    },
+    [orgSlug, router],
+  );
 
-  // React to server-provided deep-link album ID changes (e.g. navigating
-  // from global search while already on the media page — router.push triggers
-  // a server re-render that flows new searchParams down as props).
-  useEffect(() => {
-    if (!deepLinkAlbumId) return;
-    setSelectedAlbum(null);
-    setView("albums");
-    setAutoSelectAlbumId(deepLinkAlbumId);
-    setAutoSelectSeq((s) => s + 1);
-    // Clean URL so refresh doesn't replay the deep-link
-    const url = new URL(window.location.href);
-    if (url.searchParams.has("album")) {
-      url.searchParams.delete("album");
-      url.searchParams.delete("_t");
-      window.history.replaceState(null, "", url.pathname + url.search);
+  // Album list: lifted from AlbumGrid so the same list can both render the
+  // grid and resolve a URL-driven selection (`?album=<id>`) to a full album.
+  const [albums, setAlbums] = useState<MediaAlbum[]>([]);
+  const [albumsLoading, setAlbumsLoading] = useState(true);
+  const [albumsError, setAlbumsError] = useState<string | null>(null);
+  const [albumRefreshToken, setAlbumRefreshToken] = useState(0);
+
+  const fetchAlbums = useCallback(async () => {
+    setAlbumsLoading(true);
+    setAlbumsError(null);
+    try {
+      const res = await fetch(`/api/media/albums?orgId=${encodeURIComponent(orgId)}`, {
+        cache: "no-store",
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error || tMedia("failedToLoadAlbums"));
+      }
+      const result = await res.json();
+      setAlbums(result.data || []);
+    } catch (err) {
+      setAlbumsError(err instanceof Error ? err.message : tMedia("failedToLoadAlbums"));
+    } finally {
+      setAlbumsLoading(false);
     }
-  }, [deepLinkAlbumId, deepLinkKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [orgId, tMedia]);
+
+  useEffect(() => {
+    void fetchAlbums();
+  }, [fetchAlbums, albumRefreshToken]);
 
   // View tab state
   const [view, setView] = useState<GalleryView>("albums");
-  const [selectedAlbum, setSelectedAlbum] = useState<MediaAlbum | null>(null);
+  const selectedAlbum = useMemo(
+    () => (selectedAlbumId ? albums.find((a) => a.id === selectedAlbumId) ?? null : null),
+    [selectedAlbumId, albums],
+  );
   const [hiddenAlbumIds, setHiddenAlbumIds] = useState<Set<string>>(new Set());
+
+  // If the URL carries `?album=<id>`, force the albums tab so the selection
+  // actually renders (protects against user-initiated view changes that
+  // leave a stale album param behind — shouldn't normally happen, but cheap).
+  useEffect(() => {
+    if (selectedAlbumId && view !== "albums") {
+      setView("albums");
+    }
+  }, [selectedAlbumId, view]);
 
   // Photos state
   const [items, setItems] = useState<MediaItem[]>([]);
@@ -453,11 +486,11 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId, deepLin
       next.delete(album.id);
       return next;
     });
+    // Ensure the new album is in the list so the URL-driven selection resolves.
+    setAlbums((prev) => (prev.some((a) => a.id === album.id) ? prev : [album, ...prev]));
     setView("albums");
-    setSelectedAlbum(album);
-  }, []);
-
-  const [albumRefreshToken, setAlbumRefreshToken] = useState(0);
+    navigateToAlbum(album.id);
+  }, [navigateToAlbum]);
 
   const handleAlbumDeleted = useCallback((albumId: string) => {
     setHiddenAlbumIds((prev) => {
@@ -467,11 +500,11 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId, deepLin
       return next;
     });
     dismissImportAlbum(albumId);
-    setSelectedAlbum((prev) => (prev?.id === albumId ? null : prev));
-    // Force AlbumGrid to refetch with cache-busting so the deleted album
-    // doesn't reappear from a stale browser cache on remount.
+    if (selectedAlbumId === albumId) {
+      navigateToAlbum(null);
+    }
     setAlbumRefreshToken((t) => t + 1);
-  }, [dismissImportAlbum]);
+  }, [dismissImportAlbum, navigateToAlbum, selectedAlbumId]);
 
   const toggleItem = useCallback((id: string) => {
     setSelectedIds((prev) => {
@@ -582,15 +615,13 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId, deepLin
       });
   }, [fetchMedia]);
 
-  const handleAlbumPickerSuccess = useCallback((albumId: string, albumName: string) => {
+  const handleAlbumPickerSuccess = useCallback((_albumId: string, albumName: string) => {
     setShowAlbumPicker(false);
     exitSelectMode();
     showFeedback(`Added to "${albumName}"`, "success", { duration: 3000 });
-    // Navigate to the album
     setView("albums");
-    // We don't have the full album object, so we'll just go to album list
-    setSelectedAlbum(null);
-  }, [exitSelectMode]);
+    navigateToAlbum(null);
+  }, [exitSelectMode, navigateToAlbum]);
 
   const pendingCount = isAdmin ? items.filter((i) => i.status === "pending").length : 0;
 
@@ -605,7 +636,7 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId, deepLin
               key={v}
               onClick={() => {
                 setView(v);
-                setSelectedAlbum(null);
+                if (selectedAlbumId) navigateToAlbum(null);
               }}
               className={`px-4 py-1.5 text-sm font-medium rounded-full transition-colors capitalize ${
                 view === v
@@ -716,10 +747,16 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId, deepLin
           orgId={orgId}
           canCreate={canUpload}
           hiddenAlbumIds={hiddenAlbumIds}
-          onSelectAlbum={setSelectedAlbum}
-          refreshToken={albumRefreshToken}
-          autoSelectAlbumId={autoSelectAlbumId ?? undefined}
-          autoSelectSeq={autoSelectSeq}
+          albums={albums}
+          loading={albumsLoading}
+          error={albumsError}
+          onRetry={fetchAlbums}
+          onAlbumsChange={setAlbums}
+          onSelectAlbum={(album) => navigateToAlbum(album.id)}
+          onAlbumCreated={(album) => {
+            setAlbums((prev) => (prev.some((a) => a.id === album.id) ? prev : [album, ...prev]));
+            navigateToAlbum(album.id);
+          }}
         />
       )}
 
@@ -730,10 +767,12 @@ export function MediaGallery({ orgId, canUpload, isAdmin, currentUserId, deepLin
           isAdmin={isAdmin}
           canUpload={canUpload}
           currentUserId={currentUserId}
-          onBack={() => setSelectedAlbum(null)}
+          onBack={() => navigateToAlbum(null)}
           onAlbumDeleted={handleAlbumDeleted}
           onAlbumUpdated={(updates) =>
-            setSelectedAlbum((prev) => (prev ? { ...prev, ...updates } : null))
+            setAlbums((prev) =>
+              prev.map((a) => (a.id === displayedSelectedAlbum.id ? { ...a, ...updates } : a)),
+            )
           }
         />
       )}

--- a/src/components/search/GlobalSearchPalette.tsx
+++ b/src/components/search/GlobalSearchPalette.tsx
@@ -245,16 +245,7 @@ export function GlobalSearchPalette() {
         orgId,
       );
       setOpen(false);
-
-      // Add cache-bust param for album deep-links so repeated clicks for
-      // the same album always produce a fresh searchParams prop on the
-      // server-rendered media page.
-      let navUrl = url;
-      if (/\/media\?album=/.test(url)) {
-        navUrl = `${url}&_t=${Date.now()}`;
-      }
-
-      router.push(navUrl);
+      router.push(url);
     },
     [orgId, mode, orgSlug, query, router, setOpen],
   );


### PR DESCRIPTION
## Summary

Fifth attempt at the recurring album-search deep-link bug (after #112, #113, #114, #115, #117). Each prior attempt layered more machinery (`autoSelect` state, `autoSelectSeq` bump, `didAutoSelect` ref, `history.replaceState` cleanup, `&_t=` cache-buster, server-driven `searchParams`) onto a fundamentally fragile design that had two sources of truth — a `selectedAlbum` local state and a `deepLinkAlbumId` prop — constantly racing with AlbumGrid's async fetch.

This change collapses it to one source of truth: the URL.

- `MediaGallery` reads `?album=<id>` via `useSearchParams()` (reactive across cold-nav, router.push, remount). The full `MediaAlbum` is derived by looking the id up in the album list.
- Album fetching moves up from `AlbumGrid` into `MediaGallery` so the same list powers both the grid and the selection lookup.
- `AlbumGrid` becomes presentational (takes `albums`, `loading`, `error`, `onRetry`, `onAlbumsChange`, `onSelectAlbum`, `onAlbumCreated`).
- Selection / back / tab-switch now flow through `router.push(\`/\${orgSlug}/media?album=<id>\`)` — the URL never gets cleaned mid-flight.
- `GlobalSearchPalette` drops the `&_t=` cache-buster; no longer needed.

Removed: `autoSelectAlbumId`, `autoSelectSeq`, `didAutoSelect` ref, the `deepLinkAlbumId` / `deepLinkKey` prop pair, and the `history.replaceState` URL cleanup.

## Test plan

- [ ] Cold nav: from `/[orgSlug]/calendar`, Cmd+K → search album → click → lands on `/[orgSlug]/media?album=<id>` with the album open
- [ ] Already on `/media` grid: Cmd+K → search → click → album opens without flicker
- [ ] Already viewing album A: search for album B → view switches to B
- [ ] Back from a deep-linked album returns to the grid (does NOT bounce back into the album)
- [ ] Refresh on `/media?album=<id>` reloads the album view
- [ ] Clicking an album card in the grid updates the URL and opens the album; browser Back returns to grid
- [ ] Switching to "All Photos" tab while viewing an album drops `?album=` and shows photos
- [ ] Deleting an album from AlbumView returns to grid with no stale `?album=`
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run lint` clean
- [ ] Media album tests pass (verified locally)