### PR TITLE
feat(ai): Phase 2b-confirm — delete_announcement pending type + dispatcher

### DIFF
--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements.ts
@@ -15,6 +15,7 @@ import type {
 } from "@/lib/ai/draft-sessions";
 import type {
   CreateAnnouncementPendingPayload,
+  DeleteAnnouncementPendingPayload,
   EditAnnouncementPendingPayload,
   PendingActionRecord,
   updatePendingActionStatus,
@@ -23,6 +24,7 @@ import type {
   createAnnouncement,
   sendAnnouncementNotification,
 } from "@/lib/announcements/create-announcement";
+import type { softDeleteAnnouncement } from "@/lib/announcements/soft-delete-announcement";
 import type { updateAnnouncement } from "@/lib/announcements/update-announcement";
 import type { sendNotificationBlast } from "@/lib/notifications";
 
@@ -248,6 +250,104 @@ export async function handleEditAnnouncement(
   const content = announcementUrl
     ? `Updated announcement: [${displayTitle}](${announcementUrl})`
     : `Updated announcement: ${displayTitle}`;
+
+  const { error: msgError } = await ctx.serviceSupabase
+    .from("ai_messages")
+    .insert({
+      thread_id: action.thread_id,
+      org_id: ctx.orgId,
+      role: "assistant",
+      content,
+      status: "complete",
+    });
+
+  if (msgError) {
+    aiLog(
+      "error",
+      "ai-confirm",
+      "failed to insert confirmation message",
+      {
+        ...ctx.logContext,
+        userId: ctx.userId,
+        threadId: action.thread_id,
+      },
+      {
+        actionId: action.id,
+        error: msgError,
+      }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    announcement: result.value,
+    actionId: action.id,
+  });
+}
+
+// ─── Delete dispatcher ──────────────────────────────────────────────────
+//
+// Phase 2b of the Tier 1 edit/delete plan. Mirrors handleEditAnnouncement
+// but calls the softDeleteAnnouncement primitive and has no draft-session
+// clear — delete actions skip the multi-turn collection phase entirely
+// (the plan's security decision: "most-recent fallback disabled for
+// delete" means target_id is always explicit, so there's nothing to
+// collect). Matches the revoke_enterprise_invite precedent where
+// destructive single-target ops don't register a DraftSessionType.
+
+export interface DeleteAnnouncementDispatcherDeps {
+  softDeleteAnnouncementFn: typeof softDeleteAnnouncement;
+}
+
+export async function handleDeleteAnnouncement(
+  ctx: AnnouncementDispatcherContext,
+  action: PendingActionRecord<"delete_announcement">,
+  deps: DeleteAnnouncementDispatcherDeps
+): Promise<NextResponse> {
+  const payload = action.payload as DeleteAnnouncementPendingPayload;
+  const result = await deps.softDeleteAnnouncementFn({
+    supabase: ctx.serviceSupabase,
+    orgId: ctx.orgId,
+    userId: ctx.userId,
+    targetId: payload.targetId,
+    expectedUpdatedAt: payload.expectedUpdatedAt ?? null,
+  });
+
+  if (!result.ok) {
+    await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+      status: "pending",
+      expectedStatus: "confirmed",
+    });
+    return NextResponse.json(
+      result.details
+        ? { error: result.error, details: result.details }
+        : { error: result.error },
+      { status: result.status }
+    );
+  }
+
+  await ctx.updatePendingActionStatusFn(ctx.serviceSupabase, action.id, {
+    status: "executed",
+    expectedStatus: "confirmed",
+    executedAt: new Date().toISOString(),
+    resultEntityType: "announcement",
+    resultEntityId: result.value.id,
+  });
+
+  // No draft-session clear: delete_announcement is not a DraftSessionType.
+  // If a future phase adds multi-turn disambiguation for deletes (e.g. name
+  // lookup), the DraftSessionType entry will be added alongside and this
+  // dispatcher will gain the standard clear call.
+
+  const orgSlug =
+    typeof payload.orgSlug === "string" && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  const announcementUrl = orgSlug ? `/${orgSlug}/announcements` : null;
+  const displayTitle = payload.targetTitle ?? result.value.title ?? "announcement";
+  const content = announcementUrl
+    ? `Deleted announcement: [${displayTitle}](${announcementUrl})`
+    : `Deleted announcement: ${displayTitle}`;
 
   const { error: msgError } = await ctx.serviceSupabase
     .from("ai_messages")

--- a/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
+++ b/src/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/handler.ts
@@ -20,6 +20,7 @@ import {
   createAnnouncement,
   sendAnnouncementNotification,
 } from "@/lib/announcements/create-announcement";
+import { softDeleteAnnouncement } from "@/lib/announcements/soft-delete-announcement";
 import { updateAnnouncement } from "@/lib/announcements/update-announcement";
 import { sendAiAssistedDirectChatMessage } from "@/lib/chat/direct-chat";
 import { sendAiAssistedGroupChatMessage } from "@/lib/chat/group-chat";
@@ -29,6 +30,7 @@ import { syncEventToUsers } from "@/lib/google/calendar-sync";
 import { sendNotificationBlast } from "@/lib/notifications";
 import {
   handleCreateAnnouncement,
+  handleDeleteAnnouncement,
   handleEditAnnouncement,
 } from "./dispatchers/announcements";
 import { handleCreateEvent } from "./dispatchers/events";
@@ -53,6 +55,7 @@ export interface AiPendingActionConfirmRouteDeps {
   updatePendingActionStatus?: typeof updatePendingActionStatus;
   createAnnouncement?: typeof createAnnouncement;
   updateAnnouncement?: typeof updateAnnouncement;
+  softDeleteAnnouncement?: typeof softDeleteAnnouncement;
   createJobPosting?: typeof createJobPosting;
   createDiscussionReply?: typeof createDiscussionReply;
   createDiscussionThread?: typeof createDiscussionThread;
@@ -78,6 +81,7 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
   const updatePendingActionStatusFn = deps.updatePendingActionStatus ?? updatePendingActionStatus;
   const createAnnouncementFn = deps.createAnnouncement ?? createAnnouncement;
   const updateAnnouncementFn = deps.updateAnnouncement ?? updateAnnouncement;
+  const softDeleteAnnouncementFn = deps.softDeleteAnnouncement ?? softDeleteAnnouncement;
   const createJobPostingFn = deps.createJobPosting ?? createJobPosting;
   const createDiscussionReplyFn = deps.createDiscussionReply ?? createDiscussionReply;
   const createDiscussionThreadFn = deps.createDiscussionThread ?? createDiscussionThread;
@@ -222,6 +226,20 @@ export function createAiPendingActionConfirmHandler(deps: AiPendingActionConfirm
             },
             action as PendingActionRecord<"edit_announcement">,
             { updateAnnouncementFn }
+          );
+        case "delete_announcement":
+          return await handleDeleteAnnouncement(
+            {
+              serviceSupabase: ctx.serviceSupabase,
+              orgId: ctx.orgId,
+              userId: ctx.userId,
+              logContext,
+              canUseDraftSessions,
+              updatePendingActionStatusFn,
+              clearDraftSessionFn,
+            },
+            action as PendingActionRecord<"delete_announcement">,
+            { softDeleteAnnouncementFn }
           );
         case "create_job_posting":
           return await handleCreateJobPosting(

--- a/src/lib/ai/pending-actions.ts
+++ b/src/lib/ai/pending-actions.ts
@@ -13,6 +13,7 @@ export const AI_PENDING_ACTION_EXPIRY_MS = 15 * 60 * 1000;
 export type PendingActionType =
   | "create_announcement"
   | "edit_announcement"
+  | "delete_announcement"
   | "create_job_posting"
   | "send_chat_message"
   | "send_group_chat_message"
@@ -50,6 +51,25 @@ export interface EditAnnouncementPendingPayload {
   /**
    * Caller-captured prior title — only used for the confirmation ai_message
    * body. Not part of the mutation's semantics.
+   */
+  targetTitle?: string | null;
+  orgSlug?: string | null;
+}
+
+export interface DeleteAnnouncementPendingPayload {
+  targetId: string;
+  /**
+   * Optional optimistic-concurrency token captured at prepare time. Unlike
+   * edit, delete tolerates last-writer-wins semantics — the soft-delete is
+   * idempotent (second invocation on an already-deleted row no-ops). But
+   * supplying the token surfaces concurrent edits as a 409 stale_version,
+   * which the user can use to review before a destructive-op re-confirm.
+   */
+  expectedUpdatedAt?: string | null;
+  /**
+   * Caller-captured title — only used for the confirmation ai_message body.
+   * Not part of the mutation's semantics. Populated because once the row is
+   * soft-deleted, subsequent reads may filter it out.
    */
   targetTitle?: string | null;
   orgSlug?: string | null;
@@ -97,6 +117,7 @@ export interface RevokeEnterpriseInvitePendingPayload {
 export interface PendingActionPayloadByType {
   create_announcement: CreateAnnouncementPendingPayload;
   edit_announcement: EditAnnouncementPendingPayload;
+  delete_announcement: DeleteAnnouncementPendingPayload;
   create_job_posting: CreateJobPostingPendingPayload;
   send_chat_message: SendChatMessagePendingPayload;
   send_group_chat_message: SendGroupChatMessagePendingPayload;
@@ -333,6 +354,11 @@ export function buildPendingActionSummary(record: PendingActionRecord): PendingA
       return {
         title: "Review announcement edit",
         description: "Confirm the proposed changes before the announcement is updated.",
+      };
+    case "delete_announcement":
+      return {
+        title: "Delete announcement?",
+        description: "Confirm that this announcement should be removed.",
       };
     case "create_job_posting":
       return {

--- a/tests/announcements-delete-dispatcher.test.ts
+++ b/tests/announcements-delete-dispatcher.test.ts
@@ -1,0 +1,378 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { handleDeleteAnnouncement } from "@/app/api/ai/[orgId]/pending-actions/[actionId]/confirm/dispatchers/announcements";
+import type { PendingActionRecord } from "@/lib/ai/pending-actions";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────
+
+const ORG_ID = "00000000-0000-4000-8000-000000000001";
+const USER_ID = "00000000-0000-4000-8000-000000000002";
+const THREAD_ID = "00000000-0000-4000-8000-000000000003";
+const ACTION_ID = "00000000-0000-4000-8000-000000000004";
+const TARGET_ID = "00000000-0000-4000-8000-000000000005";
+const EXPECTED_UPDATED_AT = "2026-04-22T09:00:00.000Z";
+
+function buildAction(
+  overrides: Partial<PendingActionRecord<"delete_announcement">> = {}
+): PendingActionRecord<"delete_announcement"> {
+  return {
+    id: ACTION_ID,
+    organization_id: ORG_ID,
+    user_id: USER_ID,
+    thread_id: THREAD_ID,
+    action_type: "delete_announcement",
+    payload: {
+      targetId: TARGET_ID,
+      expectedUpdatedAt: EXPECTED_UPDATED_AT,
+      targetTitle: "Week 5 Practice",
+      orgSlug: "org",
+    },
+    status: "pending",
+    expires_at: "2099-01-01T00:00:00.000Z",
+    created_at: "2026-04-22T08:00:00.000Z",
+    updated_at: "2026-04-22T08:00:00.000Z",
+    executed_at: null,
+    result_entity_type: null,
+    result_entity_id: null,
+    ...overrides,
+  } as PendingActionRecord<"delete_announcement">;
+}
+
+function buildCtx(options: {
+  serviceSupabase?: any;
+  canUseDraftSessions?: boolean;
+} = {}) {
+  const insertedMessages: any[] = [];
+  const statusUpdates: any[] = [];
+  const draftClears: any[] = [];
+
+  const defaultServiceSupabase = {
+    from(table: string) {
+      if (table === "ai_messages") {
+        return {
+          insert(payload: Record<string, unknown>) {
+            insertedMessages.push(payload);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+
+  return {
+    ctx: {
+      serviceSupabase: options.serviceSupabase ?? defaultServiceSupabase,
+      orgId: ORG_ID,
+      userId: USER_ID,
+      logContext: { requestId: "test-req", orgId: ORG_ID },
+      canUseDraftSessions: options.canUseDraftSessions ?? true,
+      updatePendingActionStatusFn: (async (_supabase: any, _id: any, payload: any) => {
+        statusUpdates.push(payload);
+        return { updated: true };
+      }) as any,
+      clearDraftSessionFn: (async (_supabase: any, input: any) => {
+        draftClears.push(input);
+      }) as any,
+    },
+    insertedMessages,
+    statusUpdates,
+    draftClears,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe("handleDeleteAnnouncement — success path", () => {
+  let harness: ReturnType<typeof buildCtx>;
+  beforeEach(() => {
+    harness = buildCtx();
+  });
+
+  it("calls the primitive with targetId + expectedUpdatedAt and returns 200", async () => {
+    let captured: any = null;
+    const softDeleteAnnouncementFn = (async (req: any) => {
+      captured = req;
+      return {
+        ok: true,
+        value: {
+          id: TARGET_ID,
+          title: "Week 5 Practice",
+          body: "body",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:05:00.000Z",
+          deleted_at: "2026-04-22T09:05:00.000Z",
+        },
+      };
+    }) as any;
+
+    const response = await handleDeleteAnnouncement(
+      harness.ctx,
+      buildAction(),
+      { softDeleteAnnouncementFn }
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.announcement.id, TARGET_ID);
+    assert.ok(body.announcement.deleted_at, "response should carry deleted_at");
+    assert.equal(body.actionId, ACTION_ID);
+
+    assert.ok(captured);
+    assert.equal(captured.orgId, ORG_ID);
+    assert.equal(captured.userId, USER_ID);
+    assert.equal(captured.targetId, TARGET_ID);
+    assert.equal(captured.expectedUpdatedAt, EXPECTED_UPDATED_AT);
+  });
+
+  it("writes the executed CAS with resultEntityType=announcement after the primitive succeeds", async () => {
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "x",
+        updated_at: "2026-04-22T09:05:00.000Z",
+        deleted_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleDeleteAnnouncement(harness.ctx, buildAction(), {
+      softDeleteAnnouncementFn,
+    });
+
+    assert.equal(harness.statusUpdates.length, 1);
+    assert.equal(harness.statusUpdates[0].status, "executed");
+    assert.equal(harness.statusUpdates[0].expectedStatus, "confirmed");
+    assert.equal(harness.statusUpdates[0].resultEntityType, "announcement");
+    assert.equal(harness.statusUpdates[0].resultEntityId, TARGET_ID);
+  });
+
+  it("does NOT clear any draft session (delete_announcement is not a DraftSessionType)", async () => {
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "x",
+        updated_at: "2026-04-22T09:05:00.000Z",
+        deleted_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleDeleteAnnouncement(harness.ctx, buildAction(), {
+      softDeleteAnnouncementFn,
+    });
+
+    assert.equal(
+      harness.draftClears.length,
+      0,
+      "delete flow skips the draft-session collection phase entirely"
+    );
+  });
+
+  it("inserts an ai_messages confirmation using the captured targetTitle and org-scoped URL", async () => {
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "Different Stored Title",
+        updated_at: "2026-04-22T09:05:00.000Z",
+        deleted_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleDeleteAnnouncement(harness.ctx, buildAction(), {
+      softDeleteAnnouncementFn,
+    });
+
+    assert.equal(harness.insertedMessages.length, 1);
+    const msg = harness.insertedMessages[0];
+    assert.equal(msg.role, "assistant");
+    assert.equal(msg.thread_id, THREAD_ID);
+    assert.equal(msg.org_id, ORG_ID);
+    assert.equal(msg.status, "complete");
+    assert.match(
+      msg.content,
+      /Week 5 Practice/,
+      "content should prefer the payload's targetTitle captured at prepare time"
+    );
+    assert.match(msg.content, /Deleted announcement/);
+    assert.match(msg.content, /\/org\/announcements/);
+  });
+
+  it("falls back to result.value.title when targetTitle is absent", async () => {
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "Stored Row Title",
+        updated_at: "2026-04-22T09:05:00.000Z",
+        deleted_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleDeleteAnnouncement(
+      harness.ctx,
+      buildAction({
+        payload: {
+          targetId: TARGET_ID,
+          expectedUpdatedAt: EXPECTED_UPDATED_AT,
+          targetTitle: null,
+          orgSlug: "org",
+        },
+      }),
+      { softDeleteAnnouncementFn }
+    );
+
+    assert.match(harness.insertedMessages[0].content, /Stored Row Title/);
+  });
+
+  it("renders plain text (no markdown link) when orgSlug is missing", async () => {
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: true,
+      value: {
+        id: TARGET_ID,
+        title: "x",
+        updated_at: "2026-04-22T09:05:00.000Z",
+        deleted_at: "2026-04-22T09:05:00.000Z",
+      },
+    })) as any;
+
+    await handleDeleteAnnouncement(
+      harness.ctx,
+      buildAction({
+        payload: {
+          targetId: TARGET_ID,
+          expectedUpdatedAt: EXPECTED_UPDATED_AT,
+          targetTitle: "Plain",
+          orgSlug: "",
+        },
+      }),
+      { softDeleteAnnouncementFn }
+    );
+
+    assert.doesNotMatch(harness.insertedMessages[0].content, /\[.*\]\(/);
+  });
+});
+
+describe("handleDeleteAnnouncement — typed-failure paths (no throw)", () => {
+  for (const [status, errorKey] of [
+    [403, "forbidden"],
+    [404, "not_found"],
+    [409, "stale_version"],
+    [500, "delete_failed"],
+  ] as const) {
+    it(`rolls back confirmed→pending and returns ${status} with error=${errorKey}`, async () => {
+      const harness = buildCtx();
+      const softDeleteAnnouncementFn = (async () => ({
+        ok: false,
+        status,
+        error: errorKey,
+      })) as any;
+
+      const response = await handleDeleteAnnouncement(
+        harness.ctx,
+        buildAction(),
+        { softDeleteAnnouncementFn }
+      );
+      const body = await response.json();
+
+      assert.equal(response.status, status);
+      assert.equal(body.error, errorKey);
+
+      assert.equal(harness.statusUpdates.length, 1);
+      assert.equal(harness.statusUpdates[0].status, "pending");
+      assert.equal(harness.statusUpdates[0].expectedStatus, "confirmed");
+
+      assert.equal(harness.insertedMessages.length, 0, "no confirmation message on failure");
+    });
+  }
+
+  it("forwards the details payload on 409 stale_version", async () => {
+    const harness = buildCtx();
+    const softDeleteAnnouncementFn = (async () => ({
+      ok: false,
+      status: 409,
+      error: "stale_version",
+      details: {
+        expectedUpdatedAt: "A",
+        currentUpdatedAt: "B",
+      },
+    })) as any;
+
+    const response = await handleDeleteAnnouncement(
+      harness.ctx,
+      buildAction(),
+      { softDeleteAnnouncementFn }
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 409);
+    assert.deepEqual(body.details, {
+      expectedUpdatedAt: "A",
+      currentUpdatedAt: "B",
+    });
+  });
+});
+
+describe("handleDeleteAnnouncement — thrown-failure path (return-await regression)", () => {
+  it("lets the rejection propagate (does not swallow it) so handler.ts outer try/catch can roll back", async () => {
+    const harness = buildCtx();
+    const softDeleteAnnouncementFn = (async () => {
+      throw new Error("Supabase timeout");
+    }) as any;
+
+    await assert.rejects(
+      handleDeleteAnnouncement(harness.ctx, buildAction(), { softDeleteAnnouncementFn }),
+      { message: "Supabase timeout" }
+    );
+
+    assert.equal(harness.statusUpdates.length, 0);
+    assert.equal(harness.insertedMessages.length, 0);
+  });
+});
+
+describe("handleDeleteAnnouncement — ai_messages failure is logged, not fatal", () => {
+  it("returns 200 with the deleted announcement even when ai_messages.insert errors", async () => {
+    const insertedMessages: any[] = [];
+    const loggedErrors: unknown[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => loggedErrors.push(args);
+    try {
+      const serviceSupabase = {
+        from(table: string) {
+          if (table === "ai_messages") {
+            return {
+              insert(payload: Record<string, unknown>) {
+                insertedMessages.push(payload);
+                return Promise.resolve({ error: { message: "insert failed" } });
+              },
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        },
+      };
+      const harness = buildCtx({ serviceSupabase });
+      const softDeleteAnnouncementFn = (async () => ({
+        ok: true,
+        value: {
+          id: TARGET_ID,
+          title: "x",
+          updated_at: "2026-04-22T09:05:00.000Z",
+          deleted_at: "2026-04-22T09:05:00.000Z",
+        },
+      })) as any;
+
+      const response = await handleDeleteAnnouncement(
+        harness.ctx,
+        buildAction(),
+        { softDeleteAnnouncementFn }
+      );
+      assert.equal(response.status, 200);
+      assert.equal(insertedMessages.length, 1);
+    } finally {
+      console.error = originalError;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2b-confirm of the Tier 1 edit/delete plan. Registers \`delete_announcement\` as a first-class \`PendingActionType\` and wires a confirm dispatcher that calls the \`softDeleteAnnouncement\` primitive (integrated from #124).

**Stacks on #134** (Phase 2a-confirm, edit). Merge #134 first — this PR's handler.ts changes assume #134's \`handleEditAnnouncement\` already exists.

Mirrors the Phase 2a-confirm shape with two meaningful differences:

1. **No DraftSessionType** — delete is a single-target destructive op with no multi-turn collection phase. Per the plan's security decision ("most-recent fallback disabled for delete"), \`target_id\` is always explicit, so there's nothing to collect. Matches the \`revoke_enterprise_invite\` precedent.
2. **\`targetTitle\` preferred over \`result.value.title\`** for the \`ai_messages\` confirmation body — once the row is soft-deleted, downstream reads may filter it out. Capturing the title at prepare time keeps the user-visible confirmation stable.

### Changes

| Addition | File |
|---|---|
| \`PendingActionType += "delete_announcement"\` | \`src/lib/ai/pending-actions.ts\` |
| \`DeleteAnnouncementPendingPayload\` — \`{ targetId, expectedUpdatedAt?, targetTitle?, orgSlug? }\` | \`src/lib/ai/pending-actions.ts\` |
| \`PendingActionPayloadByType.delete_announcement\` | \`src/lib/ai/pending-actions.ts\` |
| \`buildPendingActionSummary\` case → "Delete announcement?" | \`src/lib/ai/pending-actions.ts\` |
| \`handleDeleteAnnouncement\` dispatcher (107 LOC) | \`confirm/dispatchers/announcements.ts\` |
| \`softDeleteAnnouncementFn\` dep + switch case | \`confirm/handler.ts\` |
| 13 dispatcher tests (4 suites) | \`tests/announcements-delete-dispatcher.test.ts\` |

Zero \`DRAFT_SESSION_TYPES\` change (delete skips the draft phase) — no chat handler changes needed either (nothing to infer, nothing to route).

## Testing

- **13 new dispatcher tests** covering:
  - **Success path (6)**: primitive invocation shape, CAS ordering (executed AFTER primitive), \`resultEntityType = "announcement"\`, **no draft-session clear**, ai_messages content prefers \`payload.targetTitle\` (since post-delete reads may filter out), fallback to \`result.value.title\` when targetTitle is null, plain-text rendering when orgSlug missing
  - **Typed failures (5)**: 403/404/409/500 all roll back \`confirmed → pending\`, 409 \`stale_version\` details payload forwarded
  - **Thrown failure (1)**: rejection propagates unmodified; dispatcher makes no CAS update (outer try/catch owns the rollback)
  - **ai_messages insert failure tolerance (1)**: logged, not fatal; returns 200 with the deleted announcement

- **201/201 tests pass** across the integration + Phase 2a + Phase 2b chain.
- \`npx tsc --noEmit\` clean. \`npx eslint\` clean.

## Post-Deploy Monitoring & Validation

- **Activation gate**: until the prepare-side tool ships (\`prepare_delete_announcement\`), no code path creates a \`delete_announcement\` pending action. This PR adds the confirm infrastructure only.
- **What to monitor once prepare side ships**
  - \`aiLog\` keys in \`ai-confirm\`: standard dispatcher logs (\`failed to insert confirmation message\`, \`rollback failed - action stranded in confirmed state\`).
  - Database: ratio of \`delete_announcement\` pending actions that reach \`executed\` vs those stranded in \`confirmed\`. Healthy: > 99% reach executed.
  - Rate of \`409 stale_version\` responses — indicate concurrent UI edits racing the agent delete; the \`expectedUpdatedAt\` token is designed to surface these.
- **Validation query (when prepare side is live)**
  \`\`\`sql
  SELECT status, COUNT(*) FROM ai_pending_actions
  WHERE action_type = 'delete_announcement' AND created_at > now() - interval '1 hour'
  GROUP BY status;

  -- Verify soft-delete semantics
  SELECT COUNT(*) FILTER (WHERE deleted_at IS NOT NULL) AS soft_deleted,
         COUNT(*) AS total
  FROM announcements
  WHERE organization_id = '<canary-org>';
  \`\`\`
- **Failure signals / rollback triggers**: (a) spike in \`rollback failed\` logs; (b) any hard \`DELETE\` (not soft-delete) showing up in audit — would indicate the wrong primitive is being called; (c) \`targetId\` showing up as a malformed UUID in pending-action payloads.
- **Rollback**: revert this PR. The \`softDeleteAnnouncement\` primitive and its tests remain available for other consumers (the integration branch #133 carries them independently).
- **Validation window**: 24h after Phase 2b-prepare ships. Owner: AI agent team.

## Review notes

Read \`dispatchers/announcements.ts\` — \`handleDeleteAnnouncement\` is at the bottom of the file. It intentionally looks nearly identical to \`handleEditAnnouncement\` (Phase 2a) minus the draft-session clear and the patch handling. Then \`handler.ts\` for the one-case switch addition, \`pending-actions.ts\` for the payload type.

Consider whether the "no draft session for delete" choice matches your model. If you'd prefer delete drafts for symmetry, the change is: add \`"delete_announcement"\` to \`DRAFT_SESSION_TYPES\` and \`DraftSessionPayloadByType\`, add the \`draftType: "delete_announcement"\` line back into the dispatcher's clear call, and extend the two chat-handler exhaustive switches. The current scope deliberately skips all of that per the plan's security + simplicity convergence.

---

[![Compound Engineering v2.46.0](https://img.shields.io/badge/Compound_Engineering-v2.46.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)