### PR TITLE
refactor(ai): extract create_job_posting dispatcher + fix return-await bug

### DIFF
--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/jobs.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/jobs.ts
@@ -1,0 +1,114 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatcher for the `create_job_posting` pending action type.
+//
+// Third Phase 0.5 extraction following dispatchers/announcements.ts and
+// dispatchers/events.ts. Simpler shape than either — no notification blast,
+// no calendar sync. Proves the dispatcher pattern scales down cleanly.
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  clearDraftSession,
+} from "@/lib/ai/draft-sessions";
+import type {
+  CreateJobPostingPendingPayload,
+  PendingActionRecord,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+import type { createJobPosting } from "@/lib/jobs/create-job";
+
+export interface JobDispatcherContext {
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  canUseDraftSessions: boolean;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+  clearDraftSessionFn: typeof clearDraftSession;
+}
+
+export interface JobDispatcherDeps {
+  createJobPostingFn: typeof createJobPosting;
+}
+
+export async function handleCreateJobPosting(
+  ctx: JobDispatcherContext,
+  action: PendingActionRecord<"create_job_posting">,
+  deps: JobDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as CreateJobPostingPendingPayload;
+  const result = await deps.createJobPostingFn({
+    supabase: ctx.serviceSupabase,
+    serviceSupabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    input: payload,
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "job_posting",
+    resultEntityId: result.job.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const jobUrl = orgSlug ? `/${orgSlug}/jobs/${result.job.id}` : null;
+  const content = jobUrl
+    ? `Created job posting: [${result.job.title}](${jobUrl})`
+    : `Created job posting: ${result.job.title}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({ ok: true, job: result.job, actionId: action.id });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -11,7 +11,6 @@ import {
   type SendGroupChatMessagePendingPayload,
   updatePendingActionStatus,
   type CreateDiscussionThreadPendingPayload,
-  type CreateJobPostingPendingPayload,
   type CreateEnterpriseInvitePendingPayload,
   type RevokeEnterpriseInvitePendingPayload,
 } from "@/lib/ai/pending-actions";
@@ -41,6 +40,7 @@ import { syncEventToUsers } from "@/lib/google/calendar-sync";
 import { sendNotificationBlast } from "@/lib/notifications";
 import { handleCreateAnnouncement } from "./dispatchers/announcements";
 import { handleCreateEvent } from "./dispatchers/events";
+import { handleCreateJobPosting } from "./dispatchers/jobs";
 
 export interface AiPendingActionConfirmRouteDeps {
   createClient?: typeof createClient;
@@ -182,7 +182,11 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
     try {
       switch (action.action_type) {
         case "create_announcement":
-          return handleCreateAnnouncement(
+          // `return await` (not `return`) is required: the outer try/catch must
+          // observe rejections from the dispatcher to run the rollback path.
+          // `return promise` would return the pending promise and let the
+          // rejection escape the surrounding try.
+          return await handleCreateAnnouncement(
             {
               serviceSupabase: ctx.serviceSupabase,
               orgId: ctx.orgId,
@@ -199,74 +203,20 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               sendNotificationBlastFn,
             }
           );
-        case "create_job_posting": {
-          const payload = action.payload as CreateJobPostingPendingPayload;
-          const result = await createJobPostingFn({
-            supabase: ctx.serviceSupabase,
-            serviceSupabase: ctx.serviceSupabase,
-            orgId: ctx.orgId,
-            userId: ctx.userId,
-            input: payload,
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              result.details ? { error: result.error, details: result.details } : { error: result.error },
-              { status: result.status }
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "job_posting",
-            resultEntityId: result.job.id,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
+        case "create_job_posting":
+          return await handleCreateJobPosting(
+            {
+              serviceSupabase: ctx.serviceSupabase,
+              orgId: ctx.orgId,
               userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const jobUrl = orgSlug ? `/${orgSlug}/jobs/${result.job.id}` : null;
-          const content = jobUrl
-            ? `Created job posting: [${result.job.title}](${jobUrl})`
-            : `Created job posting: ${result.job.title}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, job: result.job, actionId: action.id });
-        }
+              logContext,
+              canUseDraftSessions,
+              updatePendingActionStatusFn,
+              clearDraftSessionFn,
+            },
+            action as PendingActionRecord<"create_job_posting">,
+            { createJobPostingFn }
+          );
         case "send_chat_message": {
           const payload = action.payload as SendChatMessagePendingPayload;
           const result = await sendAiAssistedDirectChatMessageFn(ctx.serviceSupabase as DirectChatSupabase, {
@@ -564,7 +514,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
           return NextResponse.json({ ok: true, reply: result.reply, actionId: action.id });
         }
         case "create_event":
-          return handleCreateEvent(
+          return await handleCreateEvent(
             {
               serviceSupabase: ctx.serviceSupabase,
               orgId: ctx.orgId,

--- a/tests/routes/ai/pending-actions-handler.test.ts
+++ b/tests/routes/ai/pending-actions-handler.test.ts
@@ -1093,6 +1093,78 @@ test("exception during write rolls back to pending", async () => {
   assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
 });
 
+test("exception during write rolls back for create_announcement (dispatcher rejection propagates to try/catch)", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "create_announcement",
+        payload: {
+          title: "Announcement",
+          body: "body",
+          audience: "all",
+          is_pinned: false,
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    createAnnouncement: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for create_event (dispatcher rejection propagates to try/catch)", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "create_event",
+        payload: {
+          title: "Event",
+          start_date: "2026-05-01",
+          start_time: "10:00",
+          event_type: "practice",
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    createEvent: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
 test("rollback failure logs structured error and re-throws", async () => {
   const logged: any[] = [];
   const originalError = console.error;


### PR DESCRIPTION
## Summary

Third Phase 0.5 extraction. Mechanical move of the `create_job_posting` branch from `confirm/handler.ts` into `confirm/dispatchers/jobs.ts`, matching the shape of #125's `announcements.ts` and #126's `events.ts`. Simplest shape yet — no notification blast, no calendar sync — proving the dispatcher pattern scales down as cleanly as it scales up.

**Also fixes a latent bug introduced by the two prior extractions.** `return handleDispatcher(...)` inside an async `try` block returns a Promise synchronously, and the Promise's rejection escapes the surrounding try/catch. The outer rollback in `handler.ts:651` therefore never ran for the extracted cases. Fixed by using `return await handleDispatcher(...)` for all three extracted cases (announcements, events, jobs) so rejections are observed inside the try scope.

Stacks on **#126** (`feat/ai-confirm-handler-split-events`). Merge #119 → #120 → #121 → #122 → #123 → #124 → #125 → #126 first, then this.

Six case dispatchers remain: `send_chat_message`, `send_group_chat_message`, `create_discussion_thread`, `create_discussion_reply`, `create_enterprise_invite`, `revoke_enterprise_invite`.

### The return-await bug

JavaScript semantics:

\`\`\`ts
async function foo() {
  try {
    return somePromiseThatRejects();  // rejection ESCAPES the try
  } catch (e) { /* never runs */ }
}
\`\`\`

vs:

\`\`\`ts
async function foo() {
  try {
    return await somePromiseThatRejects();  // rejection CAUGHT here
  } catch (e) { /* runs */ }
}
\`\`\`

This is subtle enough that `no-return-await` ESLint rules often recommend against `return await` in general, but it is **semantically required** inside try/catch blocks. The inline code before extraction had `await` on each domain call, so rejections were always observed.

### Size delta
- `handler.ts`: **727 → 677 LOC** (-50 lines)
- `dispatchers/jobs.ts`: 114 LOC (new)

## Testing

**21/21 characterization tests pass** in `tests/routes/ai/pending-actions-handler.test.ts` (19 original + 2 new regression tests).

The new regression tests:
- `exception during write rolls back for create_announcement (dispatcher rejection propagates to try/catch)`
- `exception during write rolls back for create_event (dispatcher rejection propagates to try/catch)`

Both verify that when the domain primitive throws, the dispatcher's rejection propagates through the outer try/catch and triggers rollback from `confirmed → pending`. Reverting either `return await` back to `return` causes the corresponding regression test to fail deterministically — manually verified during implementation.

- `npx tsc --noEmit` clean
- `npx eslint` clean

## Post-Deploy Monitoring & Validation

**Relevant because this fixes a rollback regression introduced by #125 and #126.** Before merge, anything that threw from the domain primitive (DB timeout, unreachable Supabase, etc.) would have left the pending-action row stuck in `confirmed` until the 15-min reaper swept it to `failed` — with NO user-visible error response and NO immediate retry path. After merge, rollback to `pending` works as designed and the user sees the structured error immediately.

- **What to monitor**: `aiLog` keys in `ai-confirm` subsystem:
  - `rollback failed - action stranded in confirmed state` — should remain rare; any increase indicates DB-level rollback errors (distinct from this fix)
  - Any 5xx responses from `POST /api/ai/[orgId]/pending-actions/[actionId]/confirm` — before this fix, these would have been 200s with stranded confirmed rows; after, they correctly surface as 5xx with rollback
- **Validation query**: `SELECT status, COUNT(*) FROM ai_pending_actions WHERE created_at > now() - interval '1 hour' GROUP BY status;` — the ratio of `confirmed` rows that are stranded (age > 15min with no executed_at) should drop to near-zero after this merges
- **Expected healthy behavior**: pending → confirmed → executed with occasional confirmed → pending rollback when a domain call fails; rare or zero stranded-confirmed rows
- **Failure signal / rollback trigger**: spike in `rollback failed` logs OR spike in stranded-confirmed rows (> 1% of daily confirm volume). Rollback: revert this PR.
- **Validation window**: 24h after merge. Owner: AI agent team.

## Review notes

Read `dispatchers/jobs.ts` first (new file, 114 LOC, simplest dispatcher so far). Then look at `handler.ts` changes:
1. `case "create_job_posting":` replaced with 13-line dispatcher invocation
2. Three `return` → `return await` changes (announcements, events, jobs) — bug fix
3. Added explanatory comment on the `return await` pattern

The new regression tests are narrow: they construct a handler with a throwing domain primitive and assert both the CAS-confirmed and rollback-pending status transitions are observed.

---

[![Compound Engineering v2.46.0](https://img.shields.io/badge/Compound_Engineering-v2.46.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)