### PR TITLE
feat(ai): Phase 2a-confirm — edit_announcement pending type + dispatcher

### DIFF
--- a/src/app/api/ai/[orgId]/chat/handler.ts
+++ b/src/app/api/ai/[orgId]/chat/handler.ts
@@ -2886,6 +2886,16 @@ function getToolNameForDraftType(draftType: DraftSessionType): ToolName {
   switch (draftType) {
     case "create_announcement":
       return "prepare_announcement";
+    case "edit_announcement":
+      // Placeholder for Phase 2a-prepare: the prepare_edit_announcement
+      // tool is not yet registered. This branch should be unreachable
+      // until that tool ships, because no code path creates a draft
+      // session with draftType "edit_announcement" yet. Throwing makes
+      // the incomplete state explicit instead of silently attaching a
+      // non-existent tool name.
+      throw new Error(
+        "prepare_edit_announcement tool is not registered yet (Phase 2a-prepare not shipped)"
+      );
     case "create_job_posting":
       return "prepare_job_posting";
     case "send_chat_message":
@@ -3548,6 +3558,13 @@ function inferDraftSessionFromHistory(input: {
           (field) => getNonEmptyString(draftPayload[field]) == null
         );
         break;
+      case "edit_announcement":
+        // Edit drafts cannot be reconstructed from chat-history inference —
+        // they require a target_id resolved via the target_resolver. Skip
+        // this iteration; callers fall through to explicit draft-session
+        // load paths (save + get by draft_type) once the prepare-side
+        // tool is wired in a follow-up PR.
+        continue;
       case "send_chat_message":
         draftPayload = extractChatMessageDraftFromHistory(relevantMessages);
         missingFields = [

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
@@ -15,6 +15,7 @@ import type {
 } from "@/lib/ai/draft-sessions";
 import type {
   CreateAnnouncementPendingPayload,
+  EditAnnouncementPendingPayload,
   PendingActionRecord,
   updatePendingActionStatus,
 } from "@/lib/ai/pending-actions";
@@ -22,6 +23,7 @@ import type {
   createAnnouncement,
   sendAnnouncementNotification,
 } from "@/lib/announcements/create-announcement";
+import type { updateAnnouncement } from "@/lib/announcements/update-announcement";
 import type { sendNotificationBlast } from "@/lib/notifications";
 
 export interface AnnouncementDispatcherContext {
@@ -172,6 +174,111 @@ export async function handleCreateAnnouncement(
   return NextResponse.json({
     ok: true,
     announcement: result.announcement,
+    actionId: action.id,
+  });
+}
+
+// ─── Edit dispatcher ────────────────────────────────────────────────────
+//
+// Phase 2a of the Tier 1 edit/delete plan. Mirrors handleCreateAnnouncement's
+// ctx + deps shape, but calls the updateAnnouncement domain primitive and
+// surfaces the structured DomainResult failure codes (403 forbidden, 404
+// not_found, 409 stale_version, 422 invariant_violation, 500 update_failed)
+// directly into the HTTP response. The primitive enforces both the admin
+// permission check and the optimistic-concurrency `expectedUpdatedAt` token
+// captured at prepare time, so this dispatcher has no additional auth or
+// race logic — it's a thin CAS + primitive + ai_messages shell.
+
+export interface EditAnnouncementDispatcherDeps {
+  updateAnnouncementFn: typeof updateAnnouncement;
+}
+
+export async function handleEditAnnouncement(
+  ctx: AnnouncementDispatcherContext,
+  action: PendingActionRecord<"edit_announcement">,
+  deps: EditAnnouncementDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as EditAnnouncementPendingPayload;
+  const result = await deps.updateAnnouncementFn({
+    supabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    targetId: payload.targetId,
+    patch: payload.patch,
+    expectedUpdatedAt: payload.expectedUpdatedAt ?? null,
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "announcement",
+    resultEntityId: result.value.id,
+  });
+
+  if (ctx.canUseDraftSessions) {
+    await ctx.clearDraftSessionFn(ctx.serviceSupabase, {
+      organizationId: ctx.orgId,
+      userId: ctx.userId,
+      threadId: action.thread_id,
+      pendingActionId: action.id,
+      draftType: "edit_announcement",
+    });
+  }
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const announcementUrl = orgSlug ? `/${orgSlug}/announcements` : null;
+  const displayTitle = result.value.title ?? payload.targetTitle ?? "announcement";
+  const content = announcementUrl
+    ? `Updated announcement: [${displayTitle}](${announcementUrl})`
+    : `Updated announcement: ${displayTitle}`;
+
+  const { error: msgError } = await ctx.serviceSupabase
+    .from("ai_messages")
+    .insert({
+      thread_id: action.thread_id,
+      org_id: ctx.orgId,
+      role: "assistant",
+      content,
+      status: "complete",
+    });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    announcement: result.value,
     actionId: action.id,
   });
 }

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -20,13 +20,17 @@ import {
   createAnnouncement,
   sendAnnouncementNotification,
 } from "@/lib/announcements/create-announcement";
+import { updateAnnouncement } from "@/lib/announcements/update-announcement";
 import { sendAiAssistedDirectChatMessage } from "@/lib/chat/direct-chat";
 import { sendAiAssistedGroupChatMessage } from "@/lib/chat/group-chat";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { aiLog } from "@/lib/ai/logger";
 import { syncEventToUsers } from "@/lib/google/calendar-sync";
 import { sendNotificationBlast } from "@/lib/notifications";
-import { handleCreateAnnouncement } from "./dispatchers/announcements";
+import {
+  handleCreateAnnouncement,
+  handleEditAnnouncement,
+} from "./dispatchers/announcements";
 import { handleCreateEvent } from "./dispatchers/events";
 import { handleCreateJobPosting } from "./dispatchers/jobs";
 import {
@@ -48,6 +52,7 @@ export interface AiPendingActionConfirmRouteDeps {
   getPendingAction?: typeof getPendingAction;
   updatePendingActionStatus?: typeof updatePendingActionStatus;
   createAnnouncement?: typeof createAnnouncement;
+  updateAnnouncement?: typeof updateAnnouncement;
   createJobPosting?: typeof createJobPosting;
   createDiscussionReply?: typeof createDiscussionReply;
   createDiscussionThread?: typeof createDiscussionThread;
@@ -72,6 +77,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
   const getPendingActionFn = deps.getPendingAction ?? getPendingAction;
   const updatePendingActionStatusFn = deps.updatePendingActionStatus ?? updatePendingActionStatus;
   const createAnnouncementFn = deps.createAnnouncement ?? createAnnouncement;
+  const updateAnnouncementFn = deps.updateAnnouncement ?? updateAnnouncement;
   const createJobPostingFn = deps.createJobPosting ?? createJobPosting;
   const createDiscussionReplyFn = deps.createDiscussionReply ?? createDiscussionReply;
   const createDiscussionThreadFn = deps.createDiscussionThread ?? createDiscussionThread;
@@ -202,6 +208,20 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
               sendAnnouncementNotificationFn,
               sendNotificationBlastFn,
             }
+          );
+        case "edit_announcement":
+          return await handleEditAnnouncement(
+            {
+              serviceSupabase: ctx.serviceSupabase,
+              orgId: ctx.orgId,
+              userId: ctx.userId,
+              logContext,
+              canUseDraftSessions,
+              updatePendingActionStatusFn,
+              clearDraftSessionFn,
+            },
+            action as PendingActionRecord<"edit_announcement">,
+            { updateAnnouncementFn }
           );
         case "create_job_posting":
           return await handleCreateJobPosting(

--- a/src/lib/ai/draft-sessions.ts
+++ b/src/lib/ai/draft-sessions.ts
@@ -7,7 +7,10 @@ import type {
 import type { AssistantEventDraft } from "@/lib/schemas/events-ai";
 import type { AssistantJobDraft } from "@/lib/schemas/jobs";
 import type { AssistantChatMessageDraft, AssistantGroupMessageDraft } from "@/lib/schemas/chat-ai";
-import { AI_PENDING_ACTION_EXPIRY_MS } from "@/lib/ai/pending-actions";
+import {
+  AI_PENDING_ACTION_EXPIRY_MS,
+  type EditAnnouncementPendingPayload,
+} from "@/lib/ai/pending-actions";
 
 export type DraftSessionStatus = "collecting_fields" | "ready_for_confirmation";
 
@@ -16,6 +19,7 @@ export type DraftSessionStatus = "collecting_fields" | "ready_for_confirmation";
 // saveDraftSession enforces the contract at the application boundary.
 export const DRAFT_SESSION_TYPES = [
   "create_announcement",
+  "edit_announcement",
   "create_job_posting",
   "send_chat_message",
   "send_group_chat_message",
@@ -28,6 +32,7 @@ export type DraftSessionType = (typeof DRAFT_SESSION_TYPES)[number];
 
 export interface DraftSessionPayloadByType {
   create_announcement: AssistantAnnouncementDraft;
+  edit_announcement: EditAnnouncementPendingPayload;
   create_job_posting: AssistantJobDraft;
   send_chat_message: AssistantChatMessageDraft;
   send_group_chat_message: AssistantGroupMessageDraft;

--- a/src/lib/ai/pending-actions.ts
+++ b/src/lib/ai/pending-actions.ts
@@ -2,13 +2,17 @@ import type { AssistantPreparedJob } from "@/lib/schemas/jobs";
 import type { AssistantPreparedDiscussion } from "@/lib/schemas/discussion";
 import type { AssistantPreparedDiscussionReply } from "@/lib/schemas/discussion";
 import type { AssistantPreparedEvent } from "@/lib/schemas/events-ai";
-import type { AssistantPreparedAnnouncement } from "@/lib/schemas/content";
+import type {
+  AssistantAnnouncementPatch,
+  AssistantPreparedAnnouncement,
+} from "@/lib/schemas/content";
 import type { AssistantPreparedChatMessage, AssistantPreparedGroupMessage } from "@/lib/schemas/chat-ai";
 
 export const AI_PENDING_ACTION_EXPIRY_MS = 15 * 60 * 1000;
 
 export type PendingActionType =
   | "create_announcement"
+  | "edit_announcement"
   | "create_job_posting"
   | "send_chat_message"
   | "send_group_chat_message"
@@ -30,6 +34,24 @@ export interface CreateJobPostingPendingPayload extends AssistantPreparedJob {
 }
 
 export interface CreateAnnouncementPendingPayload extends AssistantPreparedAnnouncement {
+  orgSlug?: string | null;
+}
+
+export interface EditAnnouncementPendingPayload {
+  targetId: string;
+  patch: AssistantAnnouncementPatch;
+  /**
+   * `target.updated_at` captured at prepare time. When present it is used
+   * at confirm time as an optimistic-concurrency token: both a fast in-code
+   * re-read check and an `.eq("updated_at", ...)` filter on the UPDATE
+   * statement. Prevents racing with a concurrent UI edit.
+   */
+  expectedUpdatedAt?: string | null;
+  /**
+   * Caller-captured prior title — only used for the confirmation ai_message
+   * body. Not part of the mutation's semantics.
+   */
+  targetTitle?: string | null;
   orgSlug?: string | null;
 }
 
@@ -74,6 +96,7 @@ export interface RevokeEnterpriseInvitePendingPayload {
 
 export interface PendingActionPayloadByType {
   create_announcement: CreateAnnouncementPendingPayload;
+  edit_announcement: EditAnnouncementPendingPayload;
   create_job_posting: CreateJobPostingPendingPayload;
   send_chat_message: SendChatMessagePendingPayload;
   send_group_chat_message: SendGroupChatMessagePendingPayload;
@@ -305,6 +328,11 @@ export function buildPendingActionSummary(record: PendingActionRecord): PendingA
       return {
         title: "Review announcement",
         description: "Confirm the drafted announcement before it is published.",
+      };
+    case "edit_announcement":
+      return {
+        title: "Review announcement edit",
+        description: "Confirm the proposed changes before the announcement is updated.",
       };
     case "create_job_posting":
       return {

--- a/tests/ai-draft-sessions-zod-gate.test.ts
+++ b/tests/ai-draft-sessions-zod-gate.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/ai/draft-sessions";
 
 describe("DRAFT_SESSION_TYPES const tuple", () => {
-  it("exports the 7 known draft types in a readonly tuple", () => {
+  it("exports the known draft types in a readonly tuple", () => {
     assert.deepEqual(
       [...DRAFT_SESSION_TYPES].sort(),
       [
@@ -16,6 +16,7 @@ describe("DRAFT_SESSION_TYPES const tuple", () => {
         "create_discussion_thread",
         "create_event",
         "create_job_posting",
+        "edit_announcement",
         "send_chat_message",
         "send_group_chat_message",
       ]

--- a/tests/announcements-edit-dispatcher.test.ts
+++ b/tests/announcements-edit-dispatcher.test.ts
@@ -1,0 +1,361 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { handleEditAnnouncement } from "@/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements";
+import type { PendingActionRecord } from "@/lib/ai/pending-actions";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────
+
+const ORG_ID = "00000000-0000-4000-8000-000000000001";
+const USER_ID = "00000000-0000-4000-8000-000000000002";
+const THREAD_ID = "00000000-0000-4000-8000-000000000003";
+const ACTION_ID = "00000000-0000-4000-8000-000000000004";
+const TARGET_ID = "00000000-0000-4000-8000-000000000005";
+const EXPECTED_UPDATED_AT = "2026-04-22T09:00:00.000Z";
+
+function buildAction(
+  overrides: Partial<PendingActionRecord<"edit_announcement">> = {}
+): PendingActionRecord<"edit_announcement"> {
+  return {
+    id: ACTION_ID,
+    organization_id: ORG_ID,
+    user_id: USER_ID,
+    thread_id: THREAD_ID,
+    action_type: "edit_announcement",
+    payload: {
+      targetId: TARGET_ID,
+      patch: { title: "Fixed typo" },
+      expectedUpdatedAt: EXPECTED_UPDATED_AT,
+      targetTitle: "Original Title",
+      orgSlug: "org",
+    },
+    status: "pending",
+    expires_at: "2099-01-01T00:00:00.000Z",
+    created_at: "2026-04-22T08:00:00.000Z",
+    updated_at: "2026-04-22T08:00:00.000Z",
+    executed_at: null,
+    result_entity_type: null,
+    result_entity_id: null,
+    ...overrides,
+  } as PendingActionRecord<"edit_announcement">;
+}
+
+function buildCtx(options: {
+  serviceSupabase?: any;
+  canUseDraftSessions?: boolean;
+  onStatusUpdate?: (payload: any) => Promise<{ updated: boolean }>;
+  onDraftClear?: (input: any) => Promise<void>;
+} = {}) {
+  const insertedMessages: any[] = [];
+  const statusUpdates: any[] = [];
+  const draftClears: any[] = [];
+
+  const defaultServiceSupabase = {
+    from(table: string) {
+      if (table === "ai_messages") {
+        return {
+          insert(payload: Record<string, unknown>) {
+            insertedMessages.push(payload);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+
+  return {
+    ctx: {
+      serviceSupabase: options.serviceSupabase ?? defaultServiceSupabase,
+      orgId: ORG_ID,
+      userId: USER_ID,
+      logContext: { requestId: "test-req", orgId: ORG_ID },
+      canUseDraftSessions: options.canUseDraftSessions ?? true,
+      updatePendingActionStatusFn: (async (_supabase: any, _id: any, payload: any) => {
+        statusUpdates.push(payload);
+        if (options.onStatusUpdate) return options.onStatusUpdate(payload);
+        return { updated: true };
+      }) as any,
+      clearDraftSessionFn: (async (_supabase: any, input: any) => {
+        draftClears.push(input);
+        if (options.onDraftClear) return options.onDraftClear(input);
+      }) as any,
+    },
+    insertedMessages,
+    statusUpdates,
+    draftClears,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe("handleEditAnnouncement — success path", () => {
+  let harness: ReturnType<typeof buildCtx>;
+  beforeEach(() => {
+    harness = buildCtx();
+  });
+
+  it("calls the primitive with the full payload shape and returns 200 with the updated announcement", async () => {
+    let captured: any = null;
+    const updateAnnouncementFn = (async (req: any) => {
+      captured = req;
+      return {
+        ok: true,
+        value: {
+          id: TARGET_ID,
+          title: "Fixed typo",
+          body: "original body",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:05:00.000Z",
+        },
+      };
+    }) as any;
+
+    const response = await handleEditAnnouncement(
+      harness.ctx,
+      buildAction(),
+      { updateAnnouncementFn }
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.announcement.id, TARGET_ID);
+    assert.equal(body.actionId, ACTION_ID);
+
+    assert.ok(captured, "primitive must be called");
+    assert.equal(captured.orgId, ORG_ID);
+    assert.equal(captured.userId, USER_ID);
+    assert.equal(captured.targetId, TARGET_ID);
+    assert.equal(captured.expectedUpdatedAt, EXPECTED_UPDATED_AT);
+    assert.deepEqual(captured.patch, { title: "Fixed typo" });
+  });
+
+  it("writes the executed CAS transition with resultEntityType=announcement AFTER the primitive succeeds", async () => {
+    const updateAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "x",
+        updated_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleEditAnnouncement(harness.ctx, buildAction(), { updateAnnouncementFn });
+
+    assert.equal(harness.statusUpdates.length, 1, "exactly one status update on success");
+    assert.equal(harness.statusUpdates[0].status, "executed");
+    assert.equal(harness.statusUpdates[0].expectedStatus, "confirmed");
+    assert.equal(harness.statusUpdates[0].resultEntityType, "announcement");
+    assert.equal(harness.statusUpdates[0].resultEntityId, TARGET_ID);
+  });
+
+  it("clears the draft session narrowed by (thread_id, draft_type=edit_announcement, pending_action_id)", async () => {
+    const updateAnnouncementFn = (async () => ({
+      ok: true,
+      value: { id: TARGET_ID, title: "x", updated_at: "2026-04-22T09:05:00.000Z" },
+    })) as any;
+
+    await handleEditAnnouncement(harness.ctx, buildAction(), { updateAnnouncementFn });
+
+    assert.equal(harness.draftClears.length, 1);
+    assert.equal(harness.draftClears[0].organizationId, ORG_ID);
+    assert.equal(harness.draftClears[0].userId, USER_ID);
+    assert.equal(harness.draftClears[0].threadId, THREAD_ID);
+    assert.equal(harness.draftClears[0].pendingActionId, ACTION_ID);
+    assert.equal(harness.draftClears[0].draftType, "edit_announcement");
+  });
+
+  it("inserts an ai_messages confirmation row with the updated title", async () => {
+    const updateAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "New Updated Title",
+        updated_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleEditAnnouncement(harness.ctx, buildAction(), { updateAnnouncementFn });
+
+    assert.equal(harness.insertedMessages.length, 1);
+    assert.equal(harness.insertedMessages[0].role, "assistant");
+    assert.equal(harness.insertedMessages[0].thread_id, THREAD_ID);
+    assert.equal(harness.insertedMessages[0].org_id, ORG_ID);
+    assert.equal(harness.insertedMessages[0].status, "complete");
+    assert.match(
+      harness.insertedMessages[0].content,
+      /New Updated Title/,
+      "content should mention the updated title"
+    );
+    assert.match(
+      harness.insertedMessages[0].content,
+      /\/org\/announcements/,
+      "content should include the org-scoped announcements URL"
+    );
+  });
+
+  it("omits the ai_messages URL when orgSlug is empty", async () => {
+    const updateAnnouncementFn = (async () => ({
+      ok: true,
+      value: { id: TARGET_ID, title: "x", updated_at: "2026-04-22T09:05:00.000Z" },
+    })) as any;
+
+    await handleEditAnnouncement(
+      harness.ctx,
+      buildAction({
+        payload: {
+          targetId: TARGET_ID,
+          patch: { title: "x" },
+          expectedUpdatedAt: EXPECTED_UPDATED_AT,
+          targetTitle: "Original Title",
+          orgSlug: "",
+        },
+      }),
+      { updateAnnouncementFn }
+    );
+
+    assert.doesNotMatch(
+      harness.insertedMessages[0].content,
+      /\[.*\]\(/,
+      "content should be plain text (no markdown link) without orgSlug"
+    );
+  });
+
+  it("does not clear the draft session when canUseDraftSessions=false", async () => {
+    harness = buildCtx({ canUseDraftSessions: false });
+    const updateAnnouncementFn = (async () => ({
+      ok: true,
+      value: { id: TARGET_ID, title: "x", updated_at: "2026-04-22T09:05:00.000Z" },
+    })) as any;
+
+    await handleEditAnnouncement(harness.ctx, buildAction(), { updateAnnouncementFn });
+
+    assert.equal(harness.draftClears.length, 0);
+  });
+});
+
+describe("handleEditAnnouncement — typed-failure paths (no throw)", () => {
+  let harness: ReturnType<typeof buildCtx>;
+  beforeEach(() => {
+    harness = buildCtx();
+  });
+
+  for (const [status, errorKey, expectedStatus] of [
+    [403, "forbidden", 403],
+    [404, "not_found", 404],
+    [409, "stale_version", 409],
+    [422, "invariant_violation", 422],
+    [500, "update_failed", 500],
+  ] as const) {
+    it(`rolls back confirmed→pending and returns ${status} with error=${errorKey}`, async () => {
+      const updateAnnouncementFn = (async () => ({
+        ok: false,
+        status,
+        error: errorKey,
+      })) as any;
+
+      const response = await handleEditAnnouncement(
+        harness.ctx,
+        buildAction(),
+        { updateAnnouncementFn }
+      );
+      const body = await response.json();
+
+      assert.equal(response.status, expectedStatus);
+      assert.equal(body.error, errorKey);
+
+      // Single status update: the rollback to pending.
+      assert.equal(harness.statusUpdates.length, 1);
+      assert.equal(harness.statusUpdates[0].status, "pending");
+      assert.equal(harness.statusUpdates[0].expectedStatus, "confirmed");
+
+      // No message insert when the mutation failed.
+      assert.equal(harness.insertedMessages.length, 0);
+    });
+  }
+
+  it("forwards the details payload on 409 stale_version", async () => {
+    const updateAnnouncementFn = (async () => ({
+      ok: false,
+      status: 409,
+      error: "stale_version",
+      details: {
+        expectedUpdatedAt: "A",
+        currentUpdatedAt: "B",
+      },
+    })) as any;
+
+    const response = await handleEditAnnouncement(
+      harness.ctx,
+      buildAction(),
+      { updateAnnouncementFn }
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 409);
+    assert.deepEqual(body.details, {
+      expectedUpdatedAt: "A",
+      currentUpdatedAt: "B",
+    });
+  });
+});
+
+describe("handleEditAnnouncement — thrown-failure path (return-await regression)", () => {
+  it("lets the rejection propagate (does not swallow it) so handler.ts outer try/catch can roll back", async () => {
+    const harness = buildCtx();
+    const updateAnnouncementFn = (async () => {
+      throw new Error("Supabase timeout");
+    }) as any;
+
+    await assert.rejects(
+      handleEditAnnouncement(harness.ctx, buildAction(), { updateAnnouncementFn }),
+      { message: "Supabase timeout" }
+    );
+
+    // The dispatcher itself does NOT rollback on throw — that's the outer
+    // try/catch's job. So no CAS updates at this layer.
+    assert.equal(harness.statusUpdates.length, 0);
+    assert.equal(harness.insertedMessages.length, 0);
+    assert.equal(harness.draftClears.length, 0);
+  });
+});
+
+describe("handleEditAnnouncement — ai_messages failure is logged, not fatal", () => {
+  it("returns 200 with the updated announcement even when ai_messages.insert errors", async () => {
+    const insertedMessages: any[] = [];
+    const loggedErrors: unknown[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => loggedErrors.push(args);
+    try {
+      const serviceSupabase = {
+        from(table: string) {
+          if (table === "ai_messages") {
+            return {
+              insert(payload: Record<string, unknown>) {
+                insertedMessages.push(payload);
+                return Promise.resolve({ error: { message: "insert failed" } });
+              },
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        },
+      };
+      const harness = buildCtx({ serviceSupabase });
+      const updateAnnouncementFn = (async () => ({
+        ok: true,
+        value: { id: TARGET_ID, title: "x", updated_at: "2026-04-22T09:05:00.000Z" },
+      })) as any;
+
+      const response = await handleEditAnnouncement(
+        harness.ctx,
+        buildAction(),
+        { updateAnnouncementFn }
+      );
+      assert.equal(response.status, 200);
+      assert.equal(insertedMessages.length, 1, "the failing insert was still attempted");
+    } finally {
+      console.error = originalError;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2a-confirm of the Tier 1 edit/delete plan. Registers \`edit_announcement\` as a first-class \`PendingActionType\` and \`DraftSessionType\`, adds the confirm dispatcher that calls the \`updateAnnouncement\` primitive (integrated from #123), and threads the type through the Phase 0.5 switch in \`confirm/handler.ts\`.

**Stacks on #133** (\`integration/tier1-full\`). Merge #133 first.

**Scope: confirm side only.** The prepare-side LLM tool (\`prepare_edit_announcement\`) is deferred to Phase 2a-prepare and is guarded by a throwing branch in \`getToolNameForDraftType\` that makes the incomplete state explicit until it ships.

### Type additions

| Addition | File |
|---|---|
| \`PendingActionType += "edit_announcement"\` | \`src/lib/ai/pending-actions.ts\` |
| \`EditAnnouncementPendingPayload\` — \`{ targetId, patch, expectedUpdatedAt?, targetTitle?, orgSlug? }\` | \`src/lib/ai/pending-actions.ts\` |
| \`PendingActionPayloadByType.edit_announcement\` | \`src/lib/ai/pending-actions.ts\` |
| \`buildPendingActionSummary\` case \`edit_announcement\` → "Review announcement edit" | \`src/lib/ai/pending-actions.ts\` |
| \`DRAFT_SESSION_TYPES += "edit_announcement"\` | \`src/lib/ai/draft-sessions.ts\` |
| \`DraftSessionPayloadByType.edit_announcement = EditAnnouncementPendingPayload\` | \`src/lib/ai/draft-sessions.ts\` |

The compile-time \`_DraftSessionCoverageOK\` probe (introduced in #120) keeps both the tuple and the payload map in sync — any divergence is a \`tsc\` failure.

### Dispatcher

\`handleEditAnnouncement\` added to \`confirm/dispatchers/announcements.ts\`. Follows the Phase 0.5 pattern established across the nine existing dispatchers:

- Three-argument signature: \`ctx\` + \`action\` + \`deps\`
- Calls \`updateAnnouncement\` primitive with \`expectedUpdatedAt\` threaded through for optimistic-concurrency
- Typed-failure path: rolls back \`confirmed → pending\` and forwards the structured error code (403/404/409/422/500)
- Thrown-failure path: rejection propagates to handler.ts's outer try/catch (the \`return await\` rule from #127)
- \`ai_messages\` insert happens AFTER the \`confirmed → executed\` CAS, not before
- Draft-session clear narrowed to \`draftType: "edit_announcement"\`

The handler.ts switch gains a \`case "edit_announcement"\` that uses \`return await\` per the rule documented in #131's learning doc.

### Exhaustive-switch guards in chat handler

Two exhaustive switches on \`DraftSessionType\` need to cover the new value to compile:

1. **\`inferDraftSessionFromHistory\`** — \`case "edit_announcement": continue;\` because edit drafts require a target_resolver lookup, not chat-history extraction. The \`continue\` skips to the next iteration of the containing for loop.
2. **\`getToolNameForDraftType\`** — \`case "edit_announcement": throw ...\` with a specific "not yet wired" error. Unreachable at runtime today because no code path creates a draft session with draftType \`"edit_announcement"\` until the prepare-side tool ships. Throwing explicitly signals the incomplete state instead of silently returning a non-existent tool name.

## Testing

**\`tests/announcements-edit-dispatcher.test.ts\` — 14 tests, 4 suites:**

- **Success path (6 tests)**:
  - Primitive invocation shape (orgId, userId, targetId, patch, expectedUpdatedAt)
  - CAS ordering: \`executed\` fires AFTER primitive returns ok
  - \`resultEntityType = "announcement"\`
  - Draft-session clear narrowed by \`draftType: "edit_announcement"\` + \`pendingActionId\`
  - \`ai_messages\` content includes updated title and org-scoped URL
  - \`ai_messages\` plain text when \`orgSlug\` is empty
  - \`canUseDraftSessions = false\` skips the clear call
- **Typed-failure paths (6 tests)**: 403/404/409/422/500 each roll back \`confirmed → pending\` and surface the structured error. \`stale_version\` details payload forwarded.
- **Thrown-failure path (1 test)**: rejection propagates unmodified so handler.ts's outer try/catch owns the rollback. Dispatcher makes no CAS updates itself.
- **\`ai_messages\` failure tolerance (1 test)**: \`insert\` returning error is logged but non-fatal; response is still 200 with the updated announcement.

Updated \`tests/ai-draft-sessions-zod-gate.test.ts\` expectation from 7 to 8 draft types.

**188/188 tests pass** across the integration+Phase-2a-confirm branch (characterization suites from #133 plus the new dispatcher tests). \`npx tsc --noEmit\` clean. \`npx eslint\` clean.

## Post-Deploy Monitoring & Validation

- **Activation gate**: until the prepare-side tool ships, no code path creates an \`edit_announcement\` pending action. This PR adds the confirm infrastructure but cannot produce observable user behaviour on its own.
- **What to monitor once prepare side ships**
  - \`aiLog\` keys in \`ai-confirm\` subsystem: standard dispatcher logs (\`failed to insert confirmation message\`, \`rollback failed - action stranded in confirmed state\`).
  - Database: \`ai_pending_actions\` rows with \`action_type = 'edit_announcement'\`. Healthy ratio \`pending → confirmed → executed\`; stranded \`confirmed\` rows > 60s indicate a primitive throw that missed rollback.
  - Rate of \`409 stale_version\` responses — these indicate concurrent UI edits racing the agent edit, which the \`expectedUpdatedAt\` token is designed to surface explicitly.
- **Validation query (when prepare side is live)**
  \`\`\`sql
  SELECT status, COUNT(*) FROM ai_pending_actions
  WHERE action_type = 'edit_announcement' AND created_at > now() - interval '1 hour'
  GROUP BY status;
  \`\`\`
- **Rollback**: revert this PR. No data migrations; the added columns and indexes on \`ai_pending_actions\` from #121 can still carry rows of this new type (they were designed for it).
- **Validation window**: 24h after Phase 2a-prepare ships. Owner: AI agent team.

## Review notes

Read \`dispatchers/announcements.ts\` first — \`handleEditAnnouncement\` is the new code and mirrors \`handleCreateAnnouncement\` in structure. Then \`handler.ts\` for the one-case addition, then the type additions in \`pending-actions.ts\` and \`draft-sessions.ts\`. The chat handler's two switch guards are defensive additions; check that the \`continue\` and \`throw\` choices match your risk tolerance vs. a silent fallback.

---

[![Compound Engineering v2.46.0](https://img.shields.io/badge/Compound_Engineering-v2.46.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)