### PR TITLE
feat(announcements): Tier 1 Phase 2a-primitive — updateAnnouncement domain primitive

### DIFF
--- a/src/lib/announcements/update-announcement.ts
+++ b/src/lib/announcements/update-announcement.ts
@@ -1,0 +1,170 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ZodIssue } from "zod";
+import type { Database } from "@/types/database";
+import { getOrgMembership } from "@/lib/auth/api-helpers";
+import {
+  assistantAnnouncementPatchSchema,
+  assistantPreparedAnnouncementSchema,
+  type AssistantAnnouncementPatch,
+} from "@/lib/schemas/content";
+
+// Local mirror of the shared DomainResult type (defined in a companion PR).
+// Kept here so this PR is self-contained; refactor to the shared module in a
+// follow-up once both land.
+export type DomainResult<T> =
+  | { ok: true; value: T }
+  | {
+      ok: false;
+      status: 400 | 403 | 404 | 409 | 410 | 422 | 500;
+      error: string;
+      details?: Record<string, unknown>;
+    };
+
+type DatabaseClient = SupabaseClient<Database>;
+type AnnouncementRow = Database["public"]["Tables"]["announcements"]["Row"];
+
+export interface UpdateAnnouncementRequest {
+  supabase: DatabaseClient;
+  orgId: string;
+  userId: string;
+  targetId: string;
+  patch: AssistantAnnouncementPatch;
+  /**
+   * Caller-captured `target.updated_at` from prepare time. When supplied, the
+   * write uses it as an optimistic-concurrency token both in-code (fast fail)
+   * and in the UPDATE WHERE clause (race-safe). Omit for last-writer-wins
+   * semantics.
+   */
+  expectedUpdatedAt?: string | null;
+}
+
+export async function updateAnnouncement(
+  request: UpdateAnnouncementRequest
+): Promise<DomainResult<AnnouncementRow>> {
+  const parsed = assistantAnnouncementPatchSchema.safeParse(request.patch);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_patch",
+      details: issuesToDetails(parsed.error.issues),
+    };
+  }
+  const patch = parsed.data;
+
+  if (!Object.values(patch).some((v) => v !== undefined)) {
+    return { ok: false, status: 400, error: "empty_patch" };
+  }
+
+  const membership = await getOrgMembership(
+    request.supabase,
+    request.userId,
+    request.orgId
+  );
+  if (!membership || membership.role !== "admin") {
+    return { ok: false, status: 403, error: "forbidden" };
+  }
+
+  const { data: current, error: fetchError } = await request.supabase
+    .from("announcements")
+    .select("*")
+    .eq("id", request.targetId)
+    .eq("organization_id", request.orgId)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (fetchError) {
+    return { ok: false, status: 500, error: "fetch_failed" };
+  }
+  if (!current) {
+    return { ok: false, status: 404, error: "not_found" };
+  }
+
+  if (
+    request.expectedUpdatedAt != null &&
+    current.updated_at !== request.expectedUpdatedAt
+  ) {
+    return {
+      ok: false,
+      status: 409,
+      error: "stale_version",
+      details: {
+        expectedUpdatedAt: request.expectedUpdatedAt,
+        currentUpdatedAt: current.updated_at,
+      },
+    };
+  }
+
+  // Merge current + patch and re-validate against the full-row schema. This
+  // catches cross-field invariants a partial patch could violate (e.g.,
+  // changing audience to "individuals" without supplying audience_user_ids).
+  const mergedTitle = patch.title ?? current.title;
+  const mergedBody = patch.body ?? current.body;
+  const mergedIsPinned = patch.is_pinned ?? Boolean(current.is_pinned);
+  const mergedAudience = patch.audience ?? current.audience;
+  const mergedAudienceUserIds =
+    patch.audience_user_ids ?? current.audience_user_ids ?? undefined;
+
+  const invariantCheck = assistantPreparedAnnouncementSchema.safeParse({
+    title: mergedTitle,
+    body: mergedBody ?? undefined,
+    is_pinned: mergedIsPinned,
+    audience: mergedAudience,
+    send_notification: false, // not stored; satisfy the prepared-schema shape
+    audience_user_ids: mergedAudienceUserIds ?? undefined,
+  });
+
+  if (!invariantCheck.success) {
+    return {
+      ok: false,
+      status: 422,
+      error: "invariant_violation",
+      details: issuesToDetails(invariantCheck.error.issues),
+    };
+  }
+
+  // Write the merged row rather than the raw patch — with the invariant
+  // check above, this is safer than field-level last-writer-wins and the
+  // optimistic-concurrency filter below prevents overwriting concurrent
+  // changes.
+  const updatePayload = {
+    title: mergedTitle,
+    body: mergedBody,
+    is_pinned: mergedIsPinned,
+    audience: mergedAudience,
+    audience_user_ids:
+      mergedAudience === "individuals"
+        ? mergedAudienceUserIds ?? null
+        : null,
+  };
+
+  let updateQuery = request.supabase
+    .from("announcements")
+    .update(updatePayload)
+    .eq("id", request.targetId)
+    .eq("organization_id", request.orgId)
+    .is("deleted_at", null);
+
+  if (request.expectedUpdatedAt != null) {
+    updateQuery = updateQuery.eq("updated_at", request.expectedUpdatedAt);
+  }
+
+  const { data: updated, error: updateError } = await updateQuery
+    .select("*")
+    .maybeSingle();
+
+  if (updateError) {
+    return { ok: false, status: 500, error: "update_failed" };
+  }
+  if (!updated) {
+    return { ok: false, status: 409, error: "stale_version" };
+  }
+
+  return { ok: true, value: updated };
+}
+
+function issuesToDetails(issues: ZodIssue[]): Record<string, unknown> {
+  return Object.fromEntries(
+    issues.map((issue) => [issue.path.join(".") || "body", issue.message])
+  );
+}

--- a/src/lib/schemas/content.ts
+++ b/src/lib/schemas/content.ts
@@ -83,6 +83,18 @@ export const editAnnouncementSchema = z.object({
 });
 export type EditAnnouncementForm = z.infer<typeof editAnnouncementSchema>;
 
+// Agent-path patch schema. Every field is optional (patch semantics); callers
+// must supply at least one. send_notification is excluded — notifications are
+// fired once at create time; edits do not re-blast.
+export const assistantAnnouncementPatchSchema = z.object({
+  title: safeString(200).optional(),
+  body: optionalSafeString(5000),
+  is_pinned: z.boolean().optional(),
+  audience: announcementAudienceSchema.optional(),
+  audience_user_ids: z.array(z.string().uuid()).optional(),
+});
+export type AssistantAnnouncementPatch = z.infer<typeof assistantAnnouncementPatchSchema>;
+
 // ─── Recurrence schemas ───────────────────────────────────────────────
 
 export const recurrenceOccurrenceSchema = z.enum(["daily", "weekly", "monthly"]);

--- a/tests/announcements-update.test.ts
+++ b/tests/announcements-update.test.ts
@@ -1,0 +1,461 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { updateAnnouncement } from "@/lib/announcements/update-announcement";
+
+// ─── Minimal Supabase stub ──────────────────────────────────────────────
+// updateAnnouncement touches exactly two tables: user_organization_roles
+// (via getOrgMembership) and announcements. This stub routes those two and
+// records every filter call so tests can assert the exact query shape.
+
+type AnnouncementRow = {
+  id: string;
+  organization_id: string;
+  title: string;
+  body: string | null;
+  is_pinned: boolean | null;
+  audience: string;
+  audience_user_ids: string[] | null;
+  updated_at: string;
+  deleted_at: string | null;
+  created_by_user_id: string;
+  created_at: string;
+  published_at: string | null;
+};
+
+interface StubState {
+  membership: { role: string } | null;
+  announcement: AnnouncementRow | null;
+  fetchError: { message: string } | null;
+  updateError: { message: string } | null;
+  /** Rows returned by the UPDATE (maybeSingle). null = 0 rows, row = 1 row. */
+  updateResult: AnnouncementRow | null;
+  /** Captured arguments to the UPDATE call. */
+  updatePayload: Record<string, unknown> | null;
+  /** Captured WHERE-clause filters on the UPDATE query. */
+  updateFilters: Array<{ op: string; column: string; value: unknown }>;
+}
+
+// Shape-of-stub is deliberately loose — matches the subset of the Supabase
+// client that updateAnnouncement actually calls. Casting at the boundary lets
+// tests stay focused.
+type StubChain = {
+  eq: (column: string, value: unknown) => StubChain;
+  is: (column: string, value: null) => StubChain;
+  maybeSingle: () => Promise<{
+    data: AnnouncementRow | null;
+    error: { message: string } | null;
+  }>;
+};
+
+type StubUpdateChain = {
+  eq: (column: string, value: unknown) => StubUpdateChain;
+  is: (column: string, value: null) => StubUpdateChain;
+  select: () => {
+    maybeSingle: () => Promise<{
+      data: AnnouncementRow | null;
+      error: { message: string } | null;
+    }>;
+  };
+};
+
+type StubRolesChain = {
+  eq: (column: string, value: unknown) => StubRolesChain;
+  maybeSingle: () => Promise<{
+    data: { role: string } | null;
+    error: { message: string } | null;
+  }>;
+};
+
+function buildStub(state: StubState) {
+  const announcementSelectChain = (): StubChain => {
+    const chain: StubChain = {
+      eq: () => chain,
+      is: () => chain,
+      maybeSingle: async () => ({
+        data: state.announcement,
+        error: state.fetchError,
+      }),
+    };
+    return chain;
+  };
+
+  const announcementUpdateChain = (): StubUpdateChain => {
+    const chain: StubUpdateChain = {
+      eq: (column, value) => {
+        state.updateFilters.push({ op: "eq", column, value });
+        return chain;
+      },
+      is: (column, value) => {
+        state.updateFilters.push({ op: "is", column, value });
+        return chain;
+      },
+      select: () => ({
+        maybeSingle: async () => ({
+          data: state.updateResult,
+          error: state.updateError,
+        }),
+      }),
+    };
+    return chain;
+  };
+
+  const rolesSelectChain = (): StubRolesChain => {
+    const chain: StubRolesChain = {
+      eq: () => chain,
+      maybeSingle: async () => ({ data: state.membership, error: null }),
+    };
+    return chain;
+  };
+
+  return {
+    from(table: string) {
+      if (table === "user_organization_roles") {
+        return { select: () => rolesSelectChain() };
+      }
+      if (table === "announcements") {
+        return {
+          select: () => announcementSelectChain(),
+          update: (payload: Record<string, unknown>) => {
+            state.updatePayload = payload;
+            return announcementUpdateChain();
+          },
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  } as unknown as Parameters<typeof updateAnnouncement>[0]["supabase"];
+}
+
+function baseRow(overrides: Partial<AnnouncementRow> = {}): AnnouncementRow {
+  return {
+    id: "00000000-0000-0000-0000-0000000000a1",
+    organization_id: "00000000-0000-0000-0000-0000000000b1",
+    title: "Original title",
+    body: "Original body",
+    is_pinned: false,
+    audience: "all",
+    audience_user_ids: null,
+    updated_at: "2026-04-21T10:00:00.000Z",
+    deleted_at: null,
+    created_by_user_id: "00000000-0000-0000-0000-0000000000c1",
+    created_at: "2026-04-20T09:00:00.000Z",
+    published_at: "2026-04-20T09:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function freshState(): StubState {
+  return {
+    membership: { role: "admin" },
+    announcement: baseRow(),
+    fetchError: null,
+    updateError: null,
+    updateResult: baseRow({ title: "New title", updated_at: "2026-04-21T10:05:00.000Z" }),
+    updatePayload: null,
+    updateFilters: [],
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe("updateAnnouncement — input validation", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("rejects an empty patch with 400 empty_patch", async () => {
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: {},
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 400);
+      assert.equal(result.error, "empty_patch");
+    }
+  });
+
+  it("rejects a malformed patch with 400 invalid_patch", async () => {
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      // Title over 200 chars violates safeString(200).
+      patch: { title: "a".repeat(201) },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 400);
+      assert.equal(result.error, "invalid_patch");
+    }
+  });
+});
+
+describe("updateAnnouncement — permission check", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 403 forbidden when caller is not an admin", async () => {
+    state.membership = { role: "active_member" };
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 403);
+      assert.equal(result.error, "forbidden");
+    }
+  });
+
+  it("returns 403 forbidden when caller is not a member at all", async () => {
+    state.membership = null;
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 403);
+    }
+  });
+});
+
+describe("updateAnnouncement — target lookup", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 404 not_found when the announcement does not exist", async () => {
+    state.announcement = null;
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 404);
+      assert.equal(result.error, "not_found");
+    }
+  });
+});
+
+describe("updateAnnouncement — optimistic concurrency", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 409 stale_version when expectedUpdatedAt does not match current", async () => {
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New" },
+      expectedUpdatedAt: "2026-04-21T09:00:00.000Z", // older than current
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 409);
+      assert.equal(result.error, "stale_version");
+    }
+  });
+
+  it("proceeds when expectedUpdatedAt matches current", async () => {
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New title" },
+      expectedUpdatedAt: "2026-04-21T10:00:00.000Z",
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it("adds the updated_at filter to the UPDATE when expectedUpdatedAt is supplied", async () => {
+    await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New title" },
+      expectedUpdatedAt: "2026-04-21T10:00:00.000Z",
+    });
+    const updatedAtFilter = state.updateFilters.find(
+      (f) => f.op === "eq" && f.column === "updated_at"
+    );
+    assert.ok(updatedAtFilter, "UPDATE must include an eq filter on updated_at when expected stamp supplied");
+    assert.equal(updatedAtFilter!.value, "2026-04-21T10:00:00.000Z");
+  });
+
+  it("does not add updated_at filter when expectedUpdatedAt is absent", async () => {
+    await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New title" },
+    });
+    const updatedAtFilter = state.updateFilters.find(
+      (f) => f.op === "eq" && f.column === "updated_at"
+    );
+    assert.equal(updatedAtFilter, undefined);
+  });
+
+  it("returns 409 stale_version when the UPDATE affects zero rows", async () => {
+    state.updateResult = null; // zero rows
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New title" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 409);
+      assert.equal(result.error, "stale_version");
+    }
+  });
+});
+
+describe("updateAnnouncement — cross-field invariants", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("rejects audience='individuals' patch when the merged row has no audience_user_ids", async () => {
+    // Current row has audience='all', audience_user_ids=null.
+    // Patching audience→individuals without supplying ids breaks the invariant.
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { audience: "individuals" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 422);
+      assert.equal(result.error, "invariant_violation");
+    }
+  });
+
+  it("accepts audience='individuals' patch when audience_user_ids are also supplied", async () => {
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: {
+        audience: "individuals",
+        audience_user_ids: ["00000000-0000-4000-8000-000000000001"],
+      },
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it("nulls audience_user_ids on the write when patching audience away from individuals", async () => {
+    state.announcement = baseRow({
+      audience: "individuals",
+      audience_user_ids: ["00000000-0000-4000-8000-000000000001"],
+    });
+    state.updateResult = baseRow({
+      audience: "all",
+      audience_user_ids: null,
+      updated_at: "2026-04-21T10:05:00.000Z",
+    });
+    await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { audience: "all" },
+    });
+    assert.ok(state.updatePayload);
+    assert.equal(state.updatePayload!.audience, "all");
+    assert.equal(
+      state.updatePayload!.audience_user_ids,
+      null,
+      "audience_user_ids must be nulled when leaving 'individuals' audience"
+    );
+  });
+});
+
+describe("updateAnnouncement — happy path", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns the updated row on a title-only patch", async () => {
+    state.updateResult = baseRow({
+      title: "Edited title",
+      updated_at: "2026-04-21T10:05:00.000Z",
+    });
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "Edited title" },
+    });
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.value.title, "Edited title");
+      assert.equal(result.value.updated_at, "2026-04-21T10:05:00.000Z");
+    }
+  });
+
+  it("writes the merged row (not the raw patch)", async () => {
+    await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "Edited title" },
+    });
+    assert.ok(state.updatePayload);
+    // Patched field
+    assert.equal(state.updatePayload!.title, "Edited title");
+    // Unpatched fields retain current-row values
+    assert.equal(state.updatePayload!.is_pinned, false);
+    assert.equal(state.updatePayload!.audience, "all");
+  });
+
+  it("scopes the UPDATE by id, organization_id, and deleted_at IS NULL", async () => {
+    await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "Edited" },
+    });
+    const filterKeys = state.updateFilters.map(
+      (f) => `${f.op}:${f.column}`
+    );
+    assert.ok(filterKeys.includes("eq:id"));
+    assert.ok(filterKeys.includes("eq:organization_id"));
+    assert.ok(filterKeys.includes("is:deleted_at"));
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2a-primitive of the Tier 1 edit/delete parity plan. Adds the server-side domain primitive that the upcoming `prepare_edit_announcement` agent tool will consume. The primitive is self-contained and also ready to replace the current client-side \`supabase.from("announcements").update(...)\` call in \`src/app/[orgSlug]/announcements/[announcementId]/edit/page.tsx\` as a follow-up refactor.

No agent wiring in this PR. That lands in Phase 2a-wiring (pending_action_type, tool definition, executor handler, confirm-handler branch).

### Why this is a separate PR

The plan's Phase 2 touches ~7 files across two god-files (\`executor.ts\` @ 3,460 LOC, \`handler.ts\` @ 920 LOC). Splitting the domain primitive out first lets reviewers focus on the correctness of the mutation logic (Zod validation, cross-field invariants, optimistic concurrency) without also having to trace tool-registration changes. The wiring PR can then be "mirror \`prepare_announcement\` but dispatch to this primitive" — small and mechanical.

## Behavior

1. **Zod-validates** the patch via new \`assistantAnnouncementPatchSchema\`. All fields optional; at least one required (empty-patch → 400).
2. **Admin-only**. Re-checked at execute time (defense in depth against TOCTOU on role revocation per addendum A2.6).
3. **Fetches current row** with \`deleted_at IS NULL\` scoping — cannot edit a soft-deleted announcement.
4. **Optimistic concurrency** via caller-supplied \`expectedUpdatedAt\`:
    - In-code fast-fail: 409 if \`current.updated_at !== expectedUpdatedAt\`.
    - On the UPDATE: \`eq("updated_at", expectedUpdatedAt)\` makes it an atomic CAS on the target. Zero rows affected → 409 \`stale_version\`. No silent last-writer-wins when caller opts in.
    - Omit \`expectedUpdatedAt\` for legacy last-writer-wins semantics.
5. **Cross-field invariant validation**: merges current + patch and re-validates the full merged row against \`assistantPreparedAnnouncementSchema\`. This catches cases a partial patch can silently break — e.g., patching \`audience: "individuals"\` without supplying \`audience_user_ids\`. Returns 422 \`invariant_violation\` with per-field details. Addresses addendum A1.3.
6. **Writes the merged row** (not the raw patch). Audience transitions away from "individuals" set \`audience_user_ids = NULL\`.
7. **Returns \`DomainResult<AnnouncementRow>\`** with a finite numeric status union (400 | 403 | 404 | 409 | 422 | 500).

### DomainResult import trade-off

The shared \`src/lib/ai/shared/domain-result.ts\` module lives in companion PR #122. That PR is open but unmerged. Rather than create a cross-branch dependency, the \`DomainResult<T>\` type is **inlined locally** in this file with a comment pointing at the future consolidation. Both PRs can merge in either order; a follow-up refactors to the shared import.

## Testing

New: \`tests/announcements-update.test.ts\` — 16 assertions across 6 describe blocks.

\`\`\`
▶ updateAnnouncement — input validation (2 tests)
▶ updateAnnouncement — permission check (2 tests)
▶ updateAnnouncement — target lookup (1 test)
▶ updateAnnouncement — optimistic concurrency (5 tests)
▶ updateAnnouncement — cross-field invariants (3 tests)
▶ updateAnnouncement — happy path (3 tests)
ℹ tests 16, pass 16, fail 0
\`\`\`

Tests use a minimal inline Supabase stub keyed to the exact tables and call chains the primitive touches (\`user_organization_roles\` + \`announcements\`). No mock layering beyond what the code actually invokes; query-shape assertions (e.g., \`updated_at\` filter presence) verify the optimistic-concurrency contract survives future refactors.

Quality gates:
- \`npx tsc --noEmit\` — clean
- \`npx eslint\` on the three files — clean

## Post-Deploy Monitoring & Validation

**\`No additional operational monitoring required: dead code until a caller imports it.\`** No route or tool references \`updateAnnouncement\` yet. The function is importable by future UI refactors and the Phase 2a-wiring PR.

If adopted in a UI PATCH route refactor before the agent wiring lands, monitoring shifts to that route's existing dashboards.

## Related PRs

- #119 Phase 0a (drop CHECK)
- #120 Phase 1a-narrow (Zod gate)
- #121 Phase 0b (columns + indexes)
- #122 Phase 1b-narrow (DomainResult + resolver) — this PR duplicates DomainResult locally; consolidate after both merge

## Follow-up (next PRs)

- **Phase 2a-wiring:** register \`edit_announcement\` in DRAFT_SESSION_TYPES and PendingActionType; add \`prepare_edit_announcement\` tool to \`definitions.ts\` + executor handler + confirm-handler case. Mirror the existing \`prepare_announcement\` pattern.
- **Phase 2b:** \`deleteAnnouncement\` primitive + \`prepare_delete_announcement\` tool (soft-delete, full-entity preview in the confirmation card).
- **UI refactor:** swap the client-side \`supabase.from("announcements").update\` in the edit page for a \`PATCH /api/announcements/[id]\` route backed by this primitive. Single source of truth for UI + agent.

---

🤖 Generated with Claude Opus 4.7 (1M context, ultrathink) via Claude Code