### PR TITLE
refactor(ai): extract create_event dispatcher from confirm handler

### DIFF
--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/events.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/events.ts
@@ -1,0 +1,212 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatcher for the `create_event` pending action type.
+//
+// Second Phase 0.5 extraction following the announcements dispatcher
+// (see ./announcements.ts). create_event is the largest remaining branch —
+// proving the dispatcher shape handles: structured error responses with
+// `code`/`details`, three best-effort side effects (Google + Outlook calendar
+// sync, notification blast), and URL derivation that falls back to the
+// domain-computed value when orgSlug is absent.
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  clearDraftSession,
+} from "@/lib/ai/draft-sessions";
+import type {
+  CreateEventPendingPayload,
+  PendingActionRecord,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+import type { createEvent } from "@/lib/events/create-event";
+import { calendarEventDetailPath } from "@/lib/calendar/routes";
+import type { syncEventToUsers } from "@/lib/google/calendar-sync";
+import type { sendNotificationBlast } from "@/lib/notifications";
+
+export interface EventDispatcherContext {
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  canUseDraftSessions: boolean;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+  clearDraftSessionFn: typeof clearDraftSession;
+}
+
+export interface EventDispatcherDeps {
+  createEventFn: typeof createEvent;
+  syncEventToUsersFn: typeof syncEventToUsers;
+  syncOutlookEventToUsersFn: (
+    supabase: Parameters<typeof syncEventToUsers>[0],
+    organizationId: string,
+    eventId: string,
+    operation: Parameters<typeof syncEventToUsers>[3]
+  ) => Promise<void>;
+  sendNotificationBlastFn: typeof sendNotificationBlast;
+}
+
+export async function handleCreateEvent(
+  ctx: EventDispatcherContext,
+  action: PendingActionRecord<"create_event">,
+  deps: EventDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as CreateEventPendingPayload;
+  const result = await deps.createEventFn({
+    supabase: ctx.serviceSupabase,
+    serviceSupabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    input: payload,
+    orgSlug:
+      typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+        ? payload.orgSlug
+        : null,
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+
+    aiLog(
+      "error",
+      "ai-confirm",
+      "create_event confirmation failed",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        attemptedEventType: payload.event_type,
+        eventErrorCode: result.code ?? null,
+        eventError: result.error,
+        eventStatus: result.status,
+        internalError: result.internalError ?? null,
+      }
+    );
+
+    return NextResponse.json(
+      {
+        error: result.error,
+        ...(result.code ? { code: result.code } : {}),
+        ...(result.details ? { details: result.details } : {}),
+      },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "event",
+    resultEntityId: result.event.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const eventUrl = orgSlug
+    ? calendarEventDetailPath(orgSlug, result.event.id)
+    : result.eventUrl;
+  const content = eventUrl
+    ? `Created event: [${result.event.title}](${eventUrl})`
+    : `Created event: ${result.event.title}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  try {
+    await deps.syncEventToUsersFn(ctx.serviceSupabase, ctx.orgId, result.event.id, "create");
+  } catch (syncErr) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "google calendar sync failed",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      { actionId: action.id, eventId: result.event.id, error: syncErr }
+    );
+  }
+
+  try {
+    await deps.syncOutlookEventToUsersFn(ctx.serviceSupabase, ctx.orgId, result.event.id, "create");
+  } catch (outlookErr) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "outlook calendar sync failed",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      { actionId: action.id, eventId: result.event.id, error: outlookErr }
+    );
+  }
+
+  try {
+    await deps.sendNotificationBlastFn({
+      supabase: ctx.serviceSupabase,
+      organizationId: ctx.orgId,
+      audience: "both",
+      channel: "email",
+      title: `New Event: ${result.event.title}`,
+      body: `Event scheduled for ${payload.start_date} at ${payload.start_time}${payload.location ? `\nWhere: ${payload.location}` : ""}`,
+      category: "event",
+    });
+  } catch (notifyErr) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "event notification blast failed",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      { actionId: action.id, eventId: result.event.id, error: notifyErr }
+    );
+  }
+
+  return NextResponse.json({ ok: true, event: result.event, actionId: action.id });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -11,7 +11,6 @@ import {
   type SendGroupChatMessagePendingPayload,
   updatePendingActionStatus,
   type CreateDiscussionThreadPendingPayload,
-  type CreateEventPendingPayload,
   type CreateJobPostingPendingPayload,
   type CreateEnterpriseInvitePendingPayload,
   type RevokeEnterpriseInvitePendingPayload,
@@ -36,12 +35,12 @@ import {
   sendAiAssistedGroupChatMessage,
   type GroupChatSupabase,
 } from "@/lib/chat/group-chat";
-import { calendarEventDetailPath } from "@/lib/calendar/routes";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { aiLog } from "@/lib/ai/logger";
 import { syncEventToUsers } from "@/lib/google/calendar-sync";
 import { sendNotificationBlast } from "@/lib/notifications";
 import { handleCreateAnnouncement } from "./dispatchers/announcements";
+import { handleCreateEvent } from "./dispatchers/events";
 
 export interface AiPendingActionConfirmRouteDeps {
   createClient?: typeof createClient;
@@ -564,136 +563,25 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
 
           return NextResponse.json({ ok: true, reply: result.reply, actionId: action.id });
         }
-        case "create_event": {
-          const payload = action.payload as CreateEventPendingPayload;
-          const result = await createEventFn({
-            supabase: ctx.serviceSupabase,
-            serviceSupabase: ctx.serviceSupabase,
-            orgId: ctx.orgId,
-            userId: ctx.userId,
-            input: payload,
-            orgSlug:
-              typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-                ? payload.orgSlug
-                : null,
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-
-            aiLog("error", "ai-confirm", "create_event confirmation failed", {
-              ...logContext,
+        case "create_event":
+          return handleCreateEvent(
+            {
+              serviceSupabase: ctx.serviceSupabase,
+              orgId: ctx.orgId,
               userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              attemptedEventType: payload.event_type,
-              eventErrorCode: result.code ?? null,
-              eventError: result.error,
-              eventStatus: result.status,
-              internalError: result.internalError ?? null,
-            });
-
-            return NextResponse.json(
-              {
-                error: result.error,
-                ...(result.code ? { code: result.code } : {}),
-                ...(result.details ? { details: result.details } : {}),
-              },
-              { status: result.status }
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "event",
-            resultEntityId: result.event.id,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const eventUrl = orgSlug
-            ? calendarEventDetailPath(orgSlug, result.event.id)
-            : result.eventUrl;
-          const content = eventUrl
-            ? `Created event: [${result.event.title}](${eventUrl})`
-            : `Created event: ${result.event.title}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          try {
-            await syncEventToUsersFn(ctx.serviceSupabase, ctx.orgId, result.event.id, "create");
-          } catch (syncErr) {
-            aiLog("error", "ai-confirm", "google calendar sync failed", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, { actionId: action.id, eventId: result.event.id, error: syncErr });
-          }
-
-          try {
-            await syncOutlookEventToUsersFn(ctx.serviceSupabase, ctx.orgId, result.event.id, "create");
-          } catch (outlookErr) {
-            aiLog("error", "ai-confirm", "outlook calendar sync failed", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, { actionId: action.id, eventId: result.event.id, error: outlookErr });
-          }
-
-          try {
-            await sendNotificationBlastFn({
-              supabase: ctx.serviceSupabase,
-              organizationId: ctx.orgId,
-              audience: "both",
-              channel: "email",
-              title: `New Event: ${result.event.title}`,
-              body: `Event scheduled for ${payload.start_date} at ${payload.start_time}${payload.location ? `\nWhere: ${payload.location}` : ""}`,
-              category: "event",
-            });
-          } catch (notifyErr) {
-            aiLog("error", "ai-confirm", "event notification blast failed", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, { actionId: action.id, eventId: result.event.id, error: notifyErr });
-          }
-
-          return NextResponse.json({ ok: true, event: result.event, actionId: action.id });
-        }
+              logContext,
+              canUseDraftSessions,
+              updatePendingActionStatusFn,
+              clearDraftSessionFn,
+            },
+            action as PendingActionRecord<"create_event">,
+            {
+              createEventFn,
+              syncEventToUsersFn,
+              syncOutlookEventToUsersFn,
+              sendNotificationBlastFn,
+            }
+          );
         case "create_enterprise_invite": {
           const payload = action.payload as CreateEnterpriseInvitePendingPayload;
           // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Second Phase 0.5 extraction. Mechanical move of the `create_event` branch from `confirm/handler.ts` into a new `confirm/dispatchers/events.ts` module. Mirrors the shape established by #125's `dispatchers/announcements.ts` (ctx + deps injection, `NextResponse` return, `aiLog` on failure, `ai_messages` insert after CAS). **No behaviour change.**

`create_event` was the largest remaining branch (~130 LOC) and exercises the dispatcher shape on a harder surface than announcements:
- Structured error responses with `code`/`details` plus `internalError` pass-through
- Three best-effort side effects (Google calendar sync, Outlook calendar sync, notification blast) — each wrapped in its own try/catch with dedicated `aiLog` structured-error logging
- URL derivation that falls back to the domain-computed `result.eventUrl` when `orgSlug` is absent

**Stacks on top of #125** (`feat/ai-confirm-handler-split`). Merge #125 first.

Seven case dispatchers remain: `create_job_posting`, `send_chat_message`, `send_group_chat_message`, `create_discussion_thread`, `create_discussion_reply`, `create_enterprise_invite`, `revoke_enterprise_invite`.

### Size delta
- `handler.ts`: **839 → 727 LOC** (-112 lines)
- `dispatchers/events.ts`: 212 LOC (new)

## Testing
- 19/19 characterization tests in `tests/routes/ai/pending-actions-handler.test.ts` still pass (baseline was 19 pre-refactor)
- `npx tsc --noEmit` clean
- `npx eslint` clean on changed files
- No new tests added — this is a pure extraction; behaviour is unchanged and existing tests assert the observable contract (return shape, CAS transitions, logging calls, side-effect invocations)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: pure refactor of internal request-handler structure. The external contract (HTTP response shapes, logs, DB writes, side-effect calls) is unchanged, and characterisation tests assert those contracts.

If something regresses in prod, the signal will surface in the same logs as before:
- `aiLog` key `create_event confirmation failed` for domain-call rollbacks
- `aiLog` key `google calendar sync failed` / `outlook calendar sync failed` / `event notification blast failed` for best-effort-side-effect failures
- `aiLog` key `failed to insert confirmation message` for the post-CAS `ai_messages` insert failure

## Review notes

Read `dispatchers/events.ts` first (it's the new code), then scan the diff in `handler.ts` — the body of `case "create_event":` was replaced with a 16-line dispatcher invocation. No imports, no unrelated changes.

Two imports were removed from `handler.ts` because they are no longer referenced inline:
- `CreateEventPendingPayload` (now used only inside the dispatcher)
- `calendarEventDetailPath` (same)

`createEvent`, `syncEventToUsers`, and `sendNotificationBlast` remain in `handler.ts` because they're still wired through the `AiPendingActionConfirmRouteDeps` interface and passed into the dispatcher via `deps`.

---

[![Compound Engineering v2.46.0](https://img.shields.io/badge/Compound_Engineering-v2.46.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)