### PR TITLE
feat(pricing): v2 dynamic-quote checkout test slice

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -33,6 +33,11 @@ STRIPE_PRICE_ENTERPRISE_ALUMNI_BUCKET_YEARLY=price_xxx
 STRIPE_PRICE_ENTERPRISE_SUB_ORG_MONTHLY=price_xxx
 STRIPE_PRICE_ENTERPRISE_SUB_ORG_YEARLY=price_xxx
 
+# v2 pricing test slice — Stripe Product for dynamic-amount custom-quote checkout.
+# Manually create one Product in Stripe dashboard called "TeamNetwork Plan v2"
+# and paste its prod_… ID here.
+STRIPE_PRODUCT_ID_DYNAMIC=prod_your_v2_test_product
+
 # Cloudflare Turnstile (captcha)
 NEXT_PUBLIC_CAPTCHA_PROVIDER=turnstile
 CAPTCHA_PROVIDER=turnstile
@@ -74,6 +79,14 @@ BLACKBAUD_CLIENT_ID=your-blackbaud-application-id
 BLACKBAUD_CLIENT_SECRET=your-blackbaud-primary-application-secret
 BLACKBAUD_TOKEN_ENCRYPTION_KEY=your-32-byte-hex-encryption-key
 BLACKBAUD_SUBSCRIPTION_KEY=your-blackbaud-subscription-key
+
+# Blackbaud sync dev caps (NODE_ENV != production only). Production ignores these.
+# BLACKBAUD_DEV_PAGE_SIZE — page size sent to /constituents (default 500, max 500)
+# BLACKBAUD_DEV_MAX_PAGES — stop after N pages; sets result.partial=true and skips last_synced_at advance
+# BLACKBAUD_DEV_SKIP_EMAILS — "true" skips per-constituent email subresource fetch (rate-limit probing only)
+# BLACKBAUD_DEV_PAGE_SIZE=5
+# BLACKBAUD_DEV_MAX_PAGES=1
+# BLACKBAUD_DEV_SKIP_EMAILS=false
 
 # COPPA age-gate API (`/api/auth/validate-age`)
 AGE_VALIDATION_SECRET=your-random-secret

--- a/src/app/api/stripe/create-custom-quote-checkout/route.ts
+++ b/src/app/api/stripe/create-custom-quote-checkout/route.ts
@@ -1,0 +1,275 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { stripe } from "@/lib/stripe";
+import { getStripeOrigin } from "@/lib/stripe-origin";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+import {
+  baseSchemas,
+  validateJson,
+  ValidationError,
+  validationErrorResponse,
+} from "@/lib/security/validation";
+import { requireEnv } from "@/lib/env";
+import {
+  claimPaymentAttempt,
+  ensurePaymentAttempt,
+  hashFingerprint,
+  hasStripeResource,
+  IdempotencyConflictError,
+  updatePaymentAttempt,
+  waitForExistingStripeResource,
+} from "@/lib/payments/idempotency";
+import { buildDynamicQuoteCheckoutFingerprintPayload } from "@/lib/payments/dynamic-quote-checkout-fingerprint";
+import { quote } from "@/lib/pricing-v2";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const createCustomQuoteSchema = z
+  .object({
+    tier: z.enum(["single", "enterprise"]),
+    actives: z.number().int().min(0).max(1_000_000),
+    alumni: z.number().int().min(0).max(1_000_000),
+    subOrgs: z.number().int().min(0).max(1_000).optional(),
+    billingInterval: z.enum(["month", "year"]),
+    idempotencyKey: baseSchemas.idempotencyKey.optional(),
+    paymentAttemptId: baseSchemas.uuid.optional(),
+  })
+  .strict();
+
+export async function POST(req: Request) {
+  try {
+    const supabase = await createClient();
+    const serviceSupabase = createServiceClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    const rateLimit = checkRateLimit(req, {
+      userId: user?.id ?? null,
+      feature: "dynamic quote checkout",
+      limitPerIp: 30,
+      limitPerUser: 15,
+    });
+
+    if (!rateLimit.ok) {
+      return buildRateLimitResponse(rateLimit);
+    }
+
+    const respond = (payload: unknown, status = 200) =>
+      NextResponse.json(payload, { status, headers: rateLimit.headers });
+
+    if (!user) {
+      return respond({ error: "Unauthorized" }, 401);
+    }
+
+    const body = await validateJson(req, createCustomQuoteSchema, { maxBodyBytes: 8_000 });
+    const {
+      tier,
+      actives,
+      alumni,
+      subOrgs,
+      billingInterval,
+      idempotencyKey: rawIdempotencyKey,
+      paymentAttemptId,
+    } = body;
+
+    const idempotencyKey = rawIdempotencyKey ?? null;
+    const subOrgsCount = subOrgs ?? 0;
+
+    const q = quote({ tier, actives, alumni, subOrgs: subOrgsCount });
+
+    if (q.salesLed) {
+      return respond({
+        mode: "sales",
+        message: "Contact sales for >100k alumni",
+      });
+    }
+
+    const unitAmount = billingInterval === "year" ? q.yearlyCents : q.monthlyCents;
+
+    if (unitAmount <= 0) {
+      return respond({ error: "Quote total must be greater than zero" }, 400);
+    }
+
+    let resolvedAttemptId: string | null = null;
+    let stripeResourceCreated = false;
+
+    try {
+      const origin = getStripeOrigin(req.url);
+
+      const fingerprint = hashFingerprint(
+        buildDynamicQuoteCheckoutFingerprintPayload({
+          userId: user.id,
+          tier,
+          billingInterval,
+          actives,
+          alumni,
+          subOrgs: subOrgsCount,
+          monthlyCents: q.monthlyCents,
+          yearlyCents: q.yearlyCents,
+        }),
+      );
+
+      const attemptMetadata: Record<string, unknown> = {
+        pricing_model_version: "v2",
+        flow_type_v2: "dynamic_quote_checkout",
+        tier,
+        billing_interval: billingInterval,
+        actives,
+        alumni,
+        sub_orgs: subOrgsCount,
+        monthly_cents: q.monthlyCents,
+        yearly_cents: q.yearlyCents,
+        quote_breakdown: { ...q.breakdown },
+      };
+
+      const { attempt } = await ensurePaymentAttempt({
+        supabase: serviceSupabase,
+        idempotencyKey,
+        paymentAttemptId,
+        flowType: "dynamic_quote_checkout",
+        amountCents: unitAmount,
+        currency: "usd",
+        userId: user.id,
+        organizationId: null,
+        requestFingerprint: fingerprint,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        metadata: attemptMetadata as any,
+      });
+
+      resolvedAttemptId = attempt.id;
+
+      const { attempt: claimedAttempt, claimed } = await claimPaymentAttempt({
+        supabase: serviceSupabase,
+        attempt,
+        amountCents: unitAmount,
+        currency: "usd",
+        requestFingerprint: fingerprint,
+        stripeConnectedAccountId: null,
+      });
+
+      const respondWithExisting = (candidate: typeof claimedAttempt) => {
+        if (candidate.checkout_url && candidate.stripe_checkout_session_id) {
+          return respond({
+            mode: "checkout",
+            checkoutUrl: candidate.checkout_url,
+            idempotencyKey: candidate.idempotency_key,
+            paymentAttemptId: candidate.id,
+          });
+        }
+        return null;
+      };
+
+      if (!claimed) {
+        const existingResponse = hasStripeResource(claimedAttempt)
+          ? respondWithExisting(claimedAttempt)
+          : null;
+        if (existingResponse) return existingResponse;
+
+        const awaited = await waitForExistingStripeResource(serviceSupabase, claimedAttempt.id);
+        if (awaited && hasStripeResource(awaited)) {
+          const awaitedResponse = respondWithExisting(awaited);
+          if (awaitedResponse) return awaitedResponse;
+        }
+
+        return respond(
+          {
+            error: "Checkout is already processing for this idempotency key. Retry shortly with the same key.",
+            idempotencyKey: claimedAttempt.idempotency_key,
+            paymentAttemptId: claimedAttempt.id,
+          },
+          409,
+        );
+      }
+
+      // Stripe metadata caps each value at 500 chars; quote_snapshot is the
+      // only field at risk. JSON breakdown is ~180 chars worst case but guard
+      // anyway so a future field bump fails loud here, not at Stripe.
+      const quoteSnapshot = JSON.stringify(q.breakdown);
+      if (quoteSnapshot.length > 500) {
+        throw new Error("quote_snapshot exceeds Stripe metadata length cap");
+      }
+
+      const sessionMetadata = {
+        type: "dynamic_v2",
+        pricing_model_version: "v2",
+        payment_attempt_id: claimedAttempt.id,
+        creator_id: user.id,
+        tier,
+        billing_interval: billingInterval,
+        actives: String(actives),
+        alumni: String(alumni),
+        sub_orgs: String(subOrgsCount),
+        monthly_cents: String(q.monthlyCents),
+        yearly_cents: String(q.yearlyCents),
+        quote_snapshot: quoteSnapshot,
+      } as const;
+
+      const session = await stripe.checkout.sessions.create(
+        {
+          mode: "subscription",
+          customer_email: user.email ?? undefined,
+          line_items: [
+            {
+              quantity: 1,
+              price_data: {
+                currency: "usd",
+                unit_amount: unitAmount,
+                recurring: { interval: billingInterval },
+                product: requireEnv("STRIPE_PRODUCT_ID_DYNAMIC"),
+              },
+            },
+          ],
+          subscription_data: { metadata: sessionMetadata },
+          metadata: sessionMetadata,
+          success_url: `${origin}/pricing/calculator?checkout=success`,
+          cancel_url: `${origin}/pricing/calculator?checkout=cancel`,
+        },
+        { idempotencyKey: claimedAttempt.idempotency_key },
+      );
+
+      stripeResourceCreated = true;
+
+      await updatePaymentAttempt(serviceSupabase, claimedAttempt.id, {
+        stripe_checkout_session_id: session.id,
+        checkout_url: session.url,
+        status: "processing",
+      });
+
+      return respond({
+        mode: "checkout",
+        checkoutUrl: session.url,
+        idempotencyKey: claimedAttempt.idempotency_key,
+        paymentAttemptId: claimedAttempt.id,
+      });
+    } catch (error) {
+      if (error instanceof IdempotencyConflictError) {
+        return respond({ error: error.message }, 409);
+      }
+
+      const stripeErr = error as {
+        message?: string;
+        raw?: { message?: string };
+      };
+      const lastError = stripeErr?.message || stripeErr?.raw?.message || "checkout_failed";
+
+      if (resolvedAttemptId) {
+        const errorUpdate: { last_error: string; status?: string } = { last_error: lastError };
+        if (!stripeResourceCreated) {
+          errorUpdate.status = "initiated";
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await serviceSupabase.from("payment_attempts").update(errorUpdate as any).eq("id", resolvedAttemptId);
+      }
+
+      const message = error instanceof Error ? error.message : "Unable to create checkout session";
+      return respond({ error: message }, 400);
+    }
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return validationErrorResponse(error);
+    }
+    throw error;
+  }
+}

--- a/src/app/api/stripe/webhook/handler.ts
+++ b/src/app/api/stripe/webhook/handler.ts
@@ -311,6 +311,27 @@ export async function handleStripeWebhookPost(
 
         debugLog("stripe-webhook", "checkout.session.completed - org:", maskPII(session.metadata?.organization_id), "session:", maskPII(session.id), "mode:", session.mode);
 
+        // v2 dynamic-quote test slice. Must stay above the enterprise + generic
+        // subscription branches: those branches require an org_id and would 500
+        // on a v2 session that has none.
+        if (session.metadata?.type === "dynamic_v2") {
+          const attemptId =
+            (session.metadata?.payment_attempt_id as string | undefined) ?? null;
+          if (attemptId && session.payment_status === "paid") {
+            await updatePaymentAttemptStatus(supabase, {
+              paymentAttemptId: attemptId,
+              checkoutSessionId: session.id,
+              paymentIntentId:
+                typeof session.payment_intent === "string"
+                  ? session.payment_intent
+                  : session.payment_intent?.id || null,
+              status: "succeeded",
+              organizationId: null,
+            });
+          }
+          break;
+        }
+
         // Handle enterprise checkout (subscription mode)
         if (session.metadata?.type === "enterprise") {
           const enterprisePaymentAttemptId =

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -432,6 +432,7 @@ export default async function LandingPage() {
                   <Link href="#features" className="text-landing-cream/50 hover:text-landing-cream transition-colors">Features</Link>
                   <Link href="#pricing" className="text-landing-cream/50 hover:text-landing-cream transition-colors">Pricing</Link>
                   <Link href="/demos" className="text-landing-cream/50 hover:text-landing-cream transition-colors">Demos</Link>
+                  <Link href="/pricing/calculator" className="text-landing-cream/50 hover:text-landing-cream transition-colors">Pricing calculator</Link>
                 </nav>
               </div>
               <div>

--- a/src/app/pricing/calculator/page.tsx
+++ b/src/app/pricing/calculator/page.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { ButtonLink } from "@/components/ui";
+import { LandingHeader } from "@/components/marketing/LandingHeader";
+import { useIdempotencyKey } from "@/hooks";
+import { quote, type Tier, type Interval } from "@/lib/pricing-v2";
+
+const currencyFmt = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+function formatCents(cents: number): string {
+  return currencyFmt.format(cents / 100);
+}
+
+export default function PricingCalculatorPage() {
+  const searchParams = useSearchParams();
+  const checkoutStatus = searchParams.get("checkout");
+
+  const [tier, setTier] = useState<Tier>("single");
+  const [actives, setActives] = useState(200);
+  const [alumni, setAlumni] = useState(1_200);
+  const [subOrgs, setSubOrgs] = useState(0);
+  const [interval, setInterval] = useState<Interval>("month");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [salesNotice, setSalesNotice] = useState<string | null>(null);
+
+  const q = useMemo(
+    () => quote({ tier, actives, alumni, subOrgs }),
+    [tier, actives, alumni, subOrgs],
+  );
+
+  const fingerprint = useMemo(
+    () =>
+      JSON.stringify({
+        tier,
+        actives,
+        alumni,
+        subOrgs: tier === "enterprise" ? subOrgs : 0,
+        interval,
+        monthlyCents: q.monthlyCents,
+        yearlyCents: q.yearlyCents,
+      }),
+    [tier, actives, alumni, subOrgs, interval, q.monthlyCents, q.yearlyCents],
+  );
+
+  const { idempotencyKey } = useIdempotencyKey({
+    storageKey: "dynamic_quote_checkout",
+    fingerprint,
+  });
+
+  useEffect(() => {
+    setSalesNotice(null);
+  }, [tier, actives, alumni, subOrgs]);
+
+  const onCheckout = async () => {
+    if (q.salesLed || submitting) return;
+    if (!idempotencyKey) {
+      setError("Preparing checkout — try again.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/stripe/create-custom-quote-checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tier,
+          actives,
+          alumni,
+          subOrgs: tier === "enterprise" ? subOrgs : 0,
+          billingInterval: interval,
+          idempotencyKey,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Unable to start checkout");
+      }
+      if (data.mode === "sales") {
+        setSalesNotice(data.message || "Contact sales");
+        return;
+      }
+      if (data.checkoutUrl) {
+        window.location.assign(data.checkoutUrl as string);
+        return;
+      }
+      throw new Error("Missing checkout URL");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const monthly = formatCents(q.monthlyCents);
+  const yearly = formatCents(q.yearlyCents);
+
+  const segBtn = (active: boolean) =>
+    `flex-1 px-3 py-2.5 rounded-lg text-sm font-semibold transition-all border ${
+      active
+        ? "border-landing-green bg-landing-green/15 text-landing-cream"
+        : "border-landing-cream/15 bg-landing-cream/[0.03] text-landing-cream/65 hover:text-landing-cream hover:bg-landing-cream/[0.06]"
+    }`;
+
+  const inputCls =
+    "w-full rounded-lg border border-landing-cream/15 bg-landing-cream/[0.03] px-3 py-2.5 text-landing-cream placeholder:text-landing-cream/30 focus:outline-none focus:ring-2 focus:ring-landing-green/40 focus:border-landing-green/40";
+
+  return (
+    <div className="landing-page relative min-h-screen overflow-x-clip bg-landing-navy text-landing-cream noise-overlay">
+      <div className="fixed inset-0 bg-gradient-to-b from-landing-navy via-landing-navy to-landing-navy/95 pointer-events-none" />
+      <div className="relative z-10">
+        <LandingHeader />
+        <main className="mx-auto max-w-5xl px-4 sm:px-6 py-10 sm:py-16">
+          <div className="mb-8">
+            <span className="inline-block px-3 py-1 rounded-full bg-landing-green/10 border border-landing-green/30 text-landing-green text-xs font-semibold uppercase tracking-[0.2em]">
+              Preview / Test
+            </span>
+            <h1 className="font-display text-4xl sm:text-5xl font-bold text-landing-cream mt-4">
+              Pricing <span className="text-landing-green">Calculator</span>
+            </h1>
+            <p className="text-landing-cream/60 mt-3 text-lg">
+              Live calculator for the v2 per-user pricing model. Not yet the
+              production plan.
+            </p>
+          </div>
+
+          {checkoutStatus === "success" && (
+            <div className="mb-6 p-4 rounded-xl border border-landing-green/30 bg-landing-green/10 text-landing-cream">
+              Checkout completed. The webhook should mark the payment attempt as
+              succeeded.
+            </div>
+          )}
+          {checkoutStatus === "cancel" && (
+            <div className="mb-6 p-4 rounded-xl border border-landing-cream/15 bg-landing-cream/[0.04] text-landing-cream/80">
+              Checkout canceled.
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div className="rounded-2xl border border-landing-cream/10 bg-landing-navy-light/50 p-6 space-y-5">
+              <div className="space-y-2">
+                <label className="block text-xs uppercase tracking-[0.18em] text-landing-cream/50">
+                  Tier
+                </label>
+                <div className="flex gap-2">
+                  <button type="button" onClick={() => setTier("single")} className={segBtn(tier === "single")}>
+                    Single org
+                  </button>
+                  <button type="button" onClick={() => setTier("enterprise")} className={segBtn(tier === "enterprise")}>
+                    Enterprise
+                  </button>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label className="block text-xs uppercase tracking-[0.18em] text-landing-cream/50">
+                  Billing interval
+                </label>
+                <div className="flex gap-2">
+                  <button type="button" onClick={() => setInterval("month")} className={segBtn(interval === "month")}>
+                    Monthly
+                  </button>
+                  <button type="button" onClick={() => setInterval("year")} className={segBtn(interval === "year")}>
+                    Yearly · Save 17%
+                  </button>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label className="block text-xs uppercase tracking-[0.18em] text-landing-cream/50">
+                  Active members
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  value={actives}
+                  onChange={(e) => setActives(Math.max(0, parseInt(e.target.value, 10) || 0))}
+                  className={inputCls}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="block text-xs uppercase tracking-[0.18em] text-landing-cream/50">
+                  Alumni
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  value={alumni}
+                  onChange={(e) => setAlumni(Math.max(0, parseInt(e.target.value, 10) || 0))}
+                  className={inputCls}
+                />
+              </div>
+
+              {tier === "enterprise" && (
+                <div className="space-y-2">
+                  <label className="block text-xs uppercase tracking-[0.18em] text-landing-cream/50">
+                    Sub-organizations
+                  </label>
+                  <input
+                    type="number"
+                    min={0}
+                    value={subOrgs}
+                    onChange={(e) => setSubOrgs(Math.max(0, parseInt(e.target.value, 10) || 0))}
+                    className={inputCls}
+                  />
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-2xl border border-landing-cream/10 bg-landing-navy-light/50 p-6">
+              <h2 className="font-display text-lg font-bold text-landing-cream mb-4">Quote</h2>
+
+              {q.salesLed ? (
+                <div className="p-4 rounded-lg border border-landing-green/30 bg-landing-green/10 text-sm text-landing-cream/80">
+                  Custom alumni quota — contact sales for plans above 100,000
+                  alumni.
+                </div>
+              ) : (
+                <div className="space-y-2 text-sm">
+                  <Row
+                    label={`Alumni (${alumni.toLocaleString()} × ${formatCents(q.breakdown.alumniRateCents)})`}
+                    value={formatCents(q.breakdown.alumniMonthlyCents)}
+                  />
+                  <Row
+                    label={`Active members (${actives.toLocaleString()} × ${formatCents(q.breakdown.activeRateCents)})`}
+                    value={formatCents(q.breakdown.activeMonthlyCents)}
+                  />
+                  {q.breakdown.platformBaseCents > 0 && (
+                    <Row
+                      label="Enterprise platform base"
+                      value={formatCents(q.breakdown.platformBaseCents)}
+                    />
+                  )}
+                  {q.breakdown.subOrgMonthlyCents > 0 && (
+                    <Row
+                      label={`Sub-orgs (${q.breakdown.subOrgsBilled} blended)`}
+                      value={formatCents(q.breakdown.subOrgMonthlyCents)}
+                    />
+                  )}
+                  <div className="border-t border-landing-cream/10 my-3" />
+                  <div className="flex items-baseline justify-between">
+                    <span className="text-landing-cream/70">Monthly</span>
+                    <span className="athletic-number text-2xl text-landing-cream">{monthly}<span className="text-sm text-landing-cream/50">/mo</span></span>
+                  </div>
+                  <div className="flex items-baseline justify-between">
+                    <span className="text-landing-cream/70">Yearly</span>
+                    <span className="athletic-number text-2xl text-landing-cream">{yearly}<span className="text-sm text-landing-cream/50">/yr</span></span>
+                  </div>
+                </div>
+              )}
+
+              {error && (
+                <div className="mt-4 p-3 rounded-lg border border-red-500/30 bg-red-500/10 text-sm text-red-300">
+                  {error}
+                </div>
+              )}
+
+              {salesNotice && (
+                <div className="mt-4 p-3 rounded-lg border border-landing-green/30 bg-landing-green/10 text-sm text-landing-cream/80">
+                  {salesNotice}
+                </div>
+              )}
+
+              <button
+                type="button"
+                className="w-full mt-6 rounded-lg bg-landing-green-dark hover:bg-[#15803d] disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold py-3 transition-colors"
+                onClick={onCheckout}
+                disabled={submitting || q.salesLed || q.monthlyCents <= 0}
+              >
+                {submitting ? "Starting checkout…" : q.salesLed ? "Contact Sales" : "Test checkout"}
+              </button>
+              <p className="text-xs text-landing-cream/50 mt-2 text-center">
+                Will charge{" "}
+                <span className="font-medium text-landing-cream">
+                  {interval === "year" ? `${yearly}/yr` : `${monthly}/mo`}
+                </span>{" "}
+                via Stripe (test mode).
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-10 text-center">
+            <ButtonLink
+              href="/#pricing"
+              variant="custom"
+              className="text-landing-cream/60 hover:text-landing-cream text-sm"
+            >
+              ← Back to pricing
+            </ButtonLink>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex justify-between items-baseline border-b border-landing-cream/5 pb-2 last:border-0">
+      <span className="text-landing-cream/65">{label}</span>
+      <span className="font-semibold text-landing-cream">{value}</span>
+    </div>
+  );
+}

--- a/src/components/marketing/PricingSection.tsx
+++ b/src/components/marketing/PricingSection.tsx
@@ -1,190 +1,308 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ButtonLink } from "@/components/ui";
-import {
-  BASE_PRICES,
-  ALUMNI_ADD_ON_PRICES,
-  ALUMNI_BUCKET_LABELS,
-  getTotalPrice,
-  formatPrice,
-} from "@/lib/pricing";
-import type { AlumniBucket, SubscriptionInterval } from "@/types/database";
+import { quote, type Interval } from "@/lib/pricing-v2";
 
-const ALUMNI_TIERS: Exclude<AlumniBucket, "none">[] = [
-  "0-250",
-  "251-500",
-  "501-1000",
-  "1001-2500",
-  "2500-5000",
-  "5000+",
+const currencyFmt = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+function fmt(cents: number) {
+  return currencyFmt.format(cents / 100);
+}
+
+// Larger alumni slabs (10k+) exist in src/lib/pricing-v2.ts and remain
+// active in the calculator + checkout. Hidden from the landing page until
+// we're ready to publish them — for now route those orgs through sales.
+const ALUMNI_SLABS: { label: string; rateCents: number }[] = [
+  { label: "1 – 500", rateCents: 36 },
+  { label: "501 – 2,500", rateCents: 25 },
+  { label: "2,501 – 10,000", rateCents: 18 },
+];
+
+const ACTIVE_SLABS: { label: string; rateCents: number }[] = [
+  { label: "1 – 100", rateCents: 15 },
+  { label: "101 – 500", rateCents: 10 },
+  { label: "501+", rateCents: 5 },
+];
+
+const SCENARIOS = [
+  {
+    key: "club",
+    title: "Club",
+    blurb: "25 active members, no alumni yet",
+    actives: 25,
+    alumni: 0,
+    tier: "single" as const,
+    subOrgs: 0,
+  },
+  {
+    key: "small",
+    title: "Small program",
+    blurb: "200 active members, 750 alumni",
+    actives: 200,
+    alumni: 750,
+    tier: "single" as const,
+    subOrgs: 0,
+  },
+  {
+    key: "midsize",
+    title: "Midsize school",
+    blurb: "500 actives, 5,000 alumni",
+    actives: 500,
+    alumni: 5_000,
+    tier: "single" as const,
+    subOrgs: 0,
+  },
+  {
+    key: "enterprise",
+    title: "University network",
+    blurb: "1,000 actives · 10,000 alumni · 15 sub-orgs",
+    actives: 1_000,
+    alumni: 10_000,
+    tier: "enterprise" as const,
+    subOrgs: 15,
+  },
 ];
 
 export function PricingSection({ showCta = true }: { showCta?: boolean }) {
-  const [interval, setInterval] = useState<SubscriptionInterval>("month");
+  const [interval, setInterval] = useState<Interval>("month");
+  const [scenarioKey, setScenarioKey] = useState<string>("small");
+
+  const scenario = SCENARIOS.find((s) => s.key === scenarioKey) ?? SCENARIOS[0];
+
+  const q = useMemo(
+    () =>
+      quote({
+        tier: scenario.tier,
+        actives: scenario.actives,
+        alumni: scenario.alumni,
+        subOrgs: scenario.subOrgs,
+      }),
+    [scenario],
+  );
+
+  const totalCents = interval === "year" ? q.yearlyCents : q.monthlyCents;
+  const intervalLabel = interval === "year" ? "/yr" : "/mo";
 
   return (
     <section id="pricing" className="relative z-10 py-24 px-6" suppressHydrationWarning>
       <div className="max-w-5xl mx-auto">
-        <div className="text-center mb-16">
-          <div suppressHydrationWarning className="scroll-reveal inline-block px-4 py-1.5 rounded-full bg-landing-cream/5 text-landing-cream/60 text-xs uppercase tracking-[0.2em] mb-6">
+        <div className="text-center mb-12">
+          <div
+            suppressHydrationWarning
+            className="scroll-reveal inline-block px-4 py-1.5 rounded-full bg-landing-cream/5 text-landing-cream/60 text-xs uppercase tracking-[0.2em] mb-6"
+          >
             Pricing
           </div>
           <h2 className="scroll-reveal font-display text-4xl sm:text-5xl font-bold text-landing-cream mb-6">
-            Simple, <span className="text-landing-cream">Transparent</span> Pricing
+            Priced <span className="text-landing-green">per user</span>
           </h2>
           <p className="scroll-reveal text-landing-cream/60 max-w-2xl mx-auto mb-10 text-lg">
-            One base price for unlimited active members. Add alumni access only if you need it.
+            One rate per active member, one rate per alumni. Both drop as your
+            roster grows. Over 10,000 alumni? <a href="mailto:sales@myteamnetwork.com" className="underline hover:text-landing-cream">Talk to us</a>.
           </p>
 
-          {/* Toggle */}
-          <div suppressHydrationWarning role="group" aria-label="Billing interval" className="scroll-reveal inline-flex items-center bg-landing-navy-light rounded-full p-1.5 border border-landing-cream/10">
+          <div
+            suppressHydrationWarning
+            role="group"
+            aria-label="Billing interval"
+            className="scroll-reveal inline-flex items-center bg-landing-navy-light rounded-full p-1.5 border border-landing-cream/10"
+          >
             <button
               onClick={() => setInterval("month")}
               aria-pressed={interval === "month"}
-              className={`px-6 py-2.5 rounded-full text-sm font-semibold transition-all ${interval === "month"
-                ? "bg-landing-green-dark text-white shadow-lg"
-                : "text-landing-cream/60 hover:text-landing-cream"
-                }`}
+              className={`px-6 py-2.5 rounded-full text-sm font-semibold transition-all ${
+                interval === "month"
+                  ? "bg-landing-green-dark text-white shadow-lg"
+                  : "text-landing-cream/60 hover:text-landing-cream"
+              }`}
             >
               Monthly
             </button>
             <button
               onClick={() => setInterval("year")}
               aria-pressed={interval === "year"}
-              className={`px-6 py-2.5 rounded-full text-sm font-semibold transition-all flex items-center gap-2 ${interval === "year"
-                ? "bg-landing-green-dark text-white shadow-lg"
-                : "text-landing-cream/60 hover:text-landing-cream"
-                }`}
+              className={`px-6 py-2.5 rounded-full text-sm font-semibold transition-all flex items-center gap-2 ${
+                interval === "year"
+                  ? "bg-landing-green-dark text-white shadow-lg"
+                  : "text-landing-cream/60 hover:text-landing-cream"
+              }`}
             >
               Yearly
-              <span className={`text-xs px-2 py-0.5 rounded-full ${interval === "year"
-                ? "bg-white/20 text-white"
-                : "bg-landing-cream/10 text-landing-cream/60"
-                }`}>
+              <span
+                className={`text-xs px-2 py-0.5 rounded-full ${
+                  interval === "year"
+                    ? "bg-white/20 text-white"
+                    : "bg-landing-cream/10 text-landing-cream/60"
+                }`}
+              >
                 Save 17%
               </span>
             </button>
           </div>
         </div>
 
-        <div className="grid md:grid-cols-2 gap-8 mb-12">
-          {/* Base Plan */}
-          <div className="pricing-card rounded-2xl p-8 pt-10 relative">
-            {/* Pick badge */}
-            <div className="pick-badge">Starter Pick</div>
-
-            {/* Corner accent */}
-            <div className="absolute top-0 right-0 w-24 h-24">
-              <div className="absolute inset-0 bg-gradient-to-bl from-landing-green/10 to-transparent" />
-            </div>
-
-            <div className="relative">
-              <div className="mb-6">
-                <h3 className="font-display text-xl font-bold text-landing-cream mb-2">Active Team</h3>
-                <p className="text-landing-cream/50 text-sm">Everything you need for current members</p>
-              </div>
-
-              <div className="mb-8">
-                <div className="flex items-baseline gap-2">
-                  <span className="athletic-number text-5xl">{formatPrice(BASE_PRICES[interval], interval).replace('/mo', '').replace('/yr', '')}</span>
-                  <span className="text-landing-cream/50">/{interval === "month" ? "mo" : "yr"}</span>
-                </div>
-                {interval === "year" && (
-                  <p className="text-sm text-landing-cream/70 mt-2">
-                    That&apos;s just $12.50/mo
-                  </p>
-                )}
-              </div>
-
-              <ul className="space-y-4 mb-8">
-                {[
-                  "Unlimited active members",
-                  "Member directory & profiles",
-                  "Events & calendar",
-                  "Announcements",
-                  "Donations via Stripe Connect",
-                  "Forms & document uploads",
-                ].map((item) => (
-                  <li key={item} className="flex items-center gap-3 text-sm text-landing-cream/70">
-                    <svg className="w-5 h-5 text-landing-green flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                    </svg>
-                    {item}
-                  </li>
-                ))}
-              </ul>
-
-              {showCta && (
-                <ButtonLink href="/auth/signup" variant="custom" className="w-full bg-landing-green-dark hover:bg-landing-green-dark/90 text-white font-semibold py-3">
-                  Get Started
-                </ButtonLink>
-              )}
-            </div>
-          </div>
-
-          {/* Alumni Add-on */}
-          <div className="pricing-card pricing-card-featured holo-border rounded-2xl p-8 pt-10 relative pulse-glow">
-            {/* Pick badge */}
-            <div className="pick-badge" style={{ background: "linear-gradient(135deg, #15803d 0%, #22c55e 100%)" }}>Pro Pick</div>
-
-            {/* Featured badge */}
-            <div className="absolute top-14 right-6">
-              <span className="px-3 py-1 rounded-full bg-landing-green/20 text-landing-green text-xs font-semibold uppercase tracking-wider">
-                Popular Add-On
-              </span>
-            </div>
-
-            <div className="mb-6">
-              <h3 className="font-display text-xl font-bold text-landing-cream mb-2">Alumni Access</h3>
-              <p className="text-landing-cream/50 text-sm">Keep alumni connected with read access</p>
-            </div>
-
-            <div className="space-y-3 mb-8 bg-landing-navy/50 rounded-xl p-4">
-              {ALUMNI_TIERS.map((tier) => {
-                const prices = tier === "5000+" ? null : ALUMNI_ADD_ON_PRICES[tier];
-                return (
-                  <div key={tier} className="flex justify-between items-center text-sm py-1">
-                    <span className="text-landing-cream/60">{ALUMNI_BUCKET_LABELS[tier]}</span>
-                    <span className="font-semibold text-landing-cream">
-                      {prices ? (
-                        <>+{formatPrice(prices[interval], interval)}</>
-                      ) : (
-                        <span className="text-landing-green">Custom</span>
-                      )}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-
-            <ul className="space-y-4">
-              {[
-                "Alumni directory access",
-                "View events & announcements",
-                "Mentorship connections",
-              ].map((item) => (
-                <li key={item} className="flex items-center gap-3 text-sm text-landing-cream/70">
-                  <svg className="w-5 h-5 text-landing-green flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                  </svg>
-                  {item}
+        {/* Rate cards */}
+        <div className="grid md:grid-cols-2 gap-6 mb-10">
+          <div className="pricing-card rounded-2xl p-7">
+            <h3 className="font-display text-lg font-bold text-landing-cream mb-1">
+              Active members
+            </h3>
+            <p className="text-landing-cream/50 text-sm mb-5">
+              Per active member, per month. Drops as your active roster grows.
+            </p>
+            <ul className="space-y-2">
+              {ACTIVE_SLABS.map((s) => (
+                <li
+                  key={s.label}
+                  className="flex justify-between items-baseline text-sm border-b border-landing-cream/5 pb-2 last:border-0"
+                >
+                  <span className="text-landing-cream/70">{s.label} actives</span>
+                  <span className="font-semibold text-landing-cream">
+                    {fmt(s.rateCents)}/mo each
+                  </span>
                 </li>
               ))}
             </ul>
           </div>
+
+          <div className="pricing-card pricing-card-featured holo-border rounded-2xl p-7 relative">
+            <h3 className="font-display text-lg font-bold text-landing-cream mb-1">
+              Alumni
+            </h3>
+            <p className="text-landing-cream/50 text-sm mb-5">
+              Per alumni, per month. Volume rates kick in automatically.
+            </p>
+            <ul className="space-y-2">
+              {ALUMNI_SLABS.map((s) => (
+                <li
+                  key={s.label}
+                  className="flex justify-between items-baseline text-sm border-b border-landing-cream/5 pb-2 last:border-0"
+                >
+                  <span className="text-landing-cream/70">{s.label} alumni</span>
+                  <span className="font-semibold text-landing-cream">
+                    {fmt(s.rateCents)}/mo each
+                  </span>
+                </li>
+              ))}
+              <li className="flex justify-between items-baseline text-sm pt-1">
+                <span className="text-landing-cream/70">10,000+ alumni</span>
+                <span className="font-semibold text-landing-green">
+                  Contact sales
+                </span>
+              </li>
+            </ul>
+          </div>
         </div>
 
-        {/* Example calculation */}
-        <div suppressHydrationWarning className="scroll-reveal text-center p-6 rounded-xl bg-landing-navy-light/50 border border-landing-cream/10">
-          <p className="text-landing-cream/60">
-            <span className="text-landing-cream font-semibold">Example:</span> Active Team + 251–500 alumni ={" "}
-            <span className="font-bold text-landing-cream text-lg">
-              {formatPrice(getTotalPrice(interval, "251-500")!, interval)}
-            </span>
-          </p>
+        {/* Worked example */}
+        <div
+          suppressHydrationWarning
+          className="scroll-reveal rounded-2xl border border-landing-cream/10 bg-landing-navy-light/50 p-6 sm:p-8"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-3 mb-5">
+            <h3 className="font-display text-lg font-bold text-landing-cream">
+              See what you&apos;d actually pay
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {SCENARIOS.map((s) => (
+                <button
+                  key={s.key}
+                  onClick={() => setScenarioKey(s.key)}
+                  aria-pressed={scenarioKey === s.key}
+                  className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${
+                    scenarioKey === s.key
+                      ? "bg-landing-green-dark text-white border-landing-green-dark"
+                      : "border-landing-cream/15 text-landing-cream/60 hover:text-landing-cream"
+                  }`}
+                >
+                  {s.title}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <p className="text-landing-cream/60 text-sm mb-5">{scenario.blurb}</p>
+
+          <div className="grid sm:grid-cols-2 gap-6 items-start">
+            <ul className="space-y-2 text-sm">
+              <Row
+                label={`${scenario.actives.toLocaleString()} actives × ${fmt(q.breakdown.activeRateCents)}`}
+                value={`${fmt(q.breakdown.activeMonthlyCents)}/mo`}
+              />
+              <Row
+                label={`${scenario.alumni.toLocaleString()} alumni × ${fmt(q.breakdown.alumniRateCents)}`}
+                value={`${fmt(q.breakdown.alumniMonthlyCents)}/mo`}
+              />
+              {q.breakdown.platformBaseCents > 0 && (
+                <Row
+                  label="Enterprise platform base"
+                  value={`${fmt(q.breakdown.platformBaseCents)}/mo`}
+                />
+              )}
+              {q.breakdown.subOrgMonthlyCents > 0 && (
+                <Row
+                  label={`${q.breakdown.subOrgsBilled} sub-orgs (blended)`}
+                  value={`${fmt(q.breakdown.subOrgMonthlyCents)}/mo`}
+                />
+              )}
+            </ul>
+
+            <div className="rounded-xl bg-landing-navy/60 p-5 text-center">
+              <p className="text-landing-cream/50 text-xs uppercase tracking-[0.18em] mb-2">
+                Your bill
+              </p>
+              <div className="flex items-baseline justify-center gap-2">
+                <span className="athletic-number text-5xl text-landing-cream">
+                  {fmt(totalCents)}
+                </span>
+                <span className="text-landing-cream/50">{intervalLabel}</span>
+              </div>
+              {interval === "year" && q.monthlyCents > 0 && (
+                <p className="text-sm text-landing-cream/60 mt-2">
+                  ≈ {fmt(Math.round(q.yearlyCents / 12))}/mo · 17% off
+                </p>
+              )}
+              {interval === "month" && q.monthlyCents > 0 && (
+                <p className="text-sm text-landing-cream/60 mt-2">
+                  Pay yearly: {fmt(q.yearlyCents)}/yr (save 17%)
+                </p>
+              )}
+            </div>
+          </div>
+
+          {showCta && (
+            <div className="flex flex-wrap items-center justify-center gap-3 mt-7">
+              <ButtonLink
+                href="/pricing/calculator"
+                variant="custom"
+                className="bg-landing-cream/10 hover:bg-landing-cream/20 text-landing-cream font-semibold px-6 py-3 border border-landing-cream/15"
+              >
+                Run your own numbers
+              </ButtonLink>
+              <ButtonLink
+                href="/auth/signup"
+                variant="custom"
+                className="bg-landing-green-dark hover:bg-landing-green-dark/90 text-white font-semibold px-6 py-3"
+              >
+                Get Started
+              </ButtonLink>
+            </div>
+          )}
         </div>
       </div>
     </section>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <li className="flex justify-between items-baseline border-b border-landing-cream/5 pb-2 last:border-0">
+      <span className="text-landing-cream/70">{label}</span>
+      <span className="font-semibold text-landing-cream">{value}</span>
+    </li>
   );
 }

--- a/src/lib/middleware/routing-decisions.ts
+++ b/src/lib/middleware/routing-decisions.ts
@@ -25,6 +25,7 @@ const PUBLIC_ROUTES = [
   "/terms",
   "/privacy",
   "/app/parents-join",
+  "/pricing/calculator",
 ];
 
 const AUTH_ONLY_ROUTES = ["/auth/login", "/auth/signup", "/auth/forgot-password"];
@@ -36,6 +37,7 @@ const NON_ORG_TOP_LEVEL_SEGMENTS = [
   "blog",
   "settings",
   "enterprise",
+  "pricing",
   "_next",
   "favicon.ico",
 ];

--- a/src/lib/payments/dynamic-quote-checkout-fingerprint.ts
+++ b/src/lib/payments/dynamic-quote-checkout-fingerprint.ts
@@ -1,0 +1,23 @@
+export function buildDynamicQuoteCheckoutFingerprintPayload(params: {
+  userId: string;
+  tier: "single" | "enterprise";
+  billingInterval: "month" | "year";
+  actives: number;
+  alumni: number;
+  subOrgs: number;
+  monthlyCents: number;
+  yearlyCents: number;
+}): Record<string, unknown> {
+  return {
+    v: 1,
+    flow: "dynamic_quote_checkout",
+    userId: params.userId,
+    tier: params.tier,
+    billingInterval: params.billingInterval,
+    actives: params.actives,
+    alumni: params.alumni,
+    subOrgs: params.subOrgs,
+    monthlyCents: params.monthlyCents,
+    yearlyCents: params.yearlyCents,
+  };
+}

--- a/src/lib/pricing-v2.ts
+++ b/src/lib/pricing-v2.ts
@@ -1,0 +1,114 @@
+export type Tier = "single" | "enterprise";
+export type Interval = "month" | "year";
+
+export interface QuoteInput {
+  tier: Tier;
+  actives: number;
+  alumni: number;
+  subOrgs?: number;
+}
+
+export interface QuoteBreakdown {
+  alumniRateCents: number;
+  alumniMonthlyCents: number;
+  activeRateCents: number;
+  activeMonthlyCents: number;
+  platformBaseCents: number;
+  subOrgsBilled: number;
+  subOrgMonthlyCents: number;
+}
+
+export interface QuoteResult {
+  salesLed: boolean;
+  monthlyCents: number;
+  yearlyCents: number;
+  breakdown: QuoteBreakdown;
+}
+
+export const SALES_LED_ALUMNI_THRESHOLD = 100_000;
+export const YEARLY_DISCOUNT_FACTOR = 0.83;
+
+const ENTERPRISE_PLATFORM_BASE_CENTS = 25_000;
+const SUB_ORG_FIRST_TIER_CENTS = 2_000;
+const SUB_ORG_SECOND_TIER_CENTS = 1_500;
+const SUB_ORG_FIRST_TIER_LIMIT = 10;
+
+function alumniRateCents(alumni: number): number {
+  if (alumni <= 0) return 0;
+  if (alumni <= 500) return 36;
+  if (alumni <= 2_500) return 25;
+  if (alumni <= 10_000) return 18;
+  if (alumni <= 25_000) return 13;
+  if (alumni <= 50_000) return 11;
+  if (alumni <= 75_000) return 9;
+  return 7;
+}
+
+function activeRateCents(actives: number): number {
+  if (actives <= 0) return 0;
+  if (actives <= 100) return 15;
+  if (actives <= 500) return 10;
+  return 5;
+}
+
+function zeroBreakdown(): QuoteBreakdown {
+  return {
+    alumniRateCents: 0,
+    alumniMonthlyCents: 0,
+    activeRateCents: 0,
+    activeMonthlyCents: 0,
+    platformBaseCents: 0,
+    subOrgsBilled: 0,
+    subOrgMonthlyCents: 0,
+  };
+}
+
+export function quote(input: QuoteInput): QuoteResult {
+  const { tier } = input;
+  const actives = Math.max(0, Math.floor(input.actives));
+  const alumni = Math.max(0, Math.floor(input.alumni));
+  const subOrgs = Math.max(0, Math.floor(input.subOrgs ?? 0));
+
+  if (alumni > SALES_LED_ALUMNI_THRESHOLD) {
+    return {
+      salesLed: true,
+      monthlyCents: 0,
+      yearlyCents: 0,
+      breakdown: zeroBreakdown(),
+    };
+  }
+
+  const aRate = alumniRateCents(alumni);
+  const alumniMonthlyCents = alumni * aRate;
+
+  const acRate = activeRateCents(actives);
+  const activeMonthlyCents = actives * acRate;
+
+  const platformBaseCents = tier === "enterprise" ? ENTERPRISE_PLATFORM_BASE_CENTS : 0;
+
+  const subOrgsBilled = tier === "enterprise" ? subOrgs : 0;
+  const subOrgMonthlyCents =
+    tier === "enterprise"
+      ? Math.min(subOrgsBilled, SUB_ORG_FIRST_TIER_LIMIT) * SUB_ORG_FIRST_TIER_CENTS +
+        Math.max(0, subOrgsBilled - SUB_ORG_FIRST_TIER_LIMIT) * SUB_ORG_SECOND_TIER_CENTS
+      : 0;
+
+  const monthlyCents =
+    alumniMonthlyCents + activeMonthlyCents + platformBaseCents + subOrgMonthlyCents;
+  const yearlyCents = Math.round(monthlyCents * 12 * YEARLY_DISCOUNT_FACTOR);
+
+  return {
+    salesLed: false,
+    monthlyCents,
+    yearlyCents,
+    breakdown: {
+      alumniRateCents: aRate,
+      alumniMonthlyCents,
+      activeRateCents: acRate,
+      activeMonthlyCents,
+      platformBaseCents,
+      subOrgsBilled,
+      subOrgMonthlyCents,
+    },
+  };
+}

--- a/tests/pricing-v2.test.ts
+++ b/tests/pricing-v2.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+import { quote, SALES_LED_ALUMNI_THRESHOLD } from "@/lib/pricing-v2";
+
+describe("pricing-v2 quote() — pinned scenarios", () => {
+  it("single org: 200 actives + 1,200 alumni → $320/mo, $3,187.20/yr", () => {
+    const q = quote({ tier: "single", actives: 200, alumni: 1_200 });
+    assert.strictEqual(q.salesLed, false);
+    assert.strictEqual(q.monthlyCents, 32_000);
+    assert.strictEqual(q.yearlyCents, 318_720);
+    assert.deepStrictEqual(q.breakdown, {
+      alumniRateCents: 25,
+      alumniMonthlyCents: 30_000,
+      activeRateCents: 10,
+      activeMonthlyCents: 2_000,
+      platformBaseCents: 0,
+      subOrgsBilled: 0,
+      subOrgMonthlyCents: 0,
+    });
+  });
+
+  it("enterprise: 15 sub-orgs + 1,000 actives + 20,000 alumni → $3,175/mo, $31,623/yr", () => {
+    const q = quote({ tier: "enterprise", actives: 1_000, alumni: 20_000, subOrgs: 15 });
+    assert.strictEqual(q.salesLed, false);
+    assert.strictEqual(q.monthlyCents, 317_500);
+    assert.strictEqual(q.yearlyCents, 3_162_300);
+    assert.deepStrictEqual(q.breakdown, {
+      alumniRateCents: 13,
+      alumniMonthlyCents: 260_000,
+      activeRateCents: 5,
+      activeMonthlyCents: 5_000,
+      platformBaseCents: 25_000,
+      subOrgsBilled: 15,
+      subOrgMonthlyCents: 27_500,
+    });
+  });
+});
+
+describe("pricing-v2 quote() — edges", () => {
+  it("zero inputs → 0/0", () => {
+    const q = quote({ tier: "single", actives: 0, alumni: 0 });
+    assert.strictEqual(q.monthlyCents, 0);
+    assert.strictEqual(q.yearlyCents, 0);
+    assert.strictEqual(q.salesLed, false);
+    assert.strictEqual(q.breakdown.alumniRateCents, 0);
+    assert.strictEqual(q.breakdown.activeRateCents, 0);
+  });
+
+  it("alumni 500 vs 501 slab cliff", () => {
+    const a = quote({ tier: "single", actives: 0, alumni: 500 });
+    assert.strictEqual(a.monthlyCents, 18_000); // 500 × 36
+    const b = quote({ tier: "single", actives: 0, alumni: 501 });
+    assert.strictEqual(b.monthlyCents, 12_525); // 501 × 25
+  });
+
+  it("active 100 vs 101 slab cliff", () => {
+    const a = quote({ tier: "single", actives: 100, alumni: 0 });
+    assert.strictEqual(a.monthlyCents, 1_500);
+    const b = quote({ tier: "single", actives: 101, alumni: 0 });
+    assert.strictEqual(b.monthlyCents, 1_010);
+  });
+
+  it("sub-org 10 vs 11 (enterprise, 0 users)", () => {
+    const a = quote({ tier: "enterprise", actives: 0, alumni: 0, subOrgs: 10 });
+    assert.strictEqual(a.monthlyCents, 45_000); // 25k base + 10 × 2k
+    const b = quote({ tier: "enterprise", actives: 0, alumni: 0, subOrgs: 11 });
+    assert.strictEqual(b.monthlyCents, 46_500); // 25k + 10 × 2k + 1 × 1.5k
+  });
+
+  it("alumni > 100,000 → salesLed", () => {
+    const q = quote({ tier: "enterprise", actives: 1_000, alumni: 100_001, subOrgs: 5 });
+    assert.strictEqual(q.salesLed, true);
+    assert.strictEqual(q.monthlyCents, 0);
+    assert.strictEqual(q.yearlyCents, 0);
+  });
+
+  it("alumni == threshold not salesLed", () => {
+    const q = quote({ tier: "single", actives: 0, alumni: SALES_LED_ALUMNI_THRESHOLD });
+    assert.strictEqual(q.salesLed, false);
+  });
+
+  it("single tier ignores subOrgs", () => {
+    const q = quote({ tier: "single", actives: 0, alumni: 0, subOrgs: 50 });
+    assert.strictEqual(q.monthlyCents, 0);
+    assert.strictEqual(q.breakdown.subOrgMonthlyCents, 0);
+    assert.strictEqual(q.breakdown.subOrgsBilled, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds parallel v2 per-user pricing model (slab-based) alongside untouched v1.
- Public pricing calculator at `/pricing/calculator` with landing-page theme.
- Stripe Checkout via inline `price_data` + new `STRIPE_PRODUCT_ID_DYNAMIC`.
- Landing pricing section rebuilt with worked scenarios (Club / Small / Midsize / University).
- Webhook short-circuits on `metadata.type === "dynamic_v2"` — no org provisioning, no v1 collision.

## Risk
- Low. v1 routes / price IDs / `organization_subscriptions` untouched. No migrations. New Stripe Product is isolated.
- v2 only fires from the new calculator → new route → new product. Existing customers unaffected.
- Alumni slabs above 10k hidden from landing; calculator + checkout still support up to 100k, then sales-led.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `tests/pricing-v2.test.ts` 9/9 pass (pinned scenarios + slab cliffs + sales-led threshold)
- [ ] Manual: log in, hit `/pricing/calculator`, complete Stripe test-mode checkout, verify `payment_attempts.status = succeeded` with `metadata.pricing_model_version = "v2"`
- [ ] Set `STRIPE_PRODUCT_ID_DYNAMIC` in Vercel prod env before merge

## Rollback
Revert the commit. No DB or v1 changes to unwind.