### PR TITLE
feat(ai): Phase 2b-prepare — register prepare_delete_announcement tool

### DIFF
--- a/src/app/api/ai/[orgId]/chat/handler.ts
+++ b/src/app/api/ai/[orgId]/chat/handler.ts
@@ -161,6 +161,13 @@ const CREATE_ANNOUNCEMENT_PROMPT_PATTERN =
 // does NOT match "delete/remove/cancel" — that's Phase 2b-prepare.
 const EDIT_ANNOUNCEMENT_PROMPT_PATTERN =
   /(?:(?<!\w)(?:fix|change|update|edit|reword|rephrase|correct|amend|revise)(?!\w)[\s\S]{0,120}\b(?:announcement|update|news post|bulletin|typo|typos|title|wording)(?!\w)|(?<!\w)(?:announcement|update|news post|bulletin)(?!\w)[\s\S]{0,80}\b(?:fix|change|edit|reword|rephrase|correct|amend|revise)(?!\w))/i;
+// Delete-intent verbs for announcements. Destructive verbs only:
+// "delete/remove/take down/retract/unpublish/pull". Does NOT match
+// "cancel" because cancel overloads with event-cancel semantics; the
+// model should use explicit delete/remove phrasing. Does NOT match edit
+// verbs ("fix/change/edit/…") — those remain Phase 2a.
+const DELETE_ANNOUNCEMENT_PROMPT_PATTERN =
+  /(?:(?<!\w)(?:delete|remove|retract|unpublish|pull)(?!\w)[\s\S]{0,120}\b(?:announcement|update|news post|bulletin)(?!\w)|(?<!\w)(?:announcement|update|news post|bulletin)(?!\w)[\s\S]{0,80}\b(?:delete|remove|retract|unpublish|pull|take\s+down)(?!\w)|(?<!\w)take\s+down(?!\w)[\s\S]{0,120}\b(?:announcement|update|news post|bulletin)(?!\w))/i;
 const CREATE_JOB_PROMPT_PATTERN =
   /(?:(?<!\w)(?:create|add|post|publish|make|open)(?!\w)[\s\S]{0,120}\b(?:job|job posting|opening|role|position)(?!\w)|(?<!\w)(?:job|job posting|opening|role|position)(?!\w)[\s\S]{0,80}\b(?:create|add|post|publish|make|open)(?!\w))/i;
 const SEND_CHAT_MESSAGE_PROMPT_PATTERN =
@@ -1849,6 +1856,14 @@ function getPass1Tools(
 
   if (CREATE_ANNOUNCEMENT_PROMPT_PATTERN.test(message)) {
     return [AI_TOOL_MAP.prepare_announcement];
+  }
+
+  // Delete-intent attachment — check BEFORE edit because delete verbs
+  // (delete/remove/retract/unpublish) do not overlap with edit verbs and
+  // are destructively specific. A message matching both ("remove and fix"
+  // is not a thing) should never reach here.
+  if (DELETE_ANNOUNCEMENT_PROMPT_PATTERN.test(message)) {
+    return [AI_TOOL_MAP.prepare_delete_announcement];
   }
 
   // Edit-intent attachment — check AFTER create to avoid stealing turns that

--- a/src/lib/ai/tools/definitions.ts
+++ b/src/lib/ai/tools/definitions.ts
@@ -344,6 +344,31 @@ const TOOL_BY_NAME = {
       },
     },
   },
+  prepare_delete_announcement: {
+    type: "function" as const,
+    function: {
+      name: "prepare_delete_announcement" as const,
+      description:
+        "Prepare a soft-delete of an existing organization announcement. Use this when the user asks to delete, remove, cancel, take down, retract, or unpublish an announcement. Target resolution is strict — target_id must be supplied explicitly. There is no most-recent fallback because delete is destructive and cannot be undone from chat. When the user has not named a specific announcement, list recent announcements and ask them to pick one rather than guessing.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          target_id: {
+            type: "string" as const,
+            description:
+              "The ID of the announcement to delete. Required — the tool refuses to act without an explicit target_id.",
+          },
+          reasoning: {
+            type: "string" as const,
+            description:
+              "Short (one-sentence) explanation of why this delete is being proposed. Logged for audit. Example: 'user asked to remove a duplicate announcement'.",
+          },
+        },
+        required: ["target_id"] as const,
+        additionalProperties: false as const,
+      },
+    },
+  },
   prepare_job_posting: {
     type: "function" as const,
     function: {
@@ -1114,6 +1139,7 @@ export const AI_TOOLS = [
   TOOL_BY_NAME.revoke_enterprise_invite,
   TOOL_BY_NAME.prepare_announcement,
   TOOL_BY_NAME.prepare_edit_announcement,
+  TOOL_BY_NAME.prepare_delete_announcement,
   TOOL_BY_NAME.prepare_job_posting,
   TOOL_BY_NAME.prepare_chat_message,
   TOOL_BY_NAME.prepare_group_message,

--- a/src/lib/ai/tools/executor.ts
+++ b/src/lib/ai/tools/executor.ts
@@ -53,6 +53,7 @@ import {
   buildPendingActionSummary,
   type CreateAnnouncementPendingPayload,
   type EditAnnouncementPendingPayload,
+  type DeleteAnnouncementPendingPayload,
   type SendChatMessagePendingPayload,
   type SendGroupChatMessagePendingPayload,
   type CreateDiscussionReplyPendingPayload,
@@ -213,6 +214,13 @@ const prepareEditAnnouncementSchema = z
       .enum(["all", "members", "active_members", "alumni", "individuals"])
       .optional(),
     audience_user_ids: z.array(z.string().uuid()).optional(),
+    reasoning: z.string().trim().min(1).optional(),
+  })
+  .strict();
+
+const prepareDeleteAnnouncementSchema = z
+  .object({
+    target_id: z.string().uuid(),
     reasoning: z.string().trim().min(1).optional(),
   })
   .strict();
@@ -414,6 +422,7 @@ const ARG_SCHEMAS: Record<ToolName, z.ZodSchema> = {
   revoke_enterprise_invite: revokeEnterpriseInviteSchema,
   prepare_announcement: prepareAnnouncementSchema,
   prepare_edit_announcement: prepareEditAnnouncementSchema,
+  prepare_delete_announcement: prepareDeleteAnnouncementSchema,
   prepare_job_posting: prepareJobPostingSchema,
   prepare_chat_message: prepareChatMessageSchema,
   prepare_group_message: prepareGroupMessageSchema,
@@ -1674,6 +1683,150 @@ async function prepareEditAnnouncement(
         target_id: target.id,
         target_title: target.title,
         patch,
+      },
+      pending_action: {
+        id: pendingAction.id,
+        action_type: pendingAction.action_type,
+        payload: pendingPayload,
+        expires_at: pendingAction.expires_at,
+        summary,
+      },
+    },
+  };
+}
+
+// ─── prepare_delete_announcement ──────────────────────────────────────
+//
+// Phase 2b-prepare of the Tier 1 plan. Unlike edit, delete is strictly
+// target_id-required — no most-recent fallback. The plan's security-
+// hardening decision (A2.1) disables the fallback for destructive ops
+// so the assistant can never soft-delete an ambiguous target. The
+// confirm-side dispatcher (see confirm/dispatchers/announcements.ts::
+// handleDeleteAnnouncement) calls softDeleteAnnouncement, which is
+// idempotent — re-confirm on an already-deleted row no-ops.
+
+async function prepareDeleteAnnouncement(
+  sb: SB,
+  ctx: ToolExecutionContext,
+  args: z.infer<typeof prepareDeleteAnnouncementSchema>
+): Promise<ToolExecutionResult> {
+  const logContext = buildLogContext(ctx);
+  if (!ctx.threadId) {
+    return toolError("Announcement delete preparation requires a thread context");
+  }
+
+  // Target resolution is strict: explicit target_id only, no fallback.
+  // We still run the resolver for parity with edit (auth + taint checks
+  // live there), but force fallback: "none".
+  const resolution = await resolveAgentActionTarget({
+    supabase: sb as never,
+    caller: { userId: ctx.userId, organizationId: ctx.orgId },
+    entityType: "announcement",
+    op: "delete",
+    targetId: args.target_id,
+    fallback: "none",
+  });
+
+  if (resolution.kind === "needs_target_id") {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason: resolution.reason,
+      },
+    };
+  }
+  if (resolution.kind === "not_found") {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason:
+          "The requested announcement was not found in this organization.",
+      },
+    };
+  }
+
+  // Load the target row to capture the optimistic-concurrency token and
+  // current title (for the confirmation ai_message body — once the row
+  // is soft-deleted, subsequent reads may filter it out). Scope by
+  // orgId to defend against cross-org target_id spoofing — the triple-
+  // layer org assertion per the plan's security hardening.
+  const { data: target, error: targetError } = await sb
+    .from("announcements")
+    .select("id, title, updated_at, organization_id, deleted_at")
+    .eq("id", resolution.targetId)
+    .eq("organization_id", ctx.orgId)
+    .maybeSingle();
+
+  if (targetError) {
+    aiLog(
+      "warn",
+      "ai-tools",
+      "prepare_delete_announcement target lookup failed",
+      logContext,
+      { error: getSafeErrorMessage(targetError), targetId: resolution.targetId }
+    );
+    return toolError("Failed to load the target announcement");
+  }
+  if (!target) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason: "The requested announcement was not found in this organization.",
+      },
+    };
+  }
+  if (target.deleted_at !== null) {
+    return {
+      kind: "ok",
+      data: {
+        state: "missing_fields",
+        missing_fields: ["target_id"],
+        reason:
+          "The requested announcement has already been deleted.",
+      },
+    };
+  }
+
+  const { data: org, error: orgError } = await sb
+    .from("organizations")
+    .select("slug")
+    .eq("id", ctx.orgId)
+    .maybeSingle();
+  if (orgError) {
+    aiLog("warn", "ai-tools", "prepare_delete_announcement org lookup failed", logContext, {
+      error: getSafeErrorMessage(orgError),
+    });
+    return toolError("Failed to load organization context");
+  }
+
+  const pendingPayload: DeleteAnnouncementPendingPayload = {
+    targetId: target.id as string,
+    expectedUpdatedAt: (target.updated_at as string | null) ?? null,
+    targetTitle: (target.title as string | null) ?? null,
+    orgSlug: typeof org?.slug === "string" ? org.slug : null,
+  };
+  const pendingAction = await createPendingAction(sb, {
+    organizationId: ctx.orgId,
+    userId: ctx.userId,
+    threadId: ctx.threadId,
+    actionType: "delete_announcement",
+    payload: pendingPayload,
+  });
+  const summary = buildPendingActionSummary(pendingAction);
+
+  return {
+    kind: "ok",
+    data: {
+      state: "needs_confirmation",
+      draft: {
+        target_id: target.id,
+        target_title: target.title,
       },
       pending_action: {
         id: pendingAction.id,
@@ -3545,6 +3698,12 @@ export async function executeToolCall(
             sb,
             ctx,
             args as z.infer<typeof prepareEditAnnouncementSchema>
+          );
+        case "prepare_delete_announcement":
+          return prepareDeleteAnnouncement(
+            sb,
+            ctx,
+            args as z.infer<typeof prepareDeleteAnnouncementSchema>
           );
         case "prepare_job_posting":
           return prepareJobPosting(

--- a/tests/routes/ai/tool-definitions.test.ts
+++ b/tests/routes/ai/tool-definitions.test.ts
@@ -6,8 +6,8 @@ import type { ToolName } from "../../../src/lib/ai/tools/definitions.ts";
 type ToolProperties = Record<string, { type?: string; maximum?: number }>;
 type ToolParameters = { properties?: ToolProperties; additionalProperties?: boolean; required?: string[] };
 
-test("AI_TOOLS exports 35 tool definitions", () => {
-  assert.equal(AI_TOOLS.length, 35);
+test("AI_TOOLS exports 36 tool definitions", () => {
+  assert.equal(AI_TOOLS.length, 36);
 });
 
 test("every tool has type function and additionalProperties false", () => {
@@ -33,6 +33,7 @@ test("TOOL_NAMES contains all tool names", () => {
     "list_philanthropy_events",
     "prepare_announcement",
     "prepare_edit_announcement",
+    "prepare_delete_announcement",
     "prepare_job_posting",
     "prepare_chat_message",
     "list_chat_groups",
@@ -158,6 +159,23 @@ test("suggest_connections supports person_query or person_type plus person_id", 
   assert.ok(props.person_query);
   assert.equal(props.limit.maximum, 25);
   assert.equal(params.required, undefined);
+});
+
+test("prepare_delete_announcement requires target_id", () => {
+  const tool = AI_TOOLS.find(
+    (t) => t.function.name === "prepare_delete_announcement"
+  )!;
+  const params = tool.function.parameters as ToolParameters;
+  const props = params.properties as ToolProperties;
+
+  assert.ok(props.target_id);
+  assert.equal(props.target_id.type, "string");
+  assert.deepEqual(params.required, ["target_id"]);
+  // Security: description must convey strict target resolution (no fallback).
+  assert.match(
+    tool.function.description,
+    /no most-recent fallback|strict|explicit/i
+  );
 });
 
 test("find_navigation_targets requires a query string", () => {

--- a/tests/routes/ai/tool-executor.test.ts
+++ b/tests/routes/ai/tool-executor.test.ts
@@ -1127,6 +1127,143 @@ test("prepare_edit_announcement creates a pending edit_announcement action when 
   assert.equal(pending.payload.orgSlug, "upenn-sprint-football");
 });
 
+// ─── prepare_delete_announcement ────────────────────────────────────────
+// Phase 2b-prepare. Destructive op, so fallback is disabled — target_id
+// is strictly required. Still exercises the triple-layer org assertion
+// and the deleted_at guard to keep the executor from re-queueing a
+// delete for an already-soft-deleted row.
+
+const DELETE_TARGET_ID = "00000000-0000-4000-8000-000000000bbb";
+
+test("prepare_delete_announcement rejects at the arg-schema layer when target_id is missing", async () => {
+  const deleteCtx = { ...ctx, threadId: "thread-delete" };
+
+  const result = await executeToolCall(deleteCtx, {
+    name: "prepare_delete_announcement",
+    args: {},
+  });
+
+  // Zod schema makes target_id required — absent arg surfaces as a
+  // tool_error before the executor body even runs. This is the single
+  // deterministic gate that prevents ambiguous destructive ops.
+  assert.equal(result.kind, "tool_error");
+});
+
+test("prepare_delete_announcement surfaces a missing_fields response when the target is not found in the org", async () => {
+  const deleteStub = createToolSupabaseStub({
+    announcements: { maybeSingle: { data: null, error: null } },
+  });
+  const deleteCtx = { ...makeCtx(deleteStub as any), threadId: "thread-delete" };
+
+  const result = expectOk(
+    await executeToolCall(deleteCtx, {
+      name: "prepare_delete_announcement",
+      args: { target_id: DELETE_TARGET_ID },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  assert.deepEqual(
+    (result.data as { missing_fields: string[] }).missing_fields,
+    ["target_id"]
+  );
+});
+
+test("prepare_delete_announcement refuses to re-delete a soft-deleted announcement", async () => {
+  const deleteStub = createToolSupabaseStub({
+    announcements: {
+      maybeSingle: {
+        data: {
+          id: DELETE_TARGET_ID,
+          title: "Already Gone",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:00:00.000Z",
+          deleted_at: "2026-04-22T09:30:00.000Z",
+        },
+        error: null,
+      },
+    },
+  });
+  const deleteCtx = { ...makeCtx(deleteStub as any), threadId: "thread-delete" };
+
+  const result = expectOk(
+    await executeToolCall(deleteCtx, {
+      name: "prepare_delete_announcement",
+      args: { target_id: DELETE_TARGET_ID },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "missing_fields");
+  const reason = (result.data as { reason?: string }).reason;
+  assert.match(reason ?? "", /already been deleted/i);
+});
+
+test("prepare_delete_announcement creates a pending delete_announcement action when target resolves", async () => {
+  const deleteStub = createToolSupabaseStub({
+    organizations: {
+      maybeSingle: { data: { slug: "upenn-sprint-football" }, error: null },
+    },
+    announcements: {
+      maybeSingle: {
+        data: {
+          id: DELETE_TARGET_ID,
+          title: "Stale Announcement",
+          organization_id: ORG_ID,
+          updated_at: "2026-04-22T09:00:00.000Z",
+          deleted_at: null,
+        },
+        error: null,
+      },
+    },
+    ai_pending_actions: {
+      single: {
+        data: {
+          id: "pending-delete-announcement-1",
+          organization_id: ORG_ID,
+          user_id: USER_ID,
+          thread_id: "thread-delete",
+          action_type: "delete_announcement",
+          payload: {
+            targetId: DELETE_TARGET_ID,
+            expectedUpdatedAt: "2026-04-22T09:00:00.000Z",
+            targetTitle: "Stale Announcement",
+            orgSlug: "upenn-sprint-football",
+          },
+          status: "pending",
+          expires_at: "2099-01-01T00:00:00.000Z",
+          created_at: "2026-04-22T09:30:00.000Z",
+          updated_at: "2026-04-22T09:30:00.000Z",
+          executed_at: null,
+          result_entity_type: null,
+          result_entity_id: null,
+        },
+        error: null,
+      },
+    },
+  });
+  const deleteCtx = { ...makeCtx(deleteStub as any), threadId: "thread-delete" };
+
+  const result = expectOk(
+    await executeToolCall(deleteCtx, {
+      name: "prepare_delete_announcement",
+      args: {
+        target_id: DELETE_TARGET_ID,
+        reasoning: "user asked to remove the stale announcement",
+      },
+    })
+  );
+
+  assert.equal((result.data as { state: string }).state, "needs_confirmation");
+  const pending = (result.data as {
+    pending_action: { action_type: string; payload: any };
+  }).pending_action;
+  assert.equal(pending.action_type, "delete_announcement");
+  assert.equal(pending.payload.targetId, DELETE_TARGET_ID);
+  assert.equal(pending.payload.expectedUpdatedAt, "2026-04-22T09:00:00.000Z");
+  assert.equal(pending.payload.targetTitle, "Stale Announcement");
+  assert.equal(pending.payload.orgSlug, "upenn-sprint-football");
+});
+
 test("prepare_discussion_thread creates a pending confirmation action when complete", async () => {
   const discussionStub = createToolSupabaseStub({
     organizations: {


### PR DESCRIPTION
## Summary

Ships the destructive-ops half of Tier 1 edit/delete parity. Closes the end-to-end delete flow: user says "remove that announcement" → LLM calls `prepare_delete_announcement` → server resolves target strictly (no fallback) → loads target with `expectedUpdatedAt` token → creates `delete_announcement` pending action → UI renders review card → confirm → `handleDeleteAnnouncement` dispatcher (#135) calls `softDeleteAnnouncement` primitive with optimistic-concurrency enforcement.

Mirrors PR #136 (prepare_edit_announcement) but diverges deliberately on two security-motivated fronts:

1. **`target_id` is REQUIRED at the Zod layer.** No most-recent fallback — destructive ops never guess their target. Missing `target_id` surfaces as a `tool_error` before the executor body runs (the single deterministic gate per plan §A2.1).
2. **No DraftSessionType for delete.** Delete is a single-call action, not a multi-turn draft-build. No changes to `DRAFT_SESSION_TYPES` or `getToolNameForDraftType`.

## Changes

- **`definitions.ts`** — Adds `prepare_delete_announcement` tool schema with `target_id` (required uuid) + `reasoning` (optional audit field). Description explicitly conveys "no most-recent fallback" to discourage LLM guessing.
- **`executor.ts`** — Adds `prepareDeleteAnnouncement` which:
  - Calls the resolver with `fallback: "none"` (parity with edit for auth + taint checks)
  - Loads target scoped to `orgId` (triple-layer org assertion per plan's security hardening)
  - Rejects soft-deleted rows with a clear "already been deleted" reason
  - Creates a `delete_announcement` pending action with the `expectedUpdatedAt` optimistic-concurrency token captured at prepare time
- **`chat/handler.ts`** — Adds `DELETE_ANNOUNCEMENT_PROMPT_PATTERN` regex matching `delete/remove/retract/unpublish/pull/take down` verbs paired with `announcement/update/news post/bulletin` nouns. Attaches BEFORE the edit branch since delete verbs are strictly more specific and don't overlap with edit verbs. Deliberately excludes `cancel` to avoid event-cancel overload.

Stacked on #136 (prepare_edit_announcement). Merges to `feat/ai-prepare-edit-announcement-tool`; will re-target `main` once #133 → #134 → #135 → #136 chain lands.

## Testing

- `npx tsc --noEmit` clean
- `npx eslint` clean on changed files
- `tests/routes/ai/tool-definitions.test.ts` — AI_TOOLS length 35→36, new tool appears in TOOL_NAMES, new `required: ["target_id"]` assertion
- `tests/routes/ai/tool-executor.test.ts` — 4 new tests covering: Zod rejection path (missing target_id), target-not-found, soft-deleted rejection, happy-path pending action creation. 64/64 pass.
- Full `tests/routes/ai/*.test.ts` (288 tests): green

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: `prepare_delete_announcement target lookup failed` (should be rare; indicates DB layer issue)
  - Logs: `prepare_delete_announcement org lookup failed`
  - Metric: count of `pending_action.action_type = "delete_announcement"` rows created per hour
- **Expected healthy behavior**
  - Users asking "delete this announcement" produce review cards that fire on explicit target_id
  - Zero `delete_announcement` pending actions with `payload.targetId` matching rows that have `deleted_at IS NOT NULL` at creation time
- **Failure signal(s) / rollback trigger**
  - If `tool_error` rate on `prepare_delete_announcement` exceeds 5% → investigate Zod schema mismatch
  - If users report being unable to delete announcements despite specifying target_id → resolver + org assertion too strict; revisit fallback policy
- **Validation window & owner**
  - Window: 24h post-merge of the full Phase 2 chain
  - Owner: agent team