### PR TITLE
chore(ai): add Zod gate on draft_type in saveDraftSession

### DIFF
--- a/src/lib/ai/draft-sessions.ts
+++ b/src/lib/ai/draft-sessions.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { AssistantAnnouncementDraft } from "@/lib/schemas/content";
 import type {
   AssistantDiscussionDraft,
@@ -10,6 +11,21 @@ import { AI_PENDING_ACTION_EXPIRY_MS } from "@/lib/ai/pending-actions";
 
 export type DraftSessionStatus = "collecting_fields" | "ready_for_confirmation";
 
+// Single source of truth for the draft_type enum. The prior CHECK constraint
+// (see migration 20261101000000) was dropped; this tuple plus the Zod guard in
+// saveDraftSession enforces the contract at the application boundary.
+export const DRAFT_SESSION_TYPES = [
+  "create_announcement",
+  "create_job_posting",
+  "send_chat_message",
+  "send_group_chat_message",
+  "create_discussion_reply",
+  "create_discussion_thread",
+  "create_event",
+] as const;
+
+export type DraftSessionType = (typeof DRAFT_SESSION_TYPES)[number];
+
 export interface DraftSessionPayloadByType {
   create_announcement: AssistantAnnouncementDraft;
   create_job_posting: AssistantJobDraft;
@@ -20,7 +36,19 @@ export interface DraftSessionPayloadByType {
   create_event: AssistantEventDraft;
 }
 
-export type DraftSessionType = keyof DraftSessionPayloadByType;
+// Compile fails if DRAFT_SESSION_TYPES and DraftSessionPayloadByType diverge.
+type _MissingFromPayload = Exclude<DraftSessionType, keyof DraftSessionPayloadByType>;
+type _MissingFromTypes = Exclude<keyof DraftSessionPayloadByType, DraftSessionType>;
+type _DraftSessionCoverageOK = [
+  _MissingFromPayload,
+  _MissingFromTypes,
+] extends [never, never]
+  ? true
+  : never;
+const _draftSessionCoverageOK: _DraftSessionCoverageOK = true;
+void _draftSessionCoverageOK;
+
+const draftSessionTypeSchema = z.enum(DRAFT_SESSION_TYPES);
 
 export type DraftSessionPayload = DraftSessionPayloadByType[DraftSessionType];
 
@@ -120,6 +148,10 @@ export async function saveDraftSession(
     expiresAt?: string;
   }
 ): Promise<DraftSessionRecord> {
+  if (!draftSessionTypeSchema.safeParse(input.draftType).success) {
+    throw new Error(`Invalid draft_type: ${String(input.draftType)}`);
+  }
+
   const payload = {
     organization_id: input.organizationId,
     user_id: input.userId,

--- a/tests/ai-draft-sessions-zod-gate.test.ts
+++ b/tests/ai-draft-sessions-zod-gate.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DRAFT_SESSION_TYPES,
+  saveDraftSession,
+  type DraftSessionType,
+} from "@/lib/ai/draft-sessions";
+
+describe("DRAFT_SESSION_TYPES const tuple", () => {
+  it("exports the 7 known draft types in a readonly tuple", () => {
+    assert.deepEqual(
+      [...DRAFT_SESSION_TYPES].sort(),
+      [
+        "create_announcement",
+        "create_discussion_reply",
+        "create_discussion_thread",
+        "create_event",
+        "create_job_posting",
+        "send_chat_message",
+        "send_group_chat_message",
+      ]
+    );
+  });
+});
+
+describe("saveDraftSession Zod gate on draft_type", () => {
+  const failIfCalled = {
+    from: () => {
+      throw new Error(
+        "supabase.from should not be called when draft_type validation fails"
+      );
+    },
+  } as unknown as Parameters<typeof saveDraftSession>[0];
+
+  const baseInput = {
+    organizationId: "00000000-0000-0000-0000-000000000001",
+    userId: "00000000-0000-0000-0000-000000000002",
+    threadId: "00000000-0000-0000-0000-000000000003",
+    status: "collecting_fields" as const,
+    draftPayload: {} as never,
+    missingFields: [],
+  };
+
+  it("rejects an invalid draft_type string before touching supabase", async () => {
+    await assert.rejects(
+      () =>
+        saveDraftSession(failIfCalled, {
+          ...baseInput,
+          draftType: "not_a_real_type" as unknown as DraftSessionType,
+        }),
+      /Invalid draft_type/
+    );
+  });
+
+  it("rejects empty-string draft_type (simulates bad JSON input)", async () => {
+    await assert.rejects(
+      () =>
+        saveDraftSession(failIfCalled, {
+          ...baseInput,
+          draftType: "" as unknown as DraftSessionType,
+        }),
+      /Invalid draft_type/
+    );
+  });
+
+  it("rejects an attempt to insert a legacy-but-removed value", async () => {
+    // If the CHECK constraint used to allow some value we no longer support,
+    // the Zod gate should still reject it.
+    await assert.rejects(
+      () =>
+        saveDraftSession(failIfCalled, {
+          ...baseInput,
+          draftType: "retired_legacy_type" as unknown as DraftSessionType,
+        }),
+      /Invalid draft_type/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1a-narrow of the Tier 1 edit/delete parity plan. Closes the runtime-validation gap opened by [PR #119](https://github.com/cicconel11/TeamNetwork/pull/119) (Phase 0a, which dropped the `ai_draft_sessions.draft_type` CHECK constraint).

- `DRAFT_SESSION_TYPES` becomes the single source of truth — a frozen const tuple.
- `DraftSessionType` now derives from the tuple (`typeof DRAFT_SESSION_TYPES[number]`) instead of `keyof DraftSessionPayloadByType`.
- A Zod enum gate inside `saveDraftSession` rejects invalid `draft_type` values before any Supabase write.
- A bi-directional compile-time coverage check (`Exclude<…, …> extends [never, never]`) prevents the const tuple and `DraftSessionPayloadByType` from silently diverging.

This PR does **not** depend on #119 having merged. The Zod gate is defense-in-depth and works whether the CHECK is in place or not. They can land in either order.

### Trade-off / scope

Strict Phase 1a-narrow: 1 TS file modified + 1 test file added. Deliberately excludes:
- Unique-key widening on `ai_draft_sessions` (from `(thread_id)` to `(thread_id, draft_type)`) — lives in Phase 1a-full, requires caller updates in `executor.ts`.
- Phase 1b shared primitives (`resolveAgentActionTarget`, `DomainResult`).

## Testing

New: `tests/ai-draft-sessions-zod-gate.test.ts` — 4 tests.

\`\`\`
▶ DRAFT_SESSION_TYPES const tuple
  ✔ exports the 7 known draft types in a readonly tuple
▶ saveDraftSession Zod gate on draft_type
  ✔ rejects an invalid draft_type string before touching supabase
  ✔ rejects empty-string draft_type (simulates bad JSON input)
  ✔ rejects an attempt to insert a legacy-but-removed value
\`\`\`

Regression check: `tests/ai-draft-sessions-migration-contract.test.ts` and `tests/routes/ai/chat-handler-tools.test.ts` (the only other consumers of draft-session symbols) all pass — **76 tests total, 0 failures**.

Additional gates green:
- `npx tsc --noEmit` — clean
- `npx eslint src/lib/ai/draft-sessions.ts tests/ai-draft-sessions-zod-gate.test.ts` — clean

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: application errors matching `Invalid draft_type:` — **expected rate: zero** in steady state. A non-zero rate indicates either a genuine bypass of the TS type gate (worth investigating) or a malformed request hitting the agent handler.
  - Metrics: `/api/ai/*/chat` success rate and p95 latency. No regression expected (the Zod parse is sub-microsecond).

- **Validation checks (queries/commands)**
  - After deploy, exercise the agent create flow for each of the 7 draft types in a staging org. Confirm each `draft_type` round-trips into `ai_draft_sessions` without hitting the new error path.
  - Grep production logs: `grep "Invalid draft_type:"` — should return 0 matches over the 1-hour validation window.

- **Expected healthy behavior**
  - Identical request/response behavior for all well-formed agent turns — the new code path only fires on malformed input that was previously accepted silently by TS casts.

- **Failure signal(s) / rollback trigger**
  - Any `Invalid draft_type:` error in logs — investigate the source (is it a real malformed request or a TS escape hatch we missed?).
  - If the error fires on legitimate traffic for a draft type that SHOULD be supported: rollback by reverting this commit. The CHECK constraint is already dropped (PR #119), so rollback leaves the previous state — TS-only gating, no runtime validation.

- **Validation window & owner**
  - Window: 1 hour after deploy.
  - Owner: PR author.

## Follow-up (next PRs)

- **Phase 1a-full:** widen `ai_draft_sessions` unique index from `(thread_id)` to `(thread_id, draft_type)`, update `getDraftSession` signature, update all callers in `executor.ts`. Regression-heavy; separate PR.
- **Phase 0b:** `CREATE INDEX CONCURRENTLY` on `ai_pending_actions` + new columns (`target_entity_*`, `payload_before`, `attempt_count`, `replay_result`). Parallelizable with 1a-full.

---

🤖 Generated with Claude Opus 4.7 (1M context, ultrathink) via Claude Code