### PR TITLE
feat(ai): widen ai_draft_sessions unique key to (thread_id, draft_type)

### DIFF
--- a/src/app/api/ai/[orgId]/chat/handler.ts
+++ b/src/app/api/ai/[orgId]/chat/handler.ts
@@ -4196,6 +4196,7 @@ export function createChatPostHandler(deps: ChatRouteDeps = {}) {
                 userId: ctx.userId,
                 threadId,
                 pendingActionId: activeDraftSession.pending_action_id,
+                draftType: activeDraftSession.draft_type,
               });
             } catch (error) {
               aiLog("warn", "ai-chat", "failed to clear expired draft session", {
@@ -4222,6 +4223,7 @@ export function createChatPostHandler(deps: ChatRouteDeps = {}) {
                   userId: ctx.userId,
                   threadId,
                   pendingActionId: activeDraftSession.pending_action_id,
+                  draftType: activeDraftSession.draft_type,
                 });
               } catch (error) {
                 aiLog("warn", "ai-chat", "failed to clear abandoned draft session", {

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -218,6 +218,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "create_announcement",
             });
           }
 
@@ -316,6 +317,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "create_job_posting",
             });
           }
 
@@ -391,6 +393,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "send_chat_message",
             });
           }
 
@@ -462,6 +465,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "send_group_chat_message",
             });
           }
 
@@ -540,6 +544,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "create_discussion_thread",
             });
           }
 
@@ -610,6 +615,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "create_discussion_reply",
             });
           }
 
@@ -702,6 +708,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "create_event",
             });
           }
 

--- a/src/lib/ai/draft-sessions.ts
+++ b/src/lib/ai/draft-sessions.ts
@@ -41,6 +41,11 @@ export interface DraftSessionRecord<TDraftType extends DraftSessionType = DraftS
 
 interface DraftSessionSelectChain {
   eq(column: string, value: string): DraftSessionSelectChain;
+  order(
+    column: string,
+    options: { ascending: boolean }
+  ): DraftSessionSelectChain;
+  limit(count: number): DraftSessionSelectChain;
   maybeSingle(): Promise<{ data: unknown; error: unknown }>;
 }
 
@@ -89,14 +94,32 @@ export async function getDraftSession(
     organizationId: string;
     userId: string;
     threadId: string;
+    // When provided, narrows the lookup to a specific draft type — required
+    // for any caller that needs to discriminate between concurrent drafts
+    // (e.g. a `create_announcement` vs `edit_announcement` draft on the
+    // same thread). When omitted, returns the most-recently-updated draft
+    // of any type for backwards compatibility with legacy "do they have an
+    // active draft?" callers.
+    draftType?: DraftSessionType;
   }
 ): Promise<DraftSessionRecord | null> {
-  const { data, error } = await supabase
+  let chain = supabase
     .from("ai_draft_sessions")
     .select("*")
     .eq("organization_id", input.organizationId)
     .eq("user_id", input.userId)
-    .eq("thread_id", input.threadId)
+    .eq("thread_id", input.threadId);
+
+  if (input.draftType) {
+    chain = chain.eq("draft_type", input.draftType);
+  }
+
+  // order + limit keeps `.maybeSingle()` safe once the unique key widens
+  // to (thread_id, draft_type): a thread can legitimately carry multiple
+  // rows after widening, and un-narrowed callers want the most recent.
+  const { data, error } = await chain
+    .order("updated_at", { ascending: false })
+    .limit(1)
     .maybeSingle();
 
   if (error) {
@@ -133,10 +156,14 @@ export async function saveDraftSession(
       input.expiresAt ?? new Date(Date.now() + AI_PENDING_ACTION_EXPIRY_MS).toISOString(),
   };
 
+  // Existence check narrowed to draft_type so two draft types on the same
+  // thread round-trip as two rows under the widened (thread_id, draft_type)
+  // unique key.
   const existing = await getDraftSession(supabase, {
     organizationId: input.organizationId,
     userId: input.userId,
     threadId: input.threadId,
+    draftType: input.draftType,
   });
 
   if (existing) {
@@ -173,6 +200,10 @@ export async function clearDraftSession(
     userId: string;
     threadId: string;
     pendingActionId?: string | null;
+    // When provided, clears only the matching draft type. When omitted,
+    // clears every draft type for the thread (the legacy behaviour —
+    // still valid for callers that want a blanket reset).
+    draftType?: DraftSessionType;
   }
 ): Promise<void> {
   let query = supabase
@@ -181,6 +212,10 @@ export async function clearDraftSession(
     .eq("organization_id", input.organizationId)
     .eq("user_id", input.userId)
     .eq("thread_id", input.threadId);
+
+  if (input.draftType) {
+    query = query.eq("draft_type", input.draftType);
+  }
 
   if (input.pendingActionId) {
     query = query.eq("pending_action_id", input.pendingActionId);

--- a/supabase/migrations/20261101000005_ai_draft_sessions_widen_unique_key.sql
+++ b/supabase/migrations/20261101000005_ai_draft_sessions_widen_unique_key.sql
@@ -1,0 +1,19 @@
+-- Widen the ai_draft_sessions unique key from (thread_id) to
+-- (thread_id, draft_type) so a single AI chat thread can hold concurrent
+-- drafts of different types — e.g. a `create_announcement` draft and a
+-- future `edit_announcement` draft at the same time. This is the last
+-- scaffolding piece required before Phase 2+ can register edit/delete
+-- `prepare_*` tool families whose drafts coexist with create drafts on
+-- the same thread.
+--
+-- Repo convention is plain DROP/CREATE rather than CREATE INDEX
+-- CONCURRENTLY because Supabase runs migrations inside a transaction
+-- (see the note in 20260812000001_drop_unused_indexes.sql). No data
+-- cleanup is needed: strictly relaxing uniqueness cannot violate the
+-- new wider constraint, since every existing row already satisfies the
+-- narrower `(thread_id)` rule.
+
+DROP INDEX IF EXISTS idx_ai_draft_sessions_thread;
+
+CREATE UNIQUE INDEX idx_ai_draft_sessions_thread_type
+  ON public.ai_draft_sessions (thread_id, draft_type);

--- a/tests/ai-draft-sessions-concurrent-types.test.ts
+++ b/tests/ai-draft-sessions-concurrent-types.test.ts
@@ -1,0 +1,265 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  clearDraftSession,
+  getDraftSession,
+  saveDraftSession,
+  type DraftSessionRecord,
+  type DraftSessionType,
+} from "@/lib/ai/draft-sessions";
+
+// ─── Stub shape ────────────────────────────────────────────────────────
+//
+// The wrapper in src/lib/ai/draft-sessions.ts calls:
+//   supabase.from("ai_draft_sessions")
+//     .select("*").eq(...).eq(...).eq(...)[.eq("draft_type", ...)]
+//     .order("updated_at", { ascending: false }).limit(1).maybeSingle()
+//   .insert(payload).select("*").single()
+//   .update(payload).eq("id", ...).select("*")
+//   .delete().eq(...).eq(...).eq(...)[.eq("draft_type", ...)][.eq("pending_action_id", ...)]
+//
+// This stub implements that shape with an in-memory rows array so we can
+// exercise the widened unique-key semantics end-to-end.
+
+type DraftRow = DraftSessionRecord;
+
+interface StubState {
+  rows: DraftRow[];
+  nextId: number;
+}
+
+function buildStub(state: StubState) {
+  const matchesEqFilters = (row: DraftRow, filters: Array<{ col: string; val: unknown }>) =>
+    filters.every(({ col, val }) => (row as any)[col] === val);
+
+  return {
+    from(table: string) {
+      if (table !== "ai_draft_sessions") {
+        throw new Error(`unexpected table ${table}`);
+      }
+      return {
+        select(_cols: string) {
+          void _cols;
+          const filters: Array<{ col: string; val: unknown }> = [];
+          let ordered = false;
+          let limitCount = Number.POSITIVE_INFINITY;
+
+          const chain: any = {
+            eq(col: string, val: unknown) {
+              filters.push({ col, val });
+              return chain;
+            },
+            order(_col: string, _opts: { ascending: boolean }) {
+              void _col;
+              void _opts;
+              ordered = true;
+              return chain;
+            },
+            limit(count: number) {
+              limitCount = count;
+              return chain;
+            },
+            maybeSingle() {
+              const matching = state.rows.filter((r) => matchesEqFilters(r, filters));
+              if (ordered) {
+                matching.sort(
+                  (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+                );
+              }
+              const capped = matching.slice(0, limitCount);
+              if (capped.length === 0) {
+                return Promise.resolve({ data: null, error: null });
+              }
+              if (capped.length > 1) {
+                // Mirrors Supabase's .maybeSingle() contract: errors when >1 row.
+                return Promise.resolve({
+                  data: null,
+                  error: { message: "multiple rows returned" },
+                });
+              }
+              return Promise.resolve({ data: capped[0], error: null });
+            },
+          };
+          return chain;
+        },
+        insert(payload: Record<string, unknown>) {
+          const row: DraftRow = {
+            id: `row-${state.nextId++}`,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            ...(payload as any),
+          } as DraftRow;
+          state.rows.push(row);
+          return {
+            select(_c: string) {
+              void _c;
+              return {
+                single: () => Promise.resolve({ data: row, error: null }),
+              };
+            },
+          };
+        },
+        update(payload: Record<string, unknown>) {
+          const filters: Array<{ col: string; val: unknown }> = [];
+          const chain: any = {
+            eq(col: string, val: unknown) {
+              filters.push({ col, val });
+              return chain;
+            },
+            select(_c: string) {
+              void _c;
+              const matches = state.rows.filter((r) => matchesEqFilters(r, filters));
+              for (const row of matches) {
+                Object.assign(row, payload, { updated_at: new Date().toISOString() });
+              }
+              return Promise.resolve({ data: matches, error: null });
+            },
+          };
+          return chain;
+        },
+        delete() {
+          const filters: Array<{ col: string; val: unknown }> = [];
+          const chain: any = {
+            eq(col: string, val: unknown) {
+              filters.push({ col, val });
+              // Delete only runs on await — but `.eq()` is chained; Supabase's
+              // delete chain resolves the promise on the last `.eq()`. The
+              // wrapper awaits the chain directly, which triggers the `then`
+              // at whatever the last call is. We implement by making the
+              // chain itself thenable after enough eq() calls.
+              return chain;
+            },
+            then(resolve: (v: { error: unknown }) => void) {
+              state.rows = state.rows.filter((r) => !matchesEqFilters(r, filters));
+              resolve({ error: null });
+              return Promise.resolve({ error: null });
+            },
+          };
+          return chain;
+        },
+      };
+    },
+  };
+}
+
+function freshState(): StubState {
+  return { rows: [], nextId: 1 };
+}
+
+const orgId = "org-1";
+const userId = "user-1";
+const threadId = "thread-1";
+
+const saveBaseInput = (draftType: DraftSessionType, extras: Record<string, unknown> = {}) => ({
+  organizationId: orgId,
+  userId,
+  threadId,
+  draftType,
+  status: "collecting_fields" as const,
+  draftPayload: { marker: `draft-${draftType}` } as any,
+  missingFields: [],
+  pendingActionId: null,
+  ...extras,
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe("ai_draft_sessions — concurrent draft types on one thread", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("saveDraftSession inserts two separate rows when (thread, draft_type) differs", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    await saveDraftSession(stub as any, saveBaseInput("create_event"));
+
+    assert.equal(state.rows.length, 2, "two distinct draft types should round-trip as two rows");
+    const types = state.rows.map((r) => r.draft_type).sort();
+    assert.deepEqual(types, ["create_announcement", "create_event"]);
+  });
+
+  it("saveDraftSession updates in place when the same (thread, draft_type) is saved twice", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    await saveDraftSession(
+      stub as any,
+      saveBaseInput("create_announcement", { draftPayload: { marker: "v2" } })
+    );
+
+    assert.equal(state.rows.length, 1, "same type should update, not insert");
+    assert.deepEqual(state.rows[0].draft_payload, { marker: "v2" });
+  });
+
+  it("getDraftSession with draftType narrows to the matching row", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    await saveDraftSession(stub as any, saveBaseInput("create_event"));
+
+    const ann = await getDraftSession(stub as any, {
+      organizationId: orgId,
+      userId,
+      threadId,
+      draftType: "create_announcement",
+    });
+    assert.ok(ann, "announcement draft must exist");
+    assert.equal(ann!.draft_type, "create_announcement");
+
+    const evt = await getDraftSession(stub as any, {
+      organizationId: orgId,
+      userId,
+      threadId,
+      draftType: "create_event",
+    });
+    assert.ok(evt, "event draft must exist");
+    assert.equal(evt!.draft_type, "create_event");
+  });
+
+  it("getDraftSession without draftType returns the most-recently-updated row (legacy back-compat)", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    // Advance clock by forcing a distinct updated_at on the second save.
+    await new Promise((r) => setTimeout(r, 5));
+    await saveDraftSession(stub as any, saveBaseInput("create_event"));
+
+    const any = await getDraftSession(stub as any, {
+      organizationId: orgId,
+      userId,
+      threadId,
+    });
+    assert.ok(any, "should return the most-recent draft regardless of type");
+    assert.equal(any!.draft_type, "create_event", "create_event was saved second → most recent");
+  });
+
+  it("clearDraftSession with draftType removes only the matching row", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    await saveDraftSession(stub as any, saveBaseInput("create_event"));
+
+    await clearDraftSession(stub as any, {
+      organizationId: orgId,
+      userId,
+      threadId,
+      draftType: "create_announcement",
+    });
+
+    assert.equal(state.rows.length, 1, "event draft must remain");
+    assert.equal(state.rows[0].draft_type, "create_event");
+  });
+
+  it("clearDraftSession without draftType removes every draft type for that thread", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    await saveDraftSession(stub as any, saveBaseInput("create_event"));
+
+    await clearDraftSession(stub as any, {
+      organizationId: orgId,
+      userId,
+      threadId,
+    });
+
+    assert.equal(state.rows.length, 0, "blanket clear should wipe every type");
+  });
+});

--- a/tests/ai-draft-sessions-widen-unique-key-migration-contract.test.ts
+++ b/tests/ai-draft-sessions-widen-unique-key-migration-contract.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const migration = readFileSync(
+  new URL(
+    "../supabase/migrations/20261101000005_ai_draft_sessions_widen_unique_key.sql",
+    import.meta.url
+  ),
+  "utf8"
+);
+
+describe("ai_draft_sessions widen unique-key migration contract", () => {
+  it("drops the narrow (thread_id) unique index", () => {
+    assert.match(
+      migration,
+      /DROP\s+INDEX\s+IF\s+EXISTS\s+idx_ai_draft_sessions_thread\b/i
+    );
+  });
+
+  it("creates the new (thread_id, draft_type) unique index", () => {
+    assert.match(
+      migration,
+      /CREATE\s+UNIQUE\s+INDEX\s+idx_ai_draft_sessions_thread_type\b/i
+    );
+    assert.match(migration, /ON\s+public\.ai_draft_sessions\s*\(\s*thread_id\s*,\s*draft_type\s*\)/i);
+  });
+
+  it("drops before it creates — order matters for an index swap", () => {
+    const dropMatch = migration.match(/DROP\s+INDEX\s+IF\s+EXISTS\s+idx_ai_draft_sessions_thread\b/i);
+    const createMatch = migration.match(/CREATE\s+UNIQUE\s+INDEX\s+idx_ai_draft_sessions_thread_type\b/i);
+    assert.ok(dropMatch, "DROP must be present");
+    assert.ok(createMatch, "CREATE must be present");
+    assert.ok(
+      dropMatch!.index! < createMatch!.index!,
+      "DROP of the old index must appear before CREATE of the new one"
+    );
+  });
+
+  it("does not use CREATE INDEX CONCURRENTLY (Supabase migrations are transactional)", () => {
+    // Scoped to the actual DDL statement rather than any text in a SQL
+    // comment that happens to contain the word "CONCURRENTLY".
+    assert.doesNotMatch(migration, /CREATE\s+(UNIQUE\s+)?INDEX\s+CONCURRENTLY/i);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1a of the Tier 1 edit/delete plan. Widens the `ai_draft_sessions` unique key from `(thread_id)` to `(thread_id, draft_type)` so a single AI chat thread can hold concurrent drafts of different types — the last scaffolding piece required before Phase 2+ can register edit/delete `prepare_*` tool families whose drafts coexist with create drafts on the same thread.

**Branches off `main`**, not on top of the queue. No semantic dependency on #119–#131. Migration timestamp `20261101000005` falls after #121's `20261101000003` and merges cleanly regardless of order. One rebase surface: the seven `clearDraftSessionFn` call sites this PR updates in `confirm/handler.ts` overlap with the dispatcher split in #125–#128. Whichever merges first, the other rebases with a mechanical conflict on those nine lines.

## Migration

`supabase/migrations/20261101000005_ai_draft_sessions_widen_unique_key.sql`

```sql
DROP INDEX IF EXISTS idx_ai_draft_sessions_thread;

CREATE UNIQUE INDEX idx_ai_draft_sessions_thread_type
  ON public.ai_draft_sessions (thread_id, draft_type);
```

Plain DROP/CREATE per repo convention; Supabase migrations are transactional so `CONCURRENTLY` is not used (see the comment in `20260812000001_drop_unused_indexes.sql`). No data cleanup needed — the change strictly relaxes uniqueness, so every existing row already satisfies the new wider constraint.

## Wrapper API changes (`src/lib/ai/draft-sessions.ts`)

| Function | Change |
|---|---|
| `getDraftSession` | New optional `draftType`. When provided, filters. When omitted, returns the most-recently-updated draft of any type via `.order("updated_at", { ascending: false }).limit(1)` — required because `.maybeSingle()` would otherwise throw once a thread legitimately carries multiple rows after widening. |
| `saveDraftSession` | Existence check passes `draftType` through, so concurrent drafts of different types round-trip as two separate rows under the widened unique key. |
| `clearDraftSession` | New optional `draftType`. When provided, clears only that type's row. When omitted, clears every type on the thread (legacy behaviour preserved). |

The `DraftSessionSelectChain` type interface gains `.order()` and `.limit()` methods to reflect the new query shape.

## Caller updates

- **`confirm/handler.ts`** — seven `clearDraftSessionFn` call sites now pass the matching `draftType` derived from the `case` label (`create_announcement`, `create_job_posting`, `send_chat_message`, `send_group_chat_message`, `create_discussion_thread`, `create_discussion_reply`, `create_event`). The two enterprise-invite cases are untouched — they have no draft session.
- **`chat/handler.ts`** — two `clearDraftSessionFn` call sites (expired draft, abandoned draft) now pass `draftType: activeDraftSession.draft_type` for precise clearing. The `getDraftSession` call at turn entry intentionally omits `draftType` — it wants "whatever draft is currently active on this thread", and the ordered-limit fallback makes that safe.
- **`cancel/handler.ts`** — unchanged. The existing `pendingActionId` filter already narrows the delete to exactly one row regardless of unique-key shape.

## Testing

**New tests:**

- `tests/ai-draft-sessions-widen-unique-key-migration-contract.test.ts` (4 assertions)
  - DROP of old `idx_ai_draft_sessions_thread`
  - CREATE of new `idx_ai_draft_sessions_thread_type` on `(thread_id, draft_type)`
  - DROP-before-CREATE ordering
  - No `CONCURRENTLY` in the DDL statement (comments allowed)
- `tests/ai-draft-sessions-concurrent-types.test.ts` (6 tests)
  - `saveDraftSession` inserts two rows when draft_type differs
  - `saveDraftSession` updates in place when draft_type matches
  - `getDraftSession` with draftType narrows correctly
  - `getDraftSession` without draftType returns most-recently-updated (legacy back-compat)
  - `clearDraftSession` with draftType removes only the matching row
  - `clearDraftSession` without draftType removes every draft type for the thread

**Characterization unchanged:**

- `tests/routes/ai/pending-actions-handler.test.ts` — 21/21 pass (27 if this lands after #130)
- `tests/routes/ai/chat-handler.test.ts` — all pass
- `tests/routes/ai/chat-handler-tools.test.ts` — all pass
- Migration-contract tests for the existing Phase-0 migrations — all pass

**Totals: 139/139 relevant tests pass.** `npx tsc --noEmit` clean. `npx eslint` clean on all changed files.

## Scope correction

The plan's original estimate was "~31 caller updates". Exploration on 2026-04-22 showed all draft-session access already flows through one typed wrapper (`src/lib/ai/draft-sessions.ts`), which uses a `getDraftSession → insert-or-update` hybrid rather than `.upsert({ onConflict: "thread_id" })`. The actual caller delta is nine lines across three handler files, with no `onConflict:` string to grep-and-replace. The Phase 1a-full section of `~/.claude/plans/i-want-you-to-quirky-sprout.md` documents the corrected scope.

## Post-Deploy Monitoring & Validation

- **What to monitor**: `aiLog` events in `ai-chat` and `ai-confirm` subsystems. Specifically watch for `failed to load draft session` and `Failed to clear draft session` spikes after deploy — either would indicate the `.order().limit()` query shape hit an RLS edge case we didn't exercise in tests.
- **Validation query**:
  ```sql
  SELECT draft_type, COUNT(*), MAX(updated_at)
  FROM ai_draft_sessions
  WHERE updated_at > now() - interval '1 hour'
  GROUP BY draft_type
  ORDER BY draft_type;
  ```
  Post-deploy this should show the same distribution as pre-deploy; nothing in this PR introduces new draft_type values.
- **Expected healthy behavior**: zero stranded draft rows after a confirm-handler run (each dispatcher now clears exactly its own draft_type, so bulk clears are unchanged); no `.maybeSingle()` multiple-row errors in logs.
- **Failure signal / rollback trigger**: (a) spike in `Failed to load draft session` logs — likely a missed `.order()` or `.limit()` in the stub or unexpected RLS behaviour under the new index; (b) any `PGRST116`-style "multiple rows returned" error from Supabase — the `.limit(1)` guard failed to apply. **Rollback**: revert this PR; the `DROP INDEX IF EXISTS idx_ai_draft_sessions_thread_type; CREATE UNIQUE INDEX idx_ai_draft_sessions_thread ON public.ai_draft_sessions (thread_id);` sequence is safe as long as Phase 2+ has not yet introduced edit/delete draft_type values that actually coexist on the same thread.
- **Validation window & owner**: 24h after merge. Owner: AI agent team.

## Review notes

Read the migration first (20 LOC with comments), then `src/lib/ai/draft-sessions.ts` to see the three function changes. The caller diffs are one-line additions of `draftType: "..."` to existing objects — grep for `draftType:` in the diff to locate them all.

The `.order().limit(1).maybeSingle()` pattern is load-bearing: without `.limit(1)`, `.maybeSingle()` throws when two draft_types coexist on a thread, and any legacy caller that calls `getDraftSession` without a type would start failing as soon as Phase 2a ships `edit_announcement`. This PR makes the wrapper robust *before* that capability exists.

---

[![Compound Engineering v2.46.0](https://img.shields.io/badge/Compound_Engineering-v2.46.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)