### PR TITLE
refactor(ai): extract create_announcement dispatcher from confirm handler

### DIFF
--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
@@ -1,0 +1,176 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatcher for the `create_announcement` pending action type.
+//
+// Phase 0.5 pilot of the Tier 1 pre-split: extracts one case from the
+// 920-LOC confirm handler so the shape is established for the other eight
+// cases to follow. Each subsequent dispatcher owns its domain's confirm-time
+// behaviour (CAS transitions, side effects, audit message) and is imported
+// into the thin confirm/handler.ts shell.
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  clearDraftSession,
+} from "@/lib/ai/draft-sessions";
+import type {
+  CreateAnnouncementPendingPayload,
+  PendingActionRecord,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+import type {
+  createAnnouncement,
+  sendAnnouncementNotification,
+} from "@/lib/announcements/create-announcement";
+import type { sendNotificationBlast } from "@/lib/notifications";
+
+export interface AnnouncementDispatcherContext {
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  canUseDraftSessions: boolean;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+  clearDraftSessionFn: typeof clearDraftSession;
+}
+
+export interface AnnouncementDispatcherDeps {
+  createAnnouncementFn: typeof createAnnouncement;
+  sendAnnouncementNotificationFn: typeof sendAnnouncementNotification;
+  sendNotificationBlastFn: typeof sendNotificationBlast;
+}
+
+export async function handleCreateAnnouncement(
+  ctx: AnnouncementDispatcherContext,
+  action: PendingActionRecord<"create_announcement">,
+  deps: AnnouncementDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as CreateAnnouncementPendingPayload;
+  const result = await deps.createAnnouncementFn({
+    supabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    input: {
+      ...payload,
+      audience_user_ids: payload.audience_user_ids ?? null,
+    },
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "announcement",
+    resultEntityId: result.announcement.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  try {
+    await deps.sendAnnouncementNotificationFn({
+      supabase: ctx.serviceSupabase,
+      announcementId: result.announcement.id,
+      orgId: ctx.orgId,
+      input: {
+        ...payload,
+        audience_user_ids: payload.audience_user_ids ?? null,
+      },
+      sendDirectNotification: async ({
+        organizationId,
+        title,
+        body,
+        audience,
+        targetUserIds,
+      }) => {
+        await deps.sendNotificationBlastFn({
+          supabase: ctx.serviceSupabase,
+          organizationId,
+          audience,
+          channel: "email",
+          title,
+          body,
+          targetUserIds,
+          category: "announcement",
+        });
+      },
+    });
+  } catch (notificationError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "announcement notification failed",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        announcementId: result.announcement.id,
+        error: notificationError,
+      }
+    );
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const announcementUrl = orgSlug ? `/${orgSlug}/announcements` : null;
+  const content = announcementUrl
+    ? `Created announcement: [${result.announcement.title}](${announcementUrl})`
+    : `Created announcement: ${result.announcement.title}`;
+
+  const { error: msgError } = await ctx.serviceSupabase
+    .from("ai_messages")
+    .insert({
+      thread_id: action.thread_id,
+      org_id: ctx.orgId,
+      role: "assistant",
+      content,
+      status: "complete",
+    });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    announcement: result.announcement,
+    actionId: action.id,
+  });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -2,11 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getAiOrgContext } from "@/lib/ai/context";
 import {
-  type CreateAnnouncementPendingPayload,
   type CreateDiscussionReplyPendingPayload,
   getPendingAction,
   isAuthorizedAction,
   isPendingActionExpired,
+  type PendingActionRecord,
   type SendChatMessagePendingPayload,
   type SendGroupChatMessagePendingPayload,
   updatePendingActionStatus,
@@ -41,6 +41,7 @@ import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limi
 import { aiLog } from "@/lib/ai/logger";
 import { syncEventToUsers } from "@/lib/google/calendar-sync";
 import { sendNotificationBlast } from "@/lib/notifications";
+import { handleCreateAnnouncement } from "./dispatchers/announcements";
 
 export interface AiPendingActionConfirmRouteDeps {
   createClient?: typeof createClient;
@@ -181,106 +182,24 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
 
     try {
       switch (action.action_type) {
-        case "create_announcement": {
-          const payload = action.payload as CreateAnnouncementPendingPayload;
-          const result = await createAnnouncementFn({
-            supabase: ctx.serviceSupabase,
-            orgId: ctx.orgId,
-            userId: ctx.userId,
-            input: {
-              ...payload,
-              audience_user_ids: payload.audience_user_ids ?? null,
-            },
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              result.details ? { error: result.error, details: result.details } : { error: result.error },
-              { status: result.status }
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "announcement",
-            resultEntityId: result.announcement.id,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          try {
-            await sendAnnouncementNotificationFn({
-              supabase: ctx.serviceSupabase,
-              announcementId: result.announcement.id,
+        case "create_announcement":
+          return handleCreateAnnouncement(
+            {
+              serviceSupabase: ctx.serviceSupabase,
               orgId: ctx.orgId,
-              input: {
-                ...payload,
-                audience_user_ids: payload.audience_user_ids ?? null,
-              },
-              sendDirectNotification: async ({ organizationId, title, body, audience, targetUserIds }) => {
-                await sendNotificationBlastFn({
-                  supabase: ctx.serviceSupabase,
-                  organizationId,
-                  audience,
-                  channel: "email",
-                  title,
-                  body,
-                  targetUserIds,
-                  category: "announcement",
-                });
-              },
-            });
-          } catch (notificationError) {
-            aiLog("error", "ai-confirm", "announcement notification failed", {
-              ...logContext,
               userId: ctx.userId,
-              threadId: action.thread_id,
-            }, { actionId: action.id, announcementId: result.announcement.id, error: notificationError });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const announcementUrl = orgSlug ? `/${orgSlug}/announcements` : null;
-          const content = announcementUrl
-            ? `Created announcement: [${result.announcement.title}](${announcementUrl})`
-            : `Created announcement: ${result.announcement.title}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, announcement: result.announcement, actionId: action.id });
-        }
+              logContext,
+              canUseDraftSessions,
+              updatePendingActionStatusFn,
+              clearDraftSessionFn,
+            },
+            action as PendingActionRecord<"create_announcement">,
+            {
+              createAnnouncementFn,
+              sendAnnouncementNotificationFn,
+              sendNotificationBlastFn,
+            }
+          );
         case "create_job_posting": {
           const payload = action.payload as CreateJobPostingPendingPayload;
           const result = await createJobPostingFn({


### PR DESCRIPTION
## Summary

Phase 0.5 pilot of the Tier 1 pre-split. Moves the \`create_announcement\` case body out of the 920-LOC confirm handler into a dedicated \`dispatchers/\` module. Establishes the shape for the other eight cases to follow in subsequent PRs. **Independent of the #119–#124 queue** — this PR branches off clean \`main\` and touches none of the types those PRs introduce.

### What Phase 0.5 is for

The confirm handler at \`src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts\` is 920 LOC with one giant \`switch\` on \`action_type\` (9 cases, ~80 LOC each). Adding new cases for the edit / delete action types in Phases 2a-wiring through 2b-wiring — and later for Phases 3–6 — means repeated concentrated edits in this one file, with high merge-conflict risk when phases parallelize. Pre-splitting per domain lets reviewers follow one case at a time and lets future PRs land in parallel without touching each other's code.

### Before / after

| File | Before | After |
|------|--------|-------|
| \`.../confirm/handler.ts\` | 920 LOC | **839 LOC (−81)** |
| \`.../confirm/dispatchers/announcements.ts\` | — | **176 LOC (new)** |

The announcements case in handler.ts is now a 15-line dispatcher call passing explicit context and deps. The new module owns the CAS transitions, notification blast, draft-session cleanup, confirmation \`ai_messages\` insert, and the final \`NextResponse\`.

### Dispatcher shape

\`\`\`ts
handleCreateAnnouncement(
  ctx: AnnouncementDispatcherContext,
  action: PendingActionRecord<"create_announcement">,
  deps: AnnouncementDispatcherDeps,
): Promise<NextResponse>
\`\`\`

- \`ctx\` carries \`serviceSupabase\`, \`orgId\`, \`userId\`, \`logContext\`, \`canUseDraftSessions\`, and the two \`*Fn\` pending-action / draft-session utilities.
- \`deps\` carries the three domain-specific function pointers the announcement flow needs. They remain dependency-injected from the handler-level \`deps\` object so the existing test stubs keep working without change.

### Explicit non-goals

- **No behaviour changes.** No new logic, no reordered steps, no renamed fields.
- **No shared types file yet.** Plan addendum A4.1 notes that shared types should emerge from a second dispatcher, not be designed up-front. A future \`dispatchers/types.ts\` extraction happens when the second case lands.
- **The other 8 cases are untouched.** Subsequent PRs — each a ~150-200-LOC mechanical move — will follow this pattern for \`create_job_posting\`, \`send_chat_message\`, \`send_group_chat_message\`, \`create_discussion_thread\`, \`create_discussion_reply\`, \`create_event\`, \`create_enterprise_invite\`, and \`revoke_enterprise_invite\`.

## Testing

**Characterization:** \`tests/routes/ai/pending-actions-handler.test.ts\` is the existing coverage. It exercises the full confirm flow including \`create_announcement\` (4 direct references in the file, plus end-to-end flow assertions).

- Baseline (before refactor): **19 tests pass, 0 fail.**
- Post-refactor: **19 tests pass, 0 fail.**

No test modifications. The refactor is validated by the test suite continuing to pass against the extracted module, which is exactly the guarantee pre-split PRs rely on.

Quality gates:
- \`npx tsc --noEmit\` — clean
- \`npx eslint\` on both files — clean

## Post-Deploy Monitoring & Validation

**\`No additional operational monitoring required: pure refactor — no behaviour, schema, or API change.\`** Callers (both UI and tests) invoke the same top-level \`POST /api/ai/[orgId]/pending-actions/[actionId]/confirm\` route with the same request shape and receive the same response shape. The split is entirely below the HTTP boundary.

Standard "does the app still start and run the test suite green" smoke is sufficient.

## Related PRs

- #119 Phase 0a · #120 Phase 1a-narrow · #121 Phase 0b · #122 Phase 1b-narrow · #123 Phase 2a-primitive · #124 Phase 2b-primitive
- **This PR is independent.** None of the above need to merge first; this branches off clean \`main\`.

## Follow-up

One small PR per remaining case (~8 PRs, each ~150 LOC), or a single batched PR for all eight. Either works. The per-domain split unlocks parallel work on Phases 3–6.

---

🤖 Generated with Claude Opus 4.7 (1M context, ultrathink) via Claude Code