### PR TITLE
feat(ai): Tier 1 Phase 1b-narrow — DomainResult type and target resolver

### DIFF
--- a/src/lib/ai/shared/domain-result.ts
+++ b/src/lib/ai/shared/domain-result.ts
@@ -1,0 +1,13 @@
+// Discriminated result type for agent mutation primitives. The finite numeric
+// status union maps to HTTP statuses the confirm handler returns to the
+// client and keeps callers exhaustive at the type level — no accidental 500
+// escape hatches.
+
+export type DomainResult<T> =
+  | { ok: true; value: T }
+  | {
+      ok: false;
+      status: 400 | 403 | 404 | 409 | 410 | 422 | 500;
+      error: string;
+      details?: Record<string, unknown>;
+    };

--- a/src/lib/ai/tools/target-resolver.ts
+++ b/src/lib/ai/tools/target-resolver.ts
@@ -1,0 +1,135 @@
+// Target resolver for agent edit/delete tool calls. Phase 1b-narrow scope:
+// answer "which entity id are we talking about" without fetching the row or
+// touching per-domain logic. Per-domain by-id and by-name predicates arrive
+// alongside each domain tool in Phase 2+.
+//
+// The resolver handles three paths:
+//   1. Explicit targetId → short-circuit, return as-is.
+//   2. Most-recent fallback (edit only) → consult ai_pending_actions and
+//      surface the result_entity_id of the caller's most recent executed
+//      action on the same entity type, bounded by windowMs.
+//   3. fallback: "none" or fallback disabled → return needs_target_id so the
+//      model asks the user for an explicit id.
+//
+// Destructive ops (delete, cancel) deliberately disable the most-recent
+// fallback — security addendum A2.1. The lookback window is narrowed to 15m
+// for edit per performance review, down from the original 1h proposal.
+
+export type EntityType =
+  | "announcement"
+  | "event"
+  | "job"
+  | "discussion_thread"
+  | "discussion_reply"
+  | "chat_message";
+
+export type TargetOp = "edit" | "delete" | "cancel" | "expire";
+
+export type ResolverFallback = "most_recent" | "none";
+
+export const AI_RECENT_ENTITY_LOOKBACK_EDIT_MS = 15 * 60 * 1000;
+export const AI_RECENT_ENTITY_LOOKBACK_DELETE_MS = 0;
+
+// Minimal Supabase-shape the resolver relies on. Deliberately narrow so unit
+// tests don't need the real client or a heavyweight stub.
+export interface ResolverSupabaseClient {
+  from(table: "ai_pending_actions"): {
+    select(columns: string): ResolverFilterChain;
+  };
+}
+
+type ResolverRow = { result_entity_id: string | null };
+
+export interface ResolverFilterChain
+  extends PromiseLike<{ data: ResolverRow[] | null; error: unknown }> {
+  eq(column: string, value: unknown): ResolverFilterChain;
+  gte(column: string, value: string): ResolverFilterChain;
+  order(
+    column: string,
+    options: { ascending: boolean }
+  ): ResolverFilterChain;
+  limit(n: number): ResolverFilterChain;
+}
+
+export interface ResolveArgs {
+  supabase: ResolverSupabaseClient;
+  caller: { userId: string; organizationId: string };
+  entityType: EntityType;
+  op: TargetOp;
+  targetId?: string;
+  fallback: ResolverFallback;
+  windowMs?: number;
+}
+
+export type ResolveResult =
+  | { kind: "resolved"; targetId: string; entityType: EntityType }
+  | { kind: "needs_target_id"; reason: string }
+  | { kind: "not_found" };
+
+export async function resolveAgentActionTarget(
+  args: ResolveArgs
+): Promise<ResolveResult> {
+  if (args.targetId) {
+    return {
+      kind: "resolved",
+      targetId: args.targetId,
+      entityType: args.entityType,
+    };
+  }
+
+  if (args.fallback === "none") {
+    return {
+      kind: "needs_target_id",
+      reason: "Explicit target_id is required for this operation.",
+    };
+  }
+
+  const windowMs = args.windowMs ?? windowForOp(args.op);
+  if (windowMs <= 0) {
+    return {
+      kind: "needs_target_id",
+      reason: `Most-recent fallback is disabled for ${args.op}; supply an explicit target_id.`,
+    };
+  }
+
+  const cutoff = new Date(Date.now() - windowMs).toISOString();
+  const { data, error } = await args.supabase
+    .from("ai_pending_actions")
+    .select("result_entity_id")
+    .eq("user_id", args.caller.userId)
+    .eq("organization_id", args.caller.organizationId)
+    .eq("result_entity_type", args.entityType)
+    .eq("status", "executed")
+    .gte("executed_at", cutoff)
+    .order("executed_at", { ascending: false })
+    .order("id", { ascending: false })
+    .limit(1);
+
+  if (error) {
+    throw new Error(
+      "resolveAgentActionTarget: ai_pending_actions most-recent query failed"
+    );
+  }
+
+  const row = (data ?? [])[0];
+  if (!row?.result_entity_id) {
+    return { kind: "not_found" };
+  }
+
+  return {
+    kind: "resolved",
+    targetId: row.result_entity_id,
+    entityType: args.entityType,
+  };
+}
+
+function windowForOp(op: TargetOp): number {
+  switch (op) {
+    case "edit":
+    case "expire":
+      return AI_RECENT_ENTITY_LOOKBACK_EDIT_MS;
+    case "delete":
+    case "cancel":
+      return AI_RECENT_ENTITY_LOOKBACK_DELETE_MS;
+  }
+}

--- a/tests/ai-target-resolver.test.ts
+++ b/tests/ai-target-resolver.test.ts
@@ -1,0 +1,299 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  AI_RECENT_ENTITY_LOOKBACK_EDIT_MS,
+  AI_RECENT_ENTITY_LOOKBACK_DELETE_MS,
+  resolveAgentActionTarget,
+  type ResolverSupabaseClient,
+} from "@/lib/ai/tools/target-resolver";
+
+type RecordedCall =
+  | { op: "from"; table: string }
+  | { op: "select"; columns: string }
+  | { op: "eq"; column: string; value: unknown }
+  | { op: "gte"; column: string; value: unknown }
+  | { op: "order"; column: string; options: { ascending: boolean } }
+  | { op: "limit"; n: number };
+
+function stubSupabase(
+  rows: Array<{ result_entity_id: string }>,
+  calls: RecordedCall[] = []
+): { client: ResolverSupabaseClient; calls: RecordedCall[] } {
+  const chain: {
+    eq: (column: string, value: unknown) => typeof chain;
+    gte: (column: string, value: unknown) => typeof chain;
+    order: (column: string, options: { ascending: boolean }) => typeof chain;
+    limit: (n: number) => typeof chain;
+    then: <R>(
+      onFulfilled: (v: { data: typeof rows; error: null }) => R
+    ) => Promise<R>;
+  } = {
+    eq(column, value) {
+      calls.push({ op: "eq", column, value });
+      return chain;
+    },
+    gte(column, value) {
+      calls.push({ op: "gte", column, value });
+      return chain;
+    },
+    order(column, options) {
+      calls.push({ op: "order", column, options });
+      return chain;
+    },
+    limit(n) {
+      calls.push({ op: "limit", n });
+      return chain;
+    },
+    then(onFulfilled) {
+      return Promise.resolve(onFulfilled({ data: rows, error: null }));
+    },
+  };
+
+  const client = {
+    from(table: string) {
+      calls.push({ op: "from", table });
+      return {
+        select(columns: string) {
+          calls.push({ op: "select", columns });
+          return chain;
+        },
+      };
+    },
+  } as unknown as ResolverSupabaseClient;
+
+  return { client, calls };
+}
+
+describe("resolveAgentActionTarget — explicit target_id short-circuit", () => {
+  it("returns resolved immediately without touching supabase", async () => {
+    const { client, calls } = stubSupabase([]);
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "announcement",
+      op: "edit",
+      targetId: "00000000-0000-0000-0000-0000000000aa",
+      fallback: "most_recent",
+    });
+
+    assert.equal(result.kind, "resolved");
+    if (result.kind === "resolved") {
+      assert.equal(result.targetId, "00000000-0000-0000-0000-0000000000aa");
+      assert.equal(result.entityType, "announcement");
+    }
+    assert.equal(calls.length, 0);
+  });
+
+  it("short-circuits even for delete ops (explicit id always wins)", async () => {
+    const { client, calls } = stubSupabase([]);
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "event",
+      op: "cancel",
+      targetId: "00000000-0000-0000-0000-0000000000bb",
+      fallback: "most_recent",
+    });
+    assert.equal(result.kind, "resolved");
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("resolveAgentActionTarget — most-recent fallback for edit", () => {
+  it("queries ai_pending_actions with scoping, window, and tiebreaker", async () => {
+    const { client, calls } = stubSupabase([
+      { result_entity_id: "00000000-0000-0000-0000-0000000000c1" },
+    ]);
+    const before = Date.now();
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "announcement",
+      op: "edit",
+      fallback: "most_recent",
+    });
+    const after = Date.now();
+
+    assert.equal(result.kind, "resolved");
+    if (result.kind === "resolved") {
+      assert.equal(result.targetId, "00000000-0000-0000-0000-0000000000c1");
+    }
+
+    assert.deepEqual(calls[0], { op: "from", table: "ai_pending_actions" });
+    assert.deepEqual(calls[1], { op: "select", columns: "result_entity_id" });
+
+    const eqCalls = calls.filter((c) => c.op === "eq");
+    assert.deepEqual(
+      eqCalls.map((c) => (c.op === "eq" ? [c.column, c.value] : [])),
+      [
+        ["user_id", "u1"],
+        ["organization_id", "o1"],
+        ["result_entity_type", "announcement"],
+        ["status", "executed"],
+      ]
+    );
+
+    const gte = calls.find((c) => c.op === "gte");
+    assert.ok(gte && gte.op === "gte", "gte cutoff call must exist");
+    if (gte.op === "gte") {
+      assert.equal(gte.column, "executed_at");
+      const cutoffMs = Date.parse(gte.value as string);
+      const expectedLow = before - AI_RECENT_ENTITY_LOOKBACK_EDIT_MS;
+      const expectedHigh = after - AI_RECENT_ENTITY_LOOKBACK_EDIT_MS;
+      assert.ok(
+        cutoffMs >= expectedLow && cutoffMs <= expectedHigh,
+        `cutoff ${new Date(cutoffMs).toISOString()} outside window [${new Date(expectedLow).toISOString()}, ${new Date(expectedHigh).toISOString()}]`
+      );
+    }
+
+    const orderCalls = calls.filter((c) => c.op === "order");
+    assert.equal(orderCalls.length, 2, "must sort by executed_at DESC then id DESC");
+    if (orderCalls[0].op === "order") {
+      assert.equal(orderCalls[0].column, "executed_at");
+      assert.equal(orderCalls[0].options.ascending, false);
+    }
+    if (orderCalls[1].op === "order") {
+      assert.equal(orderCalls[1].column, "id");
+      assert.equal(orderCalls[1].options.ascending, false);
+    }
+
+    const limit = calls.find((c) => c.op === "limit");
+    if (limit && limit.op === "limit") {
+      assert.equal(limit.n, 1);
+    }
+  });
+
+  it("returns not_found when no recent executed row exists", async () => {
+    const { client } = stubSupabase([]);
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "announcement",
+      op: "edit",
+      fallback: "most_recent",
+    });
+    assert.equal(result.kind, "not_found");
+  });
+});
+
+describe("resolveAgentActionTarget — most-recent fallback disabled for destructive ops", () => {
+  for (const op of ["delete", "cancel"] as const) {
+    it(`refuses most-recent fallback for ${op} ops`, async () => {
+      const { client, calls } = stubSupabase([
+        { result_entity_id: "00000000-0000-0000-0000-0000000000d1" },
+      ]);
+      const result = await resolveAgentActionTarget({
+        supabase: client,
+        caller: { userId: "u1", organizationId: "o1" },
+        entityType: "announcement",
+        op,
+        fallback: "most_recent",
+      });
+      assert.equal(result.kind, "needs_target_id");
+      assert.equal(
+        calls.length,
+        0,
+        `resolver must not query supabase for ${op} without explicit target_id`
+      );
+    });
+  }
+});
+
+describe("resolveAgentActionTarget — fallback: 'none'", () => {
+  it("returns needs_target_id without querying supabase", async () => {
+    const { client, calls } = stubSupabase([
+      { result_entity_id: "00000000-0000-0000-0000-0000000000e1" },
+    ]);
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "job",
+      op: "edit",
+      fallback: "none",
+    });
+    assert.equal(result.kind, "needs_target_id");
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("resolveAgentActionTarget — windowMs override", () => {
+  it("respects a caller-supplied windowMs that narrows the window", async () => {
+    const { client, calls } = stubSupabase([
+      { result_entity_id: "00000000-0000-0000-0000-0000000000f1" },
+    ]);
+    const customWindow = 60_000;
+    const before = Date.now();
+    await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "announcement",
+      op: "edit",
+      fallback: "most_recent",
+      windowMs: customWindow,
+    });
+    const after = Date.now();
+
+    const gte = calls.find((c) => c.op === "gte");
+    assert.ok(gte && gte.op === "gte");
+    if (gte.op === "gte") {
+      const cutoffMs = Date.parse(gte.value as string);
+      assert.ok(
+        cutoffMs >= before - customWindow && cutoffMs <= after - customWindow,
+        "cutoff must honor windowMs override"
+      );
+    }
+  });
+
+  it("windowMs=0 disables the fallback even for edit ops", async () => {
+    const { client, calls } = stubSupabase([
+      { result_entity_id: "00000000-0000-0000-0000-0000000000f2" },
+    ]);
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "announcement",
+      op: "edit",
+      fallback: "most_recent",
+      windowMs: 0,
+    });
+    assert.equal(result.kind, "needs_target_id");
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("Window constants", () => {
+  it("edit lookback window is 15 minutes", () => {
+    assert.equal(AI_RECENT_ENTITY_LOOKBACK_EDIT_MS, 15 * 60 * 1000);
+  });
+  it("delete lookback window is 0 (fallback disabled)", () => {
+    assert.equal(AI_RECENT_ENTITY_LOOKBACK_DELETE_MS, 0);
+  });
+});
+
+describe("DomainResult discriminated union", () => {
+  it("accepts the ok variant with a typed value", async () => {
+    const { DomainResult: _type } = await import("@/lib/ai/shared/domain-result");
+    // Runtime check mirrors the type contract
+    const ok: import("@/lib/ai/shared/domain-result").DomainResult<number> = {
+      ok: true,
+      value: 42,
+    };
+    assert.equal(ok.ok, true);
+    if (ok.ok) assert.equal(ok.value, 42);
+    void _type;
+  });
+
+  it("accepts the error variant with a finite status", () => {
+    const err: import("@/lib/ai/shared/domain-result").DomainResult<number> = {
+      ok: false,
+      status: 422,
+      error: "invariant_violation",
+      details: { field: "title" },
+    };
+    assert.equal(err.ok, false);
+    if (!err.ok) {
+      assert.equal(err.status, 422);
+      assert.equal(err.error, "invariant_violation");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1b-narrow of the Tier 1 edit/delete parity plan. Lands two shared primitives that the `prepare_edit_*` / `prepare_delete_*` tool families (Phase 2+) will consume. **Additive only — no existing code modified, no callers yet.**

### New modules

| File | Purpose |
|------|---------|
| `src/lib/ai/shared/domain-result.ts` | `DomainResult<T>` discriminated union with a finite numeric status union (`400 \| 403 \| 404 \| 409 \| 410 \| 422 \| 500`). Keeps error handling exhaustive at the type level. |
| `src/lib/ai/tools/target-resolver.ts` | `resolveAgentActionTarget(args)` — answers "which entity id" for edit/delete tool calls. Entity types, op types, lookback-window constants, and the Supabase minimal shape interface. |

### Resolver behavior

Three paths, deterministic:

1. **Explicit `targetId`** → immediate short-circuit. No DB call. Wins over everything else.
2. **Most-recent fallback** → query `ai_pending_actions` for the caller's most recent `executed` action of the same `result_entity_type`, bounded by `windowMs`. Returns the `result_entity_id`.
3. **`fallback: "none"` or destructive op** → return `needs_target_id` so the model asks the user for an explicit id.

### Scoping / security decisions

- **Destructive ops disable the most-recent fallback.** `delete` and `cancel` ops always return `needs_target_id` when no explicit `target_id` is supplied. This implements security addendum A2.1 — destructive + ambiguous = abuse surface.
- **Edit window is 15 minutes** (`AI_RECENT_ENTITY_LOOKBACK_EDIT_MS`), narrowed from the original 1-hour proposal per performance review.
- **ORDER BY `executed_at DESC, id DESC`** provides a deterministic tiebreaker when two actions execute in the same millisecond (addendum A3.3).
- **Query shape matches the partial composite index** (`idx_ai_pending_actions_user_entity_executed`) added in Phase 0b (PR #121) — planner will pick the index-only scan.

### Deliberately out of scope

- **Per-domain by-id fetch.** The resolver returns just `{ targetId, entityType }` — it doesn't fetch the target row. Each domain's Phase 2+ tool fetches its own row (it needs that for permission checks and the `updated_at` version stamp anyway).
- **By-name disambiguation.** `candidates[]` return path deferred. Arrives alongside each domain.
- **Permission check.** Not the resolver's job. Moved into each domain's `mutations.ts` per architecture review A4.1 (collapsed from the 3-primitive proposal to 2).

## Testing

New: `tests/ai-target-resolver.test.ts` — 13 assertions across 7 suites.

\`\`\`
▶ resolveAgentActionTarget — explicit target_id short-circuit (2)
▶ resolveAgentActionTarget — most-recent fallback for edit (2)
▶ resolveAgentActionTarget — most-recent fallback disabled for destructive ops (2, one per op)
▶ resolveAgentActionTarget — fallback: 'none' (1)
▶ resolveAgentActionTarget — windowMs override (2, incl. windowMs=0 disabled)
▶ Window constants (2)
▶ DomainResult discriminated union (2)
ℹ tests 13, pass 13, fail 0
\`\`\`

The test asserts query shape precisely: `from("ai_pending_actions")`, `select("result_entity_id")`, the full `eq()` predicate list `(user_id, organization_id, result_entity_type, status='executed')`, the `gte()` cutoff within the expected window bounds, the two `order()` calls with `ascending: false`, and `limit(1)`. Any future refactor that accidentally drops a predicate will fail the test.

Quality gates green:
- `npx tsc --noEmit` — clean
- `npx eslint` on the three new files — clean

## Post-Deploy Monitoring & Validation

**`No additional operational monitoring required: this PR is dead code.`** Neither function is imported by anything that ships to production. The modules exist to establish the contract for Phase 2+ tools. If something breaks, it breaks in a future PR that adopts these primitives, not here.

Standard "does the app still start" smoke is sufficient.

## Related PRs

- #119 — Phase 0a (drop `ai_draft_sessions.draft_type` CHECK)
- #120 — Phase 1a-narrow (Zod gate + const tuple)
- #121 — Phase 0b (`ai_pending_actions` mutation columns + indexes — the partial index this resolver's most-recent query is designed to use)

All four are independent; merge in any order.

## Follow-up

- **Phase 1a-full** — widen `ai_draft_sessions` unique index to `(thread_id, draft_type)`; update `getDraftSession` callers. Regression-heavy.
- **Phase 0.5** — pre-split `handler.ts` + `executor.ts` before Phases 3–6 parallelize.
- **Phase 2** — announcements edit + delete pilot. First real behavior change; consumes the resolver.

---

🤖 Generated with Claude Opus 4.7 (1M context, ultrathink) via Claude Code