### PR TITLE
integration: Tier 1 edit/delete scaffolding — combined branch of #119-#132

### DIFF
--- a/docs/agent/assistant.md
+++ b/docs/agent/assistant.md
@@ -81,6 +81,7 @@ The assistant is locked to TeamNetwork organization tasks. Enforcement runs at f
 | Semantic Cache | [semantic-cache-codemap.md](semantic-cache-codemap.md) | Exact-hash prompt deduplication, 12h general TTL, hourly bounded purge |
 | Thread Management | [threads-codemap.md](threads-codemap.md) | CRUD for threads and messages, cursor pagination, soft-delete |
 | UI Panel | [ui-panel-codemap.md](ui-panel-codemap.md) | Slide-out panel, SSE stream consumer, thread/message display, pending-action review |
+| Confirm Dispatchers | [confirm-dispatcher-pattern.md](confirm-dispatcher-pattern.md) | Per-domain confirm-handler split, CAS + rollback contract, `return await` rule for new `prepare_*` families |
 
 ## Database Tables
 

--- a/docs/agent/confirm-dispatcher-pattern.md
+++ b/docs/agent/confirm-dispatcher-pattern.md
@@ -1,0 +1,99 @@
+# AI Confirm-Handler Dispatcher Pattern
+
+## Purpose
+
+`POST /api/ai/[orgId]/pending-actions/[actionId]/confirm` is the single route that executes every AI-drafted write action (announcements, events, jobs, discussions, chat, enterprise invites). For most of the project's life the route body held all nine per-action branches inline, which grew `handler.ts` to 920 LOC and made parallel per-domain work collision-prone.
+
+Phase 0.5 of the Tier 1 edit/delete plan split the route into:
+
+- **`handler.ts`** — shell: rate-limit, auth, CAS `pending → confirmed`, outer `try/catch` with rollback, and a nine-arm `switch` that forwards each action to a dispatcher.
+- **`dispatchers/<domain>.ts`** — per-domain confirm logic: call the domain primitive, CAS `confirmed → executed` (or rollback on typed failure), write the assistant confirmation message to `ai_messages`, and run any best-effort side effects.
+
+This document captures the shape so the remaining Tier 1 phases (and any future `prepare_*` tool families) can be added without relitigating the design.
+
+## File layout
+
+```
+src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/
+├── handler.ts
+├── route.ts
+└── dispatchers/
+    ├── announcements.ts         (create_announcement)
+    ├── chat.ts                  (send_chat_message, send_group_chat_message)
+    ├── discussions.ts           (create_discussion_thread, create_discussion_reply)
+    ├── enterprise-invites.ts    (create_enterprise_invite, revoke_enterprise_invite)
+    ├── events.ts                (create_event)
+    └── jobs.ts                  (create_job_posting)
+```
+
+One file per domain. Pair a related create/revoke, thread/reply, or group/direct pair in one file when they share primitives or types. The handler holds zero domain knowledge beyond the dispatch switch.
+
+## Dispatcher contract
+
+Each dispatcher exports one async function per `PendingActionRecord<T>` type it handles. The signature is uniform:
+
+```ts
+export async function handleCreateAnnouncement(
+  ctx: AnnouncementDispatcherContext,
+  action: PendingActionRecord<"create_announcement">,
+  deps: AnnouncementDispatcherDeps
+): Promise<NextResponse>;
+```
+
+Three arguments, always in this order:
+
+- **`ctx`** — request-scoped values the dispatcher can't derive (`serviceSupabase`, `orgId`, `userId`, `logContext`, `canUseDraftSessions`, and the wired `updatePendingActionStatusFn` / `clearDraftSessionFn`). The enterprise-invites dispatcher is the only one that also carries the auth-bound `supabase` client — it needs it for the RLS-gated RPC.
+- **`action`** — the pending-action row, typed to the dispatcher's specific discriminant so `action.payload` narrows correctly.
+- **`deps`** — domain-specific collaborators (e.g., `createAnnouncementFn`, `sendNotificationBlastFn`). Wired from `handler.ts`'s `deps` parameter so tests can inject stubs.
+
+Each dispatcher's job:
+
+1. Parse `action.payload`.
+2. Call the domain primitive (`createAnnouncement`, `createEvent`, `sendAiAssistedDirectChatMessage`, etc.).
+3. On typed failure (`result.ok === false`): rollback CAS `confirmed → pending` via `ctx.updatePendingActionStatusFn` and return `NextResponse.json({ error, ... }, { status })`. Do **not** throw.
+4. On success: CAS `confirmed → executed`, populate `result_entity_type` / `result_entity_id`, clear the draft session if applicable, insert the assistant-role confirmation message into `ai_messages`, run any best-effort side effects inside individual `try/catch` blocks with `aiLog("error", ...)` on failure, and return `NextResponse.json({ ok: true, ... })`.
+
+If the domain primitive **throws** (DB timeout, unreachable service), the dispatcher lets the exception propagate. The outer `try/catch` in `handler.ts` catches it, attempts the rollback to `pending`, logs `rollback failed - action stranded in confirmed state` if the rollback itself fails, and re-throws so the caller sees a 5xx.
+
+## The `return await` rule (critical)
+
+In `handler.ts` the switch calls each dispatcher like this:
+
+```ts
+case "create_announcement":
+  return await handleCreateAnnouncement(ctx, action, deps);
+```
+
+The `await` is **semantically required**, not stylistic. JavaScript `return somePromise` inside an async `try` block returns the promise synchronously — the promise's rejection escapes the surrounding `try/catch`. Without `await`, a throwing domain primitive bypasses the rollback path entirely, leaving the row stranded in `confirmed` until the 15-minute reaper sweeps it to `failed`.
+
+`tests/routes/ai/pending-actions-handler.test.ts` has a regression test per dispatcher that constructs a handler with a throwing domain stub and asserts both the `confirmed` CAS and the `pending` rollback are observed. Reverting `return await` to `return` causes the test to fail deterministically. Do not "simplify" it away.
+
+The bug was discovered during the `jobs` extraction (#127) after it silently shipped in the `announcements` (#125) and `events` (#126) extractions. The fix landed alongside the jobs extraction; regression tests cover all three older cases.
+
+## Adding a new dispatcher
+
+To extract the next inline case (or add a new `prepare_*` tool family that needs a confirm path):
+
+1. Create `dispatchers/<domain>.ts` following the skeleton in any existing dispatcher. `announcements.ts` is the simplest template; `events.ts` shows the shape for a dispatcher with multiple best-effort side effects; `enterprise-invites.ts` shows how to carry the auth-bound supabase client.
+2. Define `<Domain>DispatcherContext` (include `supabase` only if the dispatcher actually needs it) and `<Verb><Domain>DispatcherDeps`.
+3. Export `handle<Verb><Domain>(ctx, action, deps)` with the contract above.
+4. In `handler.ts`:
+   - Add the import.
+   - Replace the inline `case` body with `return await handle<Verb><Domain>(...)`.
+   - Wire any new deps into `AiPendingActionConfirmRouteDeps` and the resolve-default block if this is a new primitive.
+   - Remove any payload-type or library imports that are now only referenced inside the dispatcher.
+5. Run `tests/routes/ai/pending-actions-handler.test.ts`. The 19 baseline characterization tests plus 2 regression tests must all pass unchanged. `tsc` and `eslint` must remain clean.
+6. If the new dispatcher can throw from its primitive, add a regression test mirroring the existing "exception during write rolls back for create_X" cases.
+
+## Non-goals
+
+- The dispatcher layer is **not** a generic `executeMutation` HOF. That was deferred to Phase 3 of the Tier 1 plan (first edit-dispatcher). Until then every confirm path lives in its own file with its own CAS transitions. When the HOF arrives it should be adopted in one PR that covers every existing dispatcher at once, per the plan's pattern-consistency rule.
+- Dispatchers do **not** call the outer try/catch for rollback. That still lives in `handler.ts`. This keeps the rollback behavior — and the reaper contract — observable in exactly one place.
+- Dispatchers do **not** perform auth. `getAiOrgContext` runs once in `handler.ts` and the resulting `ctx` is what they receive. Permission checks for target entities belong in the domain primitive (`updateAnnouncement`, `softDeleteAnnouncement`, etc.), not here.
+
+## References
+
+- Phase 0.5 extractions: #125 (announcements), #126 (events), #127 (jobs + `return await` fix), #128 (remaining six).
+- Full Tier 1 plan: `~/.claude/plans/i-want-you-to-quirky-sprout.md` (Deepening Addendum §A4 covers the dispatcher-layer architectural choices).
+- Rollback / reaper contract: `src/lib/ai/pending-actions.ts` (`cleanupStrandedConfirmedActions`).
+- CAS + error handling baseline: `docs/plans/2026-03-27-fix-ai-confirm-handler-race-and-error-handling-plan.md`.

--- a/docs/solutions/patterns/return-await-inside-try-catch.md
+++ b/docs/solutions/patterns/return-await-inside-try-catch.md
@@ -1,0 +1,139 @@
+---
+title: "`return` vs `return await` Inside try/catch — Silent Rollback Swallowing"
+category: patterns
+tags:
+  - javascript
+  - typescript
+  - async
+  - try-catch
+  - return-await
+  - dispatcher
+  - rollback
+  - ai-confirm-handler
+  - cas-transitions
+components:
+  - ai-confirm-handler
+  - pending-action-dispatchers
+problem_type: silent-error-swallowing
+severity: high
+date: 2026-04-22
+related_prs: [125, 126, 127, 130]
+repo_area: ai-agent
+---
+
+# `return` vs `return await` Inside try/catch — Silent Rollback Swallowing
+
+## Problem
+
+During Phase 0.5 of the Tier 1 edit/delete plan (per-domain split of `src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts`), extracting inline `case` branches into per-domain dispatcher modules silently introduced a bug where the outer `try/catch` stopped observing rejections from the dispatcher. The CAS rollback from `confirmed → pending` never ran when a domain primitive threw — rows stranded in `confirmed` until the 15-min reaper swept them to `failed`, and the caller received a 5xx with no dispatched error path.
+
+## Symptoms
+
+- After extractions #125 and #126, any domain primitive that threw (DB timeout, unreachable Supabase, network failure) left `ai_pending_actions` rows in `status = 'confirmed'` instead of rolling back to `pending`.
+- No user-facing `aiLog("rollback failed …")` — the rollback code simply never fired.
+- No immediate retry path; the row sat for 15 minutes until the stranded-confirmed reaper swept it to `failed`.
+- Silently shipped in #125 and #126 because no test exercised the throw-path for those dispatchers. Caught by the existing `"exception during write rolls back to pending"` test for `create_job_posting` when #127 extracted that case.
+
+## Investigation
+
+The existing test `"exception during write rolls back to pending"` stubbed `createJobPosting` to throw `"Supabase timeout"` and asserted `updatePendingActionStatus` was called twice (CAS `confirmed` then rollback `pending`). On the `feat/ai-confirm-handler-split-jobs` branch the test started failing with `Cannot read properties of undefined (reading 'status')` — `updatedStatuses` was empty, meaning neither the CAS claim nor the rollback had fired.
+
+The CAS claim definitely should have fired (it runs before the switch), so initial suspicion fell on the stub wiring. Rechecking the handler diff against the passing pre-extraction baseline revealed the only behavioral change: the inline `await createJobPostingFn(...)` had become `return handleCreateJobPosting(...)`. The exception from inside the dispatcher was never reaching the outer rollback path because the Promise was returned synchronously, not awaited.
+
+## Root Cause
+
+JavaScript semantics of `return` inside an async `try` block:
+
+```ts
+async function foo() {
+  try {
+    return somePromiseThatRejects();  // rejection ESCAPES the try
+  } catch (e) {
+    // never runs
+  }
+}
+```
+
+vs:
+
+```ts
+async function foo() {
+  try {
+    return await somePromiseThatRejects();  // rejection CAUGHT here
+  } catch (e) {
+    // runs
+  }
+}
+```
+
+In `return promise`, the async function returns that promise as-is. The rejection surfaces on the *outer* Promise — the one the caller awaits — and the `catch` inside `foo` is never evaluated. `return await promise` inserts an `await` point inside the try scope, so the rejection reaches the `catch`.
+
+The inline code before extraction used `await` on the domain call directly, and `return` on the terminal `NextResponse.json(...)` (which is a value, not a Promise). After extraction, the whole dispatcher is a single Promise-returning call, and `return await` is what keeps its rejection inside the caller's try.
+
+This is the exact scenario `no-return-await` ESLint rules *recommend against* — but that rule's guidance applies outside try/catch blocks, where the `await` is pure overhead. Inside a try, dropping the `await` changes semantics.
+
+## Fix
+
+Use `return await` for every dispatcher invocation in the confirm handler's switch:
+
+```ts
+case "create_announcement":
+  // `return await` (not `return`) is required: the outer try/catch must
+  // observe rejections from the dispatcher to run the rollback path.
+  return await handleCreateAnnouncement(ctx, action, deps);
+```
+
+Comments on each case are annoying but the rule is subtle enough that a future engineer will want the explanation in-situ.
+
+## Regression Coverage
+
+`tests/routes/ai/pending-actions-handler.test.ts` has one regression test per dispatcher (nine total as of #130) shaped:
+
+```ts
+test("exception during write rolls back for <domain>", async () => {
+  const updatedStatuses = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () => buildPendingAction({ action_type: "<domain>", payload: {...} }),
+    updatePendingActionStatus: async (_, __, payload) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    <domainFn>: async () => { throw new Error("Supabase timeout"); },
+  });
+  await assert.rejects(handler(...), { message: "Supabase timeout" });
+  assert.equal(updatedStatuses[0].status, "confirmed");    // CAS claim fired
+  assert.equal(updatedStatuses[1].status, "pending");       // Rollback fired
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+```
+
+Reverting `return await` to `return` for any dispatcher causes the matching test to fail deterministically with `Cannot read properties of undefined (reading 'status')`. Verified manually across all nine cases.
+
+## Related PRs
+
+- **#125, #126** — Phase 0.5 extractions (announcements, events) that silently introduced the bug.
+- **#127** — Extraction of `create_job_posting` that surfaced it via pre-existing test, plus the fix (`return await`) and the first two regression tests (announcements, events).
+- **#128** — Extraction of remaining six dispatchers with the fix already in place.
+- **#130** — Regression tests for the remaining six dispatchers so any future `no-return-await` autofix is caught immediately.
+
+## Applicability
+
+Any handler that satisfies all three:
+
+1. Declares an outer `try/catch` intended to run compensating logic (rollback, logging, re-throw) on rejection.
+2. Delegates to sub-functions that return Promises.
+3. Uses `return subFn(...)` inside the try.
+
+Common shapes in this repo:
+- Route handlers that CAS-claim a row, call a domain primitive, and need to roll back on throw.
+- Saga-style workflows with multi-step compensating actions.
+- Middleware-style decorators where the inner callable can reject.
+
+When in doubt, prefer `return await` inside any try block that has a meaningful `catch`. The performance cost is a single microtask tick; the correctness cost of getting it wrong is stranded state and silent error swallowing.
+
+## Non-Applicable
+
+- `return somePromise` **outside** any try/catch is fine and `no-return-await` rules correctly prefer it.
+- `return somePromise` inside a try that only has a `finally` (no `catch`) does not change semantics — the `finally` fires regardless.
+- `return` of a non-Promise value (e.g., `return NextResponse.json({...})`) is fine; the rejection class only applies to Promise-returning expressions.

--- a/src/app/api/ai/[orgId]/chat/handler.ts
+++ b/src/app/api/ai/[orgId]/chat/handler.ts
@@ -4196,6 +4196,7 @@ export function createChatPostHandler(deps: ChatRouteDeps = {}) {
                 userId: ctx.userId,
                 threadId,
                 pendingActionId: activeDraftSession.pending_action_id,
+                draftType: activeDraftSession.draft_type,
               });
             } catch (error) {
               aiLog("warn", "ai-chat", "failed to clear expired draft session", {
@@ -4222,6 +4223,7 @@ export function createChatPostHandler(deps: ChatRouteDeps = {}) {
                   userId: ctx.userId,
                   threadId,
                   pendingActionId: activeDraftSession.pending_action_id,
+                  draftType: activeDraftSession.draft_type,
                 });
               } catch (error) {
                 aiLog("warn", "ai-chat", "failed to clear abandoned draft session", {

--- a/src/app/api/ai/[orgId]/chat/handler.ts
+++ b/src/app/api/ai/[orgId]/chat/handler.ts
@@ -161,6 +161,13 @@ const CREATE_ANNOUNCEMENT_PROMPT_PATTERN =
 // does NOT match "delete/remove/cancel" — that's Phase 2b-prepare.
 const EDIT_ANNOUNCEMENT_PROMPT_PATTERN =
   /(?:(?<!\w)(?:fix|change|update|edit|reword|rephrase|correct|amend|revise)(?!\w)[\s\S]{0,120}\b(?:announcement|update|news post|bulletin|typo|typos|title|wording)(?!\w)|(?<!\w)(?:announcement|update|news post|bulletin)(?!\w)[\s\S]{0,80}\b(?:fix|change|edit|reword|rephrase|correct|amend|revise)(?!\w))/i;
+// Delete-intent verbs for announcements. Destructive verbs only:
+// "delete/remove/take down/retract/unpublish/pull". Does NOT match
+// "cancel" because cancel overloads with event-cancel semantics; the
+// model should use explicit delete/remove phrasing. Does NOT match edit
+// verbs ("fix/change/edit/…") — those remain Phase 2a.
+const DELETE_ANNOUNCEMENT_PROMPT_PATTERN =
+  /(?:(?<!\w)(?:delete|remove|retract|unpublish|pull)(?!\w)[\s\S]{0,120}\b(?:announcement|update|news post|bulletin)(?!\w)|(?<!\w)(?:announcement|update|news post|bulletin)(?!\w)[\s\S]{0,80}\b(?:delete|remove|retract|unpublish|pull|take\s+down)(?!\w)|(?<!\w)take\s+down(?!\w)[\s\S]{0,120}\b(?:announcement|update|news post|bulletin)(?!\w))/i;
 const CREATE_JOB_PROMPT_PATTERN =
   /(?:(?<!\w)(?:create|add|post|publish|make|open)(?!\w)[\s\S]{0,120}\b(?:job|job posting|opening|role|position)(?!\w)|(?<!\w)(?:job|job posting|opening|role|position)(?!\w)[\s\S]{0,80}\b(?:create|add|post|publish|make|open)(?!\w))/i;
 const SEND_CHAT_MESSAGE_PROMPT_PATTERN =
@@ -1849,6 +1856,14 @@ function getPass1Tools(
 
   if (CREATE_ANNOUNCEMENT_PROMPT_PATTERN.test(message)) {
     return [AI_TOOL_MAP.prepare_announcement];
+  }
+
+  // Delete-intent attachment — check BEFORE edit because delete verbs
+  // (delete/remove/retract/unpublish) do not overlap with edit verbs and
+  // are destructively specific. A message matching both ("remove and fix"
+  // is not a thing) should never reach here.
+  if (DELETE_ANNOUNCEMENT_PROMPT_PATTERN.test(message)) {
+    return [AI_TOOL_MAP.prepare_delete_announcement];
   }
 
   // Edit-intent attachment — check AFTER create to avoid stealing turns that

--- a/src/app/api/ai/[orgId]/chat/handler.ts
+++ b/src/app/api/ai/[orgId]/chat/handler.ts
@@ -154,6 +154,13 @@ const DIRECT_NAVIGATION_PROMPT_PATTERN =
   /(?:(?<!\w)(?:go\s+to|take\s+me\s+to|navigate\s+to|open|where\s+is|where\s+(?:can|do)\s+i\s+find|find\s+the\s+page|link\s+to)(?!\w)|(?<!\w)show\s+me\b[\s\S]{0,80}\b(?:page|screen|tab|settings?)\b)/i;
 const CREATE_ANNOUNCEMENT_PROMPT_PATTERN =
   /(?:(?<!\w)(?:create|add|post|publish|make|send|draft|write|compose)(?!\w)[\s\S]{0,120}\b(?:announcement|update|news post|bulletin)(?!\w)|(?<!\w)(?:announcement|update|news post|bulletin)(?!\w)[\s\S]{0,80}\b(?:create|add|post|publish|make|send|draft|write|compose)(?!\w))/i;
+// Edit-intent verbs for announcements. Distinct from create verbs above:
+// "fix/change/update/edit/reword/rephrase/correct/amend/revise" paired with
+// "announcement" (or just "typo" / "typos" when the feature context is
+// announcements — see the surface-routing fallback below). Deliberately
+// does NOT match "delete/remove/cancel" — that's Phase 2b-prepare.
+const EDIT_ANNOUNCEMENT_PROMPT_PATTERN =
+  /(?:(?<!\w)(?:fix|change|update|edit|reword|rephrase|correct|amend|revise)(?!\w)[\s\S]{0,120}\b(?:announcement|update|news post|bulletin|typo|typos|title|wording)(?!\w)|(?<!\w)(?:announcement|update|news post|bulletin)(?!\w)[\s\S]{0,80}\b(?:fix|change|edit|reword|rephrase|correct|amend|revise)(?!\w))/i;
 const CREATE_JOB_PROMPT_PATTERN =
   /(?:(?<!\w)(?:create|add|post|publish|make|open)(?!\w)[\s\S]{0,120}\b(?:job|job posting|opening|role|position)(?!\w)|(?<!\w)(?:job|job posting|opening|role|position)(?!\w)[\s\S]{0,80}\b(?:create|add|post|publish|make|open)(?!\w))/i;
 const SEND_CHAT_MESSAGE_PROMPT_PATTERN =
@@ -1844,6 +1851,13 @@ function getPass1Tools(
     return [AI_TOOL_MAP.prepare_announcement];
   }
 
+  // Edit-intent attachment — check AFTER create to avoid stealing turns that
+  // match both (e.g. "create an update" would match create; "update the
+  // announcement title" matches edit only).
+  if (EDIT_ANNOUNCEMENT_PROMPT_PATTERN.test(message)) {
+    return [AI_TOOL_MAP.prepare_edit_announcement];
+  }
+
   if (CREATE_JOB_PROMPT_PATTERN.test(message) || looksLikeStructuredJobDraft(message)) {
     return [AI_TOOL_MAP.prepare_job_posting];
   }
@@ -2887,15 +2901,7 @@ function getToolNameForDraftType(draftType: DraftSessionType): ToolName {
     case "create_announcement":
       return "prepare_announcement";
     case "edit_announcement":
-      // Placeholder for Phase 2a-prepare: the prepare_edit_announcement
-      // tool is not yet registered. This branch should be unreachable
-      // until that tool ships, because no code path creates a draft
-      // session with draftType "edit_announcement" yet. Throwing makes
-      // the incomplete state explicit instead of silently attaching a
-      // non-existent tool name.
-      throw new Error(
-        "prepare_edit_announcement tool is not registered yet (Phase 2a-prepare not shipped)"
-      );
+      return "prepare_edit_announcement";
     case "create_job_posting":
       return "prepare_job_posting";
     case "send_chat_message":

--- a/src/app/api/ai/[orgId]/chat/handler.ts
+++ b/src/app/api/ai/[orgId]/chat/handler.ts
@@ -2886,6 +2886,16 @@ function getToolNameForDraftType(draftType: DraftSessionType): ToolName {
   switch (draftType) {
     case "create_announcement":
       return "prepare_announcement";
+    case "edit_announcement":
+      // Placeholder for Phase 2a-prepare: the prepare_edit_announcement
+      // tool is not yet registered. This branch should be unreachable
+      // until that tool ships, because no code path creates a draft
+      // session with draftType "edit_announcement" yet. Throwing makes
+      // the incomplete state explicit instead of silently attaching a
+      // non-existent tool name.
+      throw new Error(
+        "prepare_edit_announcement tool is not registered yet (Phase 2a-prepare not shipped)"
+      );
     case "create_job_posting":
       return "prepare_job_posting";
     case "send_chat_message":
@@ -3548,6 +3558,13 @@ function inferDraftSessionFromHistory(input: {
           (field) => getNonEmptyString(draftPayload[field]) == null
         );
         break;
+      case "edit_announcement":
+        // Edit drafts cannot be reconstructed from chat-history inference —
+        // they require a target_id resolved via the target_resolver. Skip
+        // this iteration; callers fall through to explicit draft-session
+        // load paths (save + get by draft_type) once the prepare-side
+        // tool is wired in a follow-up PR.
+        continue;
       case "send_chat_message":
         draftPayload = extractChatMessageDraftFromHistory(relevantMessages);
         missingFields = [

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
@@ -15,6 +15,7 @@ import type {
 } from "@/lib/ai/draft-sessions";
 import type {
   CreateAnnouncementPendingPayload,
+  EditAnnouncementPendingPayload,
   PendingActionRecord,
   updatePendingActionStatus,
 } from "@/lib/ai/pending-actions";
@@ -22,6 +23,7 @@ import type {
   createAnnouncement,
   sendAnnouncementNotification,
 } from "@/lib/announcements/create-announcement";
+import type { updateAnnouncement } from "@/lib/announcements/update-announcement";
 import type { sendNotificationBlast } from "@/lib/notifications";
 
 export interface AnnouncementDispatcherContext {
@@ -172,6 +174,111 @@ export async function handleCreateAnnouncement(
   return NextResponse.json({
     ok: true,
     announcement: result.announcement,
+    actionId: action.id,
+  });
+}
+
+// ─── Edit dispatcher ────────────────────────────────────────────────────
+//
+// Phase 2a of the Tier 1 edit/delete plan. Mirrors handleCreateAnnouncement's
+// ctx + deps shape, but calls the updateAnnouncement domain primitive and
+// surfaces the structured DomainResult failure codes (403 forbidden, 404
+// not_found, 409 stale_version, 422 invariant_violation, 500 update_failed)
+// directly into the HTTP response. The primitive enforces both the admin
+// permission check and the optimistic-concurrency `expectedUpdatedAt` token
+// captured at prepare time, so this dispatcher has no additional auth or
+// race logic — it's a thin CAS + primitive + ai_messages shell.
+
+export interface EditAnnouncementDispatcherDeps {
+  updateAnnouncementFn: typeof updateAnnouncement;
+}
+
+export async function handleEditAnnouncement(
+  ctx: AnnouncementDispatcherContext,
+  action: PendingActionRecord<"edit_announcement">,
+  deps: EditAnnouncementDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as EditAnnouncementPendingPayload;
+  const result = await deps.updateAnnouncementFn({
+    supabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    targetId: payload.targetId,
+    patch: payload.patch,
+    expectedUpdatedAt: payload.expectedUpdatedAt ?? null,
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "announcement",
+    resultEntityId: result.value.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+      draftType: "edit_announcement",
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const announcementUrl = orgSlug ? `/${orgSlug}/announcements` : null;
+  const displayTitle = result.value.title ?? payload.targetTitle ?? "announcement";
+  const content = announcementUrl
+    ? `Updated announcement: [${displayTitle}](${announcementUrl})`
+    : `Updated announcement: ${displayTitle}`;
+
+  const { error: msgError } = await ctx.serviceSupabase
+    .from("ai_messages")
+    .insert({
+      thread_id: action.thread_id,
+      org_id: ctx.orgId,
+      role: "assistant",
+      content,
+      status: "complete",
+    });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    announcement: result.value,
     actionId: action.id,
   });
 }

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
@@ -15,6 +15,7 @@ import type {
 } from "@/lib/ai/draft-sessions";
 import type {
   CreateAnnouncementPendingPayload,
+  DeleteAnnouncementPendingPayload,
   EditAnnouncementPendingPayload,
   PendingActionRecord,
   updatePendingActionStatus,
@@ -23,6 +24,7 @@ import type {
   createAnnouncement,
   sendAnnouncementNotification,
 } from "@/lib/announcements/create-announcement";
+import type { softDeleteAnnouncement } from "@/lib/announcements/soft-delete-announcement";
 import type { updateAnnouncement } from "@/lib/announcements/update-announcement";
 import type { sendNotificationBlast } from "@/lib/notifications";
 
@@ -248,6 +250,104 @@ export async function handleEditAnnouncement(
   const content = announcementUrl
     ? `Updated announcement: [${displayTitle}](${announcementUrl})`
     : `Updated announcement: ${displayTitle}`;
+
+  const { error: msgError } = await ctx.serviceSupabase
+    .from("ai_messages")
+    .insert({
+      thread_id: action.thread_id,
+      org_id: ctx.orgId,
+      role: "assistant",
+      content,
+      status: "complete",
+    });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    announcement: result.value,
+    actionId: action.id,
+  });
+}
+
+// ─── Delete dispatcher ──────────────────────────────────────────────────
+//
+// Phase 2b of the Tier 1 edit/delete plan. Mirrors handleEditAnnouncement
+// but calls the softDeleteAnnouncement primitive and has no draft-session
+// clear — delete actions skip the multi-turn collection phase entirely
+// (the plan's security decision: "most-recent fallback disabled for
+// delete" means target_id is always explicit, so there's nothing to
+// collect). Matches the revoke_enterprise_invite precedent where
+// destructive single-target ops don't register a DraftSessionType.
+
+export interface DeleteAnnouncementDispatcherDeps {
+  softDeleteAnnouncementFn: typeof softDeleteAnnouncement;
+}
+
+export async function handleDeleteAnnouncement(
+  ctx: AnnouncementDispatcherContext,
+  action: PendingActionRecord<"delete_announcement">,
+  deps: DeleteAnnouncementDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as DeleteAnnouncementPendingPayload;
+  const result = await deps.softDeleteAnnouncementFn({
+    supabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    targetId: payload.targetId,
+    expectedUpdatedAt: payload.expectedUpdatedAt ?? null,
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "announcement",
+    resultEntityId: result.value.id,
+  });
+
+  // No draft-session clear: delete_announcement is not a DraftSessionType.
+  // If a future phase adds multi-turn disambiguation for deletes (e.g. name
+  // lookup), the DraftSessionType entry will be added alongside and this
+  // dispatcher will gain the standard clear call.
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const announcementUrl = orgSlug ? `/${orgSlug}/announcements` : null;
+  const displayTitle = payload.targetTitle ?? result.value.title ?? "announcement";
+  const content = announcementUrl
+    ? `Deleted announcement: [${displayTitle}](${announcementUrl})`
+    : `Deleted announcement: ${displayTitle}`;
 
   const { error: msgError } = await ctx.serviceSupabase
     .from("ai_messages")

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
@@ -1,0 +1,176 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatcher for the `create_announcement` pending action type.
+//
+// Phase 0.5 pilot of the Tier 1 pre-split: extracts one case from the
+// 920-LOC confirm handler so the shape is established for the other eight
+// cases to follow. Each subsequent dispatcher owns its domain's confirm-time
+// behaviour (CAS transitions, side effects, audit message) and is imported
+// into the thin confirm/handler.ts shell.
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  clearDraftSession,
+} from "@/lib/ai/draft-sessions";
+import type {
+  CreateAnnouncementPendingPayload,
+  PendingActionRecord,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+import type {
+  createAnnouncement,
+  sendAnnouncementNotification,
+} from "@/lib/announcements/create-announcement";
+import type { sendNotificationBlast } from "@/lib/notifications";
+
+export interface AnnouncementDispatcherContext {
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  canUseDraftSessions: boolean;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+  clearDraftSessionFn: typeof clearDraftSession;
+}
+
+export interface AnnouncementDispatcherDeps {
+  createAnnouncementFn: typeof createAnnouncement;
+  sendAnnouncementNotificationFn: typeof sendAnnouncementNotification;
+  sendNotificationBlastFn: typeof sendNotificationBlast;
+}
+
+export async function handleCreateAnnouncement(
+  ctx: AnnouncementDispatcherContext,
+  action: PendingActionRecord<"create_announcement">,
+  deps: AnnouncementDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as CreateAnnouncementPendingPayload;
+  const result = await deps.createAnnouncementFn({
+    supabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    input: {
+      ...payload,
+      audience_user_ids: payload.audience_user_ids ?? null,
+    },
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "announcement",
+    resultEntityId: result.announcement.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  try {
+    await deps.sendAnnouncementNotificationFn({
+      supabase: ctx.serviceSupabase,
+      announcementId: result.announcement.id,
+      orgId: ctx.orgId,
+      input: {
+        ...payload,
+        audience_user_ids: payload.audience_user_ids ?? null,
+      },
+      sendDirectNotification: async ({
+        organizationId,
+        title,
+        body,
+        audience,
+        targetUserIds,
+      }) => {
+        await deps.sendNotificationBlastFn({
+          supabase: ctx.serviceSupabase,
+          organizationId,
+          audience,
+          channel: "email",
+          title,
+          body,
+          targetUserIds,
+          category: "announcement",
+        });
+      },
+    });
+  } catch (notificationError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "announcement notification failed",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        announcementId: result.announcement.id,
+        error: notificationError,
+      }
+    );
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const announcementUrl = orgSlug ? `/${orgSlug}/announcements` : null;
+  const content = announcementUrl
+    ? `Created announcement: [${result.announcement.title}](${announcementUrl})`
+    : `Created announcement: ${result.announcement.title}`;
+
+  const { error: msgError } = await ctx.serviceSupabase
+    .from("ai_messages")
+    .insert({
+      thread_id: action.thread_id,
+      org_id: ctx.orgId,
+      role: "assistant",
+      content,
+      status: "complete",
+    });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    announcement: result.announcement,
+    actionId: action.id,
+  });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/chat.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/chat.ts
@@ -1,0 +1,231 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatchers for the `send_chat_message` and `send_group_chat_message`
+// pending action types. Pairs in a single file because they share the chat
+// domain and their shapes are near-mirrors (different sender primitive, one
+// persists a recipient breadcrumb on ai_threads, the other respects a
+// message-approval status note).
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  clearDraftSession,
+} from "@/lib/ai/draft-sessions";
+import type {
+  PendingActionRecord,
+  SendChatMessagePendingPayload,
+  SendGroupChatMessagePendingPayload,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+import type {
+  sendAiAssistedDirectChatMessage,
+  DirectChatSupabase,
+} from "@/lib/chat/direct-chat";
+import type {
+  sendAiAssistedGroupChatMessage,
+  GroupChatSupabase,
+} from "@/lib/chat/group-chat";
+
+export interface ChatDispatcherContext {
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  canUseDraftSessions: boolean;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+  clearDraftSessionFn: typeof clearDraftSession;
+}
+
+export interface SendChatMessageDispatcherDeps {
+  sendAiAssistedDirectChatMessageFn: typeof sendAiAssistedDirectChatMessage;
+}
+
+export async function handleSendChatMessage(
+  ctx: ChatDispatcherContext,
+  action: PendingActionRecord<"send_chat_message">,
+  deps: SendChatMessageDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as SendChatMessagePendingPayload;
+  const result = await deps.sendAiAssistedDirectChatMessageFn(
+    ctx.serviceSupabase as DirectChatSupabase,
+    {
+      organizationId: ctx.orgId,
+      senderUserId: ctx.userId,
+      recipientMemberId: payload.recipient_member_id,
+      recipientUserId: payload.recipient_user_id,
+      recipientDisplayName: payload.recipient_display_name,
+      body: payload.body,
+    }
+  );
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      { error: result.error, code: result.code },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "chat_message",
+    resultEntityId: result.messageId,
+  });
+
+  // Store recipient in thread metadata for follow-up messages.
+  await ctx.serviceSupabase
+    .from("ai_threads")
+    .update({
+      metadata: { last_chat_recipient_member_id: payload.recipient_member_id },
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", action.thread_id);
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const chatUrl = orgSlug ? `/${orgSlug}/messages/chat/${result.chatGroupId}` : null;
+  const content = chatUrl
+    ? `Sent chat message to [${payload.recipient_display_name}](${chatUrl})`
+    : `Sent chat message to ${payload.recipient_display_name}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    actionId: action.id,
+    chatGroupId: result.chatGroupId,
+    messageId: result.messageId,
+  });
+}
+
+export interface SendGroupChatMessageDispatcherDeps {
+  sendAiAssistedGroupChatMessageFn: typeof sendAiAssistedGroupChatMessage;
+}
+
+export async function handleSendGroupChatMessage(
+  ctx: ChatDispatcherContext,
+  action: PendingActionRecord<"send_group_chat_message">,
+  deps: SendGroupChatMessageDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as SendGroupChatMessagePendingPayload;
+  const result = await deps.sendAiAssistedGroupChatMessageFn(
+    ctx.serviceSupabase as GroupChatSupabase,
+    {
+      organizationId: ctx.orgId,
+      senderUserId: ctx.userId,
+      chatGroupId: payload.chat_group_id,
+      groupName: payload.group_name,
+      messageStatus: payload.message_status,
+      body: payload.body,
+    }
+  );
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      { error: result.error, code: result.code },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "chat_message",
+    resultEntityId: result.messageId,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const chatUrl = orgSlug ? `/${orgSlug}/messages/chat/${result.chatGroupId}` : null;
+  const statusNote = result.messageStatus === "pending" ? " (pending approval)" : "";
+  const content = chatUrl
+    ? `Sent message to [${payload.group_name}](${chatUrl})${statusNote}`
+    : `Sent message to ${payload.group_name}${statusNote}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    actionId: action.id,
+    chatGroupId: result.chatGroupId,
+    messageId: result.messageId,
+  });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/discussions.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/discussions.ts
@@ -1,0 +1,208 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatchers for `create_discussion_thread` and
+// `create_discussion_reply`. Pairs in a single file because they share the
+// discussions domain and the reply shape depends on the thread it's attached
+// to (both dispatchers return the thread in their response body).
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  clearDraftSession,
+} from "@/lib/ai/draft-sessions";
+import type {
+  CreateDiscussionReplyPendingPayload,
+  CreateDiscussionThreadPendingPayload,
+  PendingActionRecord,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+import type { createDiscussionReply } from "@/lib/discussions/create-reply";
+import type { createDiscussionThread } from "@/lib/discussions/create-thread";
+
+export interface DiscussionDispatcherContext {
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  canUseDraftSessions: boolean;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+  clearDraftSessionFn: typeof clearDraftSession;
+}
+
+export interface CreateDiscussionThreadDispatcherDeps {
+  createDiscussionThreadFn: typeof createDiscussionThread;
+}
+
+export async function handleCreateDiscussionThread(
+  ctx: DiscussionDispatcherContext,
+  action: PendingActionRecord<"create_discussion_thread">,
+  deps: CreateDiscussionThreadDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as CreateDiscussionThreadPendingPayload;
+  const result = await deps.createDiscussionThreadFn({
+    supabase: ctx.serviceSupabase,
+    serviceSupabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    input: payload,
+    orgSlug:
+      typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+        ? payload.orgSlug
+        : null,
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "discussion_thread",
+    resultEntityId: result.thread.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const threadUrl = orgSlug
+    ? `/${orgSlug}/messages/threads/${result.thread.id}`
+    : result.threadUrl;
+  const content = threadUrl
+    ? `Created discussion thread: [${result.thread.title}](${threadUrl})`
+    : `Created discussion thread: ${result.thread.title}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({ ok: true, thread: result.thread, actionId: action.id });
+}
+
+export interface CreateDiscussionReplyDispatcherDeps {
+  createDiscussionReplyFn: typeof createDiscussionReply;
+}
+
+export async function handleCreateDiscussionReply(
+  ctx: DiscussionDispatcherContext,
+  action: PendingActionRecord<"create_discussion_reply">,
+  deps: CreateDiscussionReplyDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as CreateDiscussionReplyPendingPayload;
+  const result = await deps.createDiscussionReplyFn({
+    supabase: ctx.serviceSupabase,
+    threadId: payload.discussion_thread_id,
+    userId: ctx.userId,
+    orgId: ctx.orgId,
+    input: { body: payload.body },
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "discussion_reply",
+    resultEntityId: result.reply.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const threadUrl = orgSlug
+    ? `/${orgSlug}/messages/threads/${result.thread.id}`
+    : null;
+  const content = threadUrl
+    ? `Posted reply in discussion thread: [${result.thread.title}](${threadUrl})`
+    : `Posted reply in discussion thread: ${result.thread.title}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({ ok: true, reply: result.reply, actionId: action.id });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/enterprise-invites.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/enterprise-invites.ts
@@ -1,0 +1,159 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatchers for `create_enterprise_invite` and
+// `revoke_enterprise_invite`. Pairs in a single file because they operate on
+// the same enterprise_invites table and are the only dispatchers that use the
+// auth-bound supabase client (for the RPC; revoke uses serviceSupabase).
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  CreateEnterpriseInvitePendingPayload,
+  PendingActionRecord,
+  RevokeEnterpriseInvitePendingPayload,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+
+export interface EnterpriseInviteDispatcherContext {
+  supabase: any; // auth-bound client (required for create_enterprise_invite RPC)
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+}
+
+export async function handleCreateEnterpriseInvite(
+  ctx: EnterpriseInviteDispatcherContext,
+  action: PendingActionRecord<"create_enterprise_invite">
+): Promise<NextResponse> {
+  const payload = action.payload as CreateEnterpriseInvitePendingPayload;
+  const rpcResult = await (ctx.supabase as any).rpc("create_enterprise_invite", {
+    p_enterprise_id: payload.enterpriseId,
+    p_organization_id: payload.organizationId ?? null,
+    p_role: payload.role,
+    p_uses: payload.usesRemaining ?? null,
+    p_expires_at: payload.expiresAt ?? null,
+  });
+
+  if (rpcResult.error || !rpcResult.data || typeof rpcResult.data.id !== "string") {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      { error: rpcResult.error?.message || "Failed to create enterprise invite" },
+      { status: 400 }
+    );
+  }
+
+  const invite = rpcResult.data as {
+    id: string;
+    code?: string;
+    role?: string;
+  };
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "enterprise_invite",
+    resultEntityId: invite.id,
+  });
+
+  const inviteCode = typeof invite.code === "string" ? invite.code : "";
+  const invitePath = `/enterprise/${payload.enterpriseSlug}/invites`;
+  const content = inviteCode
+    ? `Created enterprise invite \`${inviteCode}\` (${payload.role}). Manage it at [${invitePath}](${invitePath}).`
+    : `Created enterprise invite (${payload.role}). Manage it at [${invitePath}](${invitePath}).`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({ ok: true, invite, actionId: action.id });
+}
+
+export async function handleRevokeEnterpriseInvite(
+  ctx: EnterpriseInviteDispatcherContext,
+  action: PendingActionRecord<"revoke_enterprise_invite">
+): Promise<NextResponse> {
+  const payload = action.payload as RevokeEnterpriseInvitePendingPayload;
+  const updateResult = await (ctx.serviceSupabase as any)
+    .from("enterprise_invites")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", payload.inviteId)
+    .eq("enterprise_id", payload.enterpriseId)
+    .is("revoked_at", null)
+    .select("id");
+
+  const updatedRows = Array.isArray(updateResult.data) ? updateResult.data : [];
+
+  if (updateResult.error || updatedRows.length === 0) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      { error: updateResult.error?.message || "Failed to revoke enterprise invite" },
+      { status: 400 }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "enterprise_invite",
+    resultEntityId: payload.inviteId,
+  });
+
+  const content = `Revoked enterprise invite \`${payload.inviteCode}\`.`;
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({ ok: true, actionId: action.id });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/events.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/events.ts
@@ -1,0 +1,212 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatcher for the `create_event` pending action type.
+//
+// Second Phase 0.5 extraction following the announcements dispatcher
+// (see ./announcements.ts). create_event is the largest remaining branch —
+// proving the dispatcher shape handles: structured error responses with
+// `code`/`details`, three best-effort side effects (Google + Outlook calendar
+// sync, notification blast), and URL derivation that falls back to the
+// domain-computed value when orgSlug is absent.
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  clearDraftSession,
+} from "@/lib/ai/draft-sessions";
+import type {
+  CreateEventPendingPayload,
+  PendingActionRecord,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+import type { createEvent } from "@/lib/events/create-event";
+import { calendarEventDetailPath } from "@/lib/calendar/routes";
+import type { syncEventToUsers } from "@/lib/google/calendar-sync";
+import type { sendNotificationBlast } from "@/lib/notifications";
+
+export interface EventDispatcherContext {
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  canUseDraftSessions: boolean;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+  clearDraftSessionFn: typeof clearDraftSession;
+}
+
+export interface EventDispatcherDeps {
+  createEventFn: typeof createEvent;
+  syncEventToUsersFn: typeof syncEventToUsers;
+  syncOutlookEventToUsersFn: (
+    supabase: Parameters<typeof syncEventToUsers>[0],
+    organizationId: string,
+    eventId: string,
+    operation: Parameters<typeof syncEventToUsers>[3]
+  ) => Promise<void>;
+  sendNotificationBlastFn: typeof sendNotificationBlast;
+}
+
+export async function handleCreateEvent(
+  ctx: EventDispatcherContext,
+  action: PendingActionRecord<"create_event">,
+  deps: EventDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as CreateEventPendingPayload;
+  const result = await deps.createEventFn({
+    supabase: ctx.serviceSupabase,
+    serviceSupabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    input: payload,
+    orgSlug:
+      typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+        ? payload.orgSlug
+        : null,
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+
+    aiLog(
+      "error",
+      "ai-confirm",
+      "create_event confirmation failed",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        attemptedEventType: payload.event_type,
+        eventErrorCode: result.code ?? null,
+        eventError: result.error,
+        eventStatus: result.status,
+        internalError: result.internalError ?? null,
+      }
+    );
+
+    return NextResponse.json(
+      {
+        error: result.error,
+        ...(result.code ? { code: result.code } : {}),
+        ...(result.details ? { details: result.details } : {}),
+      },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "event",
+    resultEntityId: result.event.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const eventUrl = orgSlug
+    ? calendarEventDetailPath(orgSlug, result.event.id)
+    : result.eventUrl;
+  const content = eventUrl
+    ? `Created event: [${result.event.title}](${eventUrl})`
+    : `Created event: ${result.event.title}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  try {
+    await deps.syncEventToUsersFn(ctx.serviceSupabase, ctx.orgId, result.event.id, "create");
+  } catch (syncErr) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "google calendar sync failed",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      { actionId: action.id, eventId: result.event.id, error: syncErr }
+    );
+  }
+
+  try {
+    await deps.syncOutlookEventToUsersFn(ctx.serviceSupabase, ctx.orgId, result.event.id, "create");
+  } catch (outlookErr) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "outlook calendar sync failed",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      { actionId: action.id, eventId: result.event.id, error: outlookErr }
+    );
+  }
+
+  try {
+    await deps.sendNotificationBlastFn({
+      supabase: ctx.serviceSupabase,
+      organizationId: ctx.orgId,
+      audience: "both",
+      channel: "email",
+      title: `New Event: ${result.event.title}`,
+      body: `Event scheduled for ${payload.start_date} at ${payload.start_time}${payload.location ? `\nWhere: ${payload.location}` : ""}`,
+      category: "event",
+    });
+  } catch (notifyErr) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "event notification blast failed",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      { actionId: action.id, eventId: result.event.id, error: notifyErr }
+    );
+  }
+
+  return NextResponse.json({ ok: true, event: result.event, actionId: action.id });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/jobs.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/jobs.ts
@@ -1,0 +1,114 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Domain dispatcher for the `create_job_posting` pending action type.
+//
+// Third Phase 0.5 extraction following dispatchers/announcements.ts and
+// dispatchers/events.ts. Simpler shape than either — no notification blast,
+// no calendar sync. Proves the dispatcher pattern scales down cleanly.
+
+import { NextResponse } from "next/server";
+import type { AiLogContext } from "@/lib/ai/logger";
+import { aiLog } from "@/lib/ai/logger";
+import type {
+  clearDraftSession,
+} from "@/lib/ai/draft-sessions";
+import type {
+  CreateJobPostingPendingPayload,
+  PendingActionRecord,
+  updatePendingActionStatus,
+} from "@/lib/ai/pending-actions";
+import type { createJobPosting } from "@/lib/jobs/create-job";
+
+export interface JobDispatcherContext {
+  serviceSupabase: any;
+  orgId: string;
+  userId: string;
+  logContext: AiLogContext;
+  canUseDraftSessions: boolean;
+  updatePendingActionStatusFn: typeof updatePendingActionStatus;
+  clearDraftSessionFn: typeof clearDraftSession;
+}
+
+export interface JobDispatcherDeps {
+  createJobPostingFn: typeof createJobPosting;
+}
+
+export async function handleCreateJobPosting(
+  ctx: JobDispatcherContext,
+  action: PendingActionRecord<"create_job_posting">,
+  deps: JobDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as CreateJobPostingPendingPayload;
+  const result = await deps.createJobPostingFn({
+    supabase: ctx.serviceSupabase,
+    serviceSupabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    input: payload,
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "job_posting",
+    resultEntityId: result.job.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const jobUrl = orgSlug ? `/${orgSlug}/jobs/${result.job.id}` : null;
+  const content = jobUrl
+    ? `Created job posting: [${result.job.title}](${jobUrl})`
+    : `Created job posting: ${result.job.title}`;
+
+  const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
+    thread_id: action.thread_id,
+    org_id: ctx.orgId,
+    role: "assistant",
+    content,
+    status: "complete",
+  });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({ ok: true, job: result.job, actionId: action.id });
+}

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -218,6 +218,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "create_announcement",
             });
           }
 
@@ -316,6 +317,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "create_job_posting",
             });
           }
 
@@ -391,6 +393,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "send_chat_message",
             });
           }
 
@@ -462,6 +465,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "send_group_chat_message",
             });
           }
 
@@ -540,6 +544,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "create_discussion_thread",
             });
           }
 
@@ -610,6 +615,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "create_discussion_reply",
             });
           }
 
@@ -702,6 +708,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               userId: ctx.userId,
               threadId: action.thread_id,
               pendingActionId: action.id,
+              draftType: "create_event",
             });
           }
 

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -11,7 +11,6 @@ import {
   type SendGroupChatMessagePendingPayload,
   updatePendingActionStatus,
   type CreateDiscussionThreadPendingPayload,
-  type CreateEventPendingPayload,
   type CreateJobPostingPendingPayload,
   type CreateEnterpriseInvitePendingPayload,
   type RevokeEnterpriseInvitePendingPayload,
@@ -36,12 +35,12 @@ import {
   sendAiAssistedGroupChatMessage,
   type GroupChatSupabase,
 } from "@/lib/chat/group-chat";
-import { calendarEventDetailPath } from "@/lib/calendar/routes";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { aiLog } from "@/lib/ai/logger";
 import { syncEventToUsers } from "@/lib/google/calendar-sync";
 import { sendNotificationBlast } from "@/lib/notifications";
 import { handleCreateAnnouncement } from "./dispatchers/announcements";
+import { handleCreateEvent } from "./dispatchers/events";
 
 export interface AiPendingActionConfirmRouteDeps {
   createClient?: typeof createClient;
@@ -564,136 +563,25 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
 
           return NextResponse.json({ ok: true, reply: result.reply, actionId: action.id });
         }
-        case "create_event": {
-          const payload = action.payload as CreateEventPendingPayload;
-          const result = await createEventFn({
-            supabase: ctx.serviceSupabase,
-            serviceSupabase: ctx.serviceSupabase,
-            orgId: ctx.orgId,
-            userId: ctx.userId,
-            input: payload,
-            orgSlug:
-              typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-                ? payload.orgSlug
-                : null,
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-
-            aiLog("error", "ai-confirm", "create_event confirmation failed", {
-              ...logContext,
+        case "create_event":
+          return handleCreateEvent(
+            {
+              serviceSupabase: ctx.serviceSupabase,
+              orgId: ctx.orgId,
               userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              attemptedEventType: payload.event_type,
-              eventErrorCode: result.code ?? null,
-              eventError: result.error,
-              eventStatus: result.status,
-              internalError: result.internalError ?? null,
-            });
-
-            return NextResponse.json(
-              {
-                error: result.error,
-                ...(result.code ? { code: result.code } : {}),
-                ...(result.details ? { details: result.details } : {}),
-              },
-              { status: result.status }
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "event",
-            resultEntityId: result.event.id,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const eventUrl = orgSlug
-            ? calendarEventDetailPath(orgSlug, result.event.id)
-            : result.eventUrl;
-          const content = eventUrl
-            ? `Created event: [${result.event.title}](${eventUrl})`
-            : `Created event: ${result.event.title}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          try {
-            await syncEventToUsersFn(ctx.serviceSupabase, ctx.orgId, result.event.id, "create");
-          } catch (syncErr) {
-            aiLog("error", "ai-confirm", "google calendar sync failed", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, { actionId: action.id, eventId: result.event.id, error: syncErr });
-          }
-
-          try {
-            await syncOutlookEventToUsersFn(ctx.serviceSupabase, ctx.orgId, result.event.id, "create");
-          } catch (outlookErr) {
-            aiLog("error", "ai-confirm", "outlook calendar sync failed", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, { actionId: action.id, eventId: result.event.id, error: outlookErr });
-          }
-
-          try {
-            await sendNotificationBlastFn({
-              supabase: ctx.serviceSupabase,
-              organizationId: ctx.orgId,
-              audience: "both",
-              channel: "email",
-              title: `New Event: ${result.event.title}`,
-              body: `Event scheduled for ${payload.start_date} at ${payload.start_time}${payload.location ? `\nWhere: ${payload.location}` : ""}`,
-              category: "event",
-            });
-          } catch (notifyErr) {
-            aiLog("error", "ai-confirm", "event notification blast failed", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, { actionId: action.id, eventId: result.event.id, error: notifyErr });
-          }
-
-          return NextResponse.json({ ok: true, event: result.event, actionId: action.id });
-        }
+              logContext,
+              canUseDraftSessions,
+              updatePendingActionStatusFn,
+              clearDraftSessionFn,
+            },
+            action as PendingActionRecord<"create_event">,
+            {
+              createEventFn,
+              syncEventToUsersFn,
+              syncOutlookEventToUsersFn,
+              sendNotificationBlastFn,
+            }
+          );
         case "create_enterprise_invite": {
           const payload = action.payload as CreateEnterpriseInvitePendingPayload;
           // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -2,11 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getAiOrgContext } from "@/lib/ai/context";
 import {
-  type CreateAnnouncementPendingPayload,
   type CreateDiscussionReplyPendingPayload,
   getPendingAction,
   isAuthorizedAction,
   isPendingActionExpired,
+  type PendingActionRecord,
   type SendChatMessagePendingPayload,
   type SendGroupChatMessagePendingPayload,
   updatePendingActionStatus,
@@ -41,6 +41,7 @@ import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limi
 import { aiLog } from "@/lib/ai/logger";
 import { syncEventToUsers } from "@/lib/google/calendar-sync";
 import { sendNotificationBlast } from "@/lib/notifications";
+import { handleCreateAnnouncement } from "./dispatchers/announcements";
 
 export interface AiPendingActionConfirmRouteDeps {
   createClient?: typeof createClient;
@@ -181,106 +182,24 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
 
     try {
       switch (action.action_type) {
-        case "create_announcement": {
-          const payload = action.payload as CreateAnnouncementPendingPayload;
-          const result = await createAnnouncementFn({
-            supabase: ctx.serviceSupabase,
-            orgId: ctx.orgId,
-            userId: ctx.userId,
-            input: {
-              ...payload,
-              audience_user_ids: payload.audience_user_ids ?? null,
-            },
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              result.details ? { error: result.error, details: result.details } : { error: result.error },
-              { status: result.status }
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "announcement",
-            resultEntityId: result.announcement.id,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          try {
-            await sendAnnouncementNotificationFn({
-              supabase: ctx.serviceSupabase,
-              announcementId: result.announcement.id,
+        case "create_announcement":
+          return handleCreateAnnouncement(
+            {
+              serviceSupabase: ctx.serviceSupabase,
               orgId: ctx.orgId,
-              input: {
-                ...payload,
-                audience_user_ids: payload.audience_user_ids ?? null,
-              },
-              sendDirectNotification: async ({ organizationId, title, body, audience, targetUserIds }) => {
-                await sendNotificationBlastFn({
-                  supabase: ctx.serviceSupabase,
-                  organizationId,
-                  audience,
-                  channel: "email",
-                  title,
-                  body,
-                  targetUserIds,
-                  category: "announcement",
-                });
-              },
-            });
-          } catch (notificationError) {
-            aiLog("error", "ai-confirm", "announcement notification failed", {
-              ...logContext,
               userId: ctx.userId,
-              threadId: action.thread_id,
-            }, { actionId: action.id, announcementId: result.announcement.id, error: notificationError });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const announcementUrl = orgSlug ? `/${orgSlug}/announcements` : null;
-          const content = announcementUrl
-            ? `Created announcement: [${result.announcement.title}](${announcementUrl})`
-            : `Created announcement: ${result.announcement.title}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, announcement: result.announcement, actionId: action.id });
-        }
+              logContext,
+              canUseDraftSessions,
+              updatePendingActionStatusFn,
+              clearDraftSessionFn,
+            },
+            action as PendingActionRecord<"create_announcement">,
+            {
+              createAnnouncementFn,
+              sendAnnouncementNotificationFn,
+              sendNotificationBlastFn,
+            }
+          );
         case "create_job_posting": {
           const payload = action.payload as CreateJobPostingPendingPayload;
           const result = await createJobPostingFn({

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -20,13 +20,17 @@ import {
   createAnnouncement,
   sendAnnouncementNotification,
 } from "@/lib/announcements/create-announcement";
+import { updateAnnouncement } from "@/lib/announcements/update-announcement";
 import { sendAiAssistedDirectChatMessage } from "@/lib/chat/direct-chat";
 import { sendAiAssistedGroupChatMessage } from "@/lib/chat/group-chat";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { aiLog } from "@/lib/ai/logger";
 import { syncEventToUsers } from "@/lib/google/calendar-sync";
 import { sendNotificationBlast } from "@/lib/notifications";
-import { handleCreateAnnouncement } from "./dispatchers/announcements";
+import {
+  handleCreateAnnouncement,
+  handleEditAnnouncement,
+} from "./dispatchers/announcements";
 import { handleCreateEvent } from "./dispatchers/events";
 import { handleCreateJobPosting } from "./dispatchers/jobs";
 import {
@@ -48,6 +52,7 @@ export interface AiPendingActionConfirmRouteDeps {
   getPendingAction?: typeof getPendingAction;
   updatePendingActionStatus?: typeof updatePendingActionStatus;
   createAnnouncement?: typeof createAnnouncement;
+  updateAnnouncement?: typeof updateAnnouncement;
   createJobPosting?: typeof createJobPosting;
   createDiscussionReply?: typeof createDiscussionReply;
   createDiscussionThread?: typeof createDiscussionThread;
@@ -72,6 +77,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
   const getPendingActionFn = deps.getPendingAction ?? getPendingAction;
   const updatePendingActionStatusFn = deps.updatePendingActionStatus ?? updatePendingActionStatus;
   const createAnnouncementFn = deps.createAnnouncement ?? createAnnouncement;
+  const updateAnnouncementFn = deps.updateAnnouncement ?? updateAnnouncement;
   const createJobPostingFn = deps.createJobPosting ?? createJobPosting;
   const createDiscussionReplyFn = deps.createDiscussionReply ?? createDiscussionReply;
   const createDiscussionThreadFn = deps.createDiscussionThread ?? createDiscussionThread;
@@ -202,6 +208,20 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               sendAnnouncementNotificationFn,
               sendNotificationBlastFn,
             }
+          );
+        case "edit_announcement":
+          return await handleEditAnnouncement(
+            {
+              serviceSupabase: ctx.serviceSupabase,
+              orgId: ctx.orgId,
+              userId: ctx.userId,
+              logContext,
+              canUseDraftSessions,
+              updatePendingActionStatusFn,
+              clearDraftSessionFn,
+            },
+            action as PendingActionRecord<"edit_announcement">,
+            { updateAnnouncementFn }
           );
         case "create_job_posting":
           return await handleCreateJobPosting(

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -2,17 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getAiOrgContext } from "@/lib/ai/context";
 import {
-  type CreateDiscussionReplyPendingPayload,
   getPendingAction,
   isAuthorizedAction,
   isPendingActionExpired,
   type PendingActionRecord,
-  type SendChatMessagePendingPayload,
-  type SendGroupChatMessagePendingPayload,
   updatePendingActionStatus,
-  type CreateDiscussionThreadPendingPayload,
-  type CreateEnterpriseInvitePendingPayload,
-  type RevokeEnterpriseInvitePendingPayload,
 } from "@/lib/ai/pending-actions";
 import {
   clearDraftSession,
@@ -26,14 +20,8 @@ import {
   createAnnouncement,
   sendAnnouncementNotification,
 } from "@/lib/announcements/create-announcement";
-import {
-  sendAiAssistedDirectChatMessage,
-  type DirectChatSupabase,
-} from "@/lib/chat/direct-chat";
-import {
-  sendAiAssistedGroupChatMessage,
-  type GroupChatSupabase,
-} from "@/lib/chat/group-chat";
+import { sendAiAssistedDirectChatMessage } from "@/lib/chat/direct-chat";
+import { sendAiAssistedGroupChatMessage } from "@/lib/chat/group-chat";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { aiLog } from "@/lib/ai/logger";
 import { syncEventToUsers } from "@/lib/google/calendar-sync";
@@ -41,6 +29,18 @@ import { sendNotificationBlast } from "@/lib/notifications";
 import { handleCreateAnnouncement } from "./dispatchers/announcements";
 import { handleCreateEvent } from "./dispatchers/events";
 import { handleCreateJobPosting } from "./dispatchers/jobs";
+import {
+  handleSendChatMessage,
+  handleSendGroupChatMessage,
+} from "./dispatchers/chat";
+import {
+  handleCreateDiscussionReply,
+  handleCreateDiscussionThread,
+} from "./dispatchers/discussions";
+import {
+  handleCreateEnterpriseInvite,
+  handleRevokeEnterpriseInvite,
+} from "./dispatchers/enterprise-invites";
 
 export interface AiPendingActionConfirmRouteDeps {
   createClient?: typeof createClient;
@@ -218,300 +218,68 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
             { createJobPostingFn }
           );
         case "send_chat_message": {
-          const payload = action.payload as SendChatMessagePendingPayload;
-          const result = await sendAiAssistedDirectChatMessageFn(ctx.serviceSupabase as DirectChatSupabase, {
-            organizationId: ctx.orgId,
-            senderUserId: ctx.userId,
-            recipientMemberId: payload.recipient_member_id,
-            recipientUserId: payload.recipient_user_id,
-            recipientDisplayName: payload.recipient_display_name,
-            body: payload.body,
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json({ error: result.error, code: result.code }, { status: result.status });
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "chat_message",
-            resultEntityId: result.messageId,
-          });
-
-          // Store recipient in thread metadata for follow-up messages
-          await ctx.serviceSupabase
-            .from("ai_threads")
-            .update({
-              metadata: { last_chat_recipient_member_id: payload.recipient_member_id },
-              updated_at: new Date().toISOString(),
-            })
-            .eq("id", action.thread_id);
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const chatUrl = orgSlug ? `/${orgSlug}/messages/chat/${result.chatGroupId}` : null;
-          const content = chatUrl
-            ? `Sent chat message to [${payload.recipient_display_name}](${chatUrl})`
-            : `Sent chat message to ${payload.recipient_display_name}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({
-            ok: true,
-            actionId: action.id,
-            chatGroupId: result.chatGroupId,
-            messageId: result.messageId,
-          });
-        }
-        case "send_group_chat_message": {
-          const payload = action.payload as SendGroupChatMessagePendingPayload;
-          const result = await sendAiAssistedGroupChatMessageFn(ctx.serviceSupabase as GroupChatSupabase, {
-            organizationId: ctx.orgId,
-            senderUserId: ctx.userId,
-            chatGroupId: payload.chat_group_id,
-            groupName: payload.group_name,
-            messageStatus: payload.message_status,
-            body: payload.body,
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json({ error: result.error, code: result.code }, { status: result.status });
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "chat_message",
-            resultEntityId: result.messageId,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const chatUrl = orgSlug ? `/${orgSlug}/messages/chat/${result.chatGroupId}` : null;
-          const statusNote = result.messageStatus === "pending" ? " (pending approval)" : "";
-          const content = chatUrl
-            ? `Sent message to [${payload.group_name}](${chatUrl})${statusNote}`
-            : `Sent message to ${payload.group_name}${statusNote}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({
-            ok: true,
-            actionId: action.id,
-            chatGroupId: result.chatGroupId,
-            messageId: result.messageId,
-          });
-        }
-        case "create_discussion_thread": {
-          const payload = action.payload as CreateDiscussionThreadPendingPayload;
-          const result = await createDiscussionThreadFn({
-            supabase: ctx.serviceSupabase,
+          const chatCtx = {
             serviceSupabase: ctx.serviceSupabase,
             orgId: ctx.orgId,
             userId: ctx.userId,
-            input: payload,
-            orgSlug:
-              typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-                ? payload.orgSlug
-                : null,
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              result.details ? { error: result.error, details: result.details } : { error: result.error },
-              { status: result.status }
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "discussion_thread",
-            resultEntityId: result.thread.id,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const threadUrl = orgSlug
-            ? `/${orgSlug}/messages/threads/${result.thread.id}`
-            : result.threadUrl;
-          const content = threadUrl
-            ? `Created discussion thread: [${result.thread.title}](${threadUrl})`
-            : `Created discussion thread: ${result.thread.title}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, thread: result.thread, actionId: action.id });
+            logContext,
+            canUseDraftSessions,
+            updatePendingActionStatusFn,
+            clearDraftSessionFn,
+          };
+          return await handleSendChatMessage(
+            chatCtx,
+            action as PendingActionRecord<"send_chat_message">,
+            { sendAiAssistedDirectChatMessageFn }
+          );
+        }
+        case "send_group_chat_message": {
+          const chatCtx = {
+            serviceSupabase: ctx.serviceSupabase,
+            orgId: ctx.orgId,
+            userId: ctx.userId,
+            logContext,
+            canUseDraftSessions,
+            updatePendingActionStatusFn,
+            clearDraftSessionFn,
+          };
+          return await handleSendGroupChatMessage(
+            chatCtx,
+            action as PendingActionRecord<"send_group_chat_message">,
+            { sendAiAssistedGroupChatMessageFn }
+          );
+        }
+        case "create_discussion_thread": {
+          const discussionCtx = {
+            serviceSupabase: ctx.serviceSupabase,
+            orgId: ctx.orgId,
+            userId: ctx.userId,
+            logContext,
+            canUseDraftSessions,
+            updatePendingActionStatusFn,
+            clearDraftSessionFn,
+          };
+          return await handleCreateDiscussionThread(
+            discussionCtx,
+            action as PendingActionRecord<"create_discussion_thread">,
+            { createDiscussionThreadFn }
+          );
         }
         case "create_discussion_reply": {
-          const payload = action.payload as CreateDiscussionReplyPendingPayload;
-          const result = await createDiscussionReplyFn({
-            supabase: ctx.serviceSupabase,
-            threadId: payload.discussion_thread_id,
-            userId: ctx.userId,
+          const discussionCtx = {
+            serviceSupabase: ctx.serviceSupabase,
             orgId: ctx.orgId,
-            input: { body: payload.body },
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              result.details ? { error: result.error, details: result.details } : { error: result.error },
-              { status: result.status }
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "discussion_reply",
-            resultEntityId: result.reply.id,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const threadUrl = orgSlug
-            ? `/${orgSlug}/messages/threads/${result.thread.id}`
-            : null;
-          const content = threadUrl
-            ? `Posted reply in discussion thread: [${result.thread.title}](${threadUrl})`
-            : `Posted reply in discussion thread: ${result.thread.title}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, reply: result.reply, actionId: action.id });
+            userId: ctx.userId,
+            logContext,
+            canUseDraftSessions,
+            updatePendingActionStatusFn,
+            clearDraftSessionFn,
+          };
+          return await handleCreateDiscussionReply(
+            discussionCtx,
+            action as PendingActionRecord<"create_discussion_reply">,
+            { createDiscussionReplyFn }
+          );
         }
         case "create_event":
           return await handleCreateEvent(
@@ -533,121 +301,32 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
             }
           );
         case "create_enterprise_invite": {
-          const payload = action.payload as CreateEnterpriseInvitePendingPayload;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const rpcResult = await (supabase as any).rpc("create_enterprise_invite", {
-            p_enterprise_id: payload.enterpriseId,
-            p_organization_id: payload.organizationId ?? null,
-            p_role: payload.role,
-            p_uses: payload.usesRemaining ?? null,
-            p_expires_at: payload.expiresAt ?? null,
-          });
-
-          if (rpcResult.error || !rpcResult.data || typeof rpcResult.data.id !== "string") {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              { error: rpcResult.error?.message || "Failed to create enterprise invite" },
-              { status: 400 },
-            );
-          }
-
-          const invite = rpcResult.data as {
-            id: string;
-            code?: string;
-            role?: string;
+          const enterpriseCtx = {
+            supabase,
+            serviceSupabase: ctx.serviceSupabase,
+            orgId: ctx.orgId,
+            userId: ctx.userId,
+            logContext,
+            updatePendingActionStatusFn,
           };
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "enterprise_invite",
-            resultEntityId: invite.id,
-          });
-
-          const inviteCode = typeof invite.code === "string" ? invite.code : "";
-          const invitePath = `/enterprise/${payload.enterpriseSlug}/invites`;
-          const content = inviteCode
-            ? `Created enterprise invite \`${inviteCode}\` (${payload.role}). Manage it at [${invitePath}](${invitePath}).`
-            : `Created enterprise invite (${payload.role}). Manage it at [${invitePath}](${invitePath}).`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, invite, actionId: action.id });
+          return await handleCreateEnterpriseInvite(
+            enterpriseCtx,
+            action as PendingActionRecord<"create_enterprise_invite">
+          );
         }
         case "revoke_enterprise_invite": {
-          const payload = action.payload as RevokeEnterpriseInvitePendingPayload;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const updateResult = await (ctx.serviceSupabase as any)
-            .from("enterprise_invites")
-            .update({ revoked_at: new Date().toISOString() })
-            .eq("id", payload.inviteId)
-            .eq("enterprise_id", payload.enterpriseId)
-            .is("revoked_at", null)
-            .select("id");
-
-          const updatedRows = Array.isArray(updateResult.data) ? updateResult.data : [];
-
-          if (updateResult.error || updatedRows.length === 0) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              { error: updateResult.error?.message || "Failed to revoke enterprise invite" },
-              { status: 400 },
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "enterprise_invite",
-            resultEntityId: payload.inviteId,
-          });
-
-          const content = `Revoked enterprise invite \`${payload.inviteCode}\`.`;
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, actionId: action.id });
+          const enterpriseCtx = {
+            supabase,
+            serviceSupabase: ctx.serviceSupabase,
+            orgId: ctx.orgId,
+            userId: ctx.userId,
+            logContext,
+            updatePendingActionStatusFn,
+          };
+          return await handleRevokeEnterpriseInvite(
+            enterpriseCtx,
+            action as PendingActionRecord<"revoke_enterprise_invite">
+          );
         }
         default:
           throw new Error(`Unsupported pending action type: ${action.action_type satisfies never}`);

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -11,7 +11,6 @@ import {
   type SendGroupChatMessagePendingPayload,
   updatePendingActionStatus,
   type CreateDiscussionThreadPendingPayload,
-  type CreateJobPostingPendingPayload,
   type CreateEnterpriseInvitePendingPayload,
   type RevokeEnterpriseInvitePendingPayload,
 } from "@/lib/ai/pending-actions";
@@ -41,6 +40,7 @@ import { syncEventToUsers } from "@/lib/google/calendar-sync";
 import { sendNotificationBlast } from "@/lib/notifications";
 import { handleCreateAnnouncement } from "./dispatchers/announcements";
 import { handleCreateEvent } from "./dispatchers/events";
+import { handleCreateJobPosting } from "./dispatchers/jobs";
 
 export interface AiPendingActionConfirmRouteDeps {
   createClient?: typeof createClient;
@@ -182,7 +182,11 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
     try {
       switch (action.action_type) {
         case "create_announcement":
-          return handleCreateAnnouncement(
+          // `return await` (not `return`) is required: the outer try/catch must
+          // observe rejections from the dispatcher to run the rollback path.
+          // `return promise` would return the pending promise and let the
+          // rejection escape the surrounding try.
+          return await handleCreateAnnouncement(
             {
               serviceSupabase: ctx.serviceSupabase,
               orgId: ctx.orgId,
@@ -199,74 +203,20 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               sendNotificationBlastFn,
             }
           );
-        case "create_job_posting": {
-          const payload = action.payload as CreateJobPostingPendingPayload;
-          const result = await createJobPostingFn({
-            supabase: ctx.serviceSupabase,
-            serviceSupabase: ctx.serviceSupabase,
-            orgId: ctx.orgId,
-            userId: ctx.userId,
-            input: payload,
-          });
-
-          if (!result.ok) {
-            await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-              status: "pending",
-              expectedStatus: "confirmed",
-            });
-            return NextResponse.json(
-              result.details ? { error: result.error, details: result.details } : { error: result.error },
-              { status: result.status }
-            );
-          }
-
-          await updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
-            status: "executed",
-            expectedStatus: "confirmed",
-            executedAt: new Date().toISOString(),
-            resultEntityType: "job_posting",
-            resultEntityId: result.job.id,
-          });
-
-          if (canUseDraftSessions) {
-            await clearDraftSessionFn(ctx.serviceSupabase, {
-              organizationId: ctx.orgId,
+        case "create_job_posting":
+          return await handleCreateJobPosting(
+            {
+              serviceSupabase: ctx.serviceSupabase,
+              orgId: ctx.orgId,
               userId: ctx.userId,
-              threadId: action.thread_id,
-              pendingActionId: action.id,
-            });
-          }
-
-          const orgSlug =
-            typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
-              ? payload.orgSlug
-              : null;
-          const jobUrl = orgSlug ? `/${orgSlug}/jobs/${result.job.id}` : null;
-          const content = jobUrl
-            ? `Created job posting: [${result.job.title}](${jobUrl})`
-            : `Created job posting: ${result.job.title}`;
-
-          const { error: msgError } = await ctx.serviceSupabase.from("ai_messages").insert({
-            thread_id: action.thread_id,
-            org_id: ctx.orgId,
-            role: "assistant",
-            content,
-            status: "complete",
-          });
-
-          if (msgError) {
-            aiLog("error", "ai-confirm", "failed to insert confirmation message", {
-              ...logContext,
-              userId: ctx.userId,
-              threadId: action.thread_id,
-            }, {
-              actionId: action.id,
-              error: msgError,
-            });
-          }
-
-          return NextResponse.json({ ok: true, job: result.job, actionId: action.id });
-        }
+              logContext,
+              canUseDraftSessions,
+              updatePendingActionStatusFn,
+              clearDraftSessionFn,
+            },
+            action as PendingActionRecord<"create_job_posting">,
+            { createJobPostingFn }
+          );
         case "send_chat_message": {
           const payload = action.payload as SendChatMessagePendingPayload;
           const result = await sendAiAssistedDirectChatMessageFn(ctx.serviceSupabase as DirectChatSupabase, {
@@ -564,7 +514,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
           return NextResponse.json({ ok: true, reply: result.reply, actionId: action.id });
         }
         case "create_event":
-          return handleCreateEvent(
+          return await handleCreateEvent(
             {
               serviceSupabase: ctx.serviceSupabase,
               orgId: ctx.orgId,

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -20,6 +20,7 @@ import {
   createAnnouncement,
   sendAnnouncementNotification,
 } from "@/lib/announcements/create-announcement";
+import { softDeleteAnnouncement } from "@/lib/announcements/soft-delete-announcement";
 import { updateAnnouncement } from "@/lib/announcements/update-announcement";
 import { sendAiAssistedDirectChatMessage } from "@/lib/chat/direct-chat";
 import { sendAiAssistedGroupChatMessage } from "@/lib/chat/group-chat";
@@ -29,6 +30,7 @@ import { syncEventToUsers } from "@/lib/google/calendar-sync";
 import { sendNotificationBlast } from "@/lib/notifications";
 import {
   handleCreateAnnouncement,
+  handleDeleteAnnouncement,
   handleEditAnnouncement,
 } from "./dispatchers/announcements";
 import { handleCreateEvent } from "./dispatchers/events";
@@ -53,6 +55,7 @@ export interface AiPendingActionConfirmRouteDeps {
   updatePendingActionStatus?: typeof updatePendingActionStatus;
   createAnnouncement?: typeof createAnnouncement;
   updateAnnouncement?: typeof updateAnnouncement;
+  softDeleteAnnouncement?: typeof softDeleteAnnouncement;
   createJobPosting?: typeof createJobPosting;
   createDiscussionReply?: typeof createDiscussionReply;
   createDiscussionThread?: typeof createDiscussionThread;
@@ -78,6 +81,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
   const updatePendingActionStatusFn = deps.updatePendingActionStatus ?? updatePendingActionStatus;
   const createAnnouncementFn = deps.createAnnouncement ?? createAnnouncement;
   const updateAnnouncementFn = deps.updateAnnouncement ?? updateAnnouncement;
+  const softDeleteAnnouncementFn = deps.softDeleteAnnouncement ?? softDeleteAnnouncement;
   const createJobPostingFn = deps.createJobPosting ?? createJobPosting;
   const createDiscussionReplyFn = deps.createDiscussionReply ?? createDiscussionReply;
   const createDiscussionThreadFn = deps.createDiscussionThread ?? createDiscussionThread;
@@ -222,6 +226,20 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
             },
             action as PendingActionRecord<"edit_announcement">,
             { updateAnnouncementFn }
+          );
+        case "delete_announcement":
+          return await handleDeleteAnnouncement(
+            {
+              serviceSupabase: ctx.serviceSupabase,
+              orgId: ctx.orgId,
+              userId: ctx.userId,
+              logContext,
+              canUseDraftSessions,
+              updatePendingActionStatusFn,
+              clearDraftSessionFn,
+            },
+            action as PendingActionRecord<"delete_announcement">,
+            { softDeleteAnnouncementFn }
           );
         case "create_job_posting":
           return await handleCreateJobPosting(

--- a/src/lib/ai/draft-sessions.ts
+++ b/src/lib/ai/draft-sessions.ts
@@ -7,7 +7,10 @@ import type {
 import type { AssistantEventDraft } from "@/lib/schemas/events-ai";
 import type { AssistantJobDraft } from "@/lib/schemas/jobs";
 import type { AssistantChatMessageDraft, AssistantGroupMessageDraft } from "@/lib/schemas/chat-ai";
-import { AI_PENDING_ACTION_EXPIRY_MS } from "@/lib/ai/pending-actions";
+import {
+  AI_PENDING_ACTION_EXPIRY_MS,
+  type EditAnnouncementPendingPayload,
+} from "@/lib/ai/pending-actions";
 
 export type DraftSessionStatus = "collecting_fields" | "ready_for_confirmation";
 
@@ -16,6 +19,7 @@ export type DraftSessionStatus = "collecting_fields" | "ready_for_confirmation";
 // saveDraftSession enforces the contract at the application boundary.
 export const DRAFT_SESSION_TYPES = [
   "create_announcement",
+  "edit_announcement",
   "create_job_posting",
   "send_chat_message",
   "send_group_chat_message",
@@ -28,6 +32,7 @@ export type DraftSessionType = (typeof DRAFT_SESSION_TYPES)[number];
 
 export interface DraftSessionPayloadByType {
   create_announcement: AssistantAnnouncementDraft;
+  edit_announcement: EditAnnouncementPendingPayload;
   create_job_posting: AssistantJobDraft;
   send_chat_message: AssistantChatMessageDraft;
   send_group_chat_message: AssistantGroupMessageDraft;

--- a/src/lib/ai/draft-sessions.ts
+++ b/src/lib/ai/draft-sessions.ts
@@ -41,6 +41,11 @@ export interface DraftSessionRecord<TDraftType extends DraftSessionType = DraftS
 
 interface DraftSessionSelectChain {
   eq(column: string, value: string): DraftSessionSelectChain;
+  order(
+    column: string,
+    options: { ascending: boolean }
+  ): DraftSessionSelectChain;
+  limit(count: number): DraftSessionSelectChain;
   maybeSingle(): Promise<{ data: unknown; error: unknown }>;
 }
 
@@ -89,14 +94,32 @@ export async function getDraftSession(
     organizationId: string;
     userId: string;
     threadId: string;
+    // When provided, narrows the lookup to a specific draft type — required
+    // for any caller that needs to discriminate between concurrent drafts
+    // (e.g. a `create_announcement` vs `edit_announcement` draft on the
+    // same thread). When omitted, returns the most-recently-updated draft
+    // of any type for backwards compatibility with legacy "do they have an
+    // active draft?" callers.
+    draftType?: DraftSessionType;
   }
 ): Promise<DraftSessionRecord | null> {
-  const { data, error } = await supabase
+  let chain = supabase
     .from("ai_draft_sessions")
     .select("*")
     .eq("organization_id", input.organizationId)
     .eq("user_id", input.userId)
-    .eq("thread_id", input.threadId)
+    .eq("thread_id", input.threadId);
+
+  if (input.draftType) {
+    chain = chain.eq("draft_type", input.draftType);
+  }
+
+  // order + limit keeps `.maybeSingle()` safe once the unique key widens
+  // to (thread_id, draft_type): a thread can legitimately carry multiple
+  // rows after widening, and un-narrowed callers want the most recent.
+  const { data, error } = await chain
+    .order("updated_at", { ascending: false })
+    .limit(1)
     .maybeSingle();
 
   if (error) {
@@ -133,10 +156,14 @@ export async function saveDraftSession(
       input.expiresAt ?? new Date(Date.now() + AI_PENDING_ACTION_EXPIRY_MS).toISOString(),
   };
 
+  // Existence check narrowed to draft_type so two draft types on the same
+  // thread round-trip as two rows under the widened (thread_id, draft_type)
+  // unique key.
   const existing = await getDraftSession(supabase, {
     organizationId: input.organizationId,
     userId: input.userId,
     threadId: input.threadId,
+    draftType: input.draftType,
   });
 
   if (existing) {
@@ -173,6 +200,10 @@ export async function clearDraftSession(
     userId: string;
     threadId: string;
     pendingActionId?: string | null;
+    // When provided, clears only the matching draft type. When omitted,
+    // clears every draft type for the thread (the legacy behaviour —
+    // still valid for callers that want a blanket reset).
+    draftType?: DraftSessionType;
   }
 ): Promise<void> {
   let query = supabase
@@ -181,6 +212,10 @@ export async function clearDraftSession(
     .eq("organization_id", input.organizationId)
     .eq("user_id", input.userId)
     .eq("thread_id", input.threadId);
+
+  if (input.draftType) {
+    query = query.eq("draft_type", input.draftType);
+  }
 
   if (input.pendingActionId) {
     query = query.eq("pending_action_id", input.pendingActionId);

--- a/src/lib/ai/draft-sessions.ts
+++ b/src/lib/ai/draft-sessions.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { AssistantAnnouncementDraft } from "@/lib/schemas/content";
 import type {
   AssistantDiscussionDraft,
@@ -10,6 +11,21 @@ import { AI_PENDING_ACTION_EXPIRY_MS } from "@/lib/ai/pending-actions";
 
 export type DraftSessionStatus = "collecting_fields" | "ready_for_confirmation";
 
+// Single source of truth for the draft_type enum. The prior CHECK constraint
+// (see migration 20261101000000) was dropped; this tuple plus the Zod guard in
+// saveDraftSession enforces the contract at the application boundary.
+export const DRAFT_SESSION_TYPES = [
+  "create_announcement",
+  "create_job_posting",
+  "send_chat_message",
+  "send_group_chat_message",
+  "create_discussion_reply",
+  "create_discussion_thread",
+  "create_event",
+] as const;
+
+export type DraftSessionType = (typeof DRAFT_SESSION_TYPES)[number];
+
 export interface DraftSessionPayloadByType {
   create_announcement: AssistantAnnouncementDraft;
   create_job_posting: AssistantJobDraft;
@@ -20,7 +36,19 @@ export interface DraftSessionPayloadByType {
   create_event: AssistantEventDraft;
 }
 
-export type DraftSessionType = keyof DraftSessionPayloadByType;
+// Compile fails if DRAFT_SESSION_TYPES and DraftSessionPayloadByType diverge.
+type _MissingFromPayload = Exclude<DraftSessionType, keyof DraftSessionPayloadByType>;
+type _MissingFromTypes = Exclude<keyof DraftSessionPayloadByType, DraftSessionType>;
+type _DraftSessionCoverageOK = [
+  _MissingFromPayload,
+  _MissingFromTypes,
+] extends [never, never]
+  ? true
+  : never;
+const _draftSessionCoverageOK: _DraftSessionCoverageOK = true;
+void _draftSessionCoverageOK;
+
+const draftSessionTypeSchema = z.enum(DRAFT_SESSION_TYPES);
 
 export type DraftSessionPayload = DraftSessionPayloadByType[DraftSessionType];
 
@@ -120,6 +148,10 @@ export async function saveDraftSession(
     expiresAt?: string;
   }
 ): Promise<DraftSessionRecord> {
+  if (!draftSessionTypeSchema.safeParse(input.draftType).success) {
+    throw new Error(`Invalid draft_type: ${String(input.draftType)}`);
+  }
+
   const payload = {
     organization_id: input.organizationId,
     user_id: input.userId,

--- a/src/lib/ai/pending-actions.ts
+++ b/src/lib/ai/pending-actions.ts
@@ -2,13 +2,17 @@ import type { AssistantPreparedJob } from "@/lib/schemas/jobs";
 import type { AssistantPreparedDiscussion } from "@/lib/schemas/discussion";
 import type { AssistantPreparedDiscussionReply } from "@/lib/schemas/discussion";
 import type { AssistantPreparedEvent } from "@/lib/schemas/events-ai";
-import type { AssistantPreparedAnnouncement } from "@/lib/schemas/content";
+import type {
+  AssistantAnnouncementPatch,
+  AssistantPreparedAnnouncement,
+} from "@/lib/schemas/content";
 import type { AssistantPreparedChatMessage, AssistantPreparedGroupMessage } from "@/lib/schemas/chat-ai";
 
 export const AI_PENDING_ACTION_EXPIRY_MS = 15 * 60 * 1000;
 
 export type PendingActionType =
   | "create_announcement"
+  | "edit_announcement"
   | "create_job_posting"
   | "send_chat_message"
   | "send_group_chat_message"
@@ -30,6 +34,24 @@ export interface CreateJobPostingPendingPayload extends AssistantPreparedJob {
 }
 
 export interface CreateAnnouncementPendingPayload extends AssistantPreparedAnnouncement {
+  orgSlug?: string | null;
+}
+
+export interface EditAnnouncementPendingPayload {
+  targetId: string;
+  patch: AssistantAnnouncementPatch;
+  /**
+   * `target.updated_at` captured at prepare time. When present it is used
+   * at confirm time as an optimistic-concurrency token: both a fast in-code
+   * re-read check and an `.eq("updated_at", ...)` filter on the UPDATE
+   * statement. Prevents racing with a concurrent UI edit.
+   */
+  expectedUpdatedAt?: string | null;
+  /**
+   * Caller-captured prior title — only used for the confirmation ai_message
+   * body. Not part of the mutation's semantics.
+   */
+  targetTitle?: string | null;
   orgSlug?: string | null;
 }
 
@@ -74,6 +96,7 @@ export interface RevokeEnterpriseInvitePendingPayload {
 
 export interface PendingActionPayloadByType {
   create_announcement: CreateAnnouncementPendingPayload;
+  edit_announcement: EditAnnouncementPendingPayload;
   create_job_posting: CreateJobPostingPendingPayload;
   send_chat_message: SendChatMessagePendingPayload;
   send_group_chat_message: SendGroupChatMessagePendingPayload;
@@ -305,6 +328,11 @@ export function buildPendingActionSummary(record: PendingActionRecord): PendingA
       return {
         title: "Review announcement",
         description: "Confirm the drafted announcement before it is published.",
+      };
+    case "edit_announcement":
+      return {
+        title: "Review announcement edit",
+        description: "Confirm the proposed changes before the announcement is updated.",
       };
     case "create_job_posting":
       return {

--- a/src/lib/ai/pending-actions.ts
+++ b/src/lib/ai/pending-actions.ts
@@ -13,6 +13,7 @@ export const AI_PENDING_ACTION_EXPIRY_MS = 15 * 60 * 1000;
 export type PendingActionType =
   | "create_announcement"
   | "edit_announcement"
+  | "delete_announcement"
   | "create_job_posting"
   | "send_chat_message"
   | "send_group_chat_message"
@@ -50,6 +51,25 @@ export interface EditAnnouncementPendingPayload {
   /**
    * Caller-captured prior title — only used for the confirmation ai_message
    * body. Not part of the mutation's semantics.
+   */
+  targetTitle?: string | null;
+  orgSlug?: string | null;
+}
+
+export interface DeleteAnnouncementPendingPayload {
+  targetId: string;
+  /**
+   * Optional optimistic-concurrency token captured at prepare time. Unlike
+   * edit, delete tolerates last-writer-wins semantics — the soft-delete is
+   * idempotent (second invocation on an already-deleted row no-ops). But
+   * supplying the token surfaces concurrent edits as a 409 stale_version,
+   * which the user can use to review before a destructive-op re-confirm.
+   */
+  expectedUpdatedAt?: string | null;
+  /**
+   * Caller-captured title — only used for the confirmation ai_message body.
+   * Not part of the mutation's semantics. Populated because once the row is
+   * soft-deleted, subsequent reads may filter it out.
    */
   targetTitle?: string | null;
   orgSlug?: string | null;
@@ -97,6 +117,7 @@ export interface RevokeEnterpriseInvitePendingPayload {
 export interface PendingActionPayloadByType {
   create_announcement: CreateAnnouncementPendingPayload;
   edit_announcement: EditAnnouncementPendingPayload;
+  delete_announcement: DeleteAnnouncementPendingPayload;
   create_job_posting: CreateJobPostingPendingPayload;
   send_chat_message: SendChatMessagePendingPayload;
   send_group_chat_message: SendGroupChatMessagePendingPayload;
@@ -333,6 +354,11 @@ export function buildPendingActionSummary(record: PendingActionRecord): PendingA
       return {
         title: "Review announcement edit",
         description: "Confirm the proposed changes before the announcement is updated.",
+      };
+    case "delete_announcement":
+      return {
+        title: "Delete announcement?",
+        description: "Confirm that this announcement should be removed.",
       };
     case "create_job_posting":
       return {

--- a/src/lib/ai/shared/domain-result.ts
+++ b/src/lib/ai/shared/domain-result.ts
@@ -1,0 +1,13 @@
+// Discriminated result type for agent mutation primitives. The finite numeric
+// status union maps to HTTP statuses the confirm handler returns to the
+// client and keeps callers exhaustive at the type level — no accidental 500
+// escape hatches.
+
+export type DomainResult<T> =
+  | { ok: true; value: T }
+  | {
+      ok: false;
+      status: 400 | 403 | 404 | 409 | 410 | 422 | 500;
+      error: string;
+      details?: Record<string, unknown>;
+    };

--- a/src/lib/ai/tools/definitions.ts
+++ b/src/lib/ai/tools/definitions.ts
@@ -344,6 +344,31 @@ const TOOL_BY_NAME = {
       },
     },
   },
+  prepare_delete_announcement: {
+    type: "function" as const,
+    function: {
+      name: "prepare_delete_announcement" as const,
+      description:
+        "Prepare a soft-delete of an existing organization announcement. Use this when the user asks to delete, remove, cancel, take down, retract, or unpublish an announcement. Target resolution is strict — target_id must be supplied explicitly. There is no most-recent fallback because delete is destructive and cannot be undone from chat. When the user has not named a specific announcement, list recent announcements and ask them to pick one rather than guessing.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          target_id: {
+            type: "string" as const,
+            description:
+              "The ID of the announcement to delete. Required — the tool refuses to act without an explicit target_id.",
+          },
+          reasoning: {
+            type: "string" as const,
+            description:
+              "Short (one-sentence) explanation of why this delete is being proposed. Logged for audit. Example: 'user asked to remove a duplicate announcement'.",
+          },
+        },
+        required: ["target_id"] as const,
+        additionalProperties: false as const,
+      },
+    },
+  },
   prepare_job_posting: {
     type: "function" as const,
     function: {
@@ -1114,6 +1139,7 @@ export const AI_TOOLS = [
   TOOL_BY_NAME.revoke_enterprise_invite,
   TOOL_BY_NAME.prepare_announcement,
   TOOL_BY_NAME.prepare_edit_announcement,
+  TOOL_BY_NAME.prepare_delete_announcement,
   TOOL_BY_NAME.prepare_job_posting,
   TOOL_BY_NAME.prepare_chat_message,
   TOOL_BY_NAME.prepare_group_message,

--- a/src/lib/ai/tools/definitions.ts
+++ b/src/lib/ai/tools/definitions.ts
@@ -307,6 +307,43 @@ const TOOL_BY_NAME = {
       },
     },
   },
+  prepare_edit_announcement: {
+    type: "function" as const,
+    function: {
+      name: "prepare_edit_announcement" as const,
+      description:
+        "Prepare an edit to an existing organization announcement. Use this when the user wants to fix, change, update, or reschedule an announcement they previously posted. It resolves the target announcement (via target_id, or as a fallback the most-recently-posted announcement in the last 15 minutes by the same user), validates the patch against the announcement schema, and creates a pending confirmation action. Supply only the fields that should change; unspecified fields keep their current value. At least one patch field must be provided.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          target_id: {
+            type: "string" as const,
+            description:
+              "The ID of the announcement to edit. When omitted, the tool falls back to the most recent announcement the same user created in this org within the last 15 minutes. Prefer explicit target_id whenever the user references a specific announcement by title or context.",
+          },
+          title: { type: "string" as const },
+          body: { type: "string" as const },
+          is_pinned: { type: "boolean" as const },
+          audience: {
+            type: "string" as const,
+            enum: ["all", "members", "active_members", "alumni", "individuals"],
+          },
+          audience_user_ids: {
+            type: "array" as const,
+            items: { type: "string" as const },
+            description:
+              "Replace the individual-recipient list. Only meaningful when audience is 'individuals' or when the existing announcement already targets individuals.",
+          },
+          reasoning: {
+            type: "string" as const,
+            description:
+              "Short (one-sentence) explanation of why this edit is being proposed. Logged for audit. Example: 'user asked to fix typo in the title'.",
+          },
+        },
+        additionalProperties: false as const,
+      },
+    },
+  },
   prepare_job_posting: {
     type: "function" as const,
     function: {
@@ -1076,6 +1113,7 @@ export const AI_TOOLS = [
   TOOL_BY_NAME.prepare_enterprise_invite,
   TOOL_BY_NAME.revoke_enterprise_invite,
   TOOL_BY_NAME.prepare_announcement,
+  TOOL_BY_NAME.prepare_edit_announcement,
   TOOL_BY_NAME.prepare_job_posting,
   TOOL_BY_NAME.prepare_chat_message,
   TOOL_BY_NAME.prepare_group_message,

--- a/src/lib/ai/tools/executor.ts
+++ b/src/lib/ai/tools/executor.ts
@@ -53,6 +53,7 @@ import {
   buildPendingActionSummary,
   type CreateAnnouncementPendingPayload,
   type EditAnnouncementPendingPayload,
+  type DeleteAnnouncementPendingPayload,
   type SendChatMessagePendingPayload,
   type SendGroupChatMessagePendingPayload,
   type CreateDiscussionReplyPendingPayload,
@@ -213,6 +214,13 @@ const prepareEditAnnouncementSchema = z
       .enum(["all", "members", "active_members", "alumni", "individuals"])
       .optional(),
     audience_user_ids: z.array(z.string().uuid()).optional(),
+    reasoning: z.string().trim().min(1).optional(),
+  })
+  .strict();
+
+const prepareDeleteAnnouncementSchema = z
+  .object({
+    target_id: z.string().uuid(),
     reasoning: z.string().trim().min(1).optional(),
   })
   .strict();
@@ -414,6 +422,7 @@ const ARG_SCHEMAS: Record<ToolName, z.ZodSchema> = {
   revoke_enterprise_invite: revokeEnterpriseInviteSchema,
   prepare_announcement: prepareAnnouncementSchema,
   prepare_edit_announcement: prepareEditAnnouncementSchema,
+  prepare_delete_announcement: prepareDeleteAnnouncementSchema,
   prepare_job_posting: prepareJobPostingSchema,
   prepare_chat_message: prepareChatMessageSchema,
   prepare_group_message: prepareGroupMessageSchema,
@@ -1674,6 +1683,150 @@ async function prepareEditAnnouncement(
         target_id: target.id,
         target_title: target.title,
         patch,
+      },
+      pending_action: {
+        id: pendingAction.id,
+        action_type: pendingAction.action_type,
+        payload: pendingPayload,
+        expires_at: pendingAction.expires_at,
+        summary,
+      },
+    },
+  };
+}
+
+// ─── prepare_delete_announcement ──────────────────────────────────────
+//
+// Phase 2b-prepare of the Tier 1 plan. Unlike edit, delete is strictly
+// target_id-required — no most-recent fallback. The plan's security-
+// hardening decision (A2.1) disables the fallback for destructive ops
+// so the assistant can never soft-delete an ambiguous target. The
+// confirm-side dispatcher (see confirm/dispatchers/announcements.ts::
+// handleDeleteAnnouncement) calls softDeleteAnnouncement, which is
+// idempotent — re-confirm on an already-deleted row no-ops.
+
+async function prepareDeleteAnnouncement(
+  sb: SB,
+  ctx: ToolExecutionContext,
+  args: z.infer<typeof prepareDeleteAnnouncementSchema>
+): Promise<ToolExecutionResult> {
+  const logContext = buildLogContext(ctx);
+  if (!ctx.threadId) {
+    return toolError("Announcement delete preparation requires a thread context");
+  }
+
+  // Target resolution is strict: explicit target_id only, no fallback.
+  // We still run the resolver for parity with edit (auth + taint checks
+  // live there), but force fallback: "none".
+  const resolution = await resolveAgentActionTarget({
+    supabase: sb as never,
+    caller: { userId: ctx.userId, organizationId: ctx.orgId },
+    entityType: "announcement",
+    op: "delete",
+    targetId: args.target_id,
+    fallback: "none",
+  });
+
+  if (resolution.kind === "needs_target_id") {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason: resolution.reason,
+      },
+    };
+  }
+  if (resolution.kind === "not_found") {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason:
+          "The requested announcement was not found in this organization.",
+      },
+    };
+  }
+
+  // Load the target row to capture the optimistic-concurrency token and
+  // current title (for the confirmation ai_message body — once the row
+  // is soft-deleted, subsequent reads may filter it out). Scope by
+  // orgId to defend against cross-org target_id spoofing — the triple-
+  // layer org assertion per the plan's security hardening.
+  const { data: target, error: targetError } = await sb
+    .from("announcements")
+    .select("id, title, updated_at, organization_id, deleted_at")
+    .eq("id", resolution.targetId)
+    .eq("organization_id", ctx.orgId)
+    .maybeSingle();
+
+  if (targetError) {
+    aiLog(
+      "warn",
+      "ai-tools",
+      "prepare_delete_announcement target lookup failed",
+      logContext,
+      { error: getSafeErrorMessage(targetError), targetId: resolution.targetId }
+    );
+    return toolError("Failed to load the target announcement");
+  }
+  if (!target) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason: "The requested announcement was not found in this organization.",
+      },
+    };
+  }
+  if (target.deleted_at !== null) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason:
+          "The requested announcement has already been deleted.",
+      },
+    };
+  }
+
+  const { data: org, error: orgError } = await sb
+    .from("organizations")
+    .select("slug")
+    .eq("id", ctx.orgId)
+    .maybeSingle();
+  if (orgError) {
+    aiLog("warn", "ai-tools", "prepare_delete_announcement org lookup failed", logContext, {
+      error: getSafeErrorMessage(orgError),
+    });
+    return toolError("Failed to load organization context");
+  }
+
+  const pendingPayload: DeleteAnnouncementPendingPayload = {
+    targetId: target.id as string,
+    expectedUpdatedAt: (target.updated_at as string | null) ?? null,
+    targetTitle: (target.title as string | null) ?? null,
+    orgSlug: typeof org?.slug === "string" ? org.slug : null,
+  };
+  const pendingAction = await createPendingAction(sb, {
+    organizationId: ctx.orgId,
+    userId: ctx.userId,
+    threadId: ctx.threadId,
+    actionType: "delete_announcement",
+    payload: pendingPayload,
+  });
+  const summary = buildPendingActionSummary(pendingAction);
+
+  return {
+    kind: "ok",
+    data: {
+      state: "needs_confirmation",
+      draft: {
+        target_id: target.id,
+        target_title: target.title,
       },
       pending_action: {
         id: pendingAction.id,
@@ -3545,6 +3698,12 @@ export async function executeToolCall(
             sb,
             ctx,
             args as z.infer<typeof prepareEditAnnouncementSchema>
+          );
+        case "prepare_delete_announcement":
+          return prepareDeleteAnnouncement(
+            sb,
+            ctx,
+            args as z.infer<typeof prepareDeleteAnnouncementSchema>
           );
         case "prepare_job_posting":
           return prepareJobPosting(

--- a/src/lib/ai/tools/executor.ts
+++ b/src/lib/ai/tools/executor.ts
@@ -19,7 +19,9 @@ import { searchNavigationTargets } from "@/lib/ai/navigation-targets";
 import type { NavConfig } from "@/lib/navigation/nav-items";
 import {
   assistantAnnouncementDraftSchema,
+  assistantAnnouncementPatchSchema,
   assistantPreparedAnnouncementSchema,
+  type AssistantAnnouncementPatch,
   type AssistantPreparedAnnouncement,
 } from "@/lib/schemas/content";
 import {
@@ -50,6 +52,7 @@ import { isOwnedScheduleUploadPath } from "@/lib/ai/schedule-upload-path";
 import {
   buildPendingActionSummary,
   type CreateAnnouncementPendingPayload,
+  type EditAnnouncementPendingPayload,
   type SendChatMessagePendingPayload,
   type SendGroupChatMessagePendingPayload,
   type CreateDiscussionReplyPendingPayload,
@@ -60,6 +63,7 @@ import {
   type CreateEnterpriseInvitePendingPayload,
   type RevokeEnterpriseInvitePendingPayload,
 } from "@/lib/ai/pending-actions";
+import { resolveAgentActionTarget } from "@/lib/ai/tools/target-resolver";
 import { aiLog, type AiLogContext } from "@/lib/ai/logger";
 import { sanitizeIlikeInput } from "@/lib/security/validation";
 import {
@@ -196,6 +200,20 @@ const prepareAnnouncementSchema = z
     audience: z.enum(["all", "members", "active_members", "alumni", "individuals"]).optional(),
     send_notification: z.boolean().optional(),
     audience_user_ids: z.array(z.string().uuid()).optional(),
+  })
+  .strict();
+
+const prepareEditAnnouncementSchema = z
+  .object({
+    target_id: z.string().uuid().optional(),
+    title: z.string().trim().min(1).optional(),
+    body: z.string().trim().optional(),
+    is_pinned: z.boolean().optional(),
+    audience: z
+      .enum(["all", "members", "active_members", "alumni", "individuals"])
+      .optional(),
+    audience_user_ids: z.array(z.string().uuid()).optional(),
+    reasoning: z.string().trim().min(1).optional(),
   })
   .strict();
 
@@ -395,6 +413,7 @@ const ARG_SCHEMAS: Record<ToolName, z.ZodSchema> = {
   prepare_enterprise_invite: prepareEnterpriseInviteSchema,
   revoke_enterprise_invite: revokeEnterpriseInviteSchema,
   prepare_announcement: prepareAnnouncementSchema,
+  prepare_edit_announcement: prepareEditAnnouncementSchema,
   prepare_job_posting: prepareJobPostingSchema,
   prepare_chat_message: prepareChatMessageSchema,
   prepare_group_message: prepareGroupMessageSchema,
@@ -1473,6 +1492,189 @@ async function prepareAnnouncement(
     data: {
       state: "needs_confirmation",
       draft: prepared.data,
+      pending_action: {
+        id: pendingAction.id,
+        action_type: pendingAction.action_type,
+        payload: pendingPayload,
+        expires_at: pendingAction.expires_at,
+        summary,
+      },
+    },
+  };
+}
+
+// ─── prepare_edit_announcement ──────────────────────────────────────────
+//
+// Phase 2a-prepare of the Tier 1 plan. Resolves the target announcement
+// (either via explicit target_id or most-recent fallback within 15
+// minutes per the plan's performance-review narrowing), captures the
+// optimistic-concurrency `expectedUpdatedAt` token from the target's
+// current row, validates the patch against assistantAnnouncementPatchSchema,
+// and creates an `edit_announcement` pending action. The confirm-side
+// dispatcher (see confirm/dispatchers/announcements.ts::handleEditAnnouncement)
+// applies the patch via the updateAnnouncement primitive.
+
+async function prepareEditAnnouncement(
+  sb: SB,
+  ctx: ToolExecutionContext,
+  args: z.infer<typeof prepareEditAnnouncementSchema>
+): Promise<ToolExecutionResult> {
+  const logContext = buildLogContext(ctx);
+  if (!ctx.threadId) {
+    return toolError("Announcement edit preparation requires a thread context");
+  }
+
+  // Reject empty patches fast. The model must supply at least one change.
+  const patchInput = {
+    ...(args.title !== undefined ? { title: args.title } : {}),
+    ...(args.body !== undefined ? { body: args.body } : {}),
+    ...(args.is_pinned !== undefined ? { is_pinned: args.is_pinned } : {}),
+    ...(args.audience !== undefined ? { audience: args.audience } : {}),
+    ...(args.audience_user_ids !== undefined
+      ? { audience_user_ids: args.audience_user_ids }
+      : {}),
+  };
+  if (Object.keys(patchInput).length === 0) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["patch"],
+        reason:
+          "Specify at least one field to change (title, body, is_pinned, audience, or audience_user_ids).",
+      },
+    };
+  }
+
+  const parsedPatch = assistantAnnouncementPatchSchema.safeParse(patchInput);
+  if (!parsedPatch.success) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: parsedPatch.error.issues.map(
+          (issue) => issue.path.join(".") || "patch"
+        ),
+        draft: patchInput,
+      },
+    };
+  }
+  const patch: AssistantAnnouncementPatch = parsedPatch.data;
+
+  // Resolve the target. Explicit target_id short-circuits the resolver;
+  // otherwise fall back to the most-recently-executed announcement action
+  // by the same user within the 15-minute edit window.
+  const resolution = await resolveAgentActionTarget({
+    supabase: sb as never,
+    caller: { userId: ctx.userId, organizationId: ctx.orgId },
+    entityType: "announcement",
+    op: "edit",
+    targetId: args.target_id,
+    fallback: args.target_id ? "none" : "most_recent",
+  });
+
+  if (resolution.kind === "needs_target_id") {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason: resolution.reason,
+      },
+    };
+  }
+  if (resolution.kind === "not_found") {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason:
+          "No recently-created announcement was found to edit. Ask the user which announcement to edit and pass its target_id.",
+      },
+    };
+  }
+
+  // Load the target row to capture the optimistic-concurrency token and
+  // the current title (for the confirmation ai_message body). Scope by
+  // orgId to defend against cross-org target_id spoofing — the triple-
+  // layer org assertion per the plan's security hardening.
+  const { data: target, error: targetError } = await sb
+    .from("announcements")
+    .select("id, title, updated_at, organization_id, deleted_at")
+    .eq("id", resolution.targetId)
+    .eq("organization_id", ctx.orgId)
+    .maybeSingle();
+
+  if (targetError) {
+    aiLog(
+      "warn",
+      "ai-tools",
+      "prepare_edit_announcement target lookup failed",
+      logContext,
+      { error: getSafeErrorMessage(targetError), targetId: resolution.targetId }
+    );
+    return toolError("Failed to load the target announcement");
+  }
+  if (!target) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason: "The requested announcement was not found in this organization.",
+      },
+    };
+  }
+  if (target.deleted_at !== null) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason:
+          "The requested announcement has been deleted and cannot be edited.",
+      },
+    };
+  }
+
+  const { data: org, error: orgError } = await sb
+    .from("organizations")
+    .select("slug")
+    .eq("id", ctx.orgId)
+    .maybeSingle();
+  if (orgError) {
+    aiLog("warn", "ai-tools", "prepare_edit_announcement org lookup failed", logContext, {
+      error: getSafeErrorMessage(orgError),
+    });
+    return toolError("Failed to load organization context");
+  }
+
+  const pendingPayload: EditAnnouncementPendingPayload = {
+    targetId: target.id as string,
+    patch,
+    expectedUpdatedAt: (target.updated_at as string | null) ?? null,
+    targetTitle: (target.title as string | null) ?? null,
+    orgSlug: typeof org?.slug === "string" ? org.slug : null,
+  };
+  const pendingAction = await createPendingAction(sb, {
+    organizationId: ctx.orgId,
+    userId: ctx.userId,
+    threadId: ctx.threadId,
+    actionType: "edit_announcement",
+    payload: pendingPayload,
+  });
+  const summary = buildPendingActionSummary(pendingAction);
+
+  return {
+    kind: "ok",
+    data: {
+      state: "needs_confirmation",
+      draft: {
+        target_id: target.id,
+        target_title: target.title,
+        patch,
+      },
       pending_action: {
         id: pendingAction.id,
         action_type: pendingAction.action_type,
@@ -3337,6 +3539,12 @@ export async function executeToolCall(
             sb,
             ctx,
             args as z.infer<typeof prepareAnnouncementSchema>
+          );
+        case "prepare_edit_announcement":
+          return prepareEditAnnouncement(
+            sb,
+            ctx,
+            args as z.infer<typeof prepareEditAnnouncementSchema>
           );
         case "prepare_job_posting":
           return prepareJobPosting(

--- a/src/lib/ai/tools/target-resolver.ts
+++ b/src/lib/ai/tools/target-resolver.ts
@@ -1,0 +1,135 @@
+// Target resolver for agent edit/delete tool calls. Phase 1b-narrow scope:
+// answer "which entity id are we talking about" without fetching the row or
+// touching per-domain logic. Per-domain by-id and by-name predicates arrive
+// alongside each domain tool in Phase 2+.
+//
+// The resolver handles three paths:
+//   1. Explicit targetId → short-circuit, return as-is.
+//   2. Most-recent fallback (edit only) → consult ai_pending_actions and
+//      surface the result_entity_id of the caller's most recent executed
+//      action on the same entity type, bounded by windowMs.
+//   3. fallback: "none" or fallback disabled → return needs_target_id so the
+//      model asks the user for an explicit id.
+//
+// Destructive ops (delete, cancel) deliberately disable the most-recent
+// fallback — security addendum A2.1. The lookback window is narrowed to 15m
+// for edit per performance review, down from the original 1h proposal.
+
+export type EntityType =
+  | "announcement"
+  | "event"
+  | "job"
+  | "discussion_thread"
+  | "discussion_reply"
+  | "chat_message";
+
+export type TargetOp = "edit" | "delete" | "cancel" | "expire";
+
+export type ResolverFallback = "most_recent" | "none";
+
+export const AI_RECENT_ENTITY_LOOKBACK_EDIT_MS = 15 * 60 * 1000;
+export const AI_RECENT_ENTITY_LOOKBACK_DELETE_MS = 0;
+
+// Minimal Supabase-shape the resolver relies on. Deliberately narrow so unit
+// tests don't need the real client or a heavyweight stub.
+export interface ResolverSupabaseClient {
+  from(table: "ai_pending_actions"): {
+    select(columns: string): ResolverFilterChain;
+  };
+}
+
+type ResolverRow = { result_entity_id: string | null };
+
+export interface ResolverFilterChain
+  extends PromiseLike<{ data: ResolverRow[] | null; error: unknown }> {
+  eq(column: string, value: unknown): ResolverFilterChain;
+  gte(column: string, value: string): ResolverFilterChain;
+  order(
+    column: string,
+    options: { ascending: boolean }
+  ): ResolverFilterChain;
+  limit(n: number): ResolverFilterChain;
+}
+
+export interface ResolveArgs {
+  supabase: ResolverSupabaseClient;
+  caller: { userId: string; organizationId: string };
+  entityType: EntityType;
+  op: TargetOp;
+  targetId?: string;
+  fallback: ResolverFallback;
+  windowMs?: number;
+}
+
+export type ResolveResult =
+  | { kind: "resolved"; targetId: string; entityType: EntityType }
+  | { kind: "needs_target_id"; reason: string }
+  | { kind: "not_found" };
+
+export async function resolveAgentActionTarget(
+  args: ResolveArgs
+): Promise<ResolveResult> {
+  if (args.targetId) {
+    return {
+      kind: "resolved",
+      targetId: args.targetId,
+      entityType: args.entityType,
+    };
+  }
+
+  if (args.fallback === "none") {
+    return {
+      kind: "needs_target_id",
+      reason: "Explicit target_id is required for this operation.",
+    };
+  }
+
+  const windowMs = args.windowMs ?? windowForOp(args.op);
+  if (windowMs <= 0) {
+    return {
+      kind: "needs_target_id",
+      reason: `Most-recent fallback is disabled for ${args.op}; supply an explicit target_id.`,
+    };
+  }
+
+  const cutoff = new Date(Date.now() - windowMs).toISOString();
+  const { data, error } = await args.supabase
+    .from("ai_pending_actions")
+    .select("result_entity_id")
+    .eq("user_id", args.caller.userId)
+    .eq("organization_id", args.caller.organizationId)
+    .eq("result_entity_type", args.entityType)
+    .eq("status", "executed")
+    .gte("executed_at", cutoff)
+    .order("executed_at", { ascending: false })
+    .order("id", { ascending: false })
+    .limit(1);
+
+  if (error) {
+    throw new Error(
+      "resolveAgentActionTarget: ai_pending_actions most-recent query failed"
+    );
+  }
+
+  const row = (data ?? [])[0];
+  if (!row?.result_entity_id) {
+    return { kind: "not_found" };
+  }
+
+  return {
+    kind: "resolved",
+    targetId: row.result_entity_id,
+    entityType: args.entityType,
+  };
+}
+
+function windowForOp(op: TargetOp): number {
+  switch (op) {
+    case "edit":
+    case "expire":
+      return AI_RECENT_ENTITY_LOOKBACK_EDIT_MS;
+    case "delete":
+    case "cancel":
+      return AI_RECENT_ENTITY_LOOKBACK_DELETE_MS;
+  }
+}

--- a/src/lib/announcements/soft-delete-announcement.ts
+++ b/src/lib/announcements/soft-delete-announcement.ts
@@ -1,0 +1,106 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database";
+import { getOrgMembership } from "@/lib/auth/api-helpers";
+
+type DatabaseClient = SupabaseClient<Database>;
+type AnnouncementRow = Database["public"]["Tables"]["announcements"]["Row"];
+
+// Local mirror of the shared DomainResult type (defined in a companion PR).
+// Kept here so this PR is self-contained; refactor to the shared module in a
+// follow-up once both land.
+export type DomainResult<T> =
+  | { ok: true; value: T }
+  | {
+      ok: false;
+      status: 400 | 403 | 404 | 409 | 410 | 422 | 500;
+      error: string;
+      details?: Record<string, unknown>;
+    };
+
+export interface SoftDeleteAnnouncementRequest {
+  supabase: DatabaseClient;
+  orgId: string;
+  userId: string;
+  targetId: string;
+  /**
+   * Caller-captured `target.updated_at` from prepare time. When supplied, the
+   * write uses it as an optimistic-concurrency token both in-code (fast fail)
+   * and in the UPDATE WHERE clause (race-safe). Omit for last-writer-wins
+   * semantics.
+   */
+  expectedUpdatedAt?: string | null;
+}
+
+export async function softDeleteAnnouncement(
+  request: SoftDeleteAnnouncementRequest
+): Promise<DomainResult<AnnouncementRow>> {
+  const membership = await getOrgMembership(
+    request.supabase,
+    request.userId,
+    request.orgId
+  );
+  if (!membership || membership.role !== "admin") {
+    return { ok: false, status: 403, error: "forbidden" };
+  }
+
+  const { data: current, error: fetchError } = await request.supabase
+    .from("announcements")
+    .select("*")
+    .eq("id", request.targetId)
+    .eq("organization_id", request.orgId)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (fetchError) {
+    return { ok: false, status: 500, error: "fetch_failed" };
+  }
+  if (!current) {
+    return { ok: false, status: 404, error: "not_found" };
+  }
+
+  if (
+    request.expectedUpdatedAt != null &&
+    current.updated_at !== request.expectedUpdatedAt
+  ) {
+    return {
+      ok: false,
+      status: 409,
+      error: "stale_version",
+      details: {
+        expectedUpdatedAt: request.expectedUpdatedAt,
+        currentUpdatedAt: current.updated_at,
+      },
+    };
+  }
+
+  // Stamp both deleted_at and updated_at with the same instant. updated_at
+  // serves as the next optimistic-concurrency token if anything else races
+  // with this row (e.g., a lingering edit prepared just before the delete).
+  const now = new Date().toISOString();
+
+  let updateQuery = request.supabase
+    .from("announcements")
+    .update({ deleted_at: now, updated_at: now })
+    .eq("id", request.targetId)
+    .eq("organization_id", request.orgId)
+    .is("deleted_at", null);
+
+  if (request.expectedUpdatedAt != null) {
+    updateQuery = updateQuery.eq("updated_at", request.expectedUpdatedAt);
+  }
+
+  const { data: deleted, error: updateError } = await updateQuery
+    .select("*")
+    .maybeSingle();
+
+  if (updateError) {
+    return { ok: false, status: 500, error: "delete_failed" };
+  }
+  if (!deleted) {
+    // Zero rows → either the row was deleted concurrently (deleted_at IS NULL
+    // filter miss) or updated_at advanced between our read and write.
+    return { ok: false, status: 409, error: "stale_version" };
+  }
+
+  return { ok: true, value: deleted };
+}

--- a/src/lib/announcements/update-announcement.ts
+++ b/src/lib/announcements/update-announcement.ts
@@ -1,0 +1,170 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ZodIssue } from "zod";
+import type { Database } from "@/types/database";
+import { getOrgMembership } from "@/lib/auth/api-helpers";
+import {
+  assistantAnnouncementPatchSchema,
+  assistantPreparedAnnouncementSchema,
+  type AssistantAnnouncementPatch,
+} from "@/lib/schemas/content";
+
+// Local mirror of the shared DomainResult type (defined in a companion PR).
+// Kept here so this PR is self-contained; refactor to the shared module in a
+// follow-up once both land.
+export type DomainResult<T> =
+  | { ok: true; value: T }
+  | {
+      ok: false;
+      status: 400 | 403 | 404 | 409 | 410 | 422 | 500;
+      error: string;
+      details?: Record<string, unknown>;
+    };
+
+type DatabaseClient = SupabaseClient<Database>;
+type AnnouncementRow = Database["public"]["Tables"]["announcements"]["Row"];
+
+export interface UpdateAnnouncementRequest {
+  supabase: DatabaseClient;
+  orgId: string;
+  userId: string;
+  targetId: string;
+  patch: AssistantAnnouncementPatch;
+  /**
+   * Caller-captured `target.updated_at` from prepare time. When supplied, the
+   * write uses it as an optimistic-concurrency token both in-code (fast fail)
+   * and in the UPDATE WHERE clause (race-safe). Omit for last-writer-wins
+   * semantics.
+   */
+  expectedUpdatedAt?: string | null;
+}
+
+export async function updateAnnouncement(
+  request: UpdateAnnouncementRequest
+): Promise<DomainResult<AnnouncementRow>> {
+  const parsed = assistantAnnouncementPatchSchema.safeParse(request.patch);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_patch",
+      details: issuesToDetails(parsed.error.issues),
+    };
+  }
+  const patch = parsed.data;
+
+  if (!Object.values(patch).some((v) => v !== undefined)) {
+    return { ok: false, status: 400, error: "empty_patch" };
+  }
+
+  const membership = await getOrgMembership(
+    request.supabase,
+    request.userId,
+    request.orgId
+  );
+  if (!membership || membership.role !== "admin") {
+    return { ok: false, status: 403, error: "forbidden" };
+  }
+
+  const { data: current, error: fetchError } = await request.supabase
+    .from("announcements")
+    .select("*")
+    .eq("id", request.targetId)
+    .eq("organization_id", request.orgId)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (fetchError) {
+    return { ok: false, status: 500, error: "fetch_failed" };
+  }
+  if (!current) {
+    return { ok: false, status: 404, error: "not_found" };
+  }
+
+  if (
+    request.expectedUpdatedAt != null &&
+    current.updated_at !== request.expectedUpdatedAt
+  ) {
+    return {
+      ok: false,
+      status: 409,
+      error: "stale_version",
+      details: {
+        expectedUpdatedAt: request.expectedUpdatedAt,
+        currentUpdatedAt: current.updated_at,
+      },
+    };
+  }
+
+  // Merge current + patch and re-validate against the full-row schema. This
+  // catches cross-field invariants a partial patch could violate (e.g.,
+  // changing audience to "individuals" without supplying audience_user_ids).
+  const mergedTitle = patch.title ?? current.title;
+  const mergedBody = patch.body ?? current.body;
+  const mergedIsPinned = patch.is_pinned ?? Boolean(current.is_pinned);
+  const mergedAudience = patch.audience ?? current.audience;
+  const mergedAudienceUserIds =
+    patch.audience_user_ids ?? current.audience_user_ids ?? undefined;
+
+  const invariantCheck = assistantPreparedAnnouncementSchema.safeParse({
+    title: mergedTitle,
+    body: mergedBody ?? undefined,
+    is_pinned: mergedIsPinned,
+    audience: mergedAudience,
+    send_notification: false, // not stored; satisfy the prepared-schema shape
+    audience_user_ids: mergedAudienceUserIds ?? undefined,
+  });
+
+  if (!invariantCheck.success) {
+    return {
+      ok: false,
+      status: 422,
+      error: "invariant_violation",
+      details: issuesToDetails(invariantCheck.error.issues),
+    };
+  }
+
+  // Write the merged row rather than the raw patch — with the invariant
+  // check above, this is safer than field-level last-writer-wins and the
+  // optimistic-concurrency filter below prevents overwriting concurrent
+  // changes.
+  const updatePayload = {
+    title: mergedTitle,
+    body: mergedBody,
+    is_pinned: mergedIsPinned,
+    audience: mergedAudience,
+    audience_user_ids:
+      mergedAudience === "individuals"
+        ? mergedAudienceUserIds ?? null
+        : null,
+  };
+
+  let updateQuery = request.supabase
+    .from("announcements")
+    .update(updatePayload)
+    .eq("id", request.targetId)
+    .eq("organization_id", request.orgId)
+    .is("deleted_at", null);
+
+  if (request.expectedUpdatedAt != null) {
+    updateQuery = updateQuery.eq("updated_at", request.expectedUpdatedAt);
+  }
+
+  const { data: updated, error: updateError } = await updateQuery
+    .select("*")
+    .maybeSingle();
+
+  if (updateError) {
+    return { ok: false, status: 500, error: "update_failed" };
+  }
+  if (!updated) {
+    return { ok: false, status: 409, error: "stale_version" };
+  }
+
+  return { ok: true, value: updated };
+}
+
+function issuesToDetails(issues: ZodIssue[]): Record<string, unknown> {
+  return Object.fromEntries(
+    issues.map((issue) => [issue.path.join(".") || "body", issue.message])
+  );
+}

--- a/src/lib/events/update-event.ts
+++ b/src/lib/events/update-event.ts
@@ -1,0 +1,235 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ZodIssue } from "zod";
+import type { Database } from "@/types/database";
+import { getOrgMembership } from "@/lib/auth/api-helpers";
+import {
+  assistantEventPatchSchema,
+  assistantPreparedEventSchema,
+  type AssistantEventPatch,
+} from "@/lib/schemas/events-ai";
+
+// Local mirror of the shared DomainResult type — kept here so this PR is
+// self-contained while the shared module (from the Phase 1b scaffolding)
+// propagates into `src/lib/announcements/update-announcement.ts` and the
+// rest of Tier 1. Refactor to the shared import in a follow-up.
+export type DomainResult<T> =
+  | { ok: true; value: T }
+  | {
+      ok: false;
+      status: 400 | 403 | 404 | 409 | 410 | 422 | 500;
+      error: string;
+      details?: Record<string, unknown>;
+    };
+
+type DatabaseClient = SupabaseClient<Database>;
+type EventRow = Database["public"]["Tables"]["events"]["Row"];
+
+export interface UpdateEventRequest {
+  supabase: DatabaseClient;
+  orgId: string;
+  userId: string;
+  targetId: string;
+  patch: AssistantEventPatch;
+  /**
+   * Caller-captured `target.updated_at` from prepare time. When supplied, the
+   * write uses it as an optimistic-concurrency token both in-code (fast fail)
+   * and in the UPDATE WHERE clause (race-safe). Omit for last-writer-wins
+   * semantics.
+   */
+  expectedUpdatedAt?: string | null;
+}
+
+export async function updateEvent(
+  request: UpdateEventRequest
+): Promise<DomainResult<EventRow>> {
+  const parsed = assistantEventPatchSchema.safeParse(request.patch);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_patch",
+      details: issuesToDetails(parsed.error.issues),
+    };
+  }
+  const patch = parsed.data;
+
+  if (!Object.values(patch).some((v) => v !== undefined)) {
+    return { ok: false, status: 400, error: "empty_patch" };
+  }
+
+  const membership = await getOrgMembership(
+    request.supabase,
+    request.userId,
+    request.orgId
+  );
+  if (!membership || membership.role !== "admin") {
+    return { ok: false, status: 403, error: "forbidden" };
+  }
+
+  const { data: current, error: fetchError } = await request.supabase
+    .from("events")
+    .select("*")
+    .eq("id", request.targetId)
+    .eq("organization_id", request.orgId)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (fetchError) {
+    return { ok: false, status: 500, error: "fetch_failed" };
+  }
+  if (!current) {
+    return { ok: false, status: 404, error: "not_found" };
+  }
+
+  // Tier 4 guard: recurring events are out of scope for Phase 3. Any row
+  // that is part of a recurrence series (has a group id, is the parent
+  // with a rule, or is an individual instance) is rejected. The plan
+  // explicitly defers recurrence edit semantics (`this_only` /
+  // `this_and_future` / `all_in_series`) to Tier 4.
+  if (
+    current.recurrence_group_id !== null ||
+    current.recurrence_rule !== null ||
+    current.recurrence_index !== null
+  ) {
+    return {
+      ok: false,
+      status: 422,
+      error: "recurring_event_unsupported",
+      details: {
+        message:
+          "Editing recurring events is not supported yet. Ask the user to edit a single, non-recurring event.",
+      },
+    };
+  }
+
+  if (
+    request.expectedUpdatedAt != null &&
+    current.updated_at !== request.expectedUpdatedAt
+  ) {
+    return {
+      ok: false,
+      status: 409,
+      error: "stale_version",
+      details: {
+        expectedUpdatedAt: request.expectedUpdatedAt,
+        currentUpdatedAt: current.updated_at,
+      },
+    };
+  }
+
+  // Decompose the current row's stored ISO `start_date` / `end_date` strings
+  // back into the YYYY-MM-DD + HH:MM parts used by the patch schema so we
+  // can merge patch over current and re-validate the combined shape against
+  // `assistantPreparedEventSchema` (catches end > start invariants, etc.).
+  const currentStart = decomposeIsoToDateTime(current.start_date);
+  if (!currentStart) {
+    return {
+      ok: false,
+      status: 500,
+      error: "corrupt_start_date",
+      details: { value: current.start_date },
+    };
+  }
+  const currentEnd = current.end_date
+    ? decomposeIsoToDateTime(current.end_date)
+    : null;
+
+  const mergedStartDate = patch.start_date ?? currentStart.date;
+  const mergedStartTime = patch.start_time ?? currentStart.time;
+  const mergedEndDate =
+    patch.end_date !== undefined ? patch.end_date : currentEnd?.date ?? "";
+  const mergedEndTime =
+    patch.end_time !== undefined ? patch.end_time : currentEnd?.time ?? "";
+  const mergedTitle = patch.title ?? current.title;
+  const mergedDescription =
+    patch.description !== undefined ? patch.description : current.description;
+  const mergedLocation =
+    patch.location !== undefined ? patch.location : current.location;
+  const mergedEventType = patch.event_type ?? current.event_type;
+  const mergedIsPhilanthropy =
+    patch.is_philanthropy ?? Boolean(current.is_philanthropy);
+
+  const invariantCheck = assistantPreparedEventSchema.safeParse({
+    title: mergedTitle,
+    description: mergedDescription ?? undefined,
+    start_date: mergedStartDate,
+    start_time: mergedStartTime,
+    end_date: mergedEndDate,
+    end_time: mergedEndTime,
+    location: mergedLocation ?? undefined,
+    event_type: mergedEventType,
+    is_philanthropy: mergedIsPhilanthropy,
+  });
+
+  if (!invariantCheck.success) {
+    return {
+      ok: false,
+      status: 422,
+      error: "invariant_violation",
+      details: issuesToDetails(invariantCheck.error.issues),
+    };
+  }
+
+  // Recompose merged date+time pairs back into the ISO strings the DB stores.
+  // Mirrors `createEvent`'s composition — treat as wall-clock time (no
+  // timezone shift) so browser forms and agent edits stay consistent.
+  const nextStartIso = `${mergedStartDate}T${mergedStartTime}:00.000Z`;
+  const nextEndIso =
+    mergedEndDate && mergedEndTime
+      ? `${mergedEndDate}T${mergedEndTime}:00.000Z`
+      : null;
+
+  const updatePayload: Database["public"]["Tables"]["events"]["Update"] = {
+    title: mergedTitle,
+    description: mergedDescription ?? null,
+    start_date: nextStartIso,
+    end_date: nextEndIso,
+    location: mergedLocation ?? null,
+    event_type: mergedEventType,
+    is_philanthropy: mergedIsPhilanthropy || mergedEventType === "philanthropy",
+  };
+
+  let updateQuery = request.supabase
+    .from("events")
+    .update(updatePayload)
+    .eq("id", request.targetId)
+    .eq("organization_id", request.orgId)
+    .is("deleted_at", null);
+
+  if (request.expectedUpdatedAt != null) {
+    updateQuery = updateQuery.eq("updated_at", request.expectedUpdatedAt);
+  }
+
+  const { data: updated, error: updateError } = await updateQuery
+    .select("*")
+    .maybeSingle();
+
+  if (updateError) {
+    return { ok: false, status: 500, error: "update_failed" };
+  }
+  if (!updated) {
+    return { ok: false, status: 409, error: "stale_version" };
+  }
+
+  return { ok: true, value: updated };
+}
+
+function decomposeIsoToDateTime(
+  iso: string
+): { date: string; time: string } | null {
+  // Accepts "2026-04-22T09:00:00.000Z" (UTC wall-clock) — matches how
+  // `createEvent` composes it. We parse the leading date + HH:MM chunks
+  // directly rather than routing through `new Date(…)` to avoid local-
+  // timezone drift on the HH:MM extraction.
+  const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2})/.exec(iso);
+  if (!match) {
+    return null;
+  }
+  return { date: match[1], time: `${match[2]}:${match[3]}` };
+}
+
+function issuesToDetails(issues: ZodIssue[]): Record<string, unknown> {
+  return Object.fromEntries(
+    issues.map((issue) => [issue.path.join(".") || "body", issue.message])
+  );
+}

--- a/src/lib/schemas/content.ts
+++ b/src/lib/schemas/content.ts
@@ -83,6 +83,18 @@ export const editAnnouncementSchema = z.object({
 });
 export type EditAnnouncementForm = z.infer<typeof editAnnouncementSchema>;
 
+// Agent-path patch schema. Every field is optional (patch semantics); callers
+// must supply at least one. send_notification is excluded — notifications are
+// fired once at create time; edits do not re-blast.
+export const assistantAnnouncementPatchSchema = z.object({
+  title: safeString(200).optional(),
+  body: optionalSafeString(5000),
+  is_pinned: z.boolean().optional(),
+  audience: announcementAudienceSchema.optional(),
+  audience_user_ids: z.array(z.string().uuid()).optional(),
+});
+export type AssistantAnnouncementPatch = z.infer<typeof assistantAnnouncementPatchSchema>;
+
 // ─── Recurrence schemas ───────────────────────────────────────────────
 
 export const recurrenceOccurrenceSchema = z.enum(["daily", "weekly", "monthly"]);

--- a/src/lib/schemas/events-ai.ts
+++ b/src/lib/schemas/events-ai.ts
@@ -62,3 +62,51 @@ export const assistantPreparedEventSchema = z
   );
 
 export type AssistantPreparedEvent = z.infer<typeof assistantPreparedEventSchema>;
+
+/**
+ * Patch schema for AI-agent-initiated edits to an existing event.
+ *
+ * Every field is optional; a patch can touch any subset. Fields deliberately
+ * excluded:
+ *  - `audience` / `channel` / `send_notification` — events don't re-notify
+ *    attendees on edit (unlike announcement create). The UI's edit-event
+ *    form omits these too.
+ *  - recurrence fields — editing recurring events is Tier 4 (out of scope).
+ *    The `updateEvent` primitive blocks any patch whose target row is part
+ *    of a recurrence series; the patch schema itself simply refuses to
+ *    accept recurrence-related keys.
+ *
+ * Cross-field invariants (e.g., end_date/end_time > start_date/start_time)
+ * are re-validated by `updateEvent` against the merged row, not here.
+ */
+export const assistantEventPatchSchema = z
+  .object({
+    title: safeString(200).optional(),
+    description: optionalSafeString(5000),
+    start_date: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional(),
+    start_time: z
+      .string()
+      .regex(/^\d{2}:\d{2}$/)
+      .optional(),
+    end_date: z
+      .string()
+      .refine((val) => val === "" || /^\d{4}-\d{2}-\d{2}$/.test(val), {
+        message: "Must be a valid date (YYYY-MM-DD)",
+      })
+      .optional(),
+    end_time: z
+      .string()
+      .refine((val) => val === "" || /^\d{2}:\d{2}$/.test(val), {
+        message: "Must be a valid time (HH:MM)",
+      })
+      .optional(),
+    location: optionalSafeString(500),
+    event_type: eventTypeSchema.optional(),
+    is_philanthropy: z.boolean().optional(),
+  })
+  .strict();
+
+export type AssistantEventPatch = z.infer<typeof assistantEventPatchSchema>;

--- a/supabase/migrations/20261101000000_ai_draft_sessions_drop_draft_type_check.sql
+++ b/supabase/migrations/20261101000000_ai_draft_sessions_drop_draft_type_check.sql
@@ -1,0 +1,17 @@
+-- Drop the stale ai_draft_sessions.draft_type CHECK constraint.
+--
+-- The CHECK has been amended five-plus times as the agent's tool surface has
+-- grown (create_announcement, send_chat_message, create_event, reply/chat
+-- variants, etc.). Tier 1 edit/delete parity adds more draft_type values and
+-- further tiers will add more; each amendment is another DDL change with
+-- production lock exposure on a hot-path table.
+--
+-- Validation moves to the TypeScript layer. Phase 1a lands a Zod enum gate
+-- inside saveDraftSession keyed on DRAFT_SESSION_TYPES. Until Phase 1a ships,
+-- DraftSessionType in src/lib/ai/draft-sessions.ts is the de-facto gate —
+-- every caller is type-checked against the union.
+--
+-- Plan: ~/.claude/plans/i-want-you-to-quirky-sprout.md (Phase 0a; addendum A6).
+
+ALTER TABLE public.ai_draft_sessions
+  DROP CONSTRAINT IF EXISTS ai_draft_sessions_draft_type_check;

--- a/supabase/migrations/20261101000001_ai_pending_actions_tier1_mutation_columns_and_indexes.sql
+++ b/supabase/migrations/20261101000001_ai_pending_actions_tier1_mutation_columns_and_indexes.sql
@@ -1,0 +1,56 @@
+-- Phase 0b of the Tier 1 edit/delete parity plan. Extends ai_pending_actions
+-- to support the new prepare_edit_* / prepare_delete_* tool families without
+-- further schema churn once the application code lands.
+--
+-- Columns:
+--   target_entity_{type,id}  Populated at prepare time for edit/delete ops so
+--                            resolveAgentActionTarget can index-lookup "most
+--                            recent X I touched" without decoding payload jsonb.
+--   payload_before           Pre-mutation row snapshot for destructive ops —
+--                            forensic trail required by security review A2.5.
+--   resolved_target          What the resolver returned at prepare time, distinct
+--                            from raw tool args. Lets audits separate model intent
+--                            from resolver expansion.
+--   attempt_count            Number of times this row has been claimed confirmed.
+--                            Surfaces retry behaviour to operators / UI.
+--   last_attempt_error       Error classification from the most recent failed
+--                            attempt. Cleared on executed.
+--   replay_result            Stored response shape so idempotent re-confirms
+--                            return identical data, not just { ok: true }.
+--
+-- Indexes:
+--   idx_ai_pending_actions_user_entity_executed
+--     Partial composite serving the resolver's "most-recent-entity" fallback.
+--     INCLUDE (result_entity_id) enables index-only scan.
+--     Columns: (user_id, organization_id, result_entity_type, executed_at DESC, id)
+--     id is the deterministic tiebreaker when two actions execute in the same ms.
+--   idx_ai_pending_actions_one_pending_per_target
+--     Unique partial — prevents concurrent pending mutations on the same entity
+--     (two edits, or edit+delete, racing against each other).
+--
+-- Data safety: all additions are nullable or non-volatile defaults. PG 11+
+-- handles ADD COLUMN ... NOT NULL DEFAULT as metadata-only, no table rewrite.
+-- Indexes use plain CREATE INDEX per repo convention (see
+-- 20260812000003_perf_hotpath_indexes_and_initplan.sql) — Supabase migrations
+-- run in a transaction, CONCURRENTLY would fail. ai_pending_actions is
+-- TTL-bounded and small, so the brief write lock is acceptable.
+--
+-- Plan: ~/.claude/plans/i-want-you-to-quirky-sprout.md (Phase 0b; addendum A6).
+
+ALTER TABLE public.ai_pending_actions
+  ADD COLUMN IF NOT EXISTS target_entity_type text,
+  ADD COLUMN IF NOT EXISTS target_entity_id uuid,
+  ADD COLUMN IF NOT EXISTS payload_before jsonb,
+  ADD COLUMN IF NOT EXISTS resolved_target jsonb,
+  ADD COLUMN IF NOT EXISTS attempt_count int NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_attempt_error text,
+  ADD COLUMN IF NOT EXISTS replay_result jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_ai_pending_actions_user_entity_executed
+  ON public.ai_pending_actions (user_id, organization_id, result_entity_type, executed_at DESC, id)
+  INCLUDE (result_entity_id)
+  WHERE status = 'executed' AND result_entity_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_pending_actions_one_pending_per_target
+  ON public.ai_pending_actions (organization_id, target_entity_type, target_entity_id)
+  WHERE status = 'pending' AND target_entity_id IS NOT NULL;

--- a/supabase/migrations/20261101000005_ai_draft_sessions_widen_unique_key.sql
+++ b/supabase/migrations/20261101000005_ai_draft_sessions_widen_unique_key.sql
@@ -1,0 +1,19 @@
+-- Widen the ai_draft_sessions unique key from (thread_id) to
+-- (thread_id, draft_type) so a single AI chat thread can hold concurrent
+-- drafts of different types — e.g. a `create_announcement` draft and a
+-- future `edit_announcement` draft at the same time. This is the last
+-- scaffolding piece required before Phase 2+ can register edit/delete
+-- `prepare_*` tool families whose drafts coexist with create drafts on
+-- the same thread.
+--
+-- Repo convention is plain DROP/CREATE rather than CREATE INDEX
+-- CONCURRENTLY because Supabase runs migrations inside a transaction
+-- (see the note in 20260812000001_drop_unused_indexes.sql). No data
+-- cleanup is needed: strictly relaxing uniqueness cannot violate the
+-- new wider constraint, since every existing row already satisfies the
+-- narrower `(thread_id)` rule.
+
+DROP INDEX IF EXISTS idx_ai_draft_sessions_thread;
+
+CREATE UNIQUE INDEX idx_ai_draft_sessions_thread_type
+  ON public.ai_draft_sessions (thread_id, draft_type);

--- a/tests/ai-draft-sessions-concurrent-types.test.ts
+++ b/tests/ai-draft-sessions-concurrent-types.test.ts
@@ -1,0 +1,265 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  clearDraftSession,
+  getDraftSession,
+  saveDraftSession,
+  type DraftSessionRecord,
+  type DraftSessionType,
+} from "@/lib/ai/draft-sessions";
+
+// ─── Stub shape ────────────────────────────────────────────────────────
+//
+// The wrapper in src/lib/ai/draft-sessions.ts calls:
+//   supabase.from("ai_draft_sessions")
+//     .select("*").eq(...).eq(...).eq(...)[.eq("draft_type", ...)]
+//     .order("updated_at", { ascending: false }).limit(1).maybeSingle()
+//   .insert(payload).select("*").single()
+//   .update(payload).eq("id", ...).select("*")
+//   .delete().eq(...).eq(...).eq(...)[.eq("draft_type", ...)][.eq("pending_action_id", ...)]
+//
+// This stub implements that shape with an in-memory rows array so we can
+// exercise the widened unique-key semantics end-to-end.
+
+type DraftRow = DraftSessionRecord;
+
+interface StubState {
+  rows: DraftRow[];
+  nextId: number;
+}
+
+function buildStub(state: StubState) {
+  const matchesEqFilters = (row: DraftRow, filters: Array<{ col: string; val: unknown }>) =>
+    filters.every(({ col, val }) => (row as any)[col] === val);
+
+  return {
+    from(table: string) {
+      if (table !== "ai_draft_sessions") {
+        throw new Error(`unexpected table ${table}`);
+      }
+      return {
+        select(_cols: string) {
+          void _cols;
+          const filters: Array<{ col: string; val: unknown }> = [];
+          let ordered = false;
+          let limitCount = Number.POSITIVE_INFINITY;
+
+          const chain: any = {
+            eq(col: string, val: unknown) {
+              filters.push({ col, val });
+              return chain;
+            },
+            order(_col: string, _opts: { ascending: boolean }) {
+              void _col;
+              void _opts;
+              ordered = true;
+              return chain;
+            },
+            limit(count: number) {
+              limitCount = count;
+              return chain;
+            },
+            maybeSingle() {
+              const matching = state.rows.filter((r) => matchesEqFilters(r, filters));
+              if (ordered) {
+                matching.sort(
+                  (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+                );
+              }
+              const capped = matching.slice(0, limitCount);
+              if (capped.length === 0) {
+                return Promise.resolve({ data: null, error: null });
+              }
+              if (capped.length > 1) {
+                // Mirrors Supabase's .maybeSingle() contract: errors when >1 row.
+                return Promise.resolve({
+                  data: null,
+                  error: { message: "multiple rows returned" },
+                });
+              }
+              return Promise.resolve({ data: capped[0], error: null });
+            },
+          };
+          return chain;
+        },
+        insert(payload: Record<string, unknown>) {
+          const row: DraftRow = {
+            id: `row-${state.nextId++}`,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            ...(payload as any),
+          } as DraftRow;
+          state.rows.push(row);
+          return {
+            select(_c: string) {
+              void _c;
+              return {
+                single: () => Promise.resolve({ data: row, error: null }),
+              };
+            },
+          };
+        },
+        update(payload: Record<string, unknown>) {
+          const filters: Array<{ col: string; val: unknown }> = [];
+          const chain: any = {
+            eq(col: string, val: unknown) {
+              filters.push({ col, val });
+              return chain;
+            },
+            select(_c: string) {
+              void _c;
+              const matches = state.rows.filter((r) => matchesEqFilters(r, filters));
+              for (const row of matches) {
+                Object.assign(row, payload, { updated_at: new Date().toISOString() });
+              }
+              return Promise.resolve({ data: matches, error: null });
+            },
+          };
+          return chain;
+        },
+        delete() {
+          const filters: Array<{ col: string; val: unknown }> = [];
+          const chain: any = {
+            eq(col: string, val: unknown) {
+              filters.push({ col, val });
+              // Delete only runs on await — but `.eq()` is chained; Supabase's
+              // delete chain resolves the promise on the last `.eq()`. The
+              // wrapper awaits the chain directly, which triggers the `then`
+              // at whatever the last call is. We implement by making the
+              // chain itself thenable after enough eq() calls.
+              return chain;
+            },
+            then(resolve: (v: { error: unknown }) => void) {
+              state.rows = state.rows.filter((r) => !matchesEqFilters(r, filters));
+              resolve({ error: null });
+              return Promise.resolve({ error: null });
+            },
+          };
+          return chain;
+        },
+      };
+    },
+  };
+}
+
+function freshState(): StubState {
+  return { rows: [], nextId: 1 };
+}
+
+const orgId = "org-1";
+const userId = "user-1";
+const threadId = "thread-1";
+
+const saveBaseInput = (draftType: DraftSessionType, extras: Record<string, unknown> = {}) => ({
+  organizationId: orgId,
+  userId,
+  threadId,
+  draftType,
+  status: "collecting_fields" as const,
+  draftPayload: { marker: `draft-${draftType}` } as any,
+  missingFields: [],
+  pendingActionId: null,
+  ...extras,
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe("ai_draft_sessions — concurrent draft types on one thread", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("saveDraftSession inserts two separate rows when (thread, draft_type) differs", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    await saveDraftSession(stub as any, saveBaseInput("create_event"));
+
+    assert.equal(state.rows.length, 2, "two distinct draft types should round-trip as two rows");
+    const types = state.rows.map((r) => r.draft_type).sort();
+    assert.deepEqual(types, ["create_announcement", "create_event"]);
+  });
+
+  it("saveDraftSession updates in place when the same (thread, draft_type) is saved twice", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    await saveDraftSession(
+      stub as any,
+      saveBaseInput("create_announcement", { draftPayload: { marker: "v2" } })
+    );
+
+    assert.equal(state.rows.length, 1, "same type should update, not insert");
+    assert.deepEqual(state.rows[0].draft_payload, { marker: "v2" });
+  });
+
+  it("getDraftSession with draftType narrows to the matching row", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    await saveDraftSession(stub as any, saveBaseInput("create_event"));
+
+    const ann = await getDraftSession(stub as any, {
+      organizationId: orgId,
+      userId,
+      threadId,
+      draftType: "create_announcement",
+    });
+    assert.ok(ann, "announcement draft must exist");
+    assert.equal(ann!.draft_type, "create_announcement");
+
+    const evt = await getDraftSession(stub as any, {
+      organizationId: orgId,
+      userId,
+      threadId,
+      draftType: "create_event",
+    });
+    assert.ok(evt, "event draft must exist");
+    assert.equal(evt!.draft_type, "create_event");
+  });
+
+  it("getDraftSession without draftType returns the most-recently-updated row (legacy back-compat)", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    // Advance clock by forcing a distinct updated_at on the second save.
+    await new Promise((r) => setTimeout(r, 5));
+    await saveDraftSession(stub as any, saveBaseInput("create_event"));
+
+    const any = await getDraftSession(stub as any, {
+      organizationId: orgId,
+      userId,
+      threadId,
+    });
+    assert.ok(any, "should return the most-recent draft regardless of type");
+    assert.equal(any!.draft_type, "create_event", "create_event was saved second → most recent");
+  });
+
+  it("clearDraftSession with draftType removes only the matching row", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    await saveDraftSession(stub as any, saveBaseInput("create_event"));
+
+    await clearDraftSession(stub as any, {
+      organizationId: orgId,
+      userId,
+      threadId,
+      draftType: "create_announcement",
+    });
+
+    assert.equal(state.rows.length, 1, "event draft must remain");
+    assert.equal(state.rows[0].draft_type, "create_event");
+  });
+
+  it("clearDraftSession without draftType removes every draft type for that thread", async () => {
+    const stub = buildStub(state);
+    await saveDraftSession(stub as any, saveBaseInput("create_announcement"));
+    await saveDraftSession(stub as any, saveBaseInput("create_event"));
+
+    await clearDraftSession(stub as any, {
+      organizationId: orgId,
+      userId,
+      threadId,
+    });
+
+    assert.equal(state.rows.length, 0, "blanket clear should wipe every type");
+  });
+});

--- a/tests/ai-draft-sessions-widen-unique-key-migration-contract.test.ts
+++ b/tests/ai-draft-sessions-widen-unique-key-migration-contract.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const migration = readFileSync(
+  new URL(
+    "../supabase/migrations/20261101000005_ai_draft_sessions_widen_unique_key.sql",
+    import.meta.url
+  ),
+  "utf8"
+);
+
+describe("ai_draft_sessions widen unique-key migration contract", () => {
+  it("drops the narrow (thread_id) unique index", () => {
+    assert.match(
+      migration,
+      /DROP\s+INDEX\s+IF\s+EXISTS\s+idx_ai_draft_sessions_thread\b/i
+    );
+  });
+
+  it("creates the new (thread_id, draft_type) unique index", () => {
+    assert.match(
+      migration,
+      /CREATE\s+UNIQUE\s+INDEX\s+idx_ai_draft_sessions_thread_type\b/i
+    );
+    assert.match(migration, /ON\s+public\.ai_draft_sessions\s*\(\s*thread_id\s*,\s*draft_type\s*\)/i);
+  });
+
+  it("drops before it creates — order matters for an index swap", () => {
+    const dropMatch = migration.match(/DROP\s+INDEX\s+IF\s+EXISTS\s+idx_ai_draft_sessions_thread\b/i);
+    const createMatch = migration.match(/CREATE\s+UNIQUE\s+INDEX\s+idx_ai_draft_sessions_thread_type\b/i);
+    assert.ok(dropMatch, "DROP must be present");
+    assert.ok(createMatch, "CREATE must be present");
+    assert.ok(
+      dropMatch!.index! < createMatch!.index!,
+      "DROP of the old index must appear before CREATE of the new one"
+    );
+  });
+
+  it("does not use CREATE INDEX CONCURRENTLY (Supabase migrations are transactional)", () => {
+    // Scoped to the actual DDL statement rather than any text in a SQL
+    // comment that happens to contain the word "CONCURRENTLY".
+    assert.doesNotMatch(migration, /CREATE\s+(UNIQUE\s+)?INDEX\s+CONCURRENTLY/i);
+  });
+});

--- a/tests/ai-draft-sessions-zod-gate.test.ts
+++ b/tests/ai-draft-sessions-zod-gate.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DRAFT_SESSION_TYPES,
+  saveDraftSession,
+  type DraftSessionType,
+} from "@/lib/ai/draft-sessions";
+
+describe("DRAFT_SESSION_TYPES const tuple", () => {
+  it("exports the 7 known draft types in a readonly tuple", () => {
+    assert.deepEqual(
+      [...DRAFT_SESSION_TYPES].sort(),
+      [
+        "create_announcement",
+        "create_discussion_reply",
+        "create_discussion_thread",
+        "create_event",
+        "create_job_posting",
+        "send_chat_message",
+        "send_group_chat_message",
+      ]
+    );
+  });
+});
+
+describe("saveDraftSession Zod gate on draft_type", () => {
+  const failIfCalled = {
+    from: () => {
+      throw new Error(
+        "supabase.from should not be called when draft_type validation fails"
+      );
+    },
+  } as unknown as Parameters<typeof saveDraftSession>[0];
+
+  const baseInput = {
+    organizationId: "00000000-0000-0000-0000-000000000001",
+    userId: "00000000-0000-0000-0000-000000000002",
+    threadId: "00000000-0000-0000-0000-000000000003",
+    status: "collecting_fields" as const,
+    draftPayload: {} as never,
+    missingFields: [],
+  };
+
+  it("rejects an invalid draft_type string before touching supabase", async () => {
+    await assert.rejects(
+      () =>
+        saveDraftSession(failIfCalled, {
+          ...baseInput,
+          draftType: "not_a_real_type" as unknown as DraftSessionType,
+        }),
+      /Invalid draft_type/
+    );
+  });
+
+  it("rejects empty-string draft_type (simulates bad JSON input)", async () => {
+    await assert.rejects(
+      () =>
+        saveDraftSession(failIfCalled, {
+          ...baseInput,
+          draftType: "" as unknown as DraftSessionType,
+        }),
+      /Invalid draft_type/
+    );
+  });
+
+  it("rejects an attempt to insert a legacy-but-removed value", async () => {
+    // If the CHECK constraint used to allow some value we no longer support,
+    // the Zod gate should still reject it.
+    await assert.rejects(
+      () =>
+        saveDraftSession(failIfCalled, {
+          ...baseInput,
+          draftType: "retired_legacy_type" as unknown as DraftSessionType,
+        }),
+      /Invalid draft_type/
+    );
+  });
+});

--- a/tests/ai-draft-sessions-zod-gate.test.ts
+++ b/tests/ai-draft-sessions-zod-gate.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/ai/draft-sessions";
 
 describe("DRAFT_SESSION_TYPES const tuple", () => {
-  it("exports the 7 known draft types in a readonly tuple", () => {
+  it("exports the known draft types in a readonly tuple", () => {
     assert.deepEqual(
       [...DRAFT_SESSION_TYPES].sort(),
       [
@@ -16,6 +16,7 @@ describe("DRAFT_SESSION_TYPES const tuple", () => {
         "create_discussion_thread",
         "create_event",
         "create_job_posting",
+        "edit_announcement",
         "send_chat_message",
         "send_group_chat_message",
       ]

--- a/tests/ai-pending-actions-tier1-migration-contract.test.ts
+++ b/tests/ai-pending-actions-tier1-migration-contract.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const migration = readFileSync(
+  new URL(
+    "../supabase/migrations/20261101000001_ai_pending_actions_tier1_mutation_columns_and_indexes.sql",
+    import.meta.url
+  ),
+  "utf8"
+);
+
+describe("ai_pending_actions Tier 1 migration — added columns", () => {
+  it("adds target_entity_type text", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS target_entity_type text/);
+  });
+
+  it("adds target_entity_id uuid", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS target_entity_id uuid/);
+  });
+
+  it("adds payload_before jsonb", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS payload_before jsonb/);
+  });
+
+  it("adds resolved_target jsonb", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS resolved_target jsonb/);
+  });
+
+  it("adds attempt_count int NOT NULL DEFAULT 0", () => {
+    assert.match(
+      migration,
+      /ADD COLUMN IF NOT EXISTS attempt_count\s+int\s+NOT NULL\s+DEFAULT\s+0/i
+    );
+  });
+
+  it("adds last_attempt_error text", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS last_attempt_error text/);
+  });
+
+  it("adds replay_result jsonb", () => {
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS replay_result jsonb/);
+  });
+});
+
+describe("ai_pending_actions Tier 1 migration — most-recent-entity index", () => {
+  it("creates the user_entity_executed partial composite index", () => {
+    assert.match(
+      migration,
+      /CREATE INDEX IF NOT EXISTS idx_ai_pending_actions_user_entity_executed/i
+    );
+  });
+
+  it("indexes (user_id, organization_id, result_entity_type, executed_at DESC, id)", () => {
+    assert.match(
+      migration,
+      /ON public\.ai_pending_actions\s*\(\s*user_id\s*,\s*organization_id\s*,\s*result_entity_type\s*,\s*executed_at\s+DESC\s*,\s*id\s*\)/i
+    );
+  });
+
+  it("uses INCLUDE (result_entity_id) for index-only scan", () => {
+    assert.match(migration, /INCLUDE\s*\(\s*result_entity_id\s*\)/i);
+  });
+
+  it("restricts to executed rows with a result_entity_id", () => {
+    assert.match(
+      migration,
+      /WHERE\s+status\s*=\s*'executed'\s+AND\s+result_entity_id\s+IS\s+NOT\s+NULL/i
+    );
+  });
+});
+
+describe("ai_pending_actions Tier 1 migration — one-pending-per-target unique index", () => {
+  it("creates idx_ai_pending_actions_one_pending_per_target as UNIQUE", () => {
+    assert.match(
+      migration,
+      /CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_pending_actions_one_pending_per_target/i
+    );
+  });
+
+  it("keys on (organization_id, target_entity_type, target_entity_id)", () => {
+    assert.match(
+      migration,
+      /\(\s*organization_id\s*,\s*target_entity_type\s*,\s*target_entity_id\s*\)/i
+    );
+  });
+
+  it("applies only to pending rows with a target_entity_id", () => {
+    assert.match(
+      migration,
+      /WHERE\s+status\s*=\s*'pending'\s+AND\s+target_entity_id\s+IS\s+NOT\s+NULL/i
+    );
+  });
+});
+
+describe("ai_pending_actions Tier 1 migration — repo conventions", () => {
+  it("follows the repo's plain CREATE INDEX convention (no CONCURRENTLY)", () => {
+    // Supabase wraps each migration in a transaction; CONCURRENTLY would fail.
+    // See 20260812000003_perf_hotpath_indexes_and_initplan.sql for the stated convention.
+    assert.doesNotMatch(migration, /CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY/i);
+  });
+});

--- a/tests/ai-target-resolver.test.ts
+++ b/tests/ai-target-resolver.test.ts
@@ -1,0 +1,299 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  AI_RECENT_ENTITY_LOOKBACK_EDIT_MS,
+  AI_RECENT_ENTITY_LOOKBACK_DELETE_MS,
+  resolveAgentActionTarget,
+  type ResolverSupabaseClient,
+} from "@/lib/ai/tools/target-resolver";
+
+type RecordedCall =
+  | { op: "from"; table: string }
+  | { op: "select"; columns: string }
+  | { op: "eq"; column: string; value: unknown }
+  | { op: "gte"; column: string; value: unknown }
+  | { op: "order"; column: string; options: { ascending: boolean } }
+  | { op: "limit"; n: number };
+
+function stubSupabase(
+  rows: Array<{ result_entity_id: string }>,
+  calls: RecordedCall[] = []
+): { client: ResolverSupabaseClient; calls: RecordedCall[] } {
+  const chain: {
+    eq: (column: string, value: unknown) => typeof chain;
+    gte: (column: string, value: unknown) => typeof chain;
+    order: (column: string, options: { ascending: boolean }) => typeof chain;
+    limit: (n: number) => typeof chain;
+    then: <R>(
+      onFulfilled: (v: { data: typeof rows; error: null }) => R
+    ) => Promise<R>;
+  } = {
+    eq(column, value) {
+      calls.push({ op: "eq", column, value });
+      return chain;
+    },
+    gte(column, value) {
+      calls.push({ op: "gte", column, value });
+      return chain;
+    },
+    order(column, options) {
+      calls.push({ op: "order", column, options });
+      return chain;
+    },
+    limit(n) {
+      calls.push({ op: "limit", n });
+      return chain;
+    },
+    then(onFulfilled) {
+      return Promise.resolve(onFulfilled({ data: rows, error: null }));
+    },
+  };
+
+  const client = {
+    from(table: string) {
+      calls.push({ op: "from", table });
+      return {
+        select(columns: string) {
+          calls.push({ op: "select", columns });
+          return chain;
+        },
+      };
+    },
+  } as unknown as ResolverSupabaseClient;
+
+  return { client, calls };
+}
+
+describe("resolveAgentActionTarget — explicit target_id short-circuit", () => {
+  it("returns resolved immediately without touching supabase", async () => {
+    const { client, calls } = stubSupabase([]);
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "announcement",
+      op: "edit",
+      targetId: "00000000-0000-0000-0000-0000000000aa",
+      fallback: "most_recent",
+    });
+
+    assert.equal(result.kind, "resolved");
+    if (result.kind === "resolved") {
+      assert.equal(result.targetId, "00000000-0000-0000-0000-0000000000aa");
+      assert.equal(result.entityType, "announcement");
+    }
+    assert.equal(calls.length, 0);
+  });
+
+  it("short-circuits even for delete ops (explicit id always wins)", async () => {
+    const { client, calls } = stubSupabase([]);
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "event",
+      op: "cancel",
+      targetId: "00000000-0000-0000-0000-0000000000bb",
+      fallback: "most_recent",
+    });
+    assert.equal(result.kind, "resolved");
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("resolveAgentActionTarget — most-recent fallback for edit", () => {
+  it("queries ai_pending_actions with scoping, window, and tiebreaker", async () => {
+    const { client, calls } = stubSupabase([
+      { result_entity_id: "00000000-0000-0000-0000-0000000000c1" },
+    ]);
+    const before = Date.now();
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "announcement",
+      op: "edit",
+      fallback: "most_recent",
+    });
+    const after = Date.now();
+
+    assert.equal(result.kind, "resolved");
+    if (result.kind === "resolved") {
+      assert.equal(result.targetId, "00000000-0000-0000-0000-0000000000c1");
+    }
+
+    assert.deepEqual(calls[0], { op: "from", table: "ai_pending_actions" });
+    assert.deepEqual(calls[1], { op: "select", columns: "result_entity_id" });
+
+    const eqCalls = calls.filter((c) => c.op === "eq");
+    assert.deepEqual(
+      eqCalls.map((c) => (c.op === "eq" ? [c.column, c.value] : [])),
+      [
+        ["user_id", "u1"],
+        ["organization_id", "o1"],
+        ["result_entity_type", "announcement"],
+        ["status", "executed"],
+      ]
+    );
+
+    const gte = calls.find((c) => c.op === "gte");
+    assert.ok(gte && gte.op === "gte", "gte cutoff call must exist");
+    if (gte.op === "gte") {
+      assert.equal(gte.column, "executed_at");
+      const cutoffMs = Date.parse(gte.value as string);
+      const expectedLow = before - AI_RECENT_ENTITY_LOOKBACK_EDIT_MS;
+      const expectedHigh = after - AI_RECENT_ENTITY_LOOKBACK_EDIT_MS;
+      assert.ok(
+        cutoffMs >= expectedLow && cutoffMs <= expectedHigh,
+        `cutoff ${new Date(cutoffMs).toISOString()} outside window [${new Date(expectedLow).toISOString()}, ${new Date(expectedHigh).toISOString()}]`
+      );
+    }
+
+    const orderCalls = calls.filter((c) => c.op === "order");
+    assert.equal(orderCalls.length, 2, "must sort by executed_at DESC then id DESC");
+    if (orderCalls[0].op === "order") {
+      assert.equal(orderCalls[0].column, "executed_at");
+      assert.equal(orderCalls[0].options.ascending, false);
+    }
+    if (orderCalls[1].op === "order") {
+      assert.equal(orderCalls[1].column, "id");
+      assert.equal(orderCalls[1].options.ascending, false);
+    }
+
+    const limit = calls.find((c) => c.op === "limit");
+    if (limit && limit.op === "limit") {
+      assert.equal(limit.n, 1);
+    }
+  });
+
+  it("returns not_found when no recent executed row exists", async () => {
+    const { client } = stubSupabase([]);
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "announcement",
+      op: "edit",
+      fallback: "most_recent",
+    });
+    assert.equal(result.kind, "not_found");
+  });
+});
+
+describe("resolveAgentActionTarget — most-recent fallback disabled for destructive ops", () => {
+  for (const op of ["delete", "cancel"] as const) {
+    it(`refuses most-recent fallback for ${op} ops`, async () => {
+      const { client, calls } = stubSupabase([
+        { result_entity_id: "00000000-0000-0000-0000-0000000000d1" },
+      ]);
+      const result = await resolveAgentActionTarget({
+        supabase: client,
+        caller: { userId: "u1", organizationId: "o1" },
+        entityType: "announcement",
+        op,
+        fallback: "most_recent",
+      });
+      assert.equal(result.kind, "needs_target_id");
+      assert.equal(
+        calls.length,
+        0,
+        `resolver must not query supabase for ${op} without explicit target_id`
+      );
+    });
+  }
+});
+
+describe("resolveAgentActionTarget — fallback: 'none'", () => {
+  it("returns needs_target_id without querying supabase", async () => {
+    const { client, calls } = stubSupabase([
+      { result_entity_id: "00000000-0000-0000-0000-0000000000e1" },
+    ]);
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "job",
+      op: "edit",
+      fallback: "none",
+    });
+    assert.equal(result.kind, "needs_target_id");
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("resolveAgentActionTarget — windowMs override", () => {
+  it("respects a caller-supplied windowMs that narrows the window", async () => {
+    const { client, calls } = stubSupabase([
+      { result_entity_id: "00000000-0000-0000-0000-0000000000f1" },
+    ]);
+    const customWindow = 60_000;
+    const before = Date.now();
+    await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "announcement",
+      op: "edit",
+      fallback: "most_recent",
+      windowMs: customWindow,
+    });
+    const after = Date.now();
+
+    const gte = calls.find((c) => c.op === "gte");
+    assert.ok(gte && gte.op === "gte");
+    if (gte.op === "gte") {
+      const cutoffMs = Date.parse(gte.value as string);
+      assert.ok(
+        cutoffMs >= before - customWindow && cutoffMs <= after - customWindow,
+        "cutoff must honor windowMs override"
+      );
+    }
+  });
+
+  it("windowMs=0 disables the fallback even for edit ops", async () => {
+    const { client, calls } = stubSupabase([
+      { result_entity_id: "00000000-0000-0000-0000-0000000000f2" },
+    ]);
+    const result = await resolveAgentActionTarget({
+      supabase: client,
+      caller: { userId: "u1", organizationId: "o1" },
+      entityType: "announcement",
+      op: "edit",
+      fallback: "most_recent",
+      windowMs: 0,
+    });
+    assert.equal(result.kind, "needs_target_id");
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("Window constants", () => {
+  it("edit lookback window is 15 minutes", () => {
+    assert.equal(AI_RECENT_ENTITY_LOOKBACK_EDIT_MS, 15 * 60 * 1000);
+  });
+  it("delete lookback window is 0 (fallback disabled)", () => {
+    assert.equal(AI_RECENT_ENTITY_LOOKBACK_DELETE_MS, 0);
+  });
+});
+
+describe("DomainResult discriminated union", () => {
+  it("accepts the ok variant with a typed value", async () => {
+    const { DomainResult: _type } = await import("@/lib/ai/shared/domain-result");
+    // Runtime check mirrors the type contract
+    const ok: import("@/lib/ai/shared/domain-result").DomainResult<number> = {
+      ok: true,
+      value: 42,
+    };
+    assert.equal(ok.ok, true);
+    if (ok.ok) assert.equal(ok.value, 42);
+    void _type;
+  });
+
+  it("accepts the error variant with a finite status", () => {
+    const err: import("@/lib/ai/shared/domain-result").DomainResult<number> = {
+      ok: false,
+      status: 422,
+      error: "invariant_violation",
+      details: { field: "title" },
+    };
+    assert.equal(err.ok, false);
+    if (!err.ok) {
+      assert.equal(err.status, 422);
+      assert.equal(err.error, "invariant_violation");
+    }
+  });
+});

--- a/tests/announcements-delete-dispatcher.test.ts
+++ b/tests/announcements-delete-dispatcher.test.ts
@@ -1,0 +1,378 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { handleDeleteAnnouncement } from "@/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements";
+import type { PendingActionRecord } from "@/lib/ai/pending-actions";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────
+
+const ORG_ID = "00000000-0000-4000-8000-000000000001";
+const USER_ID = "00000000-0000-4000-8000-000000000002";
+const THREAD_ID = "00000000-0000-4000-8000-000000000003";
+const ACTION_ID = "00000000-0000-4000-8000-000000000004";
+const TARGET_ID = "00000000-0000-4000-8000-000000000005";
+const EXPECTED_UPDATED_AT = "2026-04-22T09:00:00.000Z";
+
+function buildAction(
+  overrides: Partial<PendingActionRecord<"delete_announcement">> = {}
+): PendingActionRecord<"delete_announcement"> {
+  return {
+    id: ACTION_ID,
+    organization_id: ORG_ID,
+    user_id: USER_ID,
+    thread_id: THREAD_ID,
+    action_type: "delete_announcement",
+    payload: {
+      targetId: TARGET_ID,
+      expectedUpdatedAt: EXPECTED_UPDATED_AT,
+      targetTitle: "Week 5 Practice",
+      orgSlug: "org",
+    },
+    status: "pending",
+    expires_at: "2099-01-01T00:00:00.000Z",
+    created_at: "2026-04-22T08:00:00.000Z",
+    updated_at: "2026-04-22T08:00:00.000Z",
+    executed_at: null,
+    result_entity_type: null,
+    result_entity_id: null,
+    ...overrides,
+  } as PendingActionRecord<"delete_announcement">;
+}
+
+function buildCtx(options: {
+  serviceSupabase?: any;
+  canUseDraftSessions?: boolean;
+} = {}) {
+  const insertedMessages: any[] = [];
+  const statusUpdates: any[] = [];
+  const draftClears: any[] = [];
+
+  const defaultServiceSupabase = {
+    from(table: string) {
+      if (table === "ai_messages") {
+        return {
+          insert(payload: Record<string, unknown>) {
+            insertedMessages.push(payload);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+
+  return {
+    ctx: {
+      serviceSupabase: options.serviceSupabase ?? defaultServiceSupabase,
+      orgId: ORG_ID,
+      userId: USER_ID,
+      logContext: { requestId: "test-req", orgId: ORG_ID },
+      canUseDraftSessions: options.canUseDraftSessions ?? true,
+      updatePendingActionStatusFn: (async (_supabase: any, _id: any, payload: any) => {
+        statusUpdates.push(payload);
+        return { updated: true };
+      }) as any,
+      clearDraftSessionFn: (async (_supabase: any, input: any) => {
+        draftClears.push(input);
+      }) as any,
+    },
+    insertedMessages,
+    statusUpdates,
+    draftClears,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe("handleDeleteAnnouncement — success path", () => {
+  let harness: ReturnType<typeof buildCtx>;
+  beforeEach(() => {
+    harness = buildCtx();
+  });
+
+  it("calls the primitive with targetId + expectedUpdatedAt and returns 200", async () => {
+    let captured: any = null;
+    const softDeleteAnnouncementFn = (async (req: any) => {
+      captured = req;
+      return {
+        ok: true,
+        value: {
+          id: TARGET_ID,
+          title: "Week 5 Practice",
+          body: "body",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:05:00.000Z",
+          deleted_at: "2026-04-22T09:05:00.000Z",
+        },
+      };
+    }) as any;
+
+    const response = await handleDeleteAnnouncement(
+      harness.ctx,
+      buildAction(),
+      { softDeleteAnnouncementFn }
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.announcement.id, TARGET_ID);
+    assert.ok(body.announcement.deleted_at, "response should carry deleted_at");
+    assert.equal(body.actionId, ACTION_ID);
+
+    assert.ok(captured);
+    assert.equal(captured.orgId, ORG_ID);
+    assert.equal(captured.userId, USER_ID);
+    assert.equal(captured.targetId, TARGET_ID);
+    assert.equal(captured.expectedUpdatedAt, EXPECTED_UPDATED_AT);
+  });
+
+  it("writes the executed CAS with resultEntityType=announcement after the primitive succeeds", async () => {
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "x",
+        updated_at: "2026-04-22T09:05:00.000Z",
+        deleted_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleDeleteAnnouncement(harness.ctx, buildAction(), {
+      softDeleteAnnouncementFn,
+    });
+
+    assert.equal(harness.statusUpdates.length, 1);
+    assert.equal(harness.statusUpdates[0].status, "executed");
+    assert.equal(harness.statusUpdates[0].expectedStatus, "confirmed");
+    assert.equal(harness.statusUpdates[0].resultEntityType, "announcement");
+    assert.equal(harness.statusUpdates[0].resultEntityId, TARGET_ID);
+  });
+
+  it("does NOT clear any draft session (delete_announcement is not a DraftSessionType)", async () => {
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "x",
+        updated_at: "2026-04-22T09:05:00.000Z",
+        deleted_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleDeleteAnnouncement(harness.ctx, buildAction(), {
+      softDeleteAnnouncementFn,
+    });
+
+    assert.equal(
+      harness.draftClears.length,
+      0,
+      "delete flow skips the draft-session collection phase entirely"
+    );
+  });
+
+  it("inserts an ai_messages confirmation using the captured targetTitle and org-scoped URL", async () => {
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "Different Stored Title",
+        updated_at: "2026-04-22T09:05:00.000Z",
+        deleted_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleDeleteAnnouncement(harness.ctx, buildAction(), {
+      softDeleteAnnouncementFn,
+    });
+
+    assert.equal(harness.insertedMessages.length, 1);
+    const msg = harness.insertedMessages[0];
+    assert.equal(msg.role, "assistant");
+    assert.equal(msg.thread_id, THREAD_ID);
+    assert.equal(msg.org_id, ORG_ID);
+    assert.equal(msg.status, "complete");
+    assert.match(
+      msg.content,
+      /Week 5 Practice/,
+      "content should prefer the payload's targetTitle captured at prepare time"
+    );
+    assert.match(msg.content, /Deleted announcement/);
+    assert.match(msg.content, /\/org\/announcements/);
+  });
+
+  it("falls back to result.value.title when targetTitle is absent", async () => {
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "Stored Row Title",
+        updated_at: "2026-04-22T09:05:00.000Z",
+        deleted_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleDeleteAnnouncement(
+      harness.ctx,
+      buildAction({
+        payload: {
+          targetId: TARGET_ID,
+          expectedUpdatedAt: EXPECTED_UPDATED_AT,
+          targetTitle: null,
+          orgSlug: "org",
+        },
+      }),
+      { softDeleteAnnouncementFn }
+    );
+
+    assert.match(harness.insertedMessages[0].content, /Stored Row Title/);
+  });
+
+  it("renders plain text (no markdown link) when orgSlug is missing", async () => {
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "x",
+        updated_at: "2026-04-22T09:05:00.000Z",
+        deleted_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleDeleteAnnouncement(
+      harness.ctx,
+      buildAction({
+        payload: {
+          targetId: TARGET_ID,
+          expectedUpdatedAt: EXPECTED_UPDATED_AT,
+          targetTitle: "Plain",
+          orgSlug: "",
+        },
+      }),
+      { softDeleteAnnouncementFn }
+    );
+
+    assert.doesNotMatch(harness.insertedMessages[0].content, /\[.*\]\(/);
+  });
+});
+
+describe("handleDeleteAnnouncement — typed-failure paths (no throw)", () => {
+  for (const [status, errorKey] of [
+    [403, "forbidden"],
+    [404, "not_found"],
+    [409, "stale_version"],
+    [500, "delete_failed"],
+  ] as const) {
+    it(`rolls back confirmed→pending and returns ${status} with error=${errorKey}`, async () => {
+      const harness = buildCtx();
+      const softDeleteAnnouncementFn = (async () => ({
+        ok: false,
+        status,
+        error: errorKey,
+      })) as any;
+
+      const response = await handleDeleteAnnouncement(
+        harness.ctx,
+        buildAction(),
+        { softDeleteAnnouncementFn }
+      );
+      const body = await response.json();
+
+      assert.equal(response.status, status);
+      assert.equal(body.error, errorKey);
+
+      assert.equal(harness.statusUpdates.length, 1);
+      assert.equal(harness.statusUpdates[0].status, "pending");
+      assert.equal(harness.statusUpdates[0].expectedStatus, "confirmed");
+
+      assert.equal(harness.insertedMessages.length, 0, "no confirmation message on failure");
+    });
+  }
+
+  it("forwards the details payload on 409 stale_version", async () => {
+    const harness = buildCtx();
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: false,
+      status: 409,
+      error: "stale_version",
+      details: {
+        expectedUpdatedAt: "A",
+        currentUpdatedAt: "B",
+      },
+    })) as any;
+
+    const response = await handleDeleteAnnouncement(
+      harness.ctx,
+      buildAction(),
+      { softDeleteAnnouncementFn }
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 409);
+    assert.deepEqual(body.details, {
+      expectedUpdatedAt: "A",
+      currentUpdatedAt: "B",
+    });
+  });
+});
+
+describe("handleDeleteAnnouncement — thrown-failure path (return-await regression)", () => {
+  it("lets the rejection propagate (does not swallow it) so handler.ts outer try/catch can roll back", async () => {
+    const harness = buildCtx();
+    const softDeleteAnnouncementFn = (async () => {
+      throw new Error("Supabase timeout");
+    }) as any;
+
+    await assert.rejects(
+      handleDeleteAnnouncement(harness.ctx, buildAction(), { softDeleteAnnouncementFn }),
+      { message: "Supabase timeout" }
+    );
+
+    assert.equal(harness.statusUpdates.length, 0);
+    assert.equal(harness.insertedMessages.length, 0);
+  });
+});
+
+describe("handleDeleteAnnouncement — ai_messages failure is logged, not fatal", () => {
+  it("returns 200 with the deleted announcement even when ai_messages.insert errors", async () => {
+    const insertedMessages: any[] = [];
+    const loggedErrors: unknown[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => loggedErrors.push(args);
+    try {
+      const serviceSupabase = {
+        from(table: string) {
+          if (table === "ai_messages") {
+            return {
+              insert(payload: Record<string, unknown>) {
+                insertedMessages.push(payload);
+                return Promise.resolve({ error: { message: "insert failed" } });
+              },
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        },
+      };
+      const harness = buildCtx({ serviceSupabase });
+      const softDeleteAnnouncementFn = (async () => ({
+        ok: true,
+        value: {
+          id: TARGET_ID,
+          title: "x",
+          updated_at: "2026-04-22T09:05:00.000Z",
+          deleted_at: "2026-04-22T09:05:00.000Z",
+        },
+      })) as any;
+
+      const response = await handleDeleteAnnouncement(
+        harness.ctx,
+        buildAction(),
+        { softDeleteAnnouncementFn }
+      );
+      assert.equal(response.status, 200);
+      assert.equal(insertedMessages.length, 1);
+    } finally {
+      console.error = originalError;
+    }
+  });
+});

--- a/tests/announcements-edit-dispatcher.test.ts
+++ b/tests/announcements-edit-dispatcher.test.ts
@@ -1,0 +1,361 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { handleEditAnnouncement } from "@/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements";
+import type { PendingActionRecord } from "@/lib/ai/pending-actions";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────
+
+const ORG_ID = "00000000-0000-4000-8000-000000000001";
+const USER_ID = "00000000-0000-4000-8000-000000000002";
+const THREAD_ID = "00000000-0000-4000-8000-000000000003";
+const ACTION_ID = "00000000-0000-4000-8000-000000000004";
+const TARGET_ID = "00000000-0000-4000-8000-000000000005";
+const EXPECTED_UPDATED_AT = "2026-04-22T09:00:00.000Z";
+
+function buildAction(
+  overrides: Partial<PendingActionRecord<"edit_announcement">> = {}
+): PendingActionRecord<"edit_announcement"> {
+  return {
+    id: ACTION_ID,
+    organization_id: ORG_ID,
+    user_id: USER_ID,
+    thread_id: THREAD_ID,
+    action_type: "edit_announcement",
+    payload: {
+      targetId: TARGET_ID,
+      patch: { title: "Fixed typo" },
+      expectedUpdatedAt: EXPECTED_UPDATED_AT,
+      targetTitle: "Original Title",
+      orgSlug: "org",
+    },
+    status: "pending",
+    expires_at: "2099-01-01T00:00:00.000Z",
+    created_at: "2026-04-22T08:00:00.000Z",
+    updated_at: "2026-04-22T08:00:00.000Z",
+    executed_at: null,
+    result_entity_type: null,
+    result_entity_id: null,
+    ...overrides,
+  } as PendingActionRecord<"edit_announcement">;
+}
+
+function buildCtx(options: {
+  serviceSupabase?: any;
+  canUseDraftSessions?: boolean;
+  onStatusUpdate?: (payload: any) => Promise<{ updated: boolean }>;
+  onDraftClear?: (input: any) => Promise<void>;
+} = {}) {
+  const insertedMessages: any[] = [];
+  const statusUpdates: any[] = [];
+  const draftClears: any[] = [];
+
+  const defaultServiceSupabase = {
+    from(table: string) {
+      if (table === "ai_messages") {
+        return {
+          insert(payload: Record<string, unknown>) {
+            insertedMessages.push(payload);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+
+  return {
+    ctx: {
+      serviceSupabase: options.serviceSupabase ?? defaultServiceSupabase,
+      orgId: ORG_ID,
+      userId: USER_ID,
+      logContext: { requestId: "test-req", orgId: ORG_ID },
+      canUseDraftSessions: options.canUseDraftSessions ?? true,
+      updatePendingActionStatusFn: (async (_supabase: any, _id: any, payload: any) => {
+        statusUpdates.push(payload);
+        if (options.onStatusUpdate) return options.onStatusUpdate(payload);
+        return { updated: true };
+      }) as any,
+      clearDraftSessionFn: (async (_supabase: any, input: any) => {
+        draftClears.push(input);
+        if (options.onDraftClear) return options.onDraftClear(input);
+      }) as any,
+    },
+    insertedMessages,
+    statusUpdates,
+    draftClears,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe("handleEditAnnouncement — success path", () => {
+  let harness: ReturnType<typeof buildCtx>;
+  beforeEach(() => {
+    harness = buildCtx();
+  });
+
+  it("calls the primitive with the full payload shape and returns 200 with the updated announcement", async () => {
+    let captured: any = null;
+    const updateAnnouncementFn = (async (req: any) => {
+      captured = req;
+      return {
+        ok: true,
+        value: {
+          id: TARGET_ID,
+          title: "Fixed typo",
+          body: "original body",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:05:00.000Z",
+        },
+      };
+    }) as any;
+
+    const response = await handleEditAnnouncement(
+      harness.ctx,
+      buildAction(),
+      { updateAnnouncementFn }
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.announcement.id, TARGET_ID);
+    assert.equal(body.actionId, ACTION_ID);
+
+    assert.ok(captured, "primitive must be called");
+    assert.equal(captured.orgId, ORG_ID);
+    assert.equal(captured.userId, USER_ID);
+    assert.equal(captured.targetId, TARGET_ID);
+    assert.equal(captured.expectedUpdatedAt, EXPECTED_UPDATED_AT);
+    assert.deepEqual(captured.patch, { title: "Fixed typo" });
+  });
+
+  it("writes the executed CAS transition with resultEntityType=announcement AFTER the primitive succeeds", async () => {
+    const updateAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "x",
+        updated_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleEditAnnouncement(harness.ctx, buildAction(), { updateAnnouncementFn });
+
+    assert.equal(harness.statusUpdates.length, 1, "exactly one status update on success");
+    assert.equal(harness.statusUpdates[0].status, "executed");
+    assert.equal(harness.statusUpdates[0].expectedStatus, "confirmed");
+    assert.equal(harness.statusUpdates[0].resultEntityType, "announcement");
+    assert.equal(harness.statusUpdates[0].resultEntityId, TARGET_ID);
+  });
+
+  it("clears the draft session narrowed by (thread_id, draft_type=edit_announcement, pending_action_id)", async () => {
+    const updateAnnouncementFn = (async () => ({
+      ok: true,
+      value: { id: TARGET_ID, title: "x", updated_at: "2026-04-22T09:05:00.000Z" },
+    })) as any;
+
+    await handleEditAnnouncement(harness.ctx, buildAction(), { updateAnnouncementFn });
+
+    assert.equal(harness.draftClears.length, 1);
+    assert.equal(harness.draftClears[0].organizationId, ORG_ID);
+    assert.equal(harness.draftClears[0].userId, USER_ID);
+    assert.equal(harness.draftClears[0].threadId, THREAD_ID);
+    assert.equal(harness.draftClears[0].pendingActionId, ACTION_ID);
+    assert.equal(harness.draftClears[0].draftType, "edit_announcement");
+  });
+
+  it("inserts an ai_messages confirmation row with the updated title", async () => {
+    const updateAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "New Updated Title",
+        updated_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleEditAnnouncement(harness.ctx, buildAction(), { updateAnnouncementFn });
+
+    assert.equal(harness.insertedMessages.length, 1);
+    assert.equal(harness.insertedMessages[0].role, "assistant");
+    assert.equal(harness.insertedMessages[0].thread_id, THREAD_ID);
+    assert.equal(harness.insertedMessages[0].org_id, ORG_ID);
+    assert.equal(harness.insertedMessages[0].status, "complete");
+    assert.match(
+      harness.insertedMessages[0].content,
+      /New Updated Title/,
+      "content should mention the updated title"
+    );
+    assert.match(
+      harness.insertedMessages[0].content,
+      /\/org\/announcements/,
+      "content should include the org-scoped announcements URL"
+    );
+  });
+
+  it("omits the ai_messages URL when orgSlug is empty", async () => {
+    const updateAnnouncementFn = (async () => ({
+      ok: true,
+      value: { id: TARGET_ID, title: "x", updated_at: "2026-04-22T09:05:00.000Z" },
+    })) as any;
+
+    await handleEditAnnouncement(
+      harness.ctx,
+      buildAction({
+        payload: {
+          targetId: TARGET_ID,
+          patch: { title: "x" },
+          expectedUpdatedAt: EXPECTED_UPDATED_AT,
+          targetTitle: "Original Title",
+          orgSlug: "",
+        },
+      }),
+      { updateAnnouncementFn }
+    );
+
+    assert.doesNotMatch(
+      harness.insertedMessages[0].content,
+      /\[.*\]\(/,
+      "content should be plain text (no markdown link) without orgSlug"
+    );
+  });
+
+  it("does not clear the draft session when canUseDraftSessions=false", async () => {
+    harness = buildCtx({ canUseDraftSessions: false });
+    const updateAnnouncementFn = (async () => ({
+      ok: true,
+      value: { id: TARGET_ID, title: "x", updated_at: "2026-04-22T09:05:00.000Z" },
+    })) as any;
+
+    await handleEditAnnouncement(harness.ctx, buildAction(), { updateAnnouncementFn });
+
+    assert.equal(harness.draftClears.length, 0);
+  });
+});
+
+describe("handleEditAnnouncement — typed-failure paths (no throw)", () => {
+  let harness: ReturnType<typeof buildCtx>;
+  beforeEach(() => {
+    harness = buildCtx();
+  });
+
+  for (const [status, errorKey, expectedStatus] of [
+    [403, "forbidden", 403],
+    [404, "not_found", 404],
+    [409, "stale_version", 409],
+    [422, "invariant_violation", 422],
+    [500, "update_failed", 500],
+  ] as const) {
+    it(`rolls back confirmed→pending and returns ${status} with error=${errorKey}`, async () => {
+      const updateAnnouncementFn = (async () => ({
+        ok: false,
+        status,
+        error: errorKey,
+      })) as any;
+
+      const response = await handleEditAnnouncement(
+        harness.ctx,
+        buildAction(),
+        { updateAnnouncementFn }
+      );
+      const body = await response.json();
+
+      assert.equal(response.status, expectedStatus);
+      assert.equal(body.error, errorKey);
+
+      // Single status update: the rollback to pending.
+      assert.equal(harness.statusUpdates.length, 1);
+      assert.equal(harness.statusUpdates[0].status, "pending");
+      assert.equal(harness.statusUpdates[0].expectedStatus, "confirmed");
+
+      // No message insert when the mutation failed.
+      assert.equal(harness.insertedMessages.length, 0);
+    });
+  }
+
+  it("forwards the details payload on 409 stale_version", async () => {
+    const updateAnnouncementFn = (async () => ({
+      ok: false,
+      status: 409,
+      error: "stale_version",
+      details: {
+        expectedUpdatedAt: "A",
+        currentUpdatedAt: "B",
+      },
+    })) as any;
+
+    const response = await handleEditAnnouncement(
+      harness.ctx,
+      buildAction(),
+      { updateAnnouncementFn }
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 409);
+    assert.deepEqual(body.details, {
+      expectedUpdatedAt: "A",
+      currentUpdatedAt: "B",
+    });
+  });
+});
+
+describe("handleEditAnnouncement — thrown-failure path (return-await regression)", () => {
+  it("lets the rejection propagate (does not swallow it) so handler.ts outer try/catch can roll back", async () => {
+    const harness = buildCtx();
+    const updateAnnouncementFn = (async () => {
+      throw new Error("Supabase timeout");
+    }) as any;
+
+    await assert.rejects(
+      handleEditAnnouncement(harness.ctx, buildAction(), { updateAnnouncementFn }),
+      { message: "Supabase timeout" }
+    );
+
+    // The dispatcher itself does NOT rollback on throw — that's the outer
+    // try/catch's job. So no CAS updates at this layer.
+    assert.equal(harness.statusUpdates.length, 0);
+    assert.equal(harness.insertedMessages.length, 0);
+    assert.equal(harness.draftClears.length, 0);
+  });
+});
+
+describe("handleEditAnnouncement — ai_messages failure is logged, not fatal", () => {
+  it("returns 200 with the updated announcement even when ai_messages.insert errors", async () => {
+    const insertedMessages: any[] = [];
+    const loggedErrors: unknown[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => loggedErrors.push(args);
+    try {
+      const serviceSupabase = {
+        from(table: string) {
+          if (table === "ai_messages") {
+            return {
+              insert(payload: Record<string, unknown>) {
+                insertedMessages.push(payload);
+                return Promise.resolve({ error: { message: "insert failed" } });
+              },
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        },
+      };
+      const harness = buildCtx({ serviceSupabase });
+      const updateAnnouncementFn = (async () => ({
+        ok: true,
+        value: { id: TARGET_ID, title: "x", updated_at: "2026-04-22T09:05:00.000Z" },
+      })) as any;
+
+      const response = await handleEditAnnouncement(
+        harness.ctx,
+        buildAction(),
+        { updateAnnouncementFn }
+      );
+      assert.equal(response.status, 200);
+      assert.equal(insertedMessages.length, 1, "the failing insert was still attempted");
+    } finally {
+      console.error = originalError;
+    }
+  });
+});

--- a/tests/announcements-soft-delete.test.ts
+++ b/tests/announcements-soft-delete.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { softDeleteAnnouncement } from "@/lib/announcements/soft-delete-announcement";
+
+// ─── Minimal Supabase stub ──────────────────────────────────────────────
+// softDeleteAnnouncement touches user_organization_roles (via getOrgMembership)
+// and announcements (fetch + UPDATE SET deleted_at). This stub routes those
+// two and captures every filter + payload for assertion.
+
+type AnnouncementRow = {
+  id: string;
+  organization_id: string;
+  title: string;
+  body: string | null;
+  is_pinned: boolean | null;
+  audience: string;
+  audience_user_ids: string[] | null;
+  updated_at: string;
+  deleted_at: string | null;
+  created_by_user_id: string;
+  created_at: string;
+  published_at: string | null;
+};
+
+interface StubState {
+  membership: { role: string } | null;
+  announcement: AnnouncementRow | null;
+  fetchError: { message: string } | null;
+  updateError: { message: string } | null;
+  updateResult: AnnouncementRow | null;
+  updatePayload: Record<string, unknown> | null;
+  updateFilters: Array<{ op: string; column: string; value: unknown }>;
+}
+
+type StubSelectChain = {
+  eq: (column: string, value: unknown) => StubSelectChain;
+  is: (column: string, value: null) => StubSelectChain;
+  maybeSingle: () => Promise<{
+    data: AnnouncementRow | null;
+    error: { message: string } | null;
+  }>;
+};
+
+type StubUpdateChain = {
+  eq: (column: string, value: unknown) => StubUpdateChain;
+  is: (column: string, value: null) => StubUpdateChain;
+  select: () => {
+    maybeSingle: () => Promise<{
+      data: AnnouncementRow | null;
+      error: { message: string } | null;
+    }>;
+  };
+};
+
+type StubRolesChain = {
+  eq: (column: string, value: unknown) => StubRolesChain;
+  maybeSingle: () => Promise<{
+    data: { role: string } | null;
+    error: { message: string } | null;
+  }>;
+};
+
+function buildStub(state: StubState) {
+  const announcementSelectChain = (): StubSelectChain => {
+    const chain: StubSelectChain = {
+      eq: () => chain,
+      is: () => chain,
+      maybeSingle: async () => ({
+        data: state.announcement,
+        error: state.fetchError,
+      }),
+    };
+    return chain;
+  };
+
+  const announcementUpdateChain = (): StubUpdateChain => {
+    const chain: StubUpdateChain = {
+      eq: (column, value) => {
+        state.updateFilters.push({ op: "eq", column, value });
+        return chain;
+      },
+      is: (column, value) => {
+        state.updateFilters.push({ op: "is", column, value });
+        return chain;
+      },
+      select: () => ({
+        maybeSingle: async () => ({
+          data: state.updateResult,
+          error: state.updateError,
+        }),
+      }),
+    };
+    return chain;
+  };
+
+  const rolesSelectChain = (): StubRolesChain => {
+    const chain: StubRolesChain = {
+      eq: () => chain,
+      maybeSingle: async () => ({ data: state.membership, error: null }),
+    };
+    return chain;
+  };
+
+  return {
+    from(table: string) {
+      if (table === "user_organization_roles") {
+        return { select: () => rolesSelectChain() };
+      }
+      if (table === "announcements") {
+        return {
+          select: () => announcementSelectChain(),
+          update: (payload: Record<string, unknown>) => {
+            state.updatePayload = payload;
+            return announcementUpdateChain();
+          },
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  } as unknown as Parameters<typeof softDeleteAnnouncement>[0]["supabase"];
+}
+
+function baseRow(overrides: Partial<AnnouncementRow> = {}): AnnouncementRow {
+  return {
+    id: "00000000-0000-4000-8000-000000000011",
+    organization_id: "00000000-0000-4000-8000-000000000022",
+    title: "Original title",
+    body: "Original body",
+    is_pinned: false,
+    audience: "all",
+    audience_user_ids: null,
+    updated_at: "2026-04-22T09:00:00.000Z",
+    deleted_at: null,
+    created_by_user_id: "00000000-0000-4000-8000-000000000033",
+    created_at: "2026-04-20T08:00:00.000Z",
+    published_at: "2026-04-20T08:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function freshState(): StubState {
+  return {
+    membership: { role: "admin" },
+    announcement: baseRow(),
+    fetchError: null,
+    updateError: null,
+    updateResult: baseRow({
+      deleted_at: "2026-04-22T09:05:00.000Z",
+      updated_at: "2026-04-22T09:05:00.000Z",
+    }),
+    updatePayload: null,
+    updateFilters: [],
+  };
+}
+
+const orgId = "00000000-0000-4000-8000-000000000022";
+const userId = "00000000-0000-4000-8000-000000000033";
+const targetId = "00000000-0000-4000-8000-000000000011";
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe("softDeleteAnnouncement — permission check", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 403 forbidden when caller is not an admin", async () => {
+    state.membership = { role: "active_member" };
+    const result = await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 403);
+      assert.equal(result.error, "forbidden");
+    }
+  });
+
+  it("returns 403 forbidden when caller is not a member at all", async () => {
+    state.membership = null;
+    const result = await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 403);
+    }
+  });
+});
+
+describe("softDeleteAnnouncement — target lookup", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 404 not_found when the announcement does not exist or is already deleted", async () => {
+    state.announcement = null;
+    const result = await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 404);
+      assert.equal(result.error, "not_found");
+    }
+  });
+});
+
+describe("softDeleteAnnouncement — optimistic concurrency", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 409 stale_version when expectedUpdatedAt does not match current", async () => {
+    const result = await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+      expectedUpdatedAt: "2026-04-22T08:00:00.000Z", // older than current
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 409);
+      assert.equal(result.error, "stale_version");
+    }
+  });
+
+  it("adds an updated_at eq filter to the UPDATE when expectedUpdatedAt is supplied", async () => {
+    await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+      expectedUpdatedAt: "2026-04-22T09:00:00.000Z",
+    });
+    const updatedAtFilter = state.updateFilters.find(
+      (f) => f.op === "eq" && f.column === "updated_at"
+    );
+    assert.ok(updatedAtFilter, "UPDATE must include eq on updated_at when stamp supplied");
+    assert.equal(updatedAtFilter!.value, "2026-04-22T09:00:00.000Z");
+  });
+
+  it("does not add updated_at filter when expectedUpdatedAt is absent", async () => {
+    await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+    });
+    const updatedAtFilter = state.updateFilters.find(
+      (f) => f.op === "eq" && f.column === "updated_at"
+    );
+    assert.equal(updatedAtFilter, undefined);
+  });
+
+  it("returns 409 stale_version when the UPDATE affects zero rows", async () => {
+    state.updateResult = null;
+    const result = await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 409);
+      assert.equal(result.error, "stale_version");
+    }
+  });
+});
+
+describe("softDeleteAnnouncement — write shape", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("writes deleted_at as an ISO timestamp", async () => {
+    const before = Date.now();
+    await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+    });
+    const after = Date.now();
+
+    assert.ok(state.updatePayload);
+    const deletedAtValue = state.updatePayload!.deleted_at;
+    assert.equal(typeof deletedAtValue, "string");
+    const deletedAtMs = Date.parse(deletedAtValue as string);
+    assert.ok(
+      deletedAtMs >= before && deletedAtMs <= after,
+      `deleted_at ${deletedAtValue} should fall between [${new Date(before).toISOString()}, ${new Date(after).toISOString()}]`
+    );
+  });
+
+  it("writes updated_at as an ISO timestamp matching deleted_at", async () => {
+    await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+    });
+    assert.ok(state.updatePayload);
+    assert.equal(
+      state.updatePayload!.updated_at,
+      state.updatePayload!.deleted_at,
+      "deleted_at and updated_at should agree — the row changed at this instant"
+    );
+  });
+
+  it("scopes the UPDATE by id, organization_id, and deleted_at IS NULL", async () => {
+    await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+    });
+    const filterKeys = state.updateFilters.map((f) => `${f.op}:${f.column}`);
+    assert.ok(filterKeys.includes("eq:id"));
+    assert.ok(filterKeys.includes("eq:organization_id"));
+    assert.ok(
+      filterKeys.includes("is:deleted_at"),
+      "deleted_at IS NULL scoping makes the delete idempotent against concurrent deletes"
+    );
+  });
+
+  it("does not mutate any non-delete fields", async () => {
+    await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+    });
+    assert.ok(state.updatePayload);
+    const payloadKeys = Object.keys(state.updatePayload!).sort();
+    assert.deepEqual(
+      payloadKeys,
+      ["deleted_at", "updated_at"],
+      "soft-delete must not touch title/body/audience/etc"
+    );
+  });
+});
+
+describe("softDeleteAnnouncement — happy path", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns the deleted row on success", async () => {
+    const result = await softDeleteAnnouncement({
+      supabase: buildStub(state),
+      orgId,
+      userId,
+      targetId,
+    });
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.value.id, targetId);
+      assert.ok(result.value.deleted_at, "returned row must have deleted_at populated");
+    }
+  });
+});

--- a/tests/announcements-update.test.ts
+++ b/tests/announcements-update.test.ts
@@ -1,0 +1,461 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { updateAnnouncement } from "@/lib/announcements/update-announcement";
+
+// ─── Minimal Supabase stub ──────────────────────────────────────────────
+// updateAnnouncement touches exactly two tables: user_organization_roles
+// (via getOrgMembership) and announcements. This stub routes those two and
+// records every filter call so tests can assert the exact query shape.
+
+type AnnouncementRow = {
+  id: string;
+  organization_id: string;
+  title: string;
+  body: string | null;
+  is_pinned: boolean | null;
+  audience: string;
+  audience_user_ids: string[] | null;
+  updated_at: string;
+  deleted_at: string | null;
+  created_by_user_id: string;
+  created_at: string;
+  published_at: string | null;
+};
+
+interface StubState {
+  membership: { role: string } | null;
+  announcement: AnnouncementRow | null;
+  fetchError: { message: string } | null;
+  updateError: { message: string } | null;
+  /** Rows returned by the UPDATE (maybeSingle). null = 0 rows, row = 1 row. */
+  updateResult: AnnouncementRow | null;
+  /** Captured arguments to the UPDATE call. */
+  updatePayload: Record<string, unknown> | null;
+  /** Captured WHERE-clause filters on the UPDATE query. */
+  updateFilters: Array<{ op: string; column: string; value: unknown }>;
+}
+
+// Shape-of-stub is deliberately loose — matches the subset of the Supabase
+// client that updateAnnouncement actually calls. Casting at the boundary lets
+// tests stay focused.
+type StubChain = {
+  eq: (column: string, value: unknown) => StubChain;
+  is: (column: string, value: null) => StubChain;
+  maybeSingle: () => Promise<{
+    data: AnnouncementRow | null;
+    error: { message: string } | null;
+  }>;
+};
+
+type StubUpdateChain = {
+  eq: (column: string, value: unknown) => StubUpdateChain;
+  is: (column: string, value: null) => StubUpdateChain;
+  select: () => {
+    maybeSingle: () => Promise<{
+      data: AnnouncementRow | null;
+      error: { message: string } | null;
+    }>;
+  };
+};
+
+type StubRolesChain = {
+  eq: (column: string, value: unknown) => StubRolesChain;
+  maybeSingle: () => Promise<{
+    data: { role: string } | null;
+    error: { message: string } | null;
+  }>;
+};
+
+function buildStub(state: StubState) {
+  const announcementSelectChain = (): StubChain => {
+    const chain: StubChain = {
+      eq: () => chain,
+      is: () => chain,
+      maybeSingle: async () => ({
+        data: state.announcement,
+        error: state.fetchError,
+      }),
+    };
+    return chain;
+  };
+
+  const announcementUpdateChain = (): StubUpdateChain => {
+    const chain: StubUpdateChain = {
+      eq: (column, value) => {
+        state.updateFilters.push({ op: "eq", column, value });
+        return chain;
+      },
+      is: (column, value) => {
+        state.updateFilters.push({ op: "is", column, value });
+        return chain;
+      },
+      select: () => ({
+        maybeSingle: async () => ({
+          data: state.updateResult,
+          error: state.updateError,
+        }),
+      }),
+    };
+    return chain;
+  };
+
+  const rolesSelectChain = (): StubRolesChain => {
+    const chain: StubRolesChain = {
+      eq: () => chain,
+      maybeSingle: async () => ({ data: state.membership, error: null }),
+    };
+    return chain;
+  };
+
+  return {
+    from(table: string) {
+      if (table === "user_organization_roles") {
+        return { select: () => rolesSelectChain() };
+      }
+      if (table === "announcements") {
+        return {
+          select: () => announcementSelectChain(),
+          update: (payload: Record<string, unknown>) => {
+            state.updatePayload = payload;
+            return announcementUpdateChain();
+          },
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  } as unknown as Parameters<typeof updateAnnouncement>[0]["supabase"];
+}
+
+function baseRow(overrides: Partial<AnnouncementRow> = {}): AnnouncementRow {
+  return {
+    id: "00000000-0000-0000-0000-0000000000a1",
+    organization_id: "00000000-0000-0000-0000-0000000000b1",
+    title: "Original title",
+    body: "Original body",
+    is_pinned: false,
+    audience: "all",
+    audience_user_ids: null,
+    updated_at: "2026-04-21T10:00:00.000Z",
+    deleted_at: null,
+    created_by_user_id: "00000000-0000-0000-0000-0000000000c1",
+    created_at: "2026-04-20T09:00:00.000Z",
+    published_at: "2026-04-20T09:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function freshState(): StubState {
+  return {
+    membership: { role: "admin" },
+    announcement: baseRow(),
+    fetchError: null,
+    updateError: null,
+    updateResult: baseRow({ title: "New title", updated_at: "2026-04-21T10:05:00.000Z" }),
+    updatePayload: null,
+    updateFilters: [],
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe("updateAnnouncement — input validation", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("rejects an empty patch with 400 empty_patch", async () => {
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: {},
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 400);
+      assert.equal(result.error, "empty_patch");
+    }
+  });
+
+  it("rejects a malformed patch with 400 invalid_patch", async () => {
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      // Title over 200 chars violates safeString(200).
+      patch: { title: "a".repeat(201) },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 400);
+      assert.equal(result.error, "invalid_patch");
+    }
+  });
+});
+
+describe("updateAnnouncement — permission check", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 403 forbidden when caller is not an admin", async () => {
+    state.membership = { role: "active_member" };
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 403);
+      assert.equal(result.error, "forbidden");
+    }
+  });
+
+  it("returns 403 forbidden when caller is not a member at all", async () => {
+    state.membership = null;
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 403);
+    }
+  });
+});
+
+describe("updateAnnouncement — target lookup", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 404 not_found when the announcement does not exist", async () => {
+    state.announcement = null;
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 404);
+      assert.equal(result.error, "not_found");
+    }
+  });
+});
+
+describe("updateAnnouncement — optimistic concurrency", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 409 stale_version when expectedUpdatedAt does not match current", async () => {
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New" },
+      expectedUpdatedAt: "2026-04-21T09:00:00.000Z", // older than current
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 409);
+      assert.equal(result.error, "stale_version");
+    }
+  });
+
+  it("proceeds when expectedUpdatedAt matches current", async () => {
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New title" },
+      expectedUpdatedAt: "2026-04-21T10:00:00.000Z",
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it("adds the updated_at filter to the UPDATE when expectedUpdatedAt is supplied", async () => {
+    await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New title" },
+      expectedUpdatedAt: "2026-04-21T10:00:00.000Z",
+    });
+    const updatedAtFilter = state.updateFilters.find(
+      (f) => f.op === "eq" && f.column === "updated_at"
+    );
+    assert.ok(updatedAtFilter, "UPDATE must include an eq filter on updated_at when expected stamp supplied");
+    assert.equal(updatedAtFilter!.value, "2026-04-21T10:00:00.000Z");
+  });
+
+  it("does not add updated_at filter when expectedUpdatedAt is absent", async () => {
+    await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New title" },
+    });
+    const updatedAtFilter = state.updateFilters.find(
+      (f) => f.op === "eq" && f.column === "updated_at"
+    );
+    assert.equal(updatedAtFilter, undefined);
+  });
+
+  it("returns 409 stale_version when the UPDATE affects zero rows", async () => {
+    state.updateResult = null; // zero rows
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "New title" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 409);
+      assert.equal(result.error, "stale_version");
+    }
+  });
+});
+
+describe("updateAnnouncement — cross-field invariants", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("rejects audience='individuals' patch when the merged row has no audience_user_ids", async () => {
+    // Current row has audience='all', audience_user_ids=null.
+    // Patching audience→individuals without supplying ids breaks the invariant.
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { audience: "individuals" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 422);
+      assert.equal(result.error, "invariant_violation");
+    }
+  });
+
+  it("accepts audience='individuals' patch when audience_user_ids are also supplied", async () => {
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: {
+        audience: "individuals",
+        audience_user_ids: ["00000000-0000-4000-8000-000000000001"],
+      },
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it("nulls audience_user_ids on the write when patching audience away from individuals", async () => {
+    state.announcement = baseRow({
+      audience: "individuals",
+      audience_user_ids: ["00000000-0000-4000-8000-000000000001"],
+    });
+    state.updateResult = baseRow({
+      audience: "all",
+      audience_user_ids: null,
+      updated_at: "2026-04-21T10:05:00.000Z",
+    });
+    await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { audience: "all" },
+    });
+    assert.ok(state.updatePayload);
+    assert.equal(state.updatePayload!.audience, "all");
+    assert.equal(
+      state.updatePayload!.audience_user_ids,
+      null,
+      "audience_user_ids must be nulled when leaving 'individuals' audience"
+    );
+  });
+});
+
+describe("updateAnnouncement — happy path", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns the updated row on a title-only patch", async () => {
+    state.updateResult = baseRow({
+      title: "Edited title",
+      updated_at: "2026-04-21T10:05:00.000Z",
+    });
+    const result = await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "Edited title" },
+    });
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.value.title, "Edited title");
+      assert.equal(result.value.updated_at, "2026-04-21T10:05:00.000Z");
+    }
+  });
+
+  it("writes the merged row (not the raw patch)", async () => {
+    await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "Edited title" },
+    });
+    assert.ok(state.updatePayload);
+    // Patched field
+    assert.equal(state.updatePayload!.title, "Edited title");
+    // Unpatched fields retain current-row values
+    assert.equal(state.updatePayload!.is_pinned, false);
+    assert.equal(state.updatePayload!.audience, "all");
+  });
+
+  it("scopes the UPDATE by id, organization_id, and deleted_at IS NULL", async () => {
+    await updateAnnouncement({
+      supabase: buildStub(state),
+      orgId: "00000000-0000-0000-0000-0000000000b1",
+      userId: "00000000-0000-0000-0000-0000000000c1",
+      targetId: "00000000-0000-0000-0000-0000000000a1",
+      patch: { title: "Edited" },
+    });
+    const filterKeys = state.updateFilters.map(
+      (f) => `${f.op}:${f.column}`
+    );
+    assert.ok(filterKeys.includes("eq:id"));
+    assert.ok(filterKeys.includes("eq:organization_id"));
+    assert.ok(filterKeys.includes("is:deleted_at"));
+  });
+});

--- a/tests/events-update.test.ts
+++ b/tests/events-update.test.ts
@@ -1,0 +1,523 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { updateEvent } from "@/lib/events/update-event";
+
+// ─── Minimal Supabase stub ──────────────────────────────────────────────
+// updateEvent touches exactly two tables: user_organization_roles (via
+// getOrgMembership) and events. This stub routes those two and records
+// every filter call so tests can assert the exact query shape.
+
+type EventRow = {
+  id: string;
+  organization_id: string;
+  title: string;
+  description: string | null;
+  start_date: string;
+  end_date: string | null;
+  location: string | null;
+  event_type: string;
+  is_philanthropy: boolean | null;
+  created_by_user_id: string;
+  audience: string | null;
+  updated_at: string;
+  deleted_at: string | null;
+  created_at: string;
+  recurrence_group_id: string | null;
+  recurrence_index: number | null;
+  recurrence_rule: unknown | null;
+};
+
+interface StubState {
+  membership: { role: string } | null;
+  event: EventRow | null;
+  fetchError: { message: string } | null;
+  updateError: { message: string } | null;
+  updateResult: EventRow | null;
+  updatePayload: Record<string, unknown> | null;
+  updateFilters: Array<{ op: string; column: string; value: unknown }>;
+}
+
+type StubChain = {
+  eq: (column: string, value: unknown) => StubChain;
+  is: (column: string, value: null) => StubChain;
+  maybeSingle: () => Promise<{
+    data: EventRow | null;
+    error: { message: string } | null;
+  }>;
+};
+
+type StubUpdateChain = {
+  eq: (column: string, value: unknown) => StubUpdateChain;
+  is: (column: string, value: null) => StubUpdateChain;
+  select: () => {
+    maybeSingle: () => Promise<{
+      data: EventRow | null;
+      error: { message: string } | null;
+    }>;
+  };
+};
+
+type StubRolesChain = {
+  eq: (column: string, value: unknown) => StubRolesChain;
+  maybeSingle: () => Promise<{
+    data: { role: string } | null;
+    error: { message: string } | null;
+  }>;
+};
+
+function buildStub(state: StubState) {
+  const eventSelectChain = (): StubChain => {
+    const chain: StubChain = {
+      eq: () => chain,
+      is: () => chain,
+      maybeSingle: async () => ({
+        data: state.event,
+        error: state.fetchError,
+      }),
+    };
+    return chain;
+  };
+
+  const eventUpdateChain = (): StubUpdateChain => {
+    const chain: StubUpdateChain = {
+      eq: (column, value) => {
+        state.updateFilters.push({ op: "eq", column, value });
+        return chain;
+      },
+      is: (column, value) => {
+        state.updateFilters.push({ op: "is", column, value });
+        return chain;
+      },
+      select: () => ({
+        maybeSingle: async () => ({
+          data: state.updateResult,
+          error: state.updateError,
+        }),
+      }),
+    };
+    return chain;
+  };
+
+  const rolesSelectChain = (): StubRolesChain => {
+    const chain: StubRolesChain = {
+      eq: () => chain,
+      maybeSingle: async () => ({ data: state.membership, error: null }),
+    };
+    return chain;
+  };
+
+  return {
+    from(table: string) {
+      if (table === "user_organization_roles") {
+        return { select: () => rolesSelectChain() };
+      }
+      if (table === "events") {
+        return {
+          select: () => eventSelectChain(),
+          update: (payload: Record<string, unknown>) => {
+            state.updatePayload = payload;
+            return eventUpdateChain();
+          },
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  } as unknown as Parameters<typeof updateEvent>[0]["supabase"];
+}
+
+function baseRow(overrides: Partial<EventRow> = {}): EventRow {
+  return {
+    id: "00000000-0000-0000-0000-0000000000a1",
+    organization_id: "00000000-0000-0000-0000-0000000000b1",
+    title: "Original Event",
+    description: "Original description",
+    start_date: "2026-04-22T09:00:00.000Z",
+    end_date: "2026-04-22T10:00:00.000Z",
+    location: "Gym",
+    event_type: "general",
+    is_philanthropy: false,
+    created_by_user_id: "00000000-0000-0000-0000-0000000000c1",
+    audience: "both",
+    updated_at: "2026-04-21T10:00:00.000Z",
+    deleted_at: null,
+    created_at: "2026-04-20T09:00:00.000Z",
+    recurrence_group_id: null,
+    recurrence_index: null,
+    recurrence_rule: null,
+    ...overrides,
+  };
+}
+
+function freshState(): StubState {
+  return {
+    membership: { role: "admin" },
+    event: baseRow(),
+    fetchError: null,
+    updateError: null,
+    updateResult: baseRow({
+      title: "Updated Event",
+      updated_at: "2026-04-21T10:05:00.000Z",
+    }),
+    updatePayload: null,
+    updateFilters: [],
+  };
+}
+
+const ORG = "00000000-0000-0000-0000-0000000000b1";
+const USER = "00000000-0000-0000-0000-0000000000c1";
+const TARGET = "00000000-0000-0000-0000-0000000000a1";
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe("updateEvent — input validation", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("rejects an empty patch with 400 empty_patch", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: {},
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 400);
+      assert.equal(result.error, "empty_patch");
+    }
+  });
+
+  it("rejects a malformed patch with 400 invalid_patch", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "a".repeat(201) },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 400);
+      assert.equal(result.error, "invalid_patch");
+    }
+  });
+
+  it("rejects an invalid start_date format", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { start_date: "tomorrow" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 400);
+      assert.equal(result.error, "invalid_patch");
+    }
+  });
+});
+
+describe("updateEvent — permission check", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 403 forbidden when caller is not an admin", async () => {
+    state.membership = { role: "active_member" };
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 403);
+      assert.equal(result.error, "forbidden");
+    }
+  });
+
+  it("returns 403 forbidden when caller is not a member at all", async () => {
+    state.membership = null;
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 403);
+    }
+  });
+});
+
+describe("updateEvent — target lookup", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 404 not_found when the event does not exist", async () => {
+    state.event = null;
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 404);
+      assert.equal(result.error, "not_found");
+    }
+  });
+});
+
+describe("updateEvent — recurrence guard (Tier 4 out of scope)", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("rejects a recurring event (non-null recurrence_group_id) with 422", async () => {
+    state.event = baseRow({
+      recurrence_group_id: "00000000-0000-0000-0000-0000000000d1",
+      recurrence_index: 0,
+      recurrence_rule: { freq: "WEEKLY" },
+    });
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "Move the recurring series" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 422);
+      assert.equal(result.error, "recurring_event_unsupported");
+    }
+  });
+
+  it("rejects a recurring instance (recurrence_index set, rule null) with 422", async () => {
+    state.event = baseRow({
+      recurrence_group_id: "00000000-0000-0000-0000-0000000000d1",
+      recurrence_index: 3,
+      recurrence_rule: null,
+    });
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "Move this one instance only" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 422);
+      assert.equal(result.error, "recurring_event_unsupported");
+    }
+  });
+});
+
+describe("updateEvent — optimistic concurrency", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 409 stale_version when expectedUpdatedAt does not match current", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New" },
+      expectedUpdatedAt: "2026-04-21T09:00:00.000Z",
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 409);
+      assert.equal(result.error, "stale_version");
+    }
+  });
+
+  it("proceeds when expectedUpdatedAt matches current", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New title" },
+      expectedUpdatedAt: "2026-04-21T10:00:00.000Z",
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it("adds the updated_at filter to the UPDATE when expectedUpdatedAt is supplied", async () => {
+    await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New title" },
+      expectedUpdatedAt: "2026-04-21T10:00:00.000Z",
+    });
+    const updatedAtFilter = state.updateFilters.find(
+      (f) => f.op === "eq" && f.column === "updated_at"
+    );
+    assert.ok(updatedAtFilter, "UPDATE must include eq filter on updated_at");
+    assert.equal(updatedAtFilter!.value, "2026-04-21T10:00:00.000Z");
+  });
+
+  it("returns 409 stale_version when the UPDATE affects zero rows", async () => {
+    state.updateResult = null;
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New title" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 409);
+      assert.equal(result.error, "stale_version");
+    }
+  });
+});
+
+describe("updateEvent — cross-field invariants", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("rejects a patch that moves end_time before start_time with 422", async () => {
+    // Current row: 2026-04-22 09:00 → 10:00. Patch end_time to 08:00 breaks it.
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { end_time: "08:00" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 422);
+      assert.equal(result.error, "invariant_violation");
+    }
+  });
+
+  it("accepts a patch that shifts both start and end coherently", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { start_time: "11:00", end_time: "12:00" },
+    });
+    assert.equal(result.ok, true);
+  });
+});
+
+describe("updateEvent — happy path", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns the updated row on a title-only patch", async () => {
+    state.updateResult = baseRow({
+      title: "Edited title",
+      updated_at: "2026-04-21T10:05:00.000Z",
+    });
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "Edited title" },
+    });
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.value.title, "Edited title");
+    }
+  });
+
+  it("writes the merged row (not the raw patch)", async () => {
+    await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "Edited title" },
+    });
+    assert.ok(state.updatePayload);
+    // Patched field
+    assert.equal(state.updatePayload!.title, "Edited title");
+    // Unpatched fields retain current-row values (re-composed to ISO)
+    assert.equal(state.updatePayload!.start_date, "2026-04-22T09:00:00.000Z");
+    assert.equal(state.updatePayload!.end_date, "2026-04-22T10:00:00.000Z");
+    assert.equal(state.updatePayload!.location, "Gym");
+    assert.equal(state.updatePayload!.event_type, "general");
+  });
+
+  it("recomposes date+time parts into the stored ISO format on a start_time-only patch", async () => {
+    // Current row: start 09:00 → end 10:00. Shift start earlier so the
+    // end>start invariant still holds after merge. Verifies the
+    // decompose-merge-recompose pipeline carries the date component
+    // forward unchanged.
+    await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { start_time: "08:00" },
+    });
+    assert.ok(state.updatePayload);
+    // Date component retained from current row; time swapped.
+    assert.equal(state.updatePayload!.start_date, "2026-04-22T08:00:00.000Z");
+  });
+
+  it("scopes the UPDATE by id, organization_id, and deleted_at IS NULL", async () => {
+    await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "Edited" },
+    });
+    const filterKeys = state.updateFilters.map((f) => `${f.op}:${f.column}`);
+    assert.ok(filterKeys.includes("eq:id"));
+    assert.ok(filterKeys.includes("eq:organization_id"));
+    assert.ok(filterKeys.includes("is:deleted_at"));
+  });
+
+  it("promotes is_philanthropy to true when the merged event_type is 'philanthropy'", async () => {
+    state.updateResult = baseRow({
+      event_type: "philanthropy",
+      is_philanthropy: true,
+      updated_at: "2026-04-21T10:05:00.000Z",
+    });
+    await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { event_type: "philanthropy" },
+    });
+    assert.ok(state.updatePayload);
+    assert.equal(state.updatePayload!.is_philanthropy, true);
+    assert.equal(state.updatePayload!.event_type, "philanthropy");
+  });
+});

--- a/tests/routes/ai/pending-actions-handler.test.ts
+++ b/tests/routes/ai/pending-actions-handler.test.ts
@@ -1093,6 +1093,78 @@ test("exception during write rolls back to pending", async () => {
   assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
 });
 
+test("exception during write rolls back for create_announcement (dispatcher rejection propagates to try/catch)", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "create_announcement",
+        payload: {
+          title: "Announcement",
+          body: "body",
+          audience: "all",
+          is_pinned: false,
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    createAnnouncement: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for create_event (dispatcher rejection propagates to try/catch)", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "create_event",
+        payload: {
+          title: "Event",
+          start_date: "2026-05-01",
+          start_time: "10:00",
+          event_type: "practice",
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    createEvent: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
 test("rollback failure logs structured error and re-throws", async () => {
   const logged: any[] = [];
   const originalError = console.error;

--- a/tests/routes/ai/pending-actions-handler.test.ts
+++ b/tests/routes/ai/pending-actions-handler.test.ts
@@ -1165,6 +1165,264 @@ test("exception during write rolls back for create_event (dispatcher rejection p
   assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
 });
 
+// --- Remaining dispatchers: regression coverage for the return-await bug ---
+//
+// The existing "exception during write" tests above cover create_job_posting,
+// create_announcement, and create_event. The other six dispatchers extracted
+// in #128 (send_chat_message, send_group_chat_message, create_discussion_thread,
+// create_discussion_reply, create_enterprise_invite, revoke_enterprise_invite)
+// have the same structural vulnerability: if `return handleDispatcher(...)`
+// ever regresses back from `return await handleDispatcher(...)`, the outer
+// try/catch in handler.ts will miss rejections and skip the rollback.
+//
+// These tests lock in that behaviour for each dispatcher.
+
+test("exception during write rolls back for send_chat_message", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "send_chat_message",
+        payload: {
+          recipient_member_id: "member-1",
+          recipient_user_id: "user-1",
+          recipient_display_name: "Alice",
+          body: "hello",
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    sendAiAssistedDirectChatMessage: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for send_group_chat_message", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "send_group_chat_message",
+        payload: {
+          chat_group_id: "group-1",
+          group_name: "Group",
+          message_status: "complete",
+          body: "hello",
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    sendAiAssistedGroupChatMessage: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for create_discussion_thread", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "create_discussion_thread",
+        payload: {
+          title: "Thread",
+          body: "body",
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    createDiscussionThread: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for create_discussion_reply", async () => {
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "create_discussion_reply",
+        payload: {
+          discussion_thread_id: "thread-1",
+          body: "reply body",
+          orgSlug: "org",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+    createDiscussionReply: async () => {
+      throw new Error("Supabase timeout");
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for create_enterprise_invite", async () => {
+  // Enterprise-invite dispatcher uses the auth-bound supabase client (not
+  // serviceSupabase) for the RPC. Simulate the throw by overriding
+  // createClient so supabase.rpc rejects.
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps(),
+    createClient: async () =>
+      ({
+        auth: { getUser: async () => ({ data: { user: ADMIN_USER } }) },
+        rpc: async () => {
+          throw new Error("Supabase timeout");
+        },
+      }) as any,
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "create_enterprise_invite",
+        payload: {
+          enterpriseId: "enterprise-1",
+          enterpriseSlug: "ent",
+          organizationId: null,
+          role: "admin",
+          usesRemaining: null,
+          expiresAt: null,
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
+test("exception during write rolls back for revoke_enterprise_invite", async () => {
+  // Revoke uses ctx.serviceSupabase.from("enterprise_invites").update(...)...
+  // Override getAiOrgContext to return a serviceSupabase whose `.from()` on
+  // enterprise_invites returns an update chain that rejects on the final
+  // `.select()`. ai_messages still needs to succeed on insert (but won't be
+  // reached, since rollback happens first).
+  const updatedStatuses: any[] = [];
+  const handler = createAiPendingActionConfirmHandler({
+    ...buildBaseDeps({
+      getAiOrgContext: async () =>
+        ({
+          ok: true,
+          orgId: ORG_ID,
+          userId: ADMIN_USER.id,
+          role: "admin",
+          supabase: null,
+          serviceSupabase: {
+            from(table: string) {
+              if (table === "enterprise_invites") {
+                const chain: any = {
+                  update: () => chain,
+                  eq: () => chain,
+                  is: () => chain,
+                  select: () => Promise.reject(new Error("Supabase timeout")),
+                };
+                return chain;
+              }
+              if (table === "ai_messages") {
+                return { insert: () => Promise.resolve({ error: null }) };
+              }
+              throw new Error(`unexpected table ${table}`);
+            },
+          },
+        }) as any,
+    }),
+    getPendingAction: async () =>
+      buildPendingAction({
+        action_type: "revoke_enterprise_invite",
+        payload: {
+          inviteId: "invite-1",
+          inviteCode: "CODE1",
+          enterpriseId: "enterprise-1",
+        },
+      }) as any,
+    updatePendingActionStatus: async (_supabase: any, _actionId: any, payload: any) => {
+      updatedStatuses.push(payload);
+      return { updated: true };
+    },
+  });
+
+  await assert.rejects(
+    handler(buildRequest() as any, {
+      params: Promise.resolve({ orgId: ORG_ID, actionId: ACTION_ID }),
+    }),
+    { message: "Supabase timeout" }
+  );
+
+  assert.equal(updatedStatuses[0].status, "confirmed");
+  assert.equal(updatedStatuses[1].status, "pending");
+  assert.equal(updatedStatuses[1].expectedStatus, "confirmed");
+});
+
 test("rollback failure logs structured error and re-throws", async () => {
   const logged: any[] = [];
   const originalError = console.error;

--- a/tests/routes/ai/tool-definitions.test.ts
+++ b/tests/routes/ai/tool-definitions.test.ts
@@ -6,8 +6,8 @@ import type { ToolName } from "../../../src/lib/ai/tools/definitions.ts";
 type ToolProperties = Record<string, { type?: string; maximum?: number }>;
 type ToolParameters = { properties?: ToolProperties; additionalProperties?: boolean; required?: string[] };
 
-test("AI_TOOLS exports 35 tool definitions", () => {
-  assert.equal(AI_TOOLS.length, 35);
+test("AI_TOOLS exports 36 tool definitions", () => {
+  assert.equal(AI_TOOLS.length, 36);
 });
 
 test("every tool has type function and additionalProperties false", () => {
@@ -33,6 +33,7 @@ test("TOOL_NAMES contains all tool names", () => {
     "list_philanthropy_events",
     "prepare_announcement",
     "prepare_edit_announcement",
+    "prepare_delete_announcement",
     "prepare_job_posting",
     "prepare_chat_message",
     "list_chat_groups",
@@ -158,6 +159,23 @@ test("suggest_connections supports person_query or person_type plus person_id", 
   assert.ok(props.person_query);
   assert.equal(props.limit.maximum, 25);
   assert.equal(params.required, undefined);
+});
+
+test("prepare_delete_announcement requires target_id", () => {
+  const tool = AI_TOOLS.find(
+    (t) => t.function.name === "prepare_delete_announcement"
+  )!;
+  const params = tool.function.parameters as ToolParameters;
+  const props = params.properties as ToolProperties;
+
+  assert.ok(props.target_id);
+  assert.equal(props.target_id.type, "string");
+  assert.deepEqual(params.required, ["target_id"]);
+  // Security: description must convey strict target resolution (no fallback).
+  assert.match(
+    tool.function.description,
+    /no most-recent fallback|strict|explicit/i
+  );
 });
 
 test("find_navigation_targets requires a query string", () => {

--- a/tests/routes/ai/tool-definitions.test.ts
+++ b/tests/routes/ai/tool-definitions.test.ts
@@ -6,8 +6,8 @@ import type { ToolName } from "../../../src/lib/ai/tools/definitions.ts";
 type ToolProperties = Record<string, { type?: string; maximum?: number }>;
 type ToolParameters = { properties?: ToolProperties; additionalProperties?: boolean; required?: string[] };
 
-test("AI_TOOLS exports 34 tool definitions", () => {
-  assert.equal(AI_TOOLS.length, 34);
+test("AI_TOOLS exports 35 tool definitions", () => {
+  assert.equal(AI_TOOLS.length, 35);
 });
 
 test("every tool has type function and additionalProperties false", () => {
@@ -32,6 +32,7 @@ test("TOOL_NAMES contains all tool names", () => {
     "list_parents",
     "list_philanthropy_events",
     "prepare_announcement",
+    "prepare_edit_announcement",
     "prepare_job_posting",
     "prepare_chat_message",
     "list_chat_groups",

--- a/tests/routes/ai/tool-executor.test.ts
+++ b/tests/routes/ai/tool-executor.test.ts
@@ -970,6 +970,163 @@ test("prepare_announcement creates a pending confirmation action when complete",
   });
 });
 
+// ─── prepare_edit_announcement ──────────────────────────────────────────
+// Phase 2a-prepare. Mirrors the create tests but also exercises the
+// target resolver (most-recent fallback + explicit target_id).
+
+const EDIT_TARGET_ID = "00000000-0000-4000-8000-000000000aaa";
+
+test("prepare_edit_announcement returns missing_fields when no patch fields are supplied", async () => {
+  const editCtx = { ...ctx, threadId: "thread-edit" };
+
+  const result = expectOk(
+    await executeToolCall(editCtx, {
+      name: "prepare_edit_announcement",
+      args: { target_id: EDIT_TARGET_ID },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  assert.deepEqual((result.data as { missing_fields: string[] }).missing_fields, ["patch"]);
+});
+
+test("prepare_edit_announcement returns missing_fields when target_id is omitted and no recent action exists", async () => {
+  // Resolver finds no matching recent action → returns not_found.
+  const resolverStub = createToolSupabaseStub({
+    ai_pending_actions: { select: { data: [], error: null } },
+  });
+  const editCtx = { ...makeCtx(resolverStub as any), threadId: "thread-edit" };
+
+  const result = expectOk(
+    await executeToolCall(editCtx, {
+      name: "prepare_edit_announcement",
+      args: { title: "Fixed typo" },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  assert.deepEqual(
+    (result.data as { missing_fields: string[] }).missing_fields,
+    ["target_id"]
+  );
+});
+
+test("prepare_edit_announcement surfaces a missing_fields response when the target is not found in the org", async () => {
+  const editStub = createToolSupabaseStub({
+    announcements: { maybeSingle: { data: null, error: null } },
+  });
+  const editCtx = { ...makeCtx(editStub as any), threadId: "thread-edit" };
+
+  const result = expectOk(
+    await executeToolCall(editCtx, {
+      name: "prepare_edit_announcement",
+      args: { target_id: EDIT_TARGET_ID, title: "Fixed typo" },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  assert.deepEqual(
+    (result.data as { missing_fields: string[] }).missing_fields,
+    ["target_id"]
+  );
+});
+
+test("prepare_edit_announcement refuses to edit a soft-deleted announcement", async () => {
+  const editStub = createToolSupabaseStub({
+    announcements: {
+      maybeSingle: {
+        data: {
+          id: EDIT_TARGET_ID,
+          title: "Old",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:00:00.000Z",
+          deleted_at: "2026-04-22T09:30:00.000Z",
+        },
+        error: null,
+      },
+    },
+  });
+  const editCtx = { ...makeCtx(editStub as any), threadId: "thread-edit" };
+
+  const result = expectOk(
+    await executeToolCall(editCtx, {
+      name: "prepare_edit_announcement",
+      args: { target_id: EDIT_TARGET_ID, title: "Fixed typo" },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  const reason = (result.data as { reason?: string }).reason;
+  assert.match(reason ?? "", /deleted/i);
+});
+
+test("prepare_edit_announcement creates a pending edit_announcement action when complete", async () => {
+  const editStub = createToolSupabaseStub({
+    organizations: {
+      maybeSingle: { data: { slug: "upenn-sprint-football" }, error: null },
+    },
+    announcements: {
+      maybeSingle: {
+        data: {
+          id: EDIT_TARGET_ID,
+          title: "Original Title",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:00:00.000Z",
+          deleted_at: null,
+        },
+        error: null,
+      },
+    },
+    ai_pending_actions: {
+      single: {
+        data: {
+          id: "pending-edit-announcement-1",
+          organization_id: ORG_ID,
+          user_id: USER_ID,
+          thread_id: "thread-edit",
+          action_type: "edit_announcement",
+          payload: {
+            targetId: EDIT_TARGET_ID,
+            patch: { title: "Fixed Title" },
+            expectedUpdatedAt: "2026-04-22T09:00:00.000Z",
+            targetTitle: "Original Title",
+            orgSlug: "upenn-sprint-football",
+          },
+          status: "pending",
+          expires_at: "2099-01-01T00:00:00.000Z",
+          created_at: "2026-04-22T09:30:00.000Z",
+          updated_at: "2026-04-22T09:30:00.000Z",
+          executed_at: null,
+          result_entity_type: null,
+          result_entity_id: null,
+        },
+        error: null,
+      },
+    },
+  });
+  const editCtx = { ...makeCtx(editStub as any), threadId: "thread-edit" };
+
+  const result = expectOk(
+    await executeToolCall(editCtx, {
+      name: "prepare_edit_announcement",
+      args: {
+        target_id: EDIT_TARGET_ID,
+        title: "Fixed Title",
+        reasoning: "user asked to fix the title typo",
+      },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "needs_confirmation");
+  const pending = (result.data as { pending_action: { action_type: string; payload: any } }).pending_action;
+  assert.equal(pending.action_type, "edit_announcement");
+  assert.equal(pending.payload.targetId, EDIT_TARGET_ID);
+  assert.deepEqual(pending.payload.patch, { title: "Fixed Title" });
+  assert.equal(pending.payload.expectedUpdatedAt, "2026-04-22T09:00:00.000Z");
+  assert.equal(pending.payload.targetTitle, "Original Title");
+  assert.equal(pending.payload.orgSlug, "upenn-sprint-football");
+});
+
 test("prepare_discussion_thread creates a pending confirmation action when complete", async () => {
   const discussionStub = createToolSupabaseStub({
     organizations: {

--- a/tests/routes/ai/tool-executor.test.ts
+++ b/tests/routes/ai/tool-executor.test.ts
@@ -1127,6 +1127,143 @@ test("prepare_edit_announcement creates a pending edit_announcement action when 
   assert.equal(pending.payload.orgSlug, "upenn-sprint-football");
 });
 
+// ─── prepare_delete_announcement ────────────────────────────────────────
+// Phase 2b-prepare. Destructive op, so fallback is disabled — target_id
+// is strictly required. Still exercises the triple-layer org assertion
+// and the deleted_at guard to keep the executor from re-queueing a
+// delete for an already-soft-deleted row.
+
+const DELETE_TARGET_ID = "00000000-0000-4000-8000-000000000bbb";
+
+test("prepare_delete_announcement rejects at the arg-schema layer when target_id is missing", async () => {
+  const deleteCtx = { ...ctx, threadId: "thread-delete" };
+
+  const result = await executeToolCall(deleteCtx, {
+    name: "prepare_delete_announcement",
+    args: {},
+  });
+
+  // Zod schema makes target_id required — absent arg surfaces as a
+  // tool_error before the executor body even runs. This is the single
+  // deterministic gate that prevents ambiguous destructive ops.
+  assert.equal(result.kind, "tool_error");
+});
+
+test("prepare_delete_announcement surfaces a missing_fields response when the target is not found in the org", async () => {
+  const deleteStub = createToolSupabaseStub({
+    announcements: { maybeSingle: { data: null, error: null } },
+  });
+  const deleteCtx = { ...makeCtx(deleteStub as any), threadId: "thread-delete" };
+
+  const result = expectOk(
+    await executeToolCall(deleteCtx, {
+      name: "prepare_delete_announcement",
+      args: { target_id: DELETE_TARGET_ID },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  assert.deepEqual(
+    (result.data as { missing_fields: string[] }).missing_fields,
+    ["target_id"]
+  );
+});
+
+test("prepare_delete_announcement refuses to re-delete a soft-deleted announcement", async () => {
+  const deleteStub = createToolSupabaseStub({
+    announcements: {
+      maybeSingle: {
+        data: {
+          id: DELETE_TARGET_ID,
+          title: "Already Gone",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:00:00.000Z",
+          deleted_at: "2026-04-22T09:30:00.000Z",
+        },
+        error: null,
+      },
+    },
+  });
+  const deleteCtx = { ...makeCtx(deleteStub as any), threadId: "thread-delete" };
+
+  const result = expectOk(
+    await executeToolCall(deleteCtx, {
+      name: "prepare_delete_announcement",
+      args: { target_id: DELETE_TARGET_ID },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  const reason = (result.data as { reason?: string }).reason;
+  assert.match(reason ?? "", /already been deleted/i);
+});
+
+test("prepare_delete_announcement creates a pending delete_announcement action when target resolves", async () => {
+  const deleteStub = createToolSupabaseStub({
+    organizations: {
+      maybeSingle: { data: { slug: "upenn-sprint-football" }, error: null },
+    },
+    announcements: {
+      maybeSingle: {
+        data: {
+          id: DELETE_TARGET_ID,
+          title: "Stale Announcement",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:00:00.000Z",
+          deleted_at: null,
+        },
+        error: null,
+      },
+    },
+    ai_pending_actions: {
+      single: {
+        data: {
+          id: "pending-delete-announcement-1",
+          organization_id: ORG_ID,
+          user_id: USER_ID,
+          thread_id: "thread-delete",
+          action_type: "delete_announcement",
+          payload: {
+            targetId: DELETE_TARGET_ID,
+            expectedUpdatedAt: "2026-04-22T09:00:00.000Z",
+            targetTitle: "Stale Announcement",
+            orgSlug: "upenn-sprint-football",
+          },
+          status: "pending",
+          expires_at: "2099-01-01T00:00:00.000Z",
+          created_at: "2026-04-22T09:30:00.000Z",
+          updated_at: "2026-04-22T09:30:00.000Z",
+          executed_at: null,
+          result_entity_type: null,
+          result_entity_id: null,
+        },
+        error: null,
+      },
+    },
+  });
+  const deleteCtx = { ...makeCtx(deleteStub as any), threadId: "thread-delete" };
+
+  const result = expectOk(
+    await executeToolCall(deleteCtx, {
+      name: "prepare_delete_announcement",
+      args: {
+        target_id: DELETE_TARGET_ID,
+        reasoning: "user asked to remove the stale announcement",
+      },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "needs_confirmation");
+  const pending = (result.data as {
+    pending_action: { action_type: string; payload: any };
+  }).pending_action;
+  assert.equal(pending.action_type, "delete_announcement");
+  assert.equal(pending.payload.targetId, DELETE_TARGET_ID);
+  assert.equal(pending.payload.expectedUpdatedAt, "2026-04-22T09:00:00.000Z");
+  assert.equal(pending.payload.targetTitle, "Stale Announcement");
+  assert.equal(pending.payload.orgSlug, "upenn-sprint-football");
+});
+
 test("prepare_discussion_thread creates a pending confirmation action when complete", async () => {
   const discussionStub = createToolSupabaseStub({
     organizations: {


### PR DESCRIPTION
# Tier 1 — AI agent edit/delete parity

Single consolidated PR for the full Tier 1 edit/delete parity work on the TeamMeet AI agent. All per-phase PRs (#119–#132, #134–#138) have been merged into this branch and closed with a pointer back here.

Plan document: `~/.claude/plans/i-want-you-to-quirky-sprout.md`

---

## What changed

The TeamMeet AI agent ships 9 `prepare_*` create tools and ~25 read tools, but zero update/cancel/delete tools. This PR introduces a reusable pattern for edit and soft-delete operations — scaffolding, primitives, confirm dispatchers, and prepare tools — and applies it end-to-end to the announcements domain plus a starting primitive for events.

## Scope of this PR

### ✅ SHIPPED

**Scaffolding (Phases 0 + 1)**
- `ai_draft_sessions`: dropped stale `draft_type` CHECK (enforce in TS), added Zod gate on `saveDraftSession`, widened unique key to `(thread_id, draft_type)` so a user can have an edit draft and a create draft on the same thread
- `ai_pending_actions`: added mutation columns (`target_entity_type`, `target_entity_id`, `payload_before`, `resolved_target`, `attempt_count`, `last_attempt_error`, `replay_result`), unique partial index preventing two pending mutations on one entity, recent-entity lookup index for most-recent fallback resolver
- Split confirm handler (920 LOC) + executor (3,460 LOC) into per-domain dispatcher files (`confirm/dispatchers/*.ts`) — Phase 0.5 pattern
- Shared `DomainResult<T>` discriminated union + `resolveAgentActionTarget<E>` target resolver with per-op fallback window (15min for edit, disabled for delete per plan §A2.1)

**Phase 2 — Announcements edit + delete (FULLY FUNCTIONAL)**
- `updateAnnouncement` domain primitive: admin-only auth, optimistic concurrency via `expectedUpdatedAt`, merged-row invariant re-validation (catches audience=individuals without user_ids, etc.)
- `softDeleteAnnouncement` domain primitive: idempotent re-delete, triple-layer org assertion
- `edit_announcement` + `delete_announcement` pending action types with exhaustive `buildPendingActionSummary` cases
- `handleEditAnnouncement` + `handleDeleteAnnouncement` confirm dispatchers
- `prepare_edit_announcement` + `prepare_delete_announcement` LLM tools with chat-handler regex attach patterns
- End-to-end: admin says "fix the typo" → review card → confirm → announcement updated; admin says "remove this announcement" (with target_id) → review card → confirm → soft-deleted

**Phase 3a — Events edit (primitive only)**
- `updateEvent` domain primitive mirroring `updateAnnouncement` adapted for events' composed ISO datetime columns and recurrence model
- `assistantEventPatchSchema` — all fields optional, excludes audience/channel (events don't re-notify on edit)
- Recurrence guard: any row with `recurrence_group_id`/`recurrence_rule`/`recurrence_index` non-null → 422 `recurring_event_unsupported` (Tier 4 stays out of scope)
- Decompose-merge-recompose pipeline for YYYY-MM-DD + HH:MM ↔ ISO conversion

### 📋 STILL TO DO (follow-up work, NOT in this PR)

**Phase 3 — Events (remaining)**
- [ ] `softDeleteEvent` + `cancelEvent` primitive with `syncEventToUsers("delete")` hook
- [ ] `edit_event` / `cancel_event` pending types + dispatchers (must trigger `syncEventToUsers("update")` on edit)
- [ ] `prepare_edit_event` + `prepare_cancel_event` tools (UX says "cancel", semantics is soft-delete + attendee sync)

**Phase 4 — Jobs**
- [ ] `updateJobPosting`, `expireJobPosting`, `softDeleteJobPosting` primitives
- [ ] Refactor existing `PATCH/DELETE /api/jobs/[jobId]` to call new primitives so UI + agent share one code path
- [ ] 3 confirm dispatchers + 3 prepare tools

**Phase 5 — Discussions + replies**
- [ ] Build missing `PATCH/DELETE /api/discussions/[threadId]/replies/[replyId]` UI routes
- [ ] 4 primitives, 4 dispatchers, 4 prepare tools
- [ ] Locked-thread RLS must surface as clear user-facing errors, not generic 403

**Phase 6 — Chat messages (agent-authored only)**
- [ ] Migration: `chat_messages.source_pending_action_id` FK (plan §A2.4) — required to scope edits to agent-authored messages
- [ ] Migration: `chat_messages.edited_at` column (plan §A1.5) — without it, edits are invisible to recipients
- [ ] Build missing `PATCH/DELETE` chat-message UI routes
- [ ] 2 primitives, 2 dispatchers, 2 prepare tools

**Phase 7 — Capabilities + prompt tuning**
- [ ] Rewrite `src/lib/ai/capabilities.ts` per-surface `unsupported:` arrays to reflect shipped tools
- [ ] `context-builder.ts` prompt addendum teaching the model to prefer edit/delete over create when verbs indicate it
- [ ] Rename `revoke_enterprise_invite` → `prepare_revoke_enterprise_invite` for verb-stem consistency (plan §A4.7)
- [ ] Update `docs/agent/chat-pipeline-codemap.md` tool catalog; mark "destructive edits" shipped in `docs/agent/assistant.md`

**Cross-cutting hardening (required before fleet deploy)**
- [ ] `executeMutation()` HOF extraction (plan §A4.3) — defer to Phase 3 confirm per plan; will also migrate the existing 9 create-branches
- [ ] `assessAiMessageSafety` on every tool-result string reaching Pass-1 LLM context (plan §A2.2, prompt-injection hardening) — must precede Phase 5/6
- [ ] Blast-radius surfacing on delete review cards (plan §A11, OWASP LLM06:2025) — must precede Phase 5 thread-delete (cascades to replies)
- [ ] Per-domain feature flags (`AI_EDIT_DELETE_<DOMAIN>_ENABLED`) + global kill switch (`AI_AGENT_WRITE_TOOLS_ENABLED`) (plan §A9)
- [ ] Observability: CAS-transition logs, rollback counters, concurrent-edit detection histogram (plan §A7) — wire before fleet flip

---

## Testing

- `npx tsc --noEmit`: clean across merged HEAD
- `npx eslint`: clean on all changed files
- Test counts on merged HEAD:
  - `tests/events-update`: 19/19
  - `tests/announcements-update`: 16/16
  - `tests/announcements-edit-dispatcher`: 14/14
  - `tests/announcements-delete-dispatcher`: 13/13
  - `tests/routes/ai/tool-definitions`: 15/15
  - `tests/routes/ai/tool-executor`: 64/64
  - Combined Tier 1 surface: 141/141
  - Full `tests/routes/ai/*`: 288/288 (no regressions)

Migrations applied (Supabase migration folder):
- `20261101000000_ai_draft_sessions_drop_draft_type_check.sql`
- `20261101000001_ai_pending_actions_tier1_mutation_columns_and_indexes.sql`
- `20261101000005_ai_draft_sessions_widen_unique_key.sql`

---

## Deploy posture

**This PR is NOT safe for fleet rollout as-is.** Before merging to main and flipping capability flags:

1. The cross-cutting hardening items above must land
2. Per-phase canary-org soak pattern (plan §A9) — 24-48h green on one opt-in org before fleet flip
3. Feature flags must default OFF; rollback path is a flag flip, not a revert

The Phase 2 chain (announcements edit/delete) is **code-complete** and is the first candidate for canary once feature flags wire in — that's the next deployment milestone.

---

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: `pending_action.cas_transition` events — watch `target_updated_at_at_prepare` vs `target_updated_at_now` delta (non-zero at p99 = concurrent-edit signal)
  - Logs: `update_failed` / `delete_failed` 500 spikes
  - Logs: `recurring_event_unsupported` 422 count (should be rare; if users hit it often, recurrence UX gap)
- **Expected healthy behavior**
  - `pending_action.action_type = "edit_announcement"` / `"delete_announcement"` rows created and resolved cleanly
  - Zero rows stuck in `status = "confirmed"` > 60s (crash-loop signal)
  - `announcements.deleted_at` populated post-delete; no hard-delete row count drop
- **Failure signal(s) / rollback trigger**
  - Any audit row showing an announcement modified by `actor="agent"` without a matching `ai_pending_actions` row → flip `AI_AGENT_WRITE_TOOLS_ENABLED=false`
  - p99 prepare→execute latency > 30s sustained → flip kill switch
  - Any event row modified with `recurrence_group_id IS NOT NULL` → flip kill switch; guard bypassed
- **Validation window & owner**
  - Window: 48h post-canary enablement per phase
  - Owner: agent team + DB on-call