### PR TITLE
chore(ai): drop stale ai_draft_sessions.draft_type CHECK

### DIFF
--- a/supabase/migrations/20261101000000_ai_draft_sessions_drop_draft_type_check.sql
+++ b/supabase/migrations/20261101000000_ai_draft_sessions_drop_draft_type_check.sql
@@ -1,0 +1,17 @@
+-- Drop the stale ai_draft_sessions.draft_type CHECK constraint.
+--
+-- The CHECK has been amended five-plus times as the agent's tool surface has
+-- grown (create_announcement, send_chat_message, create_event, reply/chat
+-- variants, etc.). Tier 1 edit/delete parity adds more draft_type values and
+-- further tiers will add more; each amendment is another DDL change with
+-- production lock exposure on a hot-path table.
+--
+-- Validation moves to the TypeScript layer. Phase 1a lands a Zod enum gate
+-- inside saveDraftSession keyed on DRAFT_SESSION_TYPES. Until Phase 1a ships,
+-- DraftSessionType in src/lib/ai/draft-sessions.ts is the de-facto gate —
+-- every caller is type-checked against the union.
+--
+-- Plan: ~/.claude/plans/i-want-you-to-quirky-sprout.md (Phase 0a; addendum A6).
+
+ALTER TABLE public.ai_draft_sessions
+  DROP CONSTRAINT IF EXISTS ai_draft_sessions_draft_type_check;


### PR DESCRIPTION
## Summary

First PR of the Tier 1 edit/delete parity plan — **Phase 0a**. Drops the stale `ai_draft_sessions.draft_type` CHECK constraint so future tool additions don't require repeated DDL amendments on a hot-path table.

- **What:** `ALTER TABLE ... DROP CONSTRAINT IF EXISTS ai_draft_sessions_draft_type_check`
- **Why:** the CHECK has been amended repeatedly (`create_announcement`, `send_chat_message`, `create_event`, reply/chat variants). Tier 1 edit/delete parity adds more values, and future tiers add more — every amendment is another schema-lock risk.
- **What replaces the CHECK:** a TypeScript-layer Zod gate in `saveDraftSession`, landing in Phase 1a. Until then, `DraftSessionType` in `src/lib/ai/draft-sessions.ts` is the de-facto gate — every caller is type-checked against the union.

### Key decision (trade-off)

Strict Phase 0a scope per the plan owner: migration only, no TS changes in this PR. There is a small window between merging this PR and Phase 1a where the `draft_type` column has no runtime validation. Risk is low — the only production writer is `saveDraftSession`, which is already type-gated by `DraftSessionType`. Anything that bypasses TS (e.g., a manual insert, a service-role script) could insert garbage until Phase 1a lands. Mitigation: prioritize Phase 1a for the next PR.

## Testing

- Migration is a metadata-only `ALTER TABLE ... DROP CONSTRAINT IF EXISTS`. Idempotent — re-running or running against a DB where the constraint has already been amended away is a no-op.
- No application code changed. Existing tests are unaffected.
- Supabase branch preview will apply the migration end-to-end.

### Pre-deploy verification

\`\`\`sql
-- Confirm the CHECK exists and capture its current definition for rollback:
SELECT conname, pg_get_constraintdef(c.oid)
FROM pg_constraint c
WHERE c.conrelid = 'public.ai_draft_sessions'::regclass
  AND c.contype = 'c'
  AND c.conname = 'ai_draft_sessions_draft_type_check';
\`\`\`

### Post-deploy verification

\`\`\`sql
-- Expect zero rows:
SELECT conname
FROM pg_constraint c
WHERE c.conrelid = 'public.ai_draft_sessions'::regclass
  AND c.conname = 'ai_draft_sessions_draft_type_check';

-- Smoke-test insert still respects RLS and type:
-- (run through the normal agent create flow; verify draft_type column populated)
SELECT draft_type, count(*)
FROM ai_draft_sessions
WHERE created_at > now() - interval '1 hour'
GROUP BY 1;
\`\`\`

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: any Postgres error matching `ai_draft_sessions_draft_type_check` (should be zero post-deploy — absence is the signal)
  - Logs: Supabase error mentioning `violates check constraint` on `ai_draft_sessions` (should be zero)
  - Metrics: INSERT p95 latency on `ai_draft_sessions` (should be unchanged — metadata-only ALTER)

- **Validation checks (queries/commands)**
  - `SELECT conname FROM pg_constraint WHERE conrelid = 'public.ai_draft_sessions'::regclass AND conname = 'ai_draft_sessions_draft_type_check';` — expect no rows.
  - `SELECT status, draft_type, COUNT(*) FROM ai_draft_sessions WHERE created_at > now() - interval '1 hour' GROUP BY 1,2;` — verify draft flow still writes.

- **Expected healthy behavior**
  - Migration applies in <100ms against production.
  - No CHECK-constraint errors in Postgres logs.
  - Existing agent create flows (announcements, events, jobs, chat, discussions) continue to work without change.

- **Failure signal(s) / rollback trigger**
  - Any application-layer write of an unexpected `draft_type` value → rollback.
  - Rollback SQL:
    \`\`\`sql
    ALTER TABLE public.ai_draft_sessions
      ADD CONSTRAINT ai_draft_sessions_draft_type_check
      CHECK (draft_type IN (
        'create_announcement',
        'create_job_posting',
        'send_chat_message',
        'send_group_chat_message',
        'create_discussion_reply',
        'create_discussion_thread',
        'create_event'
      ));
    \`\`\`
  - Rollback validation: pre-deploy SQL above should again return one row.

- **Validation window & owner**
  - Window: 1 hour post-deploy. The only agent touchpoint is `saveDraftSession`, which emits the TS-gated value — any regression surfaces immediately.
  - Owner: the PR author.

## Follow-up (next PR, Phase 1a)

- Convert `DraftSessionType` to a `DRAFT_SESSION_TYPES` const-tuple-backed union.
- Add a Zod enum gate inside `saveDraftSession` before every insert.
- Widen the `(organization_id, user_id, thread_id)` unique key on `ai_draft_sessions` to `(thread_id, draft_type)` per addendum A3.2.

Plan: `~/.claude/plans/i-want-you-to-quirky-sprout.md` (Phase 0a; addendum A6).

---

🤖 Generated with Claude Opus 4.7 (1M context, ultrathink) via Claude Code