### PR TITLE
Fix landing page mobile layout

### DIFF
--- a/src/app/landing-styles.css
+++ b/src/app/landing-styles.css
@@ -1,5 +1,6 @@
 /* Landing Page - Athletic Heritage Theme */
 .landing-page {
+  overflow-x: clip;
   --landing-navy: #0a0a0a;
   --landing-navy-light: #1a1a1a;
   --landing-cream: #ffffff;
@@ -750,6 +751,20 @@ noscript~.scroll-reveal {
 }
 
 @media (max-width: 639px) {
+  .landing-page {
+    overflow-x: hidden;
+  }
+
+  .landing-demo-wrap,
+  .landing-demo-card {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .landing-demo-wrap::before {
+    inset: 12% 0 -6% 0;
+  }
+
   .bento-grid {
     grid-template-columns: 1fr;
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -92,7 +92,7 @@ export default async function LandingPage() {
   }
 
   return (
-    <div id="top" className="landing-page min-h-screen text-landing-cream relative noise-overlay bg-landing-navy">
+    <div id="top" className="landing-page relative min-h-screen overflow-x-clip bg-landing-navy text-landing-cream noise-overlay">
       <LandingAnimations />
 
       {/* Diagonal stripe background */}
@@ -105,7 +105,7 @@ export default async function LandingPage() {
       <LandingHeader />
 
       {/* Hero - "The Emergence" */}
-      <section className="landing-hero-stage relative z-10 overflow-hidden px-6 pb-20 pt-12 sm:px-8 lg:px-6 lg:pb-16 lg:pt-10">
+      <section className="landing-hero-stage relative z-10 overflow-hidden px-4 pb-14 pt-10 sm:px-8 sm:pb-20 sm:pt-12 lg:px-6 lg:pb-16 lg:pt-10">
         {/* Animated paths — atmospheric background */}
         <BackgroundPaths />
 
@@ -117,9 +117,9 @@ export default async function LandingPage() {
             {/* Left - Copy (centered on mobile/tablet, left-aligned on desktop) */}
             <div className="text-center lg:text-left">
               <div className="hero-animate mb-4 flex justify-center lg:justify-start">
-                <div className="inline-flex max-w-full items-center gap-2 rounded-full border border-landing-green/30 bg-landing-green/10 px-4 py-2 shadow-[0_0_40px_rgba(34,197,94,0.12)]">
+                <div className="inline-flex max-w-full items-center justify-center gap-2 rounded-full border border-landing-green/30 bg-landing-green/10 px-3 py-2 shadow-[0_0_40px_rgba(34,197,94,0.12)] sm:px-4">
                   <span className="h-2 w-2 shrink-0 rounded-full bg-landing-green gold-shimmer" />
-                  <span className="text-balance text-center text-sm font-medium text-landing-cream/80">
+                  <span className="min-w-0 text-balance text-center text-sm font-medium leading-snug text-landing-cream/80">
                     Built for organizations that go the distance
                   </span>
                 </div>
@@ -138,11 +138,11 @@ export default async function LandingPage() {
                 />
               </h1>
 
-              <p className="hero-animate mb-3 text-center text-2xl font-semibold tracking-tight text-landing-cream sm:text-3xl lg:text-left lg:text-4xl">
+              <p className="hero-animate mx-auto mb-3 max-w-[12ch] text-center text-2xl font-semibold tracking-tight text-landing-cream sm:max-w-none sm:text-3xl lg:mx-0 lg:text-left lg:text-4xl">
                 One platform. Every member,<br className="hidden sm:block" /> past and present.
               </p>
 
-              <p className="hero-animate mx-auto mb-8 max-w-xl text-base leading-relaxed text-landing-cream/80 sm:text-lg lg:mx-0 lg:mb-6">
+              <p className="hero-animate mx-auto mb-8 max-w-[32ch] text-base leading-relaxed text-landing-cream/80 sm:max-w-xl sm:text-lg lg:mx-0 lg:mb-6">
                 Directories, events, donations, philanthropy, and records — all in one place. Built for{" "}
                 <span className="font-medium text-landing-cream">sports teams</span>,{" "}
                 <span className="font-medium text-landing-cream">Greek life</span>,{" "}
@@ -150,10 +150,10 @@ export default async function LandingPage() {
               </p>
 
               <div className="hero-animate flex flex-col items-stretch gap-4 sm:flex-row sm:justify-center lg:justify-start">
-                <ButtonLink href="/auth/signup" variant="custom" size="lg" className="landing-primary-cta cta-glow bg-landing-green-dark px-6 py-4 text-base font-semibold text-white hover:bg-[#15803d] sm:px-8 sm:py-5">
+                <ButtonLink href="/auth/signup" variant="custom" size="lg" className="landing-primary-cta cta-glow w-full justify-center bg-landing-green-dark px-6 py-4 text-base font-semibold text-white hover:bg-[#15803d] sm:w-auto sm:px-8 sm:py-5">
                   Create Your Organization
                 </ButtonLink>
-                <ButtonLink href="/auth/login?redirect=/app/join" size="lg" variant="custom" className="landing-secondary-cta border border-landing-cream/20 bg-landing-cream/10 px-6 py-4 text-base text-landing-cream hover:bg-landing-cream/20 sm:px-8 sm:py-5">
+                <ButtonLink href="/auth/login?redirect=/app/join" size="lg" variant="custom" className="landing-secondary-cta w-full justify-center border border-landing-cream/20 bg-landing-cream/10 px-6 py-4 text-base text-landing-cream hover:bg-landing-cream/20 sm:w-auto sm:px-8 sm:py-5">
                   Join an Organization
                 </ButtonLink>
               </div>

--- a/src/components/marketing/LandingHeader.tsx
+++ b/src/components/marketing/LandingHeader.tsx
@@ -96,18 +96,18 @@ export function LandingHeader() {
   return (
     <>
     <header className="relative z-20 sticky top-0 bg-landing-navy/95 backdrop-blur-md border-b border-landing-cream/10">
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-2 px-3 sm:px-6 py-3 sm:py-4">
-        <Link href="#top" className="group flex min-w-0 flex-1 items-center gap-2 sm:gap-2.5">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-2 px-3 py-3 sm:px-6 sm:py-4">
+        <Link href="#top" className="group flex min-w-0 flex-1 items-center gap-1.5 sm:gap-2.5">
           <Image
             src="/TeamNetwor.png"
             alt=""
             width={541}
             height={303}
             sizes="28px"
-            className="h-8 w-auto shrink-0 object-contain sm:h-7"
+            className="h-7 w-auto shrink-0 object-contain sm:h-7"
             aria-hidden="true"
           />
-          <span className="font-display truncate text-base font-bold tracking-tight text-landing-cream sm:text-xl">
+          <span className="font-display truncate text-sm font-bold tracking-tight text-landing-cream min-[380px]:text-base sm:text-xl">
             <span className="text-landing-green">Team</span>
             <span className="text-landing-cream">Network</span>
           </span>
@@ -142,7 +142,7 @@ export function LandingHeader() {
           <ButtonLink
             href="/auth/signup"
             variant="custom"
-            className="whitespace-nowrap bg-landing-green-dark px-2.5 py-2 text-sm font-semibold text-white hover:bg-[#15803d] sm:px-5 sm:text-base"
+            className="whitespace-nowrap bg-landing-green-dark px-2 py-2 text-xs font-semibold text-white hover:bg-[#15803d] min-[380px]:px-2.5 min-[380px]:text-sm sm:px-5 sm:text-base"
           >
             Get Started
           </ButtonLink>


### PR DESCRIPTION
## Summary
- prevent horizontal overflow on the landing page
- tighten mobile hero spacing and text widths
- resize the mobile header CTA/logo and make hero CTAs full-width on phones

## Verification
- npx tsc --noEmit
- npm run lint