### PR TITLE
chore(ai): Tier 1 Phase 0b — mutation columns and indexes on ai_pending_actions

### DIFF
--- a/supabase/migrations/20261101000001_ai_pending_actions_tier1_mutation_columns_and_indexes.sql
+++ b/supabase/migrations/20261101000001_ai_pending_actions_tier1_mutation_columns_and_indexes.sql
@@ -1,0 +1,56 @@
+-- Phase 0b of the Tier 1 edit/delete parity plan. Extends ai_pending_actions
+-- to support the new prepare_edit_* / prepare_delete_* tool families without
+-- further schema churn once the application code lands.
+--
+-- Columns:
+--   target_entity_{type,id}  Populated at prepare time for edit/delete ops so
+--                            resolveAgentActionTarget can index-lookup "most
+--                            recent X I touched" without decoding payload jsonb.
+--   payload_before           Pre-mutation row snapshot for destructive ops —
+--                            forensic trail required by security review A2.5.
+--   resolved_target          What the resolver returned at prepare time, distinct
+--                            from raw tool args. Lets audits separate model intent
+--                            from resolver expansion.
+--   attempt_count            Number of times this row has been claimed confirmed.
+--                            Surfaces retry behaviour to operators / UI.
+--   last_attempt_error       Error classification from the most recent failed
+--                            attempt. Cleared on executed.
+--   replay_result            Stored response shape so idempotent re-confirms
+--                            return identical data, not just { ok: true }.
+--
+-- Indexes:
+--   idx_ai_pending_actions_user_entity_executed
+--     Partial composite serving the resolver's "most-recent-entity" fallback.
+--     INCLUDE (result_entity_id) enables index-only scan.
+--     Columns: (user_id, organization_id, result_entity_type, executed_at DESC, id)
+--     id is the deterministic tiebreaker when two actions execute in the same ms.
+--   idx_ai_pending_actions_one_pending_per_target
+--     Unique partial — prevents concurrent pending mutations on the same entity
+--     (two edits, or edit+delete, racing against each other).
+--
+-- Data safety: all additions are nullable or non-volatile defaults. PG 11+
+-- handles ADD COLUMN ... NOT NULL DEFAULT as metadata-only, no table rewrite.
+-- Indexes use plain CREATE INDEX per repo convention (see
+-- 20260812000003_perf_hotpath_indexes_and_initplan.sql) — Supabase migrations
+-- run in a transaction, CONCURRENTLY would fail. ai_pending_actions is
+-- TTL-bounded and small, so the brief write lock is acceptable.
+--
+-- Plan: ~/.claude/plans/i-want-you-to-quirky-sprout.md (Phase 0b; addendum A6).
+
+ALTER TABLE public.ai_pending_actions
+  ADD COLUMN IF NOT EXISTS target_entity_type text,
+  ADD COLUMN IF NOT EXISTS target_entity_id uuid,
+  ADD COLUMN IF NOT EXISTS payload_before jsonb,
+  ADD COLUMN IF NOT EXISTS resolved_target jsonb,
+  ADD COLUMN IF NOT EXISTS attempt_count int NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_attempt_error text,
+  ADD COLUMN IF NOT EXISTS replay_result jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_ai_pending_actions_user_entity_executed
+  ON public.ai_pending_actions (user_id, organization_id, result_entity_type, executed_at DESC, id)
+  INCLUDE (result_entity_id)
+  WHERE status = 'executed' AND result_entity_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_pending_actions_one_pending_per_target
+  ON public.ai_pending_actions (organization_id, target_entity_type, target_entity_id)
+  WHERE status = 'pending' AND target_entity_id IS NOT NULL;

--- a/tests/ai-pending-actions-tier1-migration-contract.test.ts
+++ b/tests/ai-pending-actions-tier1-migration-contract.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const migration = readFileSync(
+  new URL(
+    "../supabase/migrations/20261101000001_ai_pending_actions_tier1_mutation_columns_and_indexes.sql",
+    import.meta.url
+  ),
+  "utf8"
+);
+
+describe("ai_pending_actions Tier 1 migration — added columns", () => {
+  it("adds target_entity_type text", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS target_entity_type text/);
+  });
+
+  it("adds target_entity_id uuid", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS target_entity_id uuid/);
+  });
+
+  it("adds payload_before jsonb", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS payload_before jsonb/);
+  });
+
+  it("adds resolved_target jsonb", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS resolved_target jsonb/);
+  });
+
+  it("adds attempt_count int NOT NULL DEFAULT 0", () => {
+    assert.match(
+      migration,
+      /ADD COLUMN IF NOT EXISTS attempt_count\s+int\s+NOT NULL\s+DEFAULT\s+0/i
+    );
+  });
+
+  it("adds last_attempt_error text", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS last_attempt_error text/);
+  });
+
+  it("adds replay_result jsonb", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS replay_result jsonb/);
+  });
+});
+
+describe("ai_pending_actions Tier 1 migration — most-recent-entity index", () => {
+  it("creates the user_entity_executed partial composite index", () => {
+    assert.match(
+      migration,
+      /CREATE INDEX IF NOT EXISTS idx_ai_pending_actions_user_entity_executed/i
+    );
+  });
+
+  it("indexes (user_id, organization_id, result_entity_type, executed_at DESC, id)", () => {
+    assert.match(
+      migration,
+      /ON public\.ai_pending_actions\s*\(\s*user_id\s*,\s*organization_id\s*,\s*result_entity_type\s*,\s*executed_at\s+DESC\s*,\s*id\s*\)/i
+    );
+  });
+
+  it("uses INCLUDE (result_entity_id) for index-only scan", () => {
+    assert.match(migration, /INCLUDE\s*\(\s*result_entity_id\s*\)/i);
+  });
+
+  it("restricts to executed rows with a result_entity_id", () => {
+    assert.match(
+      migration,
+      /WHERE\s+status\s*=\s*'executed'\s+AND\s+result_entity_id\s+IS\s+NOT\s+NULL/i
+    );
+  });
+});
+
+describe("ai_pending_actions Tier 1 migration — one-pending-per-target unique index", () => {
+  it("creates idx_ai_pending_actions_one_pending_per_target as UNIQUE", () => {
+    assert.match(
+      migration,
+      /CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_pending_actions_one_pending_per_target/i
+    );
+  });
+
+  it("keys on (organization_id, target_entity_type, target_entity_id)", () => {
+    assert.match(
+      migration,
+      /\(\s*organization_id\s*,\s*target_entity_type\s*,\s*target_entity_id\s*\)/i
+    );
+  });
+
+  it("applies only to pending rows with a target_entity_id", () => {
+    assert.match(
+      migration,
+      /WHERE\s+status\s*=\s*'pending'\s+AND\s+target_entity_id\s+IS\s+NOT\s+NULL/i
+    );
+  });
+});
+
+describe("ai_pending_actions Tier 1 migration — repo conventions", () => {
+  it("follows the repo's plain CREATE INDEX convention (no CONCURRENTLY)", () => {
+    // Supabase wraps each migration in a transaction; CONCURRENTLY would fail.
+    // See 20260812000003_perf_hotpath_indexes_and_initplan.sql for the stated convention.
+    assert.doesNotMatch(migration, /CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY/i);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 0b of the Tier 1 edit/delete parity plan. Extends `ai_pending_actions` with columns and indexes required by the `prepare_edit_*` / `prepare_delete_*` tool families that will land in Phase 2 and beyond. **Pure infrastructure — zero behaviour change.** No caller imports the new columns in this PR.

### Columns added

| Column | Type | Purpose |
|--------|------|---------|
| `target_entity_type` | `text` | Populated at prepare time for edit/delete ops |
| `target_entity_id` | `uuid` | Enables indexable "most recent X I touched" lookup |
| `payload_before` | `jsonb` | Pre-mutation snapshot — security A2.5 forensic requirement |
| `resolved_target` | `jsonb` | What the resolver returned, distinct from raw tool args |
| `attempt_count` | `int NOT NULL DEFAULT 0` | CAS retry visibility (A3.7) |
| `last_attempt_error` | `text` | Most recent error class on failed confirm |
| `replay_result` | `jsonb` | Stored response for idempotent re-confirms (A3.7) |

### Indexes added

**`idx_ai_pending_actions_user_entity_executed`** — partial composite, supports the resolver's most-recent-entity fallback:

\`\`\`sql
ON (user_id, organization_id, result_entity_type, executed_at DESC, id)
INCLUDE (result_entity_id)
WHERE status = 'executed' AND result_entity_id IS NOT NULL
\`\`\`

`INCLUDE (result_entity_id)` enables an index-only scan. `id` is the deterministic tiebreaker when two actions execute in the same millisecond (addendum A3.3).

**`idx_ai_pending_actions_one_pending_per_target`** — unique partial, prevents concurrent pending mutations on one entity (addendum A3.2):

\`\`\`sql
ON (organization_id, target_entity_type, target_entity_id)
WHERE status = 'pending' AND target_entity_id IS NOT NULL
\`\`\`

### Key decision: plain CREATE INDEX, not CONCURRENTLY

The deepening review recommended `CREATE INDEX CONCURRENTLY`. This repo's **stated convention** is plain `CREATE INDEX` — see the comment in [`20260812000003_perf_hotpath_indexes_and_initplan.sql`](https://github.com/cicconel11/TeamNetwork/blob/main/supabase/migrations/20260812000003_perf_hotpath_indexes_and_initplan.sql): *"Uses plain CREATE INDEX (not CONCURRENTLY) — Supabase migrations run in a transaction."*

`ai_pending_actions` is TTL-bounded (15-min expiry on pending rows, executed rows retained briefly). At any realistic production scale the table holds thousands of rows, not millions. Plain `CREATE INDEX` on a table this size takes a write lock for milliseconds, which is acceptable. Following repo convention wins over the deepening reviewer's recommendation here.

### Reaper index audit (addendum 0b-3)

The addendum flagged a conditional check for a replacement index on `(status, expires_at)` after `idx_ai_pending_actions_thread_pending` was dropped on 2026-08-12. **No action needed** — `idx_ai_pending_actions_expires` on `(expires_at)` (created in `20260727000000`) still exists and serves the reaper cron. Verified via `git grep`.

## Testing

New: `tests/ai-pending-actions-tier1-migration-contract.test.ts` — 15 assertions across 4 test suites, following the existing `tests/ai-*-migration-contract.test.ts` pattern.

\`\`\`
▶ ai_pending_actions Tier 1 migration — added columns (7 assertions)
▶ ai_pending_actions Tier 1 migration — most-recent-entity index (4 assertions)
▶ ai_pending_actions Tier 1 migration — one-pending-per-target unique index (3 assertions)
▶ ai_pending_actions Tier 1 migration — repo conventions (1 assertion)
ℹ tests 15, pass 15, fail 0
\`\`\`

Lint on the new test file clean. No TS code changes → no tsc check needed.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: Postgres errors matching `idx_ai_pending_actions_one_pending_per_target` — **expected rate: zero**. If non-zero, it means two concurrent attempts to prepare a pending mutation on the same entity (which is exactly what this index is meant to prevent — the second one should get a unique-violation error).
  - Logs: any error mentioning `target_entity_type` or `target_entity_id` column references — should be zero (no code reads these yet).
  - Metrics: INSERT p95 on `ai_pending_actions` — compare pre-migration baseline to post. Expected impact: negligible. The ADD COLUMNs are metadata-only; the two new indexes add tiny write amplification on status-transition updates.

- **Validation checks (queries/commands)**
  - \`\`\`sql
    -- All seven columns present
    SELECT column_name, data_type, is_nullable, column_default
    FROM information_schema.columns
    WHERE table_schema = 'public' AND table_name = 'ai_pending_actions'
      AND column_name IN (
        'target_entity_type','target_entity_id','payload_before','resolved_target',
        'attempt_count','last_attempt_error','replay_result'
      )
    ORDER BY column_name;
    \`\`\`
  - \`\`\`sql
    -- Both indexes present and valid
    SELECT indexname, pg_index.indisvalid
    FROM pg_indexes
    JOIN pg_class c ON c.relname = pg_indexes.indexname
    JOIN pg_index ON pg_index.indexrelid = c.oid
    WHERE tablename = 'ai_pending_actions'
      AND indexname IN (
        'idx_ai_pending_actions_user_entity_executed',
        'idx_ai_pending_actions_one_pending_per_target'
      );
    \`\`\`
  - \`\`\`sql
    -- Planner picks the new index for the resolver query shape
    EXPLAIN (ANALYZE, BUFFERS)
    SELECT result_entity_id FROM ai_pending_actions
    WHERE user_id = gen_random_uuid()
      AND organization_id = gen_random_uuid()
      AND result_entity_type = 'announcement'
      AND status = 'executed'
      AND executed_at >= now() - interval '15 minutes'
    ORDER BY executed_at DESC, id DESC
    LIMIT 1;
    -- Expect: Index Only Scan using idx_ai_pending_actions_user_entity_executed
    \`\`\`

- **Expected healthy behavior**
  - Migration applies in well under 1 second against production (metadata-only ALTER + two small indexes on a TTL-bounded table).
  - `attempt_count` reads as `0` for every existing row.
  - All other new columns read as `NULL` for existing rows.
  - Existing agent flows (create announcements/events/jobs/discussions/chat) unchanged — none of them read or write the new columns.

- **Failure signal(s) / rollback trigger**
  - Long-running migration (>10s) → investigate table size growth since planning.
  - Planner NOT using the new `user_entity_executed` index for the EXPLAIN query above → investigate filter predicate match.
  - Rollback SQL:
    \`\`\`sql
    DROP INDEX IF EXISTS public.idx_ai_pending_actions_one_pending_per_target;
    DROP INDEX IF EXISTS public.idx_ai_pending_actions_user_entity_executed;
    ALTER TABLE public.ai_pending_actions
      DROP COLUMN IF EXISTS replay_result,
      DROP COLUMN IF EXISTS last_attempt_error,
      DROP COLUMN IF EXISTS attempt_count,
      DROP COLUMN IF EXISTS resolved_target,
      DROP COLUMN IF EXISTS payload_before,
      DROP COLUMN IF EXISTS target_entity_id,
      DROP COLUMN IF EXISTS target_entity_type;
    \`\`\`
  - Safe to rollback any time before Phase 2 starts writing to the new columns. After Phase 2, rollback requires coordinated code revert.

- **Validation window & owner**
  - Window: 1 hour post-deploy. No behaviour change, so the window is mostly "confirm no surprises from the ALTER TABLE."
  - Owner: PR author.

## Follow-up (next PRs)

- **Phase 1a-full** — widen `ai_draft_sessions` unique index from `(thread_id)` to `(thread_id, draft_type)`, update `getDraftSession` callers. Regression-heavy, separate PR.
- **Phase 0.5** — pre-split `handler.ts` (920 LOC) and `executor.ts` (3,460 LOC) by domain, enabling parallel work on Phases 3–6.
- **Phase 2** — the actual first behaviour change: announcements edit + delete (pilot).

## Related PRs

- #119 — Phase 0a (drop `ai_draft_sessions.draft_type` CHECK)
- #120 — Phase 1a-narrow (Zod gate + const tuple)

All three are independent; merge order doesn't matter.

---

🤖 Generated with Claude Opus 4.7 (1M context, ultrathink) via Claude Code