### PR TITLE
feat(ai): Phase 2a-prepare — register prepare_edit_announcement tool

### DIFF
--- a/src/app/api/ai/[orgId]/chat/handler.ts
+++ b/src/app/api/ai/[orgId]/chat/handler.ts
@@ -154,6 +154,13 @@ const DIRECT_NAVIGATION_PROMPT_PATTERN =
   /(?:(?<!\w)(?:go\s+to|take\s+me\s+to|navigate\s+to|open|where\s+is|where\s+(?:can|do)\s+i\s+find|find\s+the\s+page|link\s+to)(?!\w)|(?<!\w)show\s+me\b[\s\S]{0,80}\b(?:page|screen|tab|settings?)\b)/i;
 const CREATE_ANNOUNCEMENT_PROMPT_PATTERN =
   /(?:(?<!\w)(?:create|add|post|publish|make|send|draft|write|compose)(?!\w)[\s\S]{0,120}\b(?:announcement|update|news post|bulletin)(?!\w)|(?<!\w)(?:announcement|update|news post|bulletin)(?!\w)[\s\S]{0,80}\b(?:create|add|post|publish|make|send|draft|write|compose)(?!\w))/i;
+// Edit-intent verbs for announcements. Distinct from create verbs above:
+// "fix/change/update/edit/reword/rephrase/correct/amend/revise" paired with
+// "announcement" (or just "typo" / "typos" when the feature context is
+// announcements — see the surface-routing fallback below). Deliberately
+// does NOT match "delete/remove/cancel" — that's Phase 2b-prepare.
+const EDIT_ANNOUNCEMENT_PROMPT_PATTERN =
+  /(?:(?<!\w)(?:fix|change|update|edit|reword|rephrase|correct|amend|revise)(?!\w)[\s\S]{0,120}\b(?:announcement|update|news post|bulletin|typo|typos|title|wording)(?!\w)|(?<!\w)(?:announcement|update|news post|bulletin)(?!\w)[\s\S]{0,80}\b(?:fix|change|edit|reword|rephrase|correct|amend|revise)(?!\w))/i;
 const CREATE_JOB_PROMPT_PATTERN =
   /(?:(?<!\w)(?:create|add|post|publish|make|open)(?!\w)[\s\S]{0,120}\b(?:job|job posting|opening|role|position)(?!\w)|(?<!\w)(?:job|job posting|opening|role|position)(?!\w)[\s\S]{0,80}\b(?:create|add|post|publish|make|open)(?!\w))/i;
 const SEND_CHAT_MESSAGE_PROMPT_PATTERN =
@@ -1844,6 +1851,13 @@ function getPass1Tools(
     return [AI_TOOL_MAP.prepare_announcement];
   }
 
+  // Edit-intent attachment — check AFTER create to avoid stealing turns that
+  // match both (e.g. "create an update" would match create; "update the
+  // announcement title" matches edit only).
+  if (EDIT_ANNOUNCEMENT_PROMPT_PATTERN.test(message)) {
+    return [AI_TOOL_MAP.prepare_edit_announcement];
+  }
+
   if (CREATE_JOB_PROMPT_PATTERN.test(message) || looksLikeStructuredJobDraft(message)) {
     return [AI_TOOL_MAP.prepare_job_posting];
   }
@@ -2887,15 +2901,7 @@ function getToolNameForDraftType(draftType: DraftSessionType): ToolName {
     case "create_announcement":
       return "prepare_announcement";
     case "edit_announcement":
-      // Placeholder for Phase 2a-prepare: the prepare_edit_announcement
-      // tool is not yet registered. This branch should be unreachable
-      // until that tool ships, because no code path creates a draft
-      // session with draftType "edit_announcement" yet. Throwing makes
-      // the incomplete state explicit instead of silently attaching a
-      // non-existent tool name.
-      throw new Error(
-        "prepare_edit_announcement tool is not registered yet (Phase 2a-prepare not shipped)"
-      );
+      return "prepare_edit_announcement";
     case "create_job_posting":
       return "prepare_job_posting";
     case "send_chat_message":

--- a/src/lib/ai/tools/definitions.ts
+++ b/src/lib/ai/tools/definitions.ts
@@ -307,6 +307,43 @@ const TOOL_BY_NAME = {
       },
     },
   },
+  prepare_edit_announcement: {
+    type: "function" as const,
+    function: {
+      name: "prepare_edit_announcement" as const,
+      description:
+        "Prepare an edit to an existing organization announcement. Use this when the user wants to fix, change, update, or reschedule an announcement they previously posted. It resolves the target announcement (via target_id, or as a fallback the most-recently-posted announcement in the last 15 minutes by the same user), validates the patch against the announcement schema, and creates a pending confirmation action. Supply only the fields that should change; unspecified fields keep their current value. At least one patch field must be provided.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          target_id: {
+            type: "string" as const,
+            description:
+              "The ID of the announcement to edit. When omitted, the tool falls back to the most recent announcement the same user created in this org within the last 15 minutes. Prefer explicit target_id whenever the user references a specific announcement by title or context.",
+          },
+          title: { type: "string" as const },
+          body: { type: "string" as const },
+          is_pinned: { type: "boolean" as const },
+          audience: {
+            type: "string" as const,
+            enum: ["all", "members", "active_members", "alumni", "individuals"],
+          },
+          audience_user_ids: {
+            type: "array" as const,
+            items: { type: "string" as const },
+            description:
+              "Replace the individual-recipient list. Only meaningful when audience is 'individuals' or when the existing announcement already targets individuals.",
+          },
+          reasoning: {
+            type: "string" as const,
+            description:
+              "Short (one-sentence) explanation of why this edit is being proposed. Logged for audit. Example: 'user asked to fix typo in the title'.",
+          },
+        },
+        additionalProperties: false as const,
+      },
+    },
+  },
   prepare_job_posting: {
     type: "function" as const,
     function: {
@@ -1076,6 +1113,7 @@ export const AI_TOOLS = [
   TOOL_BY_NAME.prepare_enterprise_invite,
   TOOL_BY_NAME.revoke_enterprise_invite,
   TOOL_BY_NAME.prepare_announcement,
+  TOOL_BY_NAME.prepare_edit_announcement,
   TOOL_BY_NAME.prepare_job_posting,
   TOOL_BY_NAME.prepare_chat_message,
   TOOL_BY_NAME.prepare_group_message,

--- a/src/lib/ai/tools/executor.ts
+++ b/src/lib/ai/tools/executor.ts
@@ -19,7 +19,9 @@ import { searchNavigationTargets } from "@/lib/ai/navigation-targets";
 import type { NavConfig } from "@/lib/navigation/nav-items";
 import {
   assistantAnnouncementDraftSchema,
+  assistantAnnouncementPatchSchema,
   assistantPreparedAnnouncementSchema,
+  type AssistantAnnouncementPatch,
   type AssistantPreparedAnnouncement,
 } from "@/lib/schemas/content";
 import {
@@ -50,6 +52,7 @@ import { isOwnedScheduleUploadPath } from "@/lib/ai/schedule-upload-path";
 import {
   buildPendingActionSummary,
   type CreateAnnouncementPendingPayload,
+  type EditAnnouncementPendingPayload,
   type SendChatMessagePendingPayload,
   type SendGroupChatMessagePendingPayload,
   type CreateDiscussionReplyPendingPayload,
@@ -60,6 +63,7 @@ import {
   type CreateEnterpriseInvitePendingPayload,
   type RevokeEnterpriseInvitePendingPayload,
 } from "@/lib/ai/pending-actions";
+import { resolveAgentActionTarget } from "@/lib/ai/tools/target-resolver";
 import { aiLog, type AiLogContext } from "@/lib/ai/logger";
 import { sanitizeIlikeInput } from "@/lib/security/validation";
 import {
@@ -196,6 +200,20 @@ const prepareAnnouncementSchema = z
     audience: z.enum(["all", "members", "active_members", "alumni", "individuals"]).optional(),
     send_notification: z.boolean().optional(),
     audience_user_ids: z.array(z.string().uuid()).optional(),
+  })
+  .strict();
+
+const prepareEditAnnouncementSchema = z
+  .object({
+    target_id: z.string().uuid().optional(),
+    title: z.string().trim().min(1).optional(),
+    body: z.string().trim().optional(),
+    is_pinned: z.boolean().optional(),
+    audience: z
+      .enum(["all", "members", "active_members", "alumni", "individuals"])
+      .optional(),
+    audience_user_ids: z.array(z.string().uuid()).optional(),
+    reasoning: z.string().trim().min(1).optional(),
   })
   .strict();
 
@@ -395,6 +413,7 @@ const ARG_SCHEMAS: Record<ToolName, z.ZodSchema> = {
   prepare_enterprise_invite: prepareEnterpriseInviteSchema,
   revoke_enterprise_invite: revokeEnterpriseInviteSchema,
   prepare_announcement: prepareAnnouncementSchema,
+  prepare_edit_announcement: prepareEditAnnouncementSchema,
   prepare_job_posting: prepareJobPostingSchema,
   prepare_chat_message: prepareChatMessageSchema,
   prepare_group_message: prepareGroupMessageSchema,
@@ -1473,6 +1492,189 @@ async function prepareAnnouncement(
     data: {
       state: "needs_confirmation",
       draft: prepared.data,
+      pending_action: {
+        id: pendingAction.id,
+        action_type: pendingAction.action_type,
+        payload: pendingPayload,
+        expires_at: pendingAction.expires_at,
+        summary,
+      },
+    },
+  };
+}
+
+// ─── prepare_edit_announcement ──────────────────────────────────────────
+//
+// Phase 2a-prepare of the Tier 1 plan. Resolves the target announcement
+// (either via explicit target_id or most-recent fallback within 15
+// minutes per the plan's performance-review narrowing), captures the
+// optimistic-concurrency `expectedUpdatedAt` token from the target's
+// current row, validates the patch against assistantAnnouncementPatchSchema,
+// and creates an `edit_announcement` pending action. The confirm-side
+// dispatcher (see confirm/dispatchers/announcements.ts::handleEditAnnouncement)
+// applies the patch via the updateAnnouncement primitive.
+
+async function prepareEditAnnouncement(
+  sb: SB,
+  ctx: ToolExecutionContext,
+  args: z.infer<typeof prepareEditAnnouncementSchema>
+): Promise<ToolExecutionResult> {
+  const logContext = buildLogContext(ctx);
+  if (!ctx.threadId) {
+    return toolError("Announcement edit preparation requires a thread context");
+  }
+
+  // Reject empty patches fast. The model must supply at least one change.
+  const patchInput = {
+    ...(args.title !== undefined ? { title: args.title } : {}),
+    ...(args.body !== undefined ? { body: args.body } : {}),
+    ...(args.is_pinned !== undefined ? { is_pinned: args.is_pinned } : {}),
+    ...(args.audience !== undefined ? { audience: args.audience } : {}),
+    ...(args.audience_user_ids !== undefined
+      ? { audience_user_ids: args.audience_user_ids }
+      : {}),
+  };
+  if (Object.keys(patchInput).length === 0) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["patch"],
+        reason:
+          "Specify at least one field to change (title, body, is_pinned, audience, or audience_user_ids).",
+      },
+    };
+  }
+
+  const parsedPatch = assistantAnnouncementPatchSchema.safeParse(patchInput);
+  if (!parsedPatch.success) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: parsedPatch.error.issues.map(
+          (issue) => issue.path.join(".") || "patch"
+        ),
+        draft: patchInput,
+      },
+    };
+  }
+  const patch: AssistantAnnouncementPatch = parsedPatch.data;
+
+  // Resolve the target. Explicit target_id short-circuits the resolver;
+  // otherwise fall back to the most-recently-executed announcement action
+  // by the same user within the 15-minute edit window.
+  const resolution = await resolveAgentActionTarget({
+    supabase: sb as never,
+    caller: { userId: ctx.userId, organizationId: ctx.orgId },
+    entityType: "announcement",
+    op: "edit",
+    targetId: args.target_id,
+    fallback: args.target_id ? "none" : "most_recent",
+  });
+
+  if (resolution.kind === "needs_target_id") {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason: resolution.reason,
+      },
+    };
+  }
+  if (resolution.kind === "not_found") {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason:
+          "No recently-created announcement was found to edit. Ask the user which announcement to edit and pass its target_id.",
+      },
+    };
+  }
+
+  // Load the target row to capture the optimistic-concurrency token and
+  // the current title (for the confirmation ai_message body). Scope by
+  // orgId to defend against cross-org target_id spoofing — the triple-
+  // layer org assertion per the plan's security hardening.
+  const { data: target, error: targetError } = await sb
+    .from("announcements")
+    .select("id, title, updated_at, organization_id, deleted_at")
+    .eq("id", resolution.targetId)
+    .eq("organization_id", ctx.orgId)
+    .maybeSingle();
+
+  if (targetError) {
+    aiLog(
+      "warn",
+      "ai-tools",
+      "prepare_edit_announcement target lookup failed",
+      logContext,
+      { error: getSafeErrorMessage(targetError), targetId: resolution.targetId }
+    );
+    return toolError("Failed to load the target announcement");
+  }
+  if (!target) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason: "The requested announcement was not found in this organization.",
+      },
+    };
+  }
+  if (target.deleted_at !== null) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason:
+          "The requested announcement has been deleted and cannot be edited.",
+      },
+    };
+  }
+
+  const { data: org, error: orgError } = await sb
+    .from("organizations")
+    .select("slug")
+    .eq("id", ctx.orgId)
+    .maybeSingle();
+  if (orgError) {
+    aiLog("warn", "ai-tools", "prepare_edit_announcement org lookup failed", logContext, {
+      error: getSafeErrorMessage(orgError),
+    });
+    return toolError("Failed to load organization context");
+  }
+
+  const pendingPayload: EditAnnouncementPendingPayload = {
+    targetId: target.id as string,
+    patch,
+    expectedUpdatedAt: (target.updated_at as string | null) ?? null,
+    targetTitle: (target.title as string | null) ?? null,
+    orgSlug: typeof org?.slug === "string" ? org.slug : null,
+  };
+  const pendingAction = await createPendingAction(sb, {
+    organizationId: ctx.orgId,
+    userId: ctx.userId,
+    threadId: ctx.threadId,
+    actionType: "edit_announcement",
+    payload: pendingPayload,
+  });
+  const summary = buildPendingActionSummary(pendingAction);
+
+  return {
+    kind: "ok",
+    data: {
+      state: "needs_confirmation",
+      draft: {
+        target_id: target.id,
+        target_title: target.title,
+        patch,
+      },
       pending_action: {
         id: pendingAction.id,
         action_type: pendingAction.action_type,
@@ -3337,6 +3539,12 @@ export async function executeToolCall(
             sb,
             ctx,
             args as z.infer<typeof prepareAnnouncementSchema>
+          );
+        case "prepare_edit_announcement":
+          return prepareEditAnnouncement(
+            sb,
+            ctx,
+            args as z.infer<typeof prepareEditAnnouncementSchema>
           );
         case "prepare_job_posting":
           return prepareJobPosting(

--- a/tests/routes/ai/tool-definitions.test.ts
+++ b/tests/routes/ai/tool-definitions.test.ts
@@ -6,8 +6,8 @@ import type { ToolName } from "../../../src/lib/ai/tools/definitions.ts";
 type ToolProperties = Record<string, { type?: string; maximum?: number }>;
 type ToolParameters = { properties?: ToolProperties; additionalProperties?: boolean; required?: string[] };
 
-test("AI_TOOLS exports 34 tool definitions", () => {
-  assert.equal(AI_TOOLS.length, 34);
+test("AI_TOOLS exports 35 tool definitions", () => {
+  assert.equal(AI_TOOLS.length, 35);
 });
 
 test("every tool has type function and additionalProperties false", () => {
@@ -32,6 +32,7 @@ test("TOOL_NAMES contains all tool names", () => {
     "list_parents",
     "list_philanthropy_events",
     "prepare_announcement",
+    "prepare_edit_announcement",
     "prepare_job_posting",
     "prepare_chat_message",
     "list_chat_groups",

--- a/tests/routes/ai/tool-executor.test.ts
+++ b/tests/routes/ai/tool-executor.test.ts
@@ -970,6 +970,163 @@ test("prepare_announcement creates a pending confirmation action when complete",
   });
 });
 
+// ─── prepare_edit_announcement ──────────────────────────────────────────
+// Phase 2a-prepare. Mirrors the create tests but also exercises the
+// target resolver (most-recent fallback + explicit target_id).
+
+const EDIT_TARGET_ID = "00000000-0000-4000-8000-000000000aaa";
+
+test("prepare_edit_announcement returns missing_fields when no patch fields are supplied", async () => {
+  const editCtx = { ...ctx, threadId: "thread-edit" };
+
+  const result = expectOk(
+    await executeToolCall(editCtx, {
+      name: "prepare_edit_announcement",
+      args: { target_id: EDIT_TARGET_ID },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  assert.deepEqual((result.data as { missing_fields: string[] }).missing_fields, ["patch"]);
+});
+
+test("prepare_edit_announcement returns missing_fields when target_id is omitted and no recent action exists", async () => {
+  // Resolver finds no matching recent action → returns not_found.
+  const resolverStub = createToolSupabaseStub({
+    ai_pending_actions: { select: { data: [], error: null } },
+  });
+  const editCtx = { ...makeCtx(resolverStub as any), threadId: "thread-edit" };
+
+  const result = expectOk(
+    await executeToolCall(editCtx, {
+      name: "prepare_edit_announcement",
+      args: { title: "Fixed typo" },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  assert.deepEqual(
+    (result.data as { missing_fields: string[] }).missing_fields,
+    ["target_id"]
+  );
+});
+
+test("prepare_edit_announcement surfaces a missing_fields response when the target is not found in the org", async () => {
+  const editStub = createToolSupabaseStub({
+    announcements: { maybeSingle: { data: null, error: null } },
+  });
+  const editCtx = { ...makeCtx(editStub as any), threadId: "thread-edit" };
+
+  const result = expectOk(
+    await executeToolCall(editCtx, {
+      name: "prepare_edit_announcement",
+      args: { target_id: EDIT_TARGET_ID, title: "Fixed typo" },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  assert.deepEqual(
+    (result.data as { missing_fields: string[] }).missing_fields,
+    ["target_id"]
+  );
+});
+
+test("prepare_edit_announcement refuses to edit a soft-deleted announcement", async () => {
+  const editStub = createToolSupabaseStub({
+    announcements: {
+      maybeSingle: {
+        data: {
+          id: EDIT_TARGET_ID,
+          title: "Old",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:00:00.000Z",
+          deleted_at: "2026-04-22T09:30:00.000Z",
+        },
+        error: null,
+      },
+    },
+  });
+  const editCtx = { ...makeCtx(editStub as any), threadId: "thread-edit" };
+
+  const result = expectOk(
+    await executeToolCall(editCtx, {
+      name: "prepare_edit_announcement",
+      args: { target_id: EDIT_TARGET_ID, title: "Fixed typo" },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  const reason = (result.data as { reason?: string }).reason;
+  assert.match(reason ?? "", /deleted/i);
+});
+
+test("prepare_edit_announcement creates a pending edit_announcement action when complete", async () => {
+  const editStub = createToolSupabaseStub({
+    organizations: {
+      maybeSingle: { data: { slug: "upenn-sprint-football" }, error: null },
+    },
+    announcements: {
+      maybeSingle: {
+        data: {
+          id: EDIT_TARGET_ID,
+          title: "Original Title",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:00:00.000Z",
+          deleted_at: null,
+        },
+        error: null,
+      },
+    },
+    ai_pending_actions: {
+      single: {
+        data: {
+          id: "pending-edit-announcement-1",
+          organization_id: ORG_ID,
+          user_id: USER_ID,
+          thread_id: "thread-edit",
+          action_type: "edit_announcement",
+          payload: {
+            targetId: EDIT_TARGET_ID,
+            patch: { title: "Fixed Title" },
+            expectedUpdatedAt: "2026-04-22T09:00:00.000Z",
+            targetTitle: "Original Title",
+            orgSlug: "upenn-sprint-football",
+          },
+          status: "pending",
+          expires_at: "2099-01-01T00:00:00.000Z",
+          created_at: "2026-04-22T09:30:00.000Z",
+          updated_at: "2026-04-22T09:30:00.000Z",
+          executed_at: null,
+          result_entity_type: null,
+          result_entity_id: null,
+        },
+        error: null,
+      },
+    },
+  });
+  const editCtx = { ...makeCtx(editStub as any), threadId: "thread-edit" };
+
+  const result = expectOk(
+    await executeToolCall(editCtx, {
+      name: "prepare_edit_announcement",
+      args: {
+        target_id: EDIT_TARGET_ID,
+        title: "Fixed Title",
+        reasoning: "user asked to fix the title typo",
+      },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "needs_confirmation");
+  const pending = (result.data as { pending_action: { action_type: string; payload: any } }).pending_action;
+  assert.equal(pending.action_type, "edit_announcement");
+  assert.equal(pending.payload.targetId, EDIT_TARGET_ID);
+  assert.deepEqual(pending.payload.patch, { title: "Fixed Title" });
+  assert.equal(pending.payload.expectedUpdatedAt, "2026-04-22T09:00:00.000Z");
+  assert.equal(pending.payload.targetTitle, "Original Title");
+  assert.equal(pending.payload.orgSlug, "upenn-sprint-football");
+});
+
 test("prepare_discussion_thread creates a pending confirmation action when complete", async () => {
   const discussionStub = createToolSupabaseStub({
     organizations: {


### PR DESCRIPTION
## Summary

Phase 2a-prepare of the Tier 1 edit/delete plan. Activates the edit-side infrastructure by registering the \`prepare_edit_announcement\` LLM tool and wiring it through the executor, chat-handler intent classification, and draft-session resume paths.

**Stacks on #135** (Phase 2b-confirm). End-to-end activation for edit:

1. User: *"Fix the typo in the announcement title"*
2. LLM: calls \`prepare_edit_announcement\` (target_id resolved via 15-min most-recent fallback from #122's resolver)
3. Server: validates patch (#123 schema), loads target row with \`expectedUpdatedAt\` token, creates \`edit_announcement\` pending action
4. UI: renders the review card with the proposed patch
5. User confirms
6. Server: \`handleEditAnnouncement\` dispatcher (#134) calls \`updateAnnouncement\` primitive (#123) which enforces the optimistic-concurrency token

## Changes

### Tool schema (\`src/lib/ai/tools/definitions.ts\`)
\`prepare_edit_announcement\` registered with:
- \`target_id\` (uuid, optional — falls back to most-recent announcement by this user in the last 15 minutes)
- Patch fields: \`title\`, \`body\`, \`is_pinned\`, \`audience\`, \`audience_user_ids\`
- \`reasoning\` — short one-sentence audit note (per the plan's external-best-practices alignment)

Added to \`AI_TOOLS\` array between \`prepare_announcement\` and \`prepare_job_posting\`.

### Executor (\`src/lib/ai/tools/executor.ts\`)
\`prepareEditAnnouncement\` implements the prepare-side contract:
1. **Empty-patch rejection** → \`missing_fields: ["patch"]\`
2. **\`assistantAnnouncementPatchSchema\` validation** (#123)
3. **Target resolution** via \`resolveAgentActionTarget\` (#122):
   - Explicit \`target_id\`: short-circuits to \`resolved\`
   - Omitted: \`most_recent\` fallback with 15-min window
4. **Target row load** scoped to \`organization_id = ctx.orgId\` (triple-layer org assertion per the plan's security hardening) to capture \`expectedUpdatedAt\` and \`targetTitle\`
5. **Soft-deleted target rejection** with explicit reason
6. **Org-slug lookup** for the confirmation URL
7. **\`createPendingAction("edit_announcement", ...)\`** with the full \`EditAnnouncementPendingPayload\` from #134

### Chat handler (\`src/app/api/ai/[orgId]/chat/handler.ts\`)
- \`EDIT_ANNOUNCEMENT_PROMPT_PATTERN\` regex matches "fix / change / update / edit / reword / rephrase / correct / amend / revise" paired with announcement-related nouns. Deliberately **does not** match create verbs (create / add / post / publish / make / send) or destructive verbs (delete / remove / cancel — the latter is Phase 2b-prepare's concern).
- \`attachPrepareToolsForTurn\` attaches \`prepare_edit_announcement\` when the pattern hits. Ordered **after** the create check so "create an update" resolves as create, while "update the announcement title" resolves as edit.
- \`getToolNameForDraftType("edit_announcement")\` flipped from the Phase 2a-confirm \`throw\` (which marked the incomplete state) to returning \`"prepare_edit_announcement"\` now that the tool exists.

## Testing

**5 new executor tests** in \`tests/routes/ai/tool-executor.test.ts\`:

| Case | Expected |
|---|---|
| Empty patch | \`missing_fields: ["patch"]\` |
| No \`target_id\` + no recent action | \`missing_fields: ["target_id"]\` |
| Target not found in org | \`missing_fields: ["target_id"]\` |
| Soft-deleted target | \`missing_fields\` with reason mentioning "deleted" |
| Happy path | \`needs_confirmation\` with pending_action carrying full \`EditAnnouncementPendingPayload\` (targetId, patch, expectedUpdatedAt, targetTitle, orgSlug) |

**Updated** \`tests/routes/ai/tool-definitions.test.ts\`:
- \`AI_TOOLS.length\`: 34 → 35
- \`TOOL_NAMES\` list includes \`prepare_edit_announcement\`

**247/247 tests pass** across the stacked chain (integration #133 + Phase 2a-confirm #134 + Phase 2b-confirm #135 + this). \`npx tsc --noEmit\` clean. \`npx eslint\` clean on all changed files.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - \`aiLog\` keys in \`ai-tools\` subsystem:
    - \`prepare_edit_announcement target lookup failed\` — RLS or permission edge case
    - \`prepare_edit_announcement org lookup failed\` — rare, but fails closed
  - \`ai_pending_actions\` rows with \`action_type = 'edit_announcement'\` — healthy ratio of \`pending → confirmed → executed\` (> 99%).
  - Rate of \`missing_fields\` responses with \`missing_fields: ["target_id"]\` — if high, indicates users referring to announcements by title the resolver can't find; signals the need for a name-based resolver (future phase).
  - Rate of \`409 stale_version\` responses from the confirm dispatcher — indicates concurrent UI edits racing agent edits.
- **Validation queries**
  \`\`\`sql
  SELECT status, COUNT(*) FROM ai_pending_actions
  WHERE action_type = 'edit_announcement' AND created_at > now() - interval '1 hour'
  GROUP BY status;

  SELECT payload->>'targetId' AS target_id, COUNT(*)
  FROM ai_pending_actions
  WHERE action_type = 'edit_announcement' AND created_at > now() - interval '1 day'
  GROUP BY 1 ORDER BY 2 DESC LIMIT 10;
  \`\`\`
- **Expected healthy behavior**: edit pending actions reach \`executed\` within the 15-min expiry window in > 99% of cases. Rare \`stale_version\` (< 1%) indicating successful concurrent-edit detection.
- **Failure signals / rollback triggers**: (a) spike in \`target lookup failed\` logs; (b) stranded \`confirmed\` rows > 60s; (c) any \`prepare_edit_announcement\` call producing an edit to a soft-deleted row in audit logs.
- **Rollback**: revert this PR. The confirm-side dispatcher from #134 remains harmless (no code path creates \`edit_announcement\` pending actions without this PR's executor branch).
- **Validation window**: 48h after merge. Owner: AI agent team.

## Review notes

Read in this order:
1. \`src/lib/ai/tools/definitions.ts\` — the \`prepare_edit_announcement\` tool schema block (35 lines)
2. \`src/lib/ai/tools/executor.ts\` — \`prepareEditAnnouncement\` function (~130 LOC, mirrors \`prepareAnnouncement\` structure)
3. \`src/app/api/ai/[orgId]/chat/handler.ts\` — the \`EDIT_ANNOUNCEMENT_PROMPT_PATTERN\` regex + the one-line attach branch + the throw→return flip in \`getToolNameForDraftType\`
4. Tests

The triple-layer org assertion (\`.eq("organization_id", ctx.orgId)\` on the target load) is load-bearing — without it, a malicious \`target_id\` from org A submitted to org B's agent could return \`not_found\` or leak existence; with it, the outcome is always \`not_found\` regardless of whether the target exists elsewhere.

---

[![Compound Engineering v2.46.0](https://img.shields.io/badge/Compound_Engineering-v2.46.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)