### PR TITLE
feat(events): Tier 1 Phase 3a-primitive — updateEvent domain primitive

### DIFF
--- a/src/lib/events/update-event.ts
+++ b/src/lib/events/update-event.ts
@@ -1,0 +1,235 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ZodIssue } from "zod";
+import type { Database } from "@/types/database";
+import { getOrgMembership } from "@/lib/auth/api-helpers";
+import {
+  assistantEventPatchSchema,
+  assistantPreparedEventSchema,
+  type AssistantEventPatch,
+} from "@/lib/schemas/events-ai";
+
+// Local mirror of the shared DomainResult type — kept here so this PR is
+// self-contained while the shared module (from the Phase 1b scaffolding)
+// propagates into `src/lib/announcements/update-announcement.ts` and the
+// rest of Tier 1. Refactor to the shared import in a follow-up.
+export type DomainResult<T> =
+  | { ok: true; value: T }
+  | {
+      ok: false;
+      status: 400 | 403 | 404 | 409 | 410 | 422 | 500;
+      error: string;
+      details?: Record<string, unknown>;
+    };
+
+type DatabaseClient = SupabaseClient<Database>;
+type EventRow = Database["public"]["Tables"]["events"]["Row"];
+
+export interface UpdateEventRequest {
+  supabase: DatabaseClient;
+  orgId: string;
+  userId: string;
+  targetId: string;
+  patch: AssistantEventPatch;
+  /**
+   * Caller-captured `target.updated_at` from prepare time. When supplied, the
+   * write uses it as an optimistic-concurrency token both in-code (fast fail)
+   * and in the UPDATE WHERE clause (race-safe). Omit for last-writer-wins
+   * semantics.
+   */
+  expectedUpdatedAt?: string | null;
+}
+
+export async function updateEvent(
+  request: UpdateEventRequest
+): Promise<DomainResult<EventRow>> {
+  const parsed = assistantEventPatchSchema.safeParse(request.patch);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_patch",
+      details: issuesToDetails(parsed.error.issues),
+    };
+  }
+  const patch = parsed.data;
+
+  if (!Object.values(patch).some((v) => v !== undefined)) {
+    return { ok: false, status: 400, error: "empty_patch" };
+  }
+
+  const membership = await getOrgMembership(
+    request.supabase,
+    request.userId,
+    request.orgId
+  );
+  if (!membership || membership.role !== "admin") {
+    return { ok: false, status: 403, error: "forbidden" };
+  }
+
+  const { data: current, error: fetchError } = await request.supabase
+    .from("events")
+    .select("*")
+    .eq("id", request.targetId)
+    .eq("organization_id", request.orgId)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (fetchError) {
+    return { ok: false, status: 500, error: "fetch_failed" };
+  }
+  if (!current) {
+    return { ok: false, status: 404, error: "not_found" };
+  }
+
+  // Tier 4 guard: recurring events are out of scope for Phase 3. Any row
+  // that is part of a recurrence series (has a group id, is the parent
+  // with a rule, or is an individual instance) is rejected. The plan
+  // explicitly defers recurrence edit semantics (`this_only` /
+  // `this_and_future` / `all_in_series`) to Tier 4.
+  if (
+    current.recurrence_group_id !== null ||
+    current.recurrence_rule !== null ||
+    current.recurrence_index !== null
+  ) {
+    return {
+      ok: false,
+      status: 422,
+      error: "recurring_event_unsupported",
+      details: {
+        message:
+          "Editing recurring events is not supported yet. Ask the user to edit a single, non-recurring event.",
+      },
+    };
+  }
+
+  if (
+    request.expectedUpdatedAt != null &&
+    current.updated_at !== request.expectedUpdatedAt
+  ) {
+    return {
+      ok: false,
+      status: 409,
+      error: "stale_version",
+      details: {
+        expectedUpdatedAt: request.expectedUpdatedAt,
+        currentUpdatedAt: current.updated_at,
+      },
+    };
+  }
+
+  // Decompose the current row's stored ISO `start_date` / `end_date` strings
+  // back into the YYYY-MM-DD + HH:MM parts used by the patch schema so we
+  // can merge patch over current and re-validate the combined shape against
+  // `assistantPreparedEventSchema` (catches end > start invariants, etc.).
+  const currentStart = decomposeIsoToDateTime(current.start_date);
+  if (!currentStart) {
+    return {
+      ok: false,
+      status: 500,
+      error: "corrupt_start_date",
+      details: { value: current.start_date },
+    };
+  }
+  const currentEnd = current.end_date
+    ? decomposeIsoToDateTime(current.end_date)
+    : null;
+
+  const mergedStartDate = patch.start_date ?? currentStart.date;
+  const mergedStartTime = patch.start_time ?? currentStart.time;
+  const mergedEndDate =
+    patch.end_date !== undefined ? patch.end_date : currentEnd?.date ?? "";
+  const mergedEndTime =
+    patch.end_time !== undefined ? patch.end_time : currentEnd?.time ?? "";
+  const mergedTitle = patch.title ?? current.title;
+  const mergedDescription =
+    patch.description !== undefined ? patch.description : current.description;
+  const mergedLocation =
+    patch.location !== undefined ? patch.location : current.location;
+  const mergedEventType = patch.event_type ?? current.event_type;
+  const mergedIsPhilanthropy =
+    patch.is_philanthropy ?? Boolean(current.is_philanthropy);
+
+  const invariantCheck = assistantPreparedEventSchema.safeParse({
+    title: mergedTitle,
+    description: mergedDescription ?? undefined,
+    start_date: mergedStartDate,
+    start_time: mergedStartTime,
+    end_date: mergedEndDate,
+    end_time: mergedEndTime,
+    location: mergedLocation ?? undefined,
+    event_type: mergedEventType,
+    is_philanthropy: mergedIsPhilanthropy,
+  });
+
+  if (!invariantCheck.success) {
+    return {
+      ok: false,
+      status: 422,
+      error: "invariant_violation",
+      details: issuesToDetails(invariantCheck.error.issues),
+    };
+  }
+
+  // Recompose merged date+time pairs back into the ISO strings the DB stores.
+  // Mirrors `createEvent`'s composition — treat as wall-clock time (no
+  // timezone shift) so browser forms and agent edits stay consistent.
+  const nextStartIso = `${mergedStartDate}T${mergedStartTime}:00.000Z`;
+  const nextEndIso =
+    mergedEndDate && mergedEndTime
+      ? `${mergedEndDate}T${mergedEndTime}:00.000Z`
+      : null;
+
+  const updatePayload: Database["public"]["Tables"]["events"]["Update"] = {
+    title: mergedTitle,
+    description: mergedDescription ?? null,
+    start_date: nextStartIso,
+    end_date: nextEndIso,
+    location: mergedLocation ?? null,
+    event_type: mergedEventType,
+    is_philanthropy: mergedIsPhilanthropy || mergedEventType === "philanthropy",
+  };
+
+  let updateQuery = request.supabase
+    .from("events")
+    .update(updatePayload)
+    .eq("id", request.targetId)
+    .eq("organization_id", request.orgId)
+    .is("deleted_at", null);
+
+  if (request.expectedUpdatedAt != null) {
+    updateQuery = updateQuery.eq("updated_at", request.expectedUpdatedAt);
+  }
+
+  const { data: updated, error: updateError } = await updateQuery
+    .select("*")
+    .maybeSingle();
+
+  if (updateError) {
+    return { ok: false, status: 500, error: "update_failed" };
+  }
+  if (!updated) {
+    return { ok: false, status: 409, error: "stale_version" };
+  }
+
+  return { ok: true, value: updated };
+}
+
+function decomposeIsoToDateTime(
+  iso: string
+): { date: string; time: string } | null {
+  // Accepts "2026-04-22T09:00:00.000Z" (UTC wall-clock) — matches how
+  // `createEvent` composes it. We parse the leading date + HH:MM chunks
+  // directly rather than routing through `new Date(…)` to avoid local-
+  // timezone drift on the HH:MM extraction.
+  const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2})/.exec(iso);
+  if (!match) {
+    return null;
+  }
+  return { date: match[1], time: `${match[2]}:${match[3]}` };
+}
+
+function issuesToDetails(issues: ZodIssue[]): Record<string, unknown> {
+  return Object.fromEntries(
+    issues.map((issue) => [issue.path.join(".") || "body", issue.message])
+  );
+}

--- a/src/lib/schemas/events-ai.ts
+++ b/src/lib/schemas/events-ai.ts
@@ -62,3 +62,51 @@ export const assistantPreparedEventSchema = z
   );
 
 export type AssistantPreparedEvent = z.infer<typeof assistantPreparedEventSchema>;
+
+/**
+ * Patch schema for AI-agent-initiated edits to an existing event.
+ *
+ * Every field is optional; a patch can touch any subset. Fields deliberately
+ * excluded:
+ *  - `audience` / `channel` / `send_notification` — events don't re-notify
+ *    attendees on edit (unlike announcement create). The UI's edit-event
+ *    form omits these too.
+ *  - recurrence fields — editing recurring events is Tier 4 (out of scope).
+ *    The `updateEvent` primitive blocks any patch whose target row is part
+ *    of a recurrence series; the patch schema itself simply refuses to
+ *    accept recurrence-related keys.
+ *
+ * Cross-field invariants (e.g., end_date/end_time > start_date/start_time)
+ * are re-validated by `updateEvent` against the merged row, not here.
+ */
+export const assistantEventPatchSchema = z
+  .object({
+    title: safeString(200).optional(),
+    description: optionalSafeString(5000),
+    start_date: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional(),
+    start_time: z
+      .string()
+      .regex(/^\d{2}:\d{2}$/)
+      .optional(),
+    end_date: z
+      .string()
+      .refine((val) => val === "" || /^\d{4}-\d{2}-\d{2}$/.test(val), {
+        message: "Must be a valid date (YYYY-MM-DD)",
+      })
+      .optional(),
+    end_time: z
+      .string()
+      .refine((val) => val === "" || /^\d{2}:\d{2}$/.test(val), {
+        message: "Must be a valid time (HH:MM)",
+      })
+      .optional(),
+    location: optionalSafeString(500),
+    event_type: eventTypeSchema.optional(),
+    is_philanthropy: z.boolean().optional(),
+  })
+  .strict();
+
+export type AssistantEventPatch = z.infer<typeof assistantEventPatchSchema>;

--- a/tests/events-update.test.ts
+++ b/tests/events-update.test.ts
@@ -1,0 +1,523 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { updateEvent } from "@/lib/events/update-event";
+
+// ─── Minimal Supabase stub ──────────────────────────────────────────────
+// updateEvent touches exactly two tables: user_organization_roles (via
+// getOrgMembership) and events. This stub routes those two and records
+// every filter call so tests can assert the exact query shape.
+
+type EventRow = {
+  id: string;
+  organization_id: string;
+  title: string;
+  description: string | null;
+  start_date: string;
+  end_date: string | null;
+  location: string | null;
+  event_type: string;
+  is_philanthropy: boolean | null;
+  created_by_user_id: string;
+  audience: string | null;
+  updated_at: string;
+  deleted_at: string | null;
+  created_at: string;
+  recurrence_group_id: string | null;
+  recurrence_index: number | null;
+  recurrence_rule: unknown | null;
+};
+
+interface StubState {
+  membership: { role: string } | null;
+  event: EventRow | null;
+  fetchError: { message: string } | null;
+  updateError: { message: string } | null;
+  updateResult: EventRow | null;
+  updatePayload: Record<string, unknown> | null;
+  updateFilters: Array<{ op: string; column: string; value: unknown }>;
+}
+
+type StubChain = {
+  eq: (column: string, value: unknown) => StubChain;
+  is: (column: string, value: null) => StubChain;
+  maybeSingle: () => Promise<{
+    data: EventRow | null;
+    error: { message: string } | null;
+  }>;
+};
+
+type StubUpdateChain = {
+  eq: (column: string, value: unknown) => StubUpdateChain;
+  is: (column: string, value: null) => StubUpdateChain;
+  select: () => {
+    maybeSingle: () => Promise<{
+      data: EventRow | null;
+      error: { message: string } | null;
+    }>;
+  };
+};
+
+type StubRolesChain = {
+  eq: (column: string, value: unknown) => StubRolesChain;
+  maybeSingle: () => Promise<{
+    data: { role: string } | null;
+    error: { message: string } | null;
+  }>;
+};
+
+function buildStub(state: StubState) {
+  const eventSelectChain = (): StubChain => {
+    const chain: StubChain = {
+      eq: () => chain,
+      is: () => chain,
+      maybeSingle: async () => ({
+        data: state.event,
+        error: state.fetchError,
+      }),
+    };
+    return chain;
+  };
+
+  const eventUpdateChain = (): StubUpdateChain => {
+    const chain: StubUpdateChain = {
+      eq: (column, value) => {
+        state.updateFilters.push({ op: "eq", column, value });
+        return chain;
+      },
+      is: (column, value) => {
+        state.updateFilters.push({ op: "is", column, value });
+        return chain;
+      },
+      select: () => ({
+        maybeSingle: async () => ({
+          data: state.updateResult,
+          error: state.updateError,
+        }),
+      }),
+    };
+    return chain;
+  };
+
+  const rolesSelectChain = (): StubRolesChain => {
+    const chain: StubRolesChain = {
+      eq: () => chain,
+      maybeSingle: async () => ({ data: state.membership, error: null }),
+    };
+    return chain;
+  };
+
+  return {
+    from(table: string) {
+      if (table === "user_organization_roles") {
+        return { select: () => rolesSelectChain() };
+      }
+      if (table === "events") {
+        return {
+          select: () => eventSelectChain(),
+          update: (payload: Record<string, unknown>) => {
+            state.updatePayload = payload;
+            return eventUpdateChain();
+          },
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  } as unknown as Parameters<typeof updateEvent>[0]["supabase"];
+}
+
+function baseRow(overrides: Partial<EventRow> = {}): EventRow {
+  return {
+    id: "00000000-0000-0000-0000-0000000000a1",
+    organization_id: "00000000-0000-0000-0000-0000000000b1",
+    title: "Original Event",
+    description: "Original description",
+    start_date: "2026-04-22T09:00:00.000Z",
+    end_date: "2026-04-22T10:00:00.000Z",
+    location: "Gym",
+    event_type: "general",
+    is_philanthropy: false,
+    created_by_user_id: "00000000-0000-0000-0000-0000000000c1",
+    audience: "both",
+    updated_at: "2026-04-21T10:00:00.000Z",
+    deleted_at: null,
+    created_at: "2026-04-20T09:00:00.000Z",
+    recurrence_group_id: null,
+    recurrence_index: null,
+    recurrence_rule: null,
+    ...overrides,
+  };
+}
+
+function freshState(): StubState {
+  return {
+    membership: { role: "admin" },
+    event: baseRow(),
+    fetchError: null,
+    updateError: null,
+    updateResult: baseRow({
+      title: "Updated Event",
+      updated_at: "2026-04-21T10:05:00.000Z",
+    }),
+    updatePayload: null,
+    updateFilters: [],
+  };
+}
+
+const ORG = "00000000-0000-0000-0000-0000000000b1";
+const USER = "00000000-0000-0000-0000-0000000000c1";
+const TARGET = "00000000-0000-0000-0000-0000000000a1";
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe("updateEvent — input validation", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("rejects an empty patch with 400 empty_patch", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: {},
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 400);
+      assert.equal(result.error, "empty_patch");
+    }
+  });
+
+  it("rejects a malformed patch with 400 invalid_patch", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "a".repeat(201) },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 400);
+      assert.equal(result.error, "invalid_patch");
+    }
+  });
+
+  it("rejects an invalid start_date format", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { start_date: "tomorrow" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 400);
+      assert.equal(result.error, "invalid_patch");
+    }
+  });
+});
+
+describe("updateEvent — permission check", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 403 forbidden when caller is not an admin", async () => {
+    state.membership = { role: "active_member" };
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 403);
+      assert.equal(result.error, "forbidden");
+    }
+  });
+
+  it("returns 403 forbidden when caller is not a member at all", async () => {
+    state.membership = null;
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 403);
+    }
+  });
+});
+
+describe("updateEvent — target lookup", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 404 not_found when the event does not exist", async () => {
+    state.event = null;
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 404);
+      assert.equal(result.error, "not_found");
+    }
+  });
+});
+
+describe("updateEvent — recurrence guard (Tier 4 out of scope)", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("rejects a recurring event (non-null recurrence_group_id) with 422", async () => {
+    state.event = baseRow({
+      recurrence_group_id: "00000000-0000-0000-0000-0000000000d1",
+      recurrence_index: 0,
+      recurrence_rule: { freq: "WEEKLY" },
+    });
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "Move the recurring series" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 422);
+      assert.equal(result.error, "recurring_event_unsupported");
+    }
+  });
+
+  it("rejects a recurring instance (recurrence_index set, rule null) with 422", async () => {
+    state.event = baseRow({
+      recurrence_group_id: "00000000-0000-0000-0000-0000000000d1",
+      recurrence_index: 3,
+      recurrence_rule: null,
+    });
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "Move this one instance only" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 422);
+      assert.equal(result.error, "recurring_event_unsupported");
+    }
+  });
+});
+
+describe("updateEvent — optimistic concurrency", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns 409 stale_version when expectedUpdatedAt does not match current", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New" },
+      expectedUpdatedAt: "2026-04-21T09:00:00.000Z",
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 409);
+      assert.equal(result.error, "stale_version");
+    }
+  });
+
+  it("proceeds when expectedUpdatedAt matches current", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New title" },
+      expectedUpdatedAt: "2026-04-21T10:00:00.000Z",
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it("adds the updated_at filter to the UPDATE when expectedUpdatedAt is supplied", async () => {
+    await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New title" },
+      expectedUpdatedAt: "2026-04-21T10:00:00.000Z",
+    });
+    const updatedAtFilter = state.updateFilters.find(
+      (f) => f.op === "eq" && f.column === "updated_at"
+    );
+    assert.ok(updatedAtFilter, "UPDATE must include eq filter on updated_at");
+    assert.equal(updatedAtFilter!.value, "2026-04-21T10:00:00.000Z");
+  });
+
+  it("returns 409 stale_version when the UPDATE affects zero rows", async () => {
+    state.updateResult = null;
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "New title" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 409);
+      assert.equal(result.error, "stale_version");
+    }
+  });
+});
+
+describe("updateEvent — cross-field invariants", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("rejects a patch that moves end_time before start_time with 422", async () => {
+    // Current row: 2026-04-22 09:00 → 10:00. Patch end_time to 08:00 breaks it.
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { end_time: "08:00" },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 422);
+      assert.equal(result.error, "invariant_violation");
+    }
+  });
+
+  it("accepts a patch that shifts both start and end coherently", async () => {
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { start_time: "11:00", end_time: "12:00" },
+    });
+    assert.equal(result.ok, true);
+  });
+});
+
+describe("updateEvent — happy path", () => {
+  let state: StubState;
+  beforeEach(() => {
+    state = freshState();
+  });
+
+  it("returns the updated row on a title-only patch", async () => {
+    state.updateResult = baseRow({
+      title: "Edited title",
+      updated_at: "2026-04-21T10:05:00.000Z",
+    });
+    const result = await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "Edited title" },
+    });
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.value.title, "Edited title");
+    }
+  });
+
+  it("writes the merged row (not the raw patch)", async () => {
+    await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "Edited title" },
+    });
+    assert.ok(state.updatePayload);
+    // Patched field
+    assert.equal(state.updatePayload!.title, "Edited title");
+    // Unpatched fields retain current-row values (re-composed to ISO)
+    assert.equal(state.updatePayload!.start_date, "2026-04-22T09:00:00.000Z");
+    assert.equal(state.updatePayload!.end_date, "2026-04-22T10:00:00.000Z");
+    assert.equal(state.updatePayload!.location, "Gym");
+    assert.equal(state.updatePayload!.event_type, "general");
+  });
+
+  it("recomposes date+time parts into the stored ISO format on a start_time-only patch", async () => {
+    // Current row: start 09:00 → end 10:00. Shift start earlier so the
+    // end>start invariant still holds after merge. Verifies the
+    // decompose-merge-recompose pipeline carries the date component
+    // forward unchanged.
+    await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { start_time: "08:00" },
+    });
+    assert.ok(state.updatePayload);
+    // Date component retained from current row; time swapped.
+    assert.equal(state.updatePayload!.start_date, "2026-04-22T08:00:00.000Z");
+  });
+
+  it("scopes the UPDATE by id, organization_id, and deleted_at IS NULL", async () => {
+    await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { title: "Edited" },
+    });
+    const filterKeys = state.updateFilters.map((f) => `${f.op}:${f.column}`);
+    assert.ok(filterKeys.includes("eq:id"));
+    assert.ok(filterKeys.includes("eq:organization_id"));
+    assert.ok(filterKeys.includes("is:deleted_at"));
+  });
+
+  it("promotes is_philanthropy to true when the merged event_type is 'philanthropy'", async () => {
+    state.updateResult = baseRow({
+      event_type: "philanthropy",
+      is_philanthropy: true,
+      updated_at: "2026-04-21T10:05:00.000Z",
+    });
+    await updateEvent({
+      supabase: buildStub(state),
+      orgId: ORG,
+      userId: USER,
+      targetId: TARGET,
+      patch: { event_type: "philanthropy" },
+    });
+    assert.ok(state.updatePayload);
+    assert.equal(state.updatePayload!.is_philanthropy, true);
+    assert.equal(state.updatePayload!.event_type, "philanthropy");
+  });
+});


### PR DESCRIPTION
## Summary

Opens the events half of Tier 1 edit/delete parity. Mirrors the `updateAnnouncement` primitive (#123) with the same `DomainResult<T>` contract, same CAS + optimistic-concurrency semantics, same admin-only auth — adapted for the events table's distinct shape (composed ISO datetime columns rather than separate fields) and its recurrence model.

Branches off `integration/tier1-full`. Independent of the Phase 2 stack (#134–#137).

## Changes

- **New:** `src/lib/events/update-event.ts` — `updateEvent()` primitive
- **New:** `tests/events-update.test.ts` — 19-test harness covering validation, permission, recurrence guard, optimistic concurrency, invariants, happy path
- **Modified:** `src/lib/schemas/events-ai.ts` — adds `assistantEventPatchSchema` (`.strict()`, all fields optional) and `AssistantEventPatch` type. Deliberately excludes `audience/channel/send_notification` per the plan — events don't re-notify attendees on edit.

## Key design decisions

1. **Recurrence guard blocks all recurrence-linked rows.** Any row with non-null `recurrence_group_id` OR `recurrence_rule` OR `recurrence_index` returns `422 recurring_event_unsupported`. Per plan, editing recurring events is Tier 4 — `this_only` / `this_and_future` / `all_in_series` scope semantics are out of scope for Phase 3.

2. **Decompose-merge-recompose pipeline.** The events table stores `start_date` / `end_date` as composed ISO strings (\`\"2026-04-22T09:00:00.000Z\"\`) while the schema exposes them as separate `YYYY-MM-DD` + `HH:MM` pairs. `updateEvent` decomposes the current row, merges patch over the decomposed parts, re-validates via `assistantPreparedEventSchema` (catches end>start), then recomposes. Matches `createEvent`'s wall-clock convention.

3. **Cross-field invariants re-checked on the merged row.** A patch of `{ end_time: \"08:00\" }` against a row ending at 10:00 returns `422 invariant_violation` even though `end_time=08:00` is individually valid Zod-wise — the merged shape violates end > start.

4. **`is_philanthropy` auto-promotion mirrors `createEvent`.** When the merged `event_type` is `\"philanthropy\"`, `is_philanthropy` is written as `true` regardless of patch/current value.

5. **Local `DomainResult` mirror** — same pattern as `updateAnnouncement`, kept local so this PR is self-contained. Refactor to the shared module in a follow-up once Phase 1b's shared type propagates.

## What's NOT here (deliberate)

- No `syncEventToUsers(\"update\")` call — dispatcher-level concern (Phase 3a-confirm). The primitive is pure data-layer.
- No dispatcher or pending-action type — Phase 3a-confirm wires `edit_event` pending type and `handleEditEvent` dispatcher on top.
- No `prepare_edit_event` tool — Phase 3a-prepare lands after confirm, same pattern as the announcements chain.

## Testing

- `npx tsc --noEmit`: clean
- `npx eslint` on changed files: clean
- `tests/events-update.test.ts`: 19/19 pass
- `tests/announcements-update.test.ts`: 16/16 pass (regression-safe)

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: `update_failed` error counts on `update-event` endpoints (should stay at 0 this phase — no caller yet)
  - Metric: `recurring_event_unsupported` 422 count when Phase 3a-confirm lands — confirms the guard is catching recurrence edits rather than silently corrupting series
- **Expected healthy behavior**
  - Zero `update_failed` until the dispatcher PR merges (no callers)
  - After Phase 3a-confirm: `stale_version` 409s are rare (concurrent UI+agent edits); `recurring_event_unsupported` 422s trigger clear user-facing error messages, not silent DB writes
- **Failure signal(s) / rollback trigger**
  - Any `update_failed` 500 spike after Phase 3a-confirm ships → DB-layer regression; revisit the Update payload shape
  - Any event row with modified `start_date` but `recurrence_group_id IS NOT NULL` in post-deploy audit → guard bypassed; **rollback immediately**
- **Validation window & owner**
  - Window: 24h post-merge of the full Phase 3 chain (this PR + confirm + prepare)
  - Owner: agent team
- **If no operational impact**
  - This PR alone has no runtime impact — primitive has no callers yet. Monitoring activates when the dispatcher lands.