### PR TITLE
test(ai): add return-await rollback regression tests for remaining 6 dispatchers

### DIFF
--- a/tests/routes/ai/pending-actions-handler.test.ts
+++ b/tests/routes/ai/pending-actions-handler.test.ts
@@ -1165,6 +1165,264 @@ test("exception during write rolls back for create_event (dispatcher rejection p
   assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
 });
 
+// --- Remaining dispatchers: regression coverage for the return-await bug ---
+//
+// The existing "exception during write" tests above cover create_job_posting,
+// create_announcement, and create_event. The other six dispatchers extracted
+// in #128 (send_chat_message, send_group_chat_message, create_discussion_thread,
+// create_discussion_reply, create_enterprise_invite, revoke_enterprise_invite)
+// have the same structural vulnerability: if `return handleDispatcher(...)`
+// ever regresses back from `return await handleDispatcher(...)`, the outer
+// try/catch in handler.ts will miss rejections and skip the rollback.
+//
+// These tests lock in that behaviour for each dispatcher.
+
+test("exception during write rolls back for send_chat_message", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "send_chat_message",
+        payload: {
+          recipient_member_id: "member-1",
+          recipient_user_id: "user-1",
+          recipient_display_name: "Alice",
+          body: "hello",
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    sendAiAssistedDirectChatMessage: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for send_group_chat_message", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "send_group_chat_message",
+        payload: {
+          chat_group_id: "group-1",
+          group_name: "Group",
+          message_status: "complete",
+          body: "hello",
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    sendAiAssistedGroupChatMessage: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for create_discussion_thread", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "create_discussion_thread",
+        payload: {
+          title: "Thread",
+          body: "body",
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    createDiscussionThread: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for create_discussion_reply", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "create_discussion_reply",
+        payload: {
+          discussion_thread_id: "thread-1",
+          body: "reply body",
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    createDiscussionReply: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for create_enterprise_invite", async () => {
+  // Enterprise-invite dispatcher uses the auth-bound supabase client (not
+  // serviceSupabase) for the RPC. Simulate the throw by overriding
+  // createClient so supabase.rpc rejects.
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    createClient: async () =>
+      ({
+        auth: { getUser: async () => ({ data: { user: ADMIN_USER } }) },
+        rpc: async () => {
+          throw new Error("Supabase timeout");
+        },
+      }) as any,
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "create_enterprise_invite",
+        payload: {
+          enterpriseId: "enterprise-1",
+          enterpriseSlug: "ent",
+          organizationId: null,
+          role: "admin",
+          usesRemaining: null,
+          expiresAt: null,
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for revoke_enterprise_invite", async () => {
+  // Revoke uses ctx.serviceSupabase.from("enterprise_invites").update(...)...
+  // Override getAiOrgContext to return a serviceSupabase whose `.from()` on
+  // enterprise_invites returns an update chain that rejects on the final
+  // `.select()`. ai_messages still needs to succeed on insert (but won't be
+  // reached, since rollback happens first).
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps({
+      getAiOrgContext: async () =>
+        ({
+          ok: true,
+          orgId: ORG_ID,
+          userId: ADMIN_USER.id,
+          role: "admin",
+          supabase: null,
+          serviceSupabase: {
+            from(table: string) {
+              if (table === "enterprise_invites") {
+                const chain: any = {
+                  update: () => chain,
+                  eq: () => chain,
+                  is: () => chain,
+                  select: () => Promise.reject(new Error("Supabase timeout")),
+                };
+                return chain;
+              }
+              if (table === "ai_messages") {
+                return { insert: () => Promise.resolve({ error: null }) };
+              }
+              throw new Error(`unexpected table ${table}`);
+            },
+          },
+        }) as any,
+    }),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "revoke_enterprise_invite",
+        payload: {
+          inviteId: "invite-1",
+          inviteCode: "CODE1",
+          enterpriseId: "enterprise-1",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
 test("rollback failure logs structured error and re-throws", async () => {
   const logged: any[] = [];
   const originalError = console.error;


### PR DESCRIPTION
## Summary

#127 locked in the return-await bug fix with regression tests for \`create_announcement\`, \`create_event\`, and \`create_job_posting\`. #128 then extracted six more dispatchers but shipped without equivalent regression coverage. This PR closes that gap — all nine extracted dispatchers now have matching tests that prove the outer rollback path fires when the domain primitive throws.

**Stacks on #128** (\`feat/ai-confirm-handler-split-rest\`). Test-only; no source changes.

### Why this matters

Every one of the six extracted dispatchers in #128 is structurally vulnerable to the same bug #127 caught in the extraction of \`create_job_posting\`: a \`return handleDispatcher(...)\` (without \`await\`) inside an async \`try\` block returns the unresolved Promise, and the rejection escapes the surrounding \`try/catch\`. When the rollback path is skipped, the pending-action row strands in \`confirmed\` until the 15-minute reaper sweeps it to \`failed\` — with no user-visible error and no retry path.

Today each of the six \`case\` branches in \`handler.ts\` uses the correct \`return await\` form, so the bug is latent. Without these tests, it will stay latent only until someone runs \`eslint --fix\` with the \`no-return-await\` rule enabled, or hand-edits the switch to "match" one of the fixed cases.

### What's covered now

| Dispatcher | Regression test |
|-----------|-----------------|
| \`create_announcement\` | ✅ (#127) |
| \`create_event\` | ✅ (#127) |
| \`create_job_posting\` | ✅ (#127) |
| \`send_chat_message\` | ✅ (this PR) |
| \`send_group_chat_message\` | ✅ (this PR) |
| \`create_discussion_thread\` | ✅ (this PR) |
| \`create_discussion_reply\` | ✅ (this PR) |
| \`create_enterprise_invite\` | ✅ (this PR) |
| \`revoke_enterprise_invite\` | ✅ (this PR) |

## Testing

- **27/27 tests pass** in \`tests/routes/ai/pending-actions-handler.test.ts\` (up from 21)
- \`tsc --noEmit\` clean
- \`eslint\` clean on the changed file
- **Manually verified** the new tests catch the bug: reverting \`return await handleCreateEnterpriseInvite\` to \`return handleCreateEnterpriseInvite\` in \`handler.ts\` causes the matching test to fail deterministically with \`Cannot read properties of undefined (reading 'status')\`.

### Test notes

Four of the six tests follow the template from #127: override \`getPendingAction\` to return an action of the right type, override \`updatePendingActionStatus\` to capture the sequence of CAS transitions, and override the single domain-call dep to throw.

The enterprise-invite tests are slightly larger because their dispatchers don't use a typical dep function:

- **\`create_enterprise_invite\`** uses the auth-bound \`supabase\` client for the RPC (not \`serviceSupabase\`). Test overrides \`createClient\` so \`supabase.rpc\` rejects.
- **\`revoke_enterprise_invite\`** uses \`serviceSupabase.from("enterprise_invites").update(...).eq(...).is(...).select()\`. Test overrides \`getAiOrgContext\` to return a \`serviceSupabase\` whose \`.select()\` step rejects, while keeping \`ai_messages.insert\` healthy.

Both correctly reproduce the rejection path that the current-state code catches.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: tests-only change, no runtime impact. The tests lock in behaviour that the production code already has correctly today.

---

[![Compound Engineering v2.46.0](https://img.shields.io/badge/Compound_Engineering-v2.46.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)