### PR TITLE
refactor(ai): extract remaining 6 confirm-handler dispatchers (Phase 0.5 complete)

### DIFF
--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/chat.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/chat.ts
@@ -1,0 +1,231 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatchers for the `send_chat_message` and `send_group_chat_message`
+// pending action types. Pairs in a single file because they share the chat
+// domain and their shapes are near-mirrors (different sender primitive, one
+// persists a recipient breadcrumb on ai_threads, the other respects a
+// message-approval status note).
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  clearDraftSession,
+} from "@/lib/ai/draft-sessions";
+import type {
+  PendingActionRecord,
+  SendChatMessagePendingPayload,
+  SendGroupChatMessagePendingPayload,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+import type {
+  sendAiAssistedDirectChatMessage,
+  DirectChatSupabase,
+} from "@/lib/chat/direct-chat";
+import type {
+  sendAiAssistedGroupChatMessage,
+  GroupChatSupabase,
+} from "@/lib/chat/group-chat";
+
+export interface ChatDispatcherContext {
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  canUseDraftSessions: boolean;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+  clearDraftSessionFn: typeof clearDraftSession;
+}
+
+export interface SendChatMessageDispatcherDeps {
+  sendAiAssistedDirectChatMessageFn: typeof sendAiAssistedDirectChatMessage;
+}
+
+export async function handleSendChatMessage(
+  ctx: ChatDispatcherContext,
+  action: PendingActionRecord<"send_chat_message">,
+  deps: SendChatMessageDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as SendChatMessagePendingPayload;
+  const result = await deps.sendAiAssistedDirectChatMessageFn(
+    ctx.serviceSupabase as DirectChatSupabase,
+    {
+      organizationId: ctx.orgId,
+      senderUserId: ctx.userId,
+      recipientMemberId: payload.recipient_member_id,
+      recipientUserId: payload.recipient_user_id,
+      recipientDisplayName: payload.recipient_display_name,
+      body: payload.body,
+    }
+  );
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      { error: result.error, code: result.code },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "chat_message",
+    resultEntityId: result.messageId,
+  });
+
+  // Store recipient in thread metadata for follow-up messages.
+  await ctx.serviceSupabase
+    .from("ai_threads")
+    .update({
+      metadata: { last_chat_recipient_member_id: payload.recipient_member_id },
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", action.thread_id);
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const chatUrl = orgSlug ? `/${orgSlug}/messages/chat/${result.chatGroupId}` : null;
+  const content = chatUrl
+    ? `Sent chat message to [${payload.recipient_display_name}](${chatUrl})`
+    : `Sent chat message to ${payload.recipient_display_name}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    actionId: action.id,
+    chatGroupId: result.chatGroupId,
+    messageId: result.messageId,
+  });
+}
+
+export interface SendGroupChatMessageDispatcherDeps {
+  sendAiAssistedGroupChatMessageFn: typeof sendAiAssistedGroupChatMessage;
+}
+
+export async function handleSendGroupChatMessage(
+  ctx: ChatDispatcherContext,
+  action: PendingActionRecord<"send_group_chat_message">,
+  deps: SendGroupChatMessageDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as SendGroupChatMessagePendingPayload;
+  const result = await deps.sendAiAssistedGroupChatMessageFn(
+    ctx.serviceSupabase as GroupChatSupabase,
+    {
+      organizationId: ctx.orgId,
+      senderUserId: ctx.userId,
+      chatGroupId: payload.chat_group_id,
+      groupName: payload.group_name,
+      messageStatus: payload.message_status,
+      body: payload.body,
+    }
+  );
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      { error: result.error, code: result.code },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "chat_message",
+    resultEntityId: result.messageId,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const chatUrl = orgSlug ? `/${orgSlug}/messages/chat/${result.chatGroupId}` : null;
+  const statusNote = result.messageStatus === "pending" ? " (pending approval)" : "";
+  const content = chatUrl
+    ? `Sent message to [${payload.group_name}](${chatUrl})${statusNote}`
+    : `Sent message to ${payload.group_name}${statusNote}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    actionId: action.id,
+    chatGroupId: result.chatGroupId,
+    messageId: result.messageId,
+  });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/discussions.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/discussions.ts
@@ -1,0 +1,208 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatchers for `create_discussion_thread` and
+// `create_discussion_reply`. Pairs in a single file because they share the
+// discussions domain and the reply shape depends on the thread it's attached
+// to (both dispatchers return the thread in their response body).
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  clearDraftSession,
+} from "@/lib/ai/draft-sessions";
+import type {
+  CreateDiscussionReplyPendingPayload,
+  CreateDiscussionThreadPendingPayload,
+  PendingActionRecord,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+import type { createDiscussionReply } from "@/lib/discussions/create-reply";
+import type { createDiscussionThread } from "@/lib/discussions/create-thread";
+
+export interface DiscussionDispatcherContext {
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  canUseDraftSessions: boolean;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+  clearDraftSessionFn: typeof clearDraftSession;
+}
+
+export interface CreateDiscussionThreadDispatcherDeps {
+  createDiscussionThreadFn: typeof createDiscussionThread;
+}
+
+export async function handleCreateDiscussionThread(
+  ctx: DiscussionDispatcherContext,
+  action: PendingActionRecord<"create_discussion_thread">,
+  deps: CreateDiscussionThreadDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as CreateDiscussionThreadPendingPayload;
+  const result = await deps.createDiscussionThreadFn({
+    supabase: ctx.serviceSupabase,
+    serviceSupabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    input: payload,
+    orgSlug:
+      typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+        ? payload.orgSlug
+        : null,
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "discussion_thread",
+    resultEntityId: result.thread.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const threadUrl = orgSlug
+    ? `/${orgSlug}/messages/threads/${result.thread.id}`
+    : result.threadUrl;
+  const content = threadUrl
+    ? `Created discussion thread: [${result.thread.title}](${threadUrl})`
+    : `Created discussion thread: ${result.thread.title}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({ ok: true, thread: result.thread, actionId: action.id });
+}
+
+export interface CreateDiscussionReplyDispatcherDeps {
+  createDiscussionReplyFn: typeof createDiscussionReply;
+}
+
+export async function handleCreateDiscussionReply(
+  ctx: DiscussionDispatcherContext,
+  action: PendingActionRecord<"create_discussion_reply">,
+  deps: CreateDiscussionReplyDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as CreateDiscussionReplyPendingPayload;
+  const result = await deps.createDiscussionReplyFn({
+    supabase: ctx.serviceSupabase,
+    threadId: payload.discussion_thread_id,
+    userId: ctx.userId,
+    orgId: ctx.orgId,
+    input: { body: payload.body },
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "discussion_reply",
+    resultEntityId: result.reply.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const threadUrl = orgSlug
+    ? `/${orgSlug}/messages/threads/${result.thread.id}`
+    : null;
+  const content = threadUrl
+    ? `Posted reply in discussion thread: [${result.thread.title}](${threadUrl})`
+    : `Posted reply in discussion thread: ${result.thread.title}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({ ok: true, reply: result.reply, actionId: action.id });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/enterprise-invites.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/enterprise-invites.ts
@@ -1,0 +1,159 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatchers for `create_enterprise_invite` and
+// `revoke_enterprise_invite`. Pairs in a single file because they operate on
+// the same enterprise_invites table and are the only dispatchers that use the
+// auth-bound supabase client (for the RPC; revoke uses serviceSupabase).
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  CreateEnterpriseInvitePendingPayload,
+  PendingActionRecord,
+  RevokeEnterpriseInvitePendingPayload,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+
+export interface EnterpriseInviteDispatcherContext {
+  supabase: any; // auth-bound client (required for create_enterprise_invite RPC)
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+}
+
+export async function handleCreateEnterpriseInvite(
+  ctx: EnterpriseInviteDispatcherContext,
+  action: PendingActionRecord<"create_enterprise_invite">
+): Promise<NextResponse> {
+  const payload = action.payload as CreateEnterpriseInvitePendingPayload;
+  const rpcResult = await (ctx.supabase as any).rpc("create_enterprise_invite", {
+    p_enterprise_id: payload.enterpriseId,
+    p_organization_id: payload.organizationId ?? null,
+    p_role: payload.role,
+    p_uses: payload.usesRemaining ?? null,
+    p_expires_at: payload.expiresAt ?? null,
+  });
+
+  if (rpcResult.error || !rpcResult.data || typeof rpcResult.data.id !== "string") {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      { error: rpcResult.error?.message || "Failed to create enterprise invite" },
+      { status: 400 }
+    );
+  }
+
+  const invite = rpcResult.data as {
+    id: string;
+    code?: string;
+    role?: string;
+  };
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "enterprise_invite",
+    resultEntityId: invite.id,
+  });
+
+  const inviteCode = typeof invite.code === "string" ? invite.code : "";
+  const invitePath = `/enterprise/${payload.enterpriseSlug}/invites`;
+  const content = inviteCode
+    ? `Created enterprise invite \`${inviteCode}\` (${payload.role}). Manage it at [${invitePath}](${invitePath}).`
+    : `Created enterprise invite (${payload.role}). Manage it at [${invitePath}](${invitePath}).`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({ ok: true, invite, actionId: action.id });
+}
+
+export async function handleRevokeEnterpriseInvite(
+  ctx: EnterpriseInviteDispatcherContext,
+  action: PendingActionRecord<"revoke_enterprise_invite">
+): Promise<NextResponse> {
+  const payload = action.payload as RevokeEnterpriseInvitePendingPayload;
+  const updateResult = await (ctx.serviceSupabase as any)
+    .from("enterprise_invites")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", payload.inviteId)
+    .eq("enterprise_id", payload.enterpriseId)
+    .is("revoked_at", null)
+    .select("id");
+
+  const updatedRows = Array.isArray(updateResult.data) ? updateResult.data : [];
+
+  if (updateResult.error || updatedRows.length === 0) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      { error: updateResult.error?.message || "Failed to revoke enterprise invite" },
+      { status: 400 }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "enterprise_invite",
+    resultEntityId: payload.inviteId,
+  });
+
+  const content = `Revoked enterprise invite \`${payload.inviteCode}\`.`;
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({ ok: true, actionId: action.id });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -2,17 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getAiOrgContext } from "@/lib/ai/context";
 import {
-  type CreateDiscussionReplyPendingPayload,
   getPendingAction,
   isAuthorizedAction,
   isPendingActionExpired,
   type PendingActionRecord,
-  type SendChatMessagePendingPayload,
-  type SendGroupChatMessagePendingPayload,
   updatePendingActionStatus,
-  type CreateDiscussionThreadPendingPayload,
-  type CreateEnterpriseInvitePendingPayload,
-  type RevokeEnterpriseInvitePendingPayload,
 } from "@/lib/ai/pending-actions";
 import {
   clearDraftSession,
@@ -26,14 +20,8 @@ import {
   createAnnouncement,
   sendAnnouncementNotification,
 } from "@/lib/announcements/create-announcement";
-import {
-  sendAiAssistedDirectChatMessage,
-  type DirectChatSupabase,
-} from "@/lib/chat/direct-chat";
-import {
-  sendAiAssistedGroupChatMessage,
-  type GroupChatSupabase,
-} from "@/lib/chat/group-chat";
+import { sendAiAssistedDirectChatMessage } from "@/lib/chat/direct-chat";
+import { sendAiAssistedGroupChatMessage } from "@/lib/chat/group-chat";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { aiLog } from "@/lib/ai/logger";
 import { syncEventToUsers } from "@/lib/google/calendar-sync";
@@ -41,6 +29,18 @@ import { sendNotificationBlast } from "@/lib/notifications";
 import { handleCreateAnnouncement } from "./dispatchers/announcements";
 import { handleCreateEvent } from "./dispatchers/events";
 import { handleCreateJobPosting } from "./dispatchers/jobs";
+import {
+  handleSendChatMessage,
+  handleSendGroupChatMessage,
+} from "./dispatchers/chat";
+import {
+  handleCreateDiscussionReply,
+  handleCreateDiscussionThread,
+} from "./dispatchers/discussions";
+import {
+  handleCreateEnterpriseInvite,
+  handleRevokeEnterpriseInvite,
+} from "./dispatchers/enterprise-invites";
 
 export interface AiPendingActionConfirmRouteDeps {
   createClient?: typeof createClient;
@@ -218,300 +218,68 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
             { createJobPostingFn }
           );
         case "send_chat_message": {
-          const payload = action.payload as SendChatMessagePendingPayload;
-          const result = await sendAiAssistedDirectChatMessageFn(ctx.serviceSupabase as DirectChatSupabase, {
-            organizationId: ctx.orgId,
-            senderUserId: ctx.userId,
-            recipientMemberId: payload.recipient_member_id,
-            recipientUserId: payload.recipient_user_id,
-            recipientDisplayName: payload.recipient_display_name,
-            body: payload.body,
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json({ error: result.error, code: result.code }, { status: result.status });
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "chat_message",
-            resultEntityId: result.messageId,
-          });
-
-          // Store recipient in thread metadata for follow-up messages
-          await ctx.serviceSupabase
-            .from("ai_threads")
-            .update({
-              metadata: { last_chat_recipient_member_id: payload.recipient_member_id },
-              updated_at: new Date().toISOString(),
-            })
-            .eq("id", action.thread_id);
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const chatUrl = orgSlug ? `/${orgSlug}/messages/chat/${result.chatGroupId}` : null;
-          const content = chatUrl
-            ? `Sent chat message to [${payload.recipient_display_name}](${chatUrl})`
-            : `Sent chat message to ${payload.recipient_display_name}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({
-            ok: true,
-            actionId: action.id,
-            chatGroupId: result.chatGroupId,
-            messageId: result.messageId,
-          });
-        }
-        case "send_group_chat_message": {
-          const payload = action.payload as SendGroupChatMessagePendingPayload;
-          const result = await sendAiAssistedGroupChatMessageFn(ctx.serviceSupabase as GroupChatSupabase, {
-            organizationId: ctx.orgId,
-            senderUserId: ctx.userId,
-            chatGroupId: payload.chat_group_id,
-            groupName: payload.group_name,
-            messageStatus: payload.message_status,
-            body: payload.body,
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json({ error: result.error, code: result.code }, { status: result.status });
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "chat_message",
-            resultEntityId: result.messageId,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const chatUrl = orgSlug ? `/${orgSlug}/messages/chat/${result.chatGroupId}` : null;
-          const statusNote = result.messageStatus === "pending" ? " (pending approval)" : "";
-          const content = chatUrl
-            ? `Sent message to [${payload.group_name}](${chatUrl})${statusNote}`
-            : `Sent message to ${payload.group_name}${statusNote}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({
-            ok: true,
-            actionId: action.id,
-            chatGroupId: result.chatGroupId,
-            messageId: result.messageId,
-          });
-        }
-        case "create_discussion_thread": {
-          const payload = action.payload as CreateDiscussionThreadPendingPayload;
-          const result = await createDiscussionThreadFn({
-            supabase: ctx.serviceSupabase,
+          const chatCtx = {
             serviceSupabase: ctx.serviceSupabase,
             orgId: ctx.orgId,
             userId: ctx.userId,
-            input: payload,
-            orgSlug:
-              typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-                ? payload.orgSlug
-                : null,
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              result.details ? { error: result.error, details: result.details } : { error: result.error },
-              { status: result.status }
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "discussion_thread",
-            resultEntityId: result.thread.id,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const threadUrl = orgSlug
-            ? `/${orgSlug}/messages/threads/${result.thread.id}`
-            : result.threadUrl;
-          const content = threadUrl
-            ? `Created discussion thread: [${result.thread.title}](${threadUrl})`
-            : `Created discussion thread: ${result.thread.title}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, thread: result.thread, actionId: action.id });
+            logContext,
+            canUseDraftSessions,
+            updatePendingActionStatusFn,
+            clearDraftSessionFn,
+          };
+          return await handleSendChatMessage(
+            chatCtx,
+            action as PendingActionRecord<"send_chat_message">,
+            { sendAiAssistedDirectChatMessageFn }
+          );
+        }
+        case "send_group_chat_message": {
+          const chatCtx = {
+            serviceSupabase: ctx.serviceSupabase,
+            orgId: ctx.orgId,
+            userId: ctx.userId,
+            logContext,
+            canUseDraftSessions,
+            updatePendingActionStatusFn,
+            clearDraftSessionFn,
+          };
+          return await handleSendGroupChatMessage(
+            chatCtx,
+            action as PendingActionRecord<"send_group_chat_message">,
+            { sendAiAssistedGroupChatMessageFn }
+          );
+        }
+        case "create_discussion_thread": {
+          const discussionCtx = {
+            serviceSupabase: ctx.serviceSupabase,
+            orgId: ctx.orgId,
+            userId: ctx.userId,
+            logContext,
+            canUseDraftSessions,
+            updatePendingActionStatusFn,
+            clearDraftSessionFn,
+          };
+          return await handleCreateDiscussionThread(
+            discussionCtx,
+            action as PendingActionRecord<"create_discussion_thread">,
+            { createDiscussionThreadFn }
+          );
         }
         case "create_discussion_reply": {
-          const payload = action.payload as CreateDiscussionReplyPendingPayload;
-          const result = await createDiscussionReplyFn({
-            supabase: ctx.serviceSupabase,
-            threadId: payload.discussion_thread_id,
-            userId: ctx.userId,
+          const discussionCtx = {
+            serviceSupabase: ctx.serviceSupabase,
             orgId: ctx.orgId,
-            input: { body: payload.body },
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              result.details ? { error: result.error, details: result.details } : { error: result.error },
-              { status: result.status }
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "discussion_reply",
-            resultEntityId: result.reply.id,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const threadUrl = orgSlug
-            ? `/${orgSlug}/messages/threads/${result.thread.id}`
-            : null;
-          const content = threadUrl
-            ? `Posted reply in discussion thread: [${result.thread.title}](${threadUrl})`
-            : `Posted reply in discussion thread: ${result.thread.title}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, reply: result.reply, actionId: action.id });
+            userId: ctx.userId,
+            logContext,
+            canUseDraftSessions,
+            updatePendingActionStatusFn,
+            clearDraftSessionFn,
+          };
+          return await handleCreateDiscussionReply(
+            discussionCtx,
+            action as PendingActionRecord<"create_discussion_reply">,
+            { createDiscussionReplyFn }
+          );
         }
         case "create_event":
           return await handleCreateEvent(
@@ -533,121 +301,32 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
             }
           );
         case "create_enterprise_invite": {
-          const payload = action.payload as CreateEnterpriseInvitePendingPayload;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const rpcResult = await (supabase as any).rpc("create_enterprise_invite", {
-            p_enterprise_id: payload.enterpriseId,
-            p_organization_id: payload.organizationId ?? null,
-            p_role: payload.role,
-            p_uses: payload.usesRemaining ?? null,
-            p_expires_at: payload.expiresAt ?? null,
-          });
-
-          if (rpcResult.error || !rpcResult.data || typeof rpcResult.data.id !== "string") {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              { error: rpcResult.error?.message || "Failed to create enterprise invite" },
-              { status: 400 },
-            );
-          }
-
-          const invite = rpcResult.data as {
-            id: string;
-            code?: string;
-            role?: string;
+          const enterpriseCtx = {
+            supabase,
+            serviceSupabase: ctx.serviceSupabase,
+            orgId: ctx.orgId,
+            userId: ctx.userId,
+            logContext,
+            updatePendingActionStatusFn,
           };
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "enterprise_invite",
-            resultEntityId: invite.id,
-          });
-
-          const inviteCode = typeof invite.code === "string" ? invite.code : "";
-          const invitePath = `/enterprise/${payload.enterpriseSlug}/invites`;
-          const content = inviteCode
-            ? `Created enterprise invite \`${inviteCode}\` (${payload.role}). Manage it at [${invitePath}](${invitePath}).`
-            : `Created enterprise invite (${payload.role}). Manage it at [${invitePath}](${invitePath}).`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, invite, actionId: action.id });
+          return await handleCreateEnterpriseInvite(
+            enterpriseCtx,
+            action as PendingActionRecord<"create_enterprise_invite">
+          );
         }
         case "revoke_enterprise_invite": {
-          const payload = action.payload as RevokeEnterpriseInvitePendingPayload;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const updateResult = await (ctx.serviceSupabase as any)
-            .from("enterprise_invites")
-            .update({ revoked_at: new Date().toISOString() })
-            .eq("id", payload.inviteId)
-            .eq("enterprise_id", payload.enterpriseId)
-            .is("revoked_at", null)
-            .select("id");
-
-          const updatedRows = Array.isArray(updateResult.data) ? updateResult.data : [];
-
-          if (updateResult.error || updatedRows.length === 0) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              { error: updateResult.error?.message || "Failed to revoke enterprise invite" },
-              { status: 400 },
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "enterprise_invite",
-            resultEntityId: payload.inviteId,
-          });
-
-          const content = `Revoked enterprise invite \`${payload.inviteCode}\`.`;
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, actionId: action.id });
+          const enterpriseCtx = {
+            supabase,
+            serviceSupabase: ctx.serviceSupabase,
+            orgId: ctx.orgId,
+            userId: ctx.userId,
+            logContext,
+            updatePendingActionStatusFn,
+          };
+          return await handleRevokeEnterpriseInvite(
+            enterpriseCtx,
+            action as PendingActionRecord<"revoke_enterprise_invite">
+          );
         }
         default:
           throw new Error(`Unsupported pending action type: ${action.action_type satisfies never}`);


### PR DESCRIPTION
## Summary

Final Phase 0.5 batch. Extracts the **six remaining case branches** from `confirm/handler.ts` into per-domain dispatcher modules, completing the split begun in #125 (announcements), #126 (events), and #127 (jobs). All nine cases now flow through `dispatchers/` with the `return await` pattern established in #127.

**Stacks on #127** (`feat/ai-confirm-handler-split-jobs`). Merge order: #119 → #120 → #121 → #122 → #123 → #124 → #125 → #126 → #127 → this.

### New dispatcher files

| File | LOC | Cases | Notes |
|------|-----|-------|-------|
| `dispatchers/chat.ts` | 231 | `send_chat_message`, `send_group_chat_message` | Uses `DirectChatSupabase` / `GroupChatSupabase` type adapters. Direct-chat variant also persists `last_chat_recipient_member_id` to `ai_threads.metadata`. |
| `dispatchers/discussions.ts` | 208 | `create_discussion_thread`, `create_discussion_reply` | Standard shape. Reply returns both `result.reply` and `result.thread` in its response body. |
| `dispatchers/enterprise-invites.ts` | 159 | `create_enterprise_invite`, `revoke_enterprise_invite` | Only dispatcher that takes `supabase` (auth-bound) in addition to `serviceSupabase`. Create uses the auth-bound client for the RPC per RLS policy; revoke uses `serviceSupabase` for the direct UPDATE. Threaded through `EnterpriseInviteDispatcherContext`. |

### Size delta (full Phase 0.5)

- `handler.ts` before Phase 0.5: **920 LOC**
- After #125 (announcements): 839 LOC
- After #126 (events): 727 LOC
- After #127 (jobs): 677 LOC
- **After this PR: 356 LOC (-564 lines, 61% reduction)**

Nine dispatcher invocations, each 10-15 lines wrapping an identical `ctx + deps` shape. handler.ts is now a thin dispatch shell handling rate-limit, auth, CAS, and the outer try/catch — no domain logic remains inline.

## Testing

- **21/21** characterization tests in `tests/routes/ai/pending-actions-handler.test.ts` pass (no behaviour change)
- **272/272** AI route tests pass (all of `tests/routes/ai/*.ts`)
- `npx tsc --noEmit` clean
- `npx eslint` clean

## Why batch the last 6 instead of stacking 6 more PRs?

After three incremental extractions (#125, #126, #127):
1. The dispatcher shape is locked in (ctx + deps injection, `return await`, `NextResponse` return, `aiLog` on failure)
2. The only real latent bug (`return` vs `return await`) was discovered and fixed in #127 with regression tests that already cover all dispatchers
3. Each remaining extraction is a mechanical move with zero novel decisions

Three differently-shaped pilots (simple / multi-side-effect / simple-with-bug-fix) established the pattern. Batching the remaining six saves ~5 review cycles without introducing any new risk surface — each extraction is a pure textual move into a new module.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: pure refactor. The external contract (HTTP response shapes, logs, DB writes, side-effect calls) is identical to pre-Phase-0.5. Characterization tests assert the contract; 272/272 AI route tests confirm no regression in adjacent code.

If something regresses in prod after this stack merges, the same logs apply as before:
- `aiLog` keys in `ai-confirm` subsystem unchanged
- `rollback failed - action stranded in confirmed state` for rollback-of-rollback edge cases
- 5xx rate on `POST /api/ai/[orgId]/pending-actions/[actionId]/confirm` should remain flat

**Rollback plan:** revert this PR alone leaves #125-#127 intact and still functional; the remaining 6 cases return to their pre-split inline form.

## Review notes

Read the three new files first — each is a straightforward mirror of its inline-case predecessor. Then scan `handler.ts`: the six `case` blocks are each replaced with a ~12-line dispatcher invocation. Three imports moved (removed from `handler.ts`, absorbed into the dispatchers that need them): `SendChatMessagePendingPayload`, `DirectChatSupabase`, `GroupChatSupabase`, `CreateDiscussionThreadPendingPayload`, `CreateDiscussionReplyPendingPayload`, `CreateEnterpriseInvitePendingPayload`, `RevokeEnterpriseInvitePendingPayload`.

The `EnterpriseInviteDispatcherContext` explicitly carries `supabase` (auth-bound) because the RPC path requires it for RLS enforcement. All other dispatchers use only `serviceSupabase`.

---

[![Compound Engineering v2.46.0](https://img.shields.io/badge/Compound_Engineering-v2.46.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)