### PR TITLE
feat(pricing): switch new-org and enterprise signup to pricing v2

### DIFF
--- a/src/app/api/stripe/create-enterprise-checkout/route.ts
+++ b/src/app/api/stripe/create-enterprise-checkout/route.ts
@@ -1,3 +1,6 @@
+// v1 pricing route retired from UI 2026-04-29. New signup flows use
+// /api/stripe/create-enterprise-v2-checkout. Route retained for in-flight v1
+// sessions and prior idempotency keys. Do not link new UI here.
 import { randomUUID } from "crypto";
 import { NextResponse } from "next/server";
 import { z } from "zod";

--- a/src/app/api/stripe/create-enterprise-v2-checkout/route.ts
+++ b/src/app/api/stripe/create-enterprise-v2-checkout/route.ts
@@ -1,0 +1,343 @@
+import { NextResponse } from "next/server";
+import { stripe } from "@/lib/stripe";
+import { getStripeOrigin } from "@/lib/stripe-origin";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+import {
+  validateJson,
+  ValidationError,
+  validationErrorResponse,
+} from "@/lib/security/validation";
+import { requireEnv } from "@/lib/env";
+import {
+  claimPaymentAttempt,
+  ensurePaymentAttempt,
+  hashFingerprint,
+  hasStripeResource,
+  IdempotencyConflictError,
+  updatePaymentAttempt,
+  waitForExistingStripeResource,
+} from "@/lib/payments/idempotency";
+import { buildEnterpriseV2CheckoutFingerprintPayload } from "@/lib/payments/enterprise-v2-checkout-fingerprint";
+import { quote, isSelfServeSalesLed } from "@/lib/pricing-v2";
+import { createEnterpriseV2Schema } from "@/lib/schemas/organization-v2";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    const supabase = await createClient();
+    const serviceSupabase = createServiceClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    const rateLimit = checkRateLimit(req, {
+      userId: user?.id ?? null,
+      feature: "enterprise v2 checkout",
+      limitPerIp: 30,
+      limitPerUser: 15,
+    });
+
+    if (!rateLimit.ok) {
+      return buildRateLimitResponse(rateLimit);
+    }
+
+    const respond = (payload: unknown, status = 200) =>
+      NextResponse.json(payload, { status, headers: rateLimit.headers });
+
+    if (!user) {
+      return respond({ error: "Unauthorized" }, 401);
+    }
+
+    const body = await validateJson(req, createEnterpriseV2Schema, { maxBodyBytes: 8_000 });
+    const {
+      name,
+      slug,
+      description,
+      primaryColor,
+      billingInterval,
+      actives,
+      alumni,
+      subOrgs,
+      billingContactEmail,
+      idempotencyKey: rawIdempotencyKey,
+      paymentAttemptId,
+    } = body;
+
+    const idempotencyKey = rawIdempotencyKey ?? null;
+
+    // Slug uniqueness across enterprises + organizations
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: existingEnterprise } = await (serviceSupabase as any)
+      .from("enterprises")
+      .select("id")
+      .eq("slug", slug)
+      .maybeSingle();
+    if (existingEnterprise) {
+      return respond({ error: "Slug is already taken" }, 409);
+    }
+    const { data: existingOrg } = await serviceSupabase
+      .from("organizations")
+      .select("id")
+      .eq("slug", slug)
+      .maybeSingle();
+    if (existingOrg) {
+      return respond({ error: "Slug is already taken" }, 409);
+    }
+
+    // Sales-led pre-creation: enterprise row + owner role + pending_sales subscription.
+    if (isSelfServeSalesLed({ tier: "enterprise", actives, alumni, subOrgs })) {
+      const q = quote({ tier: "enterprise", actives, alumni, subOrgs });
+      const snapshot = {
+        tier: "enterprise",
+        actives,
+        alumni,
+        subOrgs,
+        monthlyCents: q.monthlyCents,
+        yearlyCents: q.yearlyCents,
+        billingInterval,
+        breakdown: q.breakdown,
+        salesLed: true,
+      };
+
+      let enterpriseId: string | null = null;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data: ent, error: entErr } = await (serviceSupabase as any)
+          .from("enterprises")
+          .insert({
+            name,
+            slug,
+            description: description || null,
+            billing_contact_email: billingContactEmail,
+          })
+          .select()
+          .single();
+        if (entErr || !ent) throw new Error(entErr?.message || "Unable to create enterprise");
+        enterpriseId = ent.id;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { error: roleErr } = await (serviceSupabase as any)
+          .from("user_enterprise_roles")
+          .insert({ user_id: user.id, enterprise_id: ent.id, role: "owner" });
+        if (roleErr) throw new Error(roleErr.message);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { error: subErr } = await (serviceSupabase as any)
+          .from("enterprise_subscriptions")
+          .insert({
+            enterprise_id: ent.id,
+            billing_interval: billingInterval,
+            status: "pending_sales",
+            pricing_model_version: "v2",
+            pricing_v2_snapshot: snapshot,
+          });
+        if (subErr) throw new Error(subErr.message);
+
+        return respond({ mode: "sales", enterpriseSlug: ent.slug });
+      } catch (error) {
+        if (enterpriseId) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await (serviceSupabase as any).from("enterprise_subscriptions").delete().eq("enterprise_id", enterpriseId);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await (serviceSupabase as any).from("user_enterprise_roles").delete().eq("enterprise_id", enterpriseId).eq("user_id", user.id);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await (serviceSupabase as any).from("enterprises").delete().eq("id", enterpriseId);
+        }
+        const message = error instanceof Error ? error.message : "Unable to start checkout";
+        console.error("[create-enterprise-v2-checkout] Sales-led error:", message);
+        return respond({ error: "Unable to start checkout" }, 400);
+      }
+    }
+
+    const q = quote({ tier: "enterprise", actives, alumni, subOrgs });
+    const unitAmount = billingInterval === "year" ? q.yearlyCents : q.monthlyCents;
+    if (unitAmount <= 0) {
+      return respond({ error: "Quote total must be greater than zero" }, 400);
+    }
+
+    let resolvedAttemptId: string | null = null;
+    let stripeResourceCreated = false;
+
+    try {
+      const origin = getStripeOrigin(req.url);
+
+      const fingerprint = hashFingerprint(
+        buildEnterpriseV2CheckoutFingerprintPayload({
+          userId: user.id,
+          slug,
+          billingInterval,
+          actives,
+          alumni,
+          subOrgs,
+          monthlyCents: q.monthlyCents,
+          yearlyCents: q.yearlyCents,
+          billingContactEmail,
+        }),
+      );
+
+      const attemptMetadata: Record<string, unknown> = {
+        flow_type_v2: "enterprise_v2_checkout",
+        pricing_model_version: "v2",
+        tier: "enterprise",
+        slug,
+        billing_interval: billingInterval,
+        actives,
+        alumni,
+        sub_orgs: subOrgs,
+        monthly_cents: q.monthlyCents,
+        yearly_cents: q.yearlyCents,
+        quote_breakdown: { ...q.breakdown },
+      };
+
+      const { attempt } = await ensurePaymentAttempt({
+        supabase: serviceSupabase,
+        idempotencyKey,
+        paymentAttemptId,
+        flowType: "enterprise_v2_checkout",
+        amountCents: unitAmount,
+        currency: "usd",
+        userId: user.id,
+        organizationId: null,
+        requestFingerprint: fingerprint,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        metadata: attemptMetadata as any,
+      });
+
+      resolvedAttemptId = attempt.id;
+
+      const { attempt: claimedAttempt, claimed } = await claimPaymentAttempt({
+        supabase: serviceSupabase,
+        attempt,
+        amountCents: unitAmount,
+        currency: "usd",
+        requestFingerprint: fingerprint,
+        stripeConnectedAccountId: null,
+      });
+
+      const respondWithExisting = (candidate: typeof claimedAttempt) => {
+        if (candidate.checkout_url && candidate.stripe_checkout_session_id) {
+          return respond({
+            mode: "checkout",
+            checkoutUrl: candidate.checkout_url,
+            url: candidate.checkout_url,
+            idempotencyKey: candidate.idempotency_key,
+            paymentAttemptId: candidate.id,
+          });
+        }
+        return null;
+      };
+
+      if (!claimed) {
+        const existingResponse = hasStripeResource(claimedAttempt)
+          ? respondWithExisting(claimedAttempt)
+          : null;
+        if (existingResponse) return existingResponse;
+
+        const awaited = await waitForExistingStripeResource(serviceSupabase, claimedAttempt.id);
+        if (awaited && hasStripeResource(awaited)) {
+          const awaitedResponse = respondWithExisting(awaited);
+          if (awaitedResponse) return awaitedResponse;
+        }
+
+        return respond(
+          {
+            error: "Checkout is already processing for this idempotency key. Retry shortly with the same key.",
+            idempotencyKey: claimedAttempt.idempotency_key,
+            paymentAttemptId: claimedAttempt.id,
+          },
+          409,
+        );
+      }
+
+      const quoteSnapshot = JSON.stringify(q.breakdown);
+      if (quoteSnapshot.length > 500) {
+        throw new Error("quote_snapshot exceeds Stripe metadata length cap");
+      }
+
+      const sessionMetadata = {
+        type: "enterprise_v2",
+        pricing_model_version: "v2",
+        payment_attempt_id: claimedAttempt.id,
+        creator_id: user.id,
+        tier: "enterprise",
+        billing_interval: billingInterval,
+        actives: String(actives),
+        alumni: String(alumni),
+        sub_orgs: String(subOrgs),
+        monthly_cents: String(q.monthlyCents),
+        yearly_cents: String(q.yearlyCents),
+        quote_snapshot: quoteSnapshot,
+        enterprise_name: name.slice(0, 200),
+        enterprise_slug: slug,
+        enterprise_description: (description || "").slice(0, 500),
+        enterprise_primary_color: primaryColor,
+        billing_contact_email: billingContactEmail,
+      } as const;
+
+      const session = await stripe.checkout.sessions.create(
+        {
+          mode: "subscription",
+          customer_email: billingContactEmail,
+          line_items: [
+            {
+              quantity: 1,
+              price_data: {
+                currency: "usd",
+                unit_amount: unitAmount,
+                recurring: { interval: billingInterval },
+                product: requireEnv("STRIPE_PRODUCT_ID_DYNAMIC"),
+              },
+            },
+          ],
+          subscription_data: { metadata: sessionMetadata },
+          metadata: sessionMetadata,
+          success_url: `${origin}/app?enterprise=${slug}&checkout=success`,
+          cancel_url: `${origin}/app/create-enterprise?checkout=cancel`,
+        },
+        { idempotencyKey: claimedAttempt.idempotency_key },
+      );
+
+      stripeResourceCreated = true;
+
+      await updatePaymentAttempt(serviceSupabase, claimedAttempt.id, {
+        stripe_checkout_session_id: session.id,
+        checkout_url: session.url,
+        status: "processing",
+      });
+
+      return respond({
+        mode: "checkout",
+        checkoutUrl: session.url,
+        url: session.url,
+        idempotencyKey: claimedAttempt.idempotency_key,
+        paymentAttemptId: claimedAttempt.id,
+      });
+    } catch (error) {
+      if (error instanceof IdempotencyConflictError) {
+        return respond({ error: error.message }, 409);
+      }
+
+      const stripeErr = error as { message?: string; raw?: { message?: string } };
+      const lastError = stripeErr?.message || stripeErr?.raw?.message || "checkout_failed";
+
+      if (resolvedAttemptId) {
+        const errorUpdate: { last_error: string; status?: string } = { last_error: lastError };
+        if (!stripeResourceCreated) {
+          errorUpdate.status = "initiated";
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await serviceSupabase.from("payment_attempts").update(errorUpdate as any).eq("id", resolvedAttemptId);
+      }
+
+      console.error("[create-enterprise-v2-checkout] error:", lastError);
+      return respond({ error: "Unable to start checkout" }, 400);
+    }
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return validationErrorResponse(error);
+    }
+    throw error;
+  }
+}

--- a/src/app/api/stripe/create-org-checkout/route.ts
+++ b/src/app/api/stripe/create-org-checkout/route.ts
@@ -1,3 +1,6 @@
+// v1 pricing route retired from UI 2026-04-29. New signup flows use
+// /api/stripe/create-org-v2-checkout. Route retained for in-flight v1 sessions
+// and prior idempotency keys. Do not link new UI here.
 import { randomUUID } from "crypto";
 import { NextResponse } from "next/server";
 import { stripe, getPriceIds, isSalesLedBucket } from "@/lib/stripe";

--- a/src/app/api/stripe/create-org-v2-checkout/route.ts
+++ b/src/app/api/stripe/create-org-v2-checkout/route.ts
@@ -1,0 +1,323 @@
+import { NextResponse } from "next/server";
+import { stripe } from "@/lib/stripe";
+import { getStripeOrigin } from "@/lib/stripe-origin";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+import {
+  validateJson,
+  ValidationError,
+  validationErrorResponse,
+} from "@/lib/security/validation";
+import { requireEnv } from "@/lib/env";
+import {
+  claimPaymentAttempt,
+  ensurePaymentAttempt,
+  hashFingerprint,
+  hasStripeResource,
+  IdempotencyConflictError,
+  updatePaymentAttempt,
+  waitForExistingStripeResource,
+} from "@/lib/payments/idempotency";
+import { buildOrgV2CheckoutFingerprintPayload } from "@/lib/payments/org-v2-checkout-fingerprint";
+import { quote, isSelfServeSalesLed } from "@/lib/pricing-v2";
+import { createOrgV2Schema } from "@/lib/schemas/organization-v2";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    const supabase = await createClient();
+    const serviceSupabase = createServiceClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    const rateLimit = checkRateLimit(req, {
+      userId: user?.id ?? null,
+      feature: "org v2 checkout",
+      limitPerIp: 45,
+      limitPerUser: 25,
+    });
+
+    if (!rateLimit.ok) {
+      return buildRateLimitResponse(rateLimit);
+    }
+
+    const respond = (payload: unknown, status = 200) =>
+      NextResponse.json(payload, { status, headers: rateLimit.headers });
+
+    if (!user) {
+      return respond({ error: "Unauthorized" }, 401);
+    }
+
+    const body = await validateJson(req, createOrgV2Schema, { maxBodyBytes: 8_000 });
+    const {
+      name,
+      slug,
+      description,
+      primaryColor,
+      billingInterval,
+      actives,
+      alumni,
+      idempotencyKey: rawIdempotencyKey,
+      paymentAttemptId,
+    } = body;
+
+    const idempotencyKey = rawIdempotencyKey ?? null;
+
+    const { data: existingOrg } = await serviceSupabase
+      .from("organizations")
+      .select("id")
+      .eq("slug", slug)
+      .maybeSingle();
+    if (existingOrg) {
+      return respond({ error: "Slug is already taken" }, 409);
+    }
+
+    // Sales-led: bypass Stripe, pre-create org with status=pending_sales.
+    if (isSelfServeSalesLed({ tier: "single", actives, alumni })) {
+      const q = quote({ tier: "single", actives, alumni });
+      const snapshot = {
+        tier: "single",
+        actives,
+        alumni,
+        monthlyCents: q.monthlyCents,
+        yearlyCents: q.yearlyCents,
+        billingInterval,
+        breakdown: q.breakdown,
+        salesLed: true,
+      };
+
+      let orgId: string | null = null;
+      try {
+        const { data: org, error: orgError } = await supabase
+          .from("organizations")
+          .insert({
+            name,
+            slug,
+            description: description || null,
+            primary_color: primaryColor,
+          })
+          .select()
+          .single();
+        if (orgError || !org) throw new Error(orgError?.message || "Unable to create organization");
+        orgId = org.id;
+
+        const { error: roleError } = await supabase
+          .from("user_organization_roles")
+          .insert({ user_id: user.id, organization_id: org.id, role: "admin" });
+        if (roleError) throw new Error(roleError.message);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { error: subError } = await (serviceSupabase as any)
+          .from("organization_subscriptions")
+          .insert({
+            organization_id: org.id,
+            base_plan_interval: billingInterval,
+            alumni_bucket: "none",
+            alumni_plan_interval: null,
+            status: "pending_sales",
+            pricing_model_version: "v2",
+            pricing_v2_snapshot: snapshot,
+          });
+        if (subError) throw new Error(subError.message);
+
+        return respond({ mode: "sales", organizationSlug: org.slug });
+      } catch (error) {
+        if (orgId) {
+          await supabase.from("organization_subscriptions").delete().eq("organization_id", orgId);
+          await supabase.from("user_organization_roles").delete().eq("organization_id", orgId).eq("user_id", user.id);
+          await supabase.from("organizations").delete().eq("id", orgId);
+        }
+        const message = error instanceof Error ? error.message : "Unable to start checkout";
+        console.error("[create-org-v2-checkout] Sales-led error:", message);
+        return respond({ error: "Unable to start checkout" }, 400);
+      }
+    }
+
+    const q = quote({ tier: "single", actives, alumni });
+    const unitAmount = billingInterval === "year" ? q.yearlyCents : q.monthlyCents;
+    if (unitAmount <= 0) {
+      return respond({ error: "Quote total must be greater than zero" }, 400);
+    }
+
+    let resolvedAttemptId: string | null = null;
+    let stripeResourceCreated = false;
+
+    try {
+      const origin = getStripeOrigin(req.url);
+
+      const fingerprint = hashFingerprint(
+        buildOrgV2CheckoutFingerprintPayload({
+          userId: user.id,
+          slug,
+          billingInterval,
+          actives,
+          alumni,
+          monthlyCents: q.monthlyCents,
+          yearlyCents: q.yearlyCents,
+          primaryColor,
+        }),
+      );
+
+      const attemptMetadata: Record<string, unknown> = {
+        flow_type_v2: "org_v2_checkout",
+        pricing_model_version: "v2",
+        tier: "single",
+        slug,
+        billing_interval: billingInterval,
+        actives,
+        alumni,
+        monthly_cents: q.monthlyCents,
+        yearly_cents: q.yearlyCents,
+        quote_breakdown: { ...q.breakdown },
+      };
+
+      const { attempt } = await ensurePaymentAttempt({
+        supabase: serviceSupabase,
+        idempotencyKey,
+        paymentAttemptId,
+        flowType: "org_v2_checkout",
+        amountCents: unitAmount,
+        currency: "usd",
+        userId: user.id,
+        organizationId: null,
+        requestFingerprint: fingerprint,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        metadata: attemptMetadata as any,
+      });
+
+      resolvedAttemptId = attempt.id;
+
+      const { attempt: claimedAttempt, claimed } = await claimPaymentAttempt({
+        supabase: serviceSupabase,
+        attempt,
+        amountCents: unitAmount,
+        currency: "usd",
+        requestFingerprint: fingerprint,
+        stripeConnectedAccountId: null,
+      });
+
+      const respondWithExisting = (candidate: typeof claimedAttempt) => {
+        if (candidate.checkout_url && candidate.stripe_checkout_session_id) {
+          return respond({
+            mode: "checkout",
+            checkoutUrl: candidate.checkout_url,
+            url: candidate.checkout_url,
+            idempotencyKey: candidate.idempotency_key,
+            paymentAttemptId: candidate.id,
+          });
+        }
+        return null;
+      };
+
+      if (!claimed) {
+        const existingResponse = hasStripeResource(claimedAttempt)
+          ? respondWithExisting(claimedAttempt)
+          : null;
+        if (existingResponse) return existingResponse;
+
+        const awaited = await waitForExistingStripeResource(serviceSupabase, claimedAttempt.id);
+        if (awaited && hasStripeResource(awaited)) {
+          const awaitedResponse = respondWithExisting(awaited);
+          if (awaitedResponse) return awaitedResponse;
+        }
+
+        return respond(
+          {
+            error: "Checkout is already processing for this idempotency key. Retry shortly with the same key.",
+            idempotencyKey: claimedAttempt.idempotency_key,
+            paymentAttemptId: claimedAttempt.id,
+          },
+          409,
+        );
+      }
+
+      const quoteSnapshot = JSON.stringify(q.breakdown);
+      if (quoteSnapshot.length > 500) {
+        throw new Error("quote_snapshot exceeds Stripe metadata length cap");
+      }
+
+      const sessionMetadata = {
+        type: "org_v2",
+        pricing_model_version: "v2",
+        payment_attempt_id: claimedAttempt.id,
+        creator_id: user.id,
+        tier: "single",
+        billing_interval: billingInterval,
+        actives: String(actives),
+        alumni: String(alumni),
+        monthly_cents: String(q.monthlyCents),
+        yearly_cents: String(q.yearlyCents),
+        quote_snapshot: quoteSnapshot,
+        org_name: name.slice(0, 200),
+        org_slug: slug,
+        org_description: (description || "").slice(0, 500),
+        org_primary_color: primaryColor,
+      } as const;
+
+      const session = await stripe.checkout.sessions.create(
+        {
+          mode: "subscription",
+          customer_email: user.email ?? undefined,
+          line_items: [
+            {
+              quantity: 1,
+              price_data: {
+                currency: "usd",
+                unit_amount: unitAmount,
+                recurring: { interval: billingInterval },
+                product: requireEnv("STRIPE_PRODUCT_ID_DYNAMIC"),
+              },
+            },
+          ],
+          subscription_data: { metadata: sessionMetadata },
+          metadata: sessionMetadata,
+          success_url: `${origin}/app?org=${slug}&checkout=success`,
+          cancel_url: `${origin}/app/create-org?checkout=cancel`,
+        },
+        { idempotencyKey: claimedAttempt.idempotency_key },
+      );
+
+      stripeResourceCreated = true;
+
+      await updatePaymentAttempt(serviceSupabase, claimedAttempt.id, {
+        stripe_checkout_session_id: session.id,
+        checkout_url: session.url,
+        status: "processing",
+      });
+
+      return respond({
+        mode: "checkout",
+        checkoutUrl: session.url,
+        url: session.url,
+        idempotencyKey: claimedAttempt.idempotency_key,
+        paymentAttemptId: claimedAttempt.id,
+      });
+    } catch (error) {
+      if (error instanceof IdempotencyConflictError) {
+        return respond({ error: error.message }, 409);
+      }
+
+      const stripeErr = error as { message?: string; raw?: { message?: string } };
+      const lastError = stripeErr?.message || stripeErr?.raw?.message || "checkout_failed";
+
+      if (resolvedAttemptId) {
+        const errorUpdate: { last_error: string; status?: string } = { last_error: lastError };
+        if (!stripeResourceCreated) {
+          errorUpdate.status = "initiated";
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await serviceSupabase.from("payment_attempts").update(errorUpdate as any).eq("id", resolvedAttemptId);
+      }
+
+      console.error("[create-org-v2-checkout] error:", lastError);
+      return respond({ error: "Unable to start checkout" }, 400);
+    }
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return validationErrorResponse(error);
+    }
+    throw error;
+  }
+}

--- a/src/app/api/stripe/webhook/handler.ts
+++ b/src/app/api/stripe/webhook/handler.ts
@@ -151,6 +151,10 @@ export async function handleStripeWebhookPost(
   const {
     resolveOrgForSubscriptionFlow,
     validateOrgOwnsStripeResource,
+    ensureOrganizationFromMetadata,
+    ensureSubscriptionSeedV2,
+    grantAdminRole,
+    resolveCreatorFromPaymentAttempt,
   } = createOrgProvisioner({ supabase, debugLog });
 
   const objectId =
@@ -310,6 +314,346 @@ export async function handleStripeWebhookPost(
           typeof session.customer === "string" ? session.customer : session.customer?.id || null;
 
         debugLog("stripe-webhook", "checkout.session.completed - org:", maskPII(session.metadata?.organization_id), "session:", maskPII(session.id), "mode:", session.mode);
+
+        // v2 self-serve org signup. MUST short-circuit before the generic
+        // `mode === "subscription"` branch -- that branch reads v1-only
+        // metadata fields (alumni_bucket, base_interval) and would clobber
+        // v2 state with v1 column defaults.
+        if (session.metadata?.type === "org_v2") {
+          const v2AttemptId =
+            (session.metadata?.payment_attempt_id as string | undefined) ?? null;
+
+          if (v2AttemptId) {
+            const { data: priorAttempt } = await supabase
+              .from("payment_attempts")
+              .select("status")
+              .eq("id", v2AttemptId)
+              .maybeSingle();
+            if (priorAttempt?.status === "succeeded") {
+              debugLog("stripe-webhook", "org_v2 attempt already succeeded; skipping reprovision");
+              break;
+            }
+          }
+
+          if (session.payment_status !== "paid") {
+            debugLog("stripe-webhook", "org_v2 checkout completed without payment; skipping");
+            break;
+          }
+
+          const creatorId = (session.metadata?.creator_id as string | undefined) ?? null;
+          const orgSlug = (session.metadata?.org_slug as string | undefined) ?? null;
+          const orgName = (session.metadata?.org_name as string | undefined) ?? null;
+          const orgDescription = (session.metadata?.org_description as string | undefined) ?? null;
+          const orgPrimaryColor = (session.metadata?.org_primary_color as string | undefined) ?? null;
+          const billingInterval = session.metadata?.billing_interval === "year" ? "year" : "month";
+
+          if (!creatorId || !orgSlug || !orgName) {
+            console.error("[stripe-webhook] org_v2 missing required metadata", {
+              eventId: maskPII(event.id),
+              sessionId: maskPII(session.id),
+            });
+            if (v2AttemptId) {
+              await updatePaymentAttemptStatus(supabase, {
+                paymentAttemptId: v2AttemptId,
+                status: "failed",
+                lastError: "missing_required_metadata",
+              });
+            }
+            return NextResponse.json(
+              { error: "org_v2 provisioning failed - missing metadata" },
+              { status: 500 },
+            );
+          }
+
+          const orgId = await ensureOrganizationFromMetadata({
+            organizationId: null,
+            organizationSlug: orgSlug,
+            organizationName: orgName,
+            organizationDescription: orgDescription,
+            organizationColor: orgPrimaryColor,
+            createdBy: null,
+            baseInterval: billingInterval,
+            alumniBucket: "none",
+            isTrial: false,
+          });
+
+          if (!orgId) {
+            console.error("[stripe-webhook] org_v2 organization provisioning failed", {
+              eventId: maskPII(event.id),
+              sessionId: maskPII(session.id),
+            });
+            return NextResponse.json(
+              { error: "org_v2 organization provisioning failed - will retry" },
+              { status: 500 },
+            );
+          }
+
+          let v2Status = "active";
+          let v2PeriodEnd: string | null = null;
+          if (subscriptionId) {
+            try {
+              const subscription = await stripeClient.subscriptions.retrieve(subscriptionId);
+              v2Status = normalizeSubscriptionStatus(subscription);
+              v2PeriodEnd = extractSubscriptionPeriodEndIso(subscription);
+            } catch (error) {
+              console.error("[stripe-webhook] org_v2 subscription retrieve failed", error);
+            }
+          }
+
+          let snapshot: Record<string, unknown> = {};
+          const rawSnapshot = session.metadata?.quote_snapshot;
+          if (typeof rawSnapshot === "string" && rawSnapshot.length > 0) {
+            try {
+              const parsed = JSON.parse(rawSnapshot);
+              if (parsed && typeof parsed === "object") {
+                snapshot = parsed as Record<string, unknown>;
+              }
+            } catch {
+              // ignore — snapshot stays empty object, breakdown rebuildable from cents
+            }
+          }
+          snapshot.tier = "single";
+          snapshot.actives = parseInt(String(session.metadata?.actives ?? "0"), 10) || 0;
+          snapshot.alumni = parseInt(String(session.metadata?.alumni ?? "0"), 10) || 0;
+          snapshot.monthlyCents = parseInt(String(session.metadata?.monthly_cents ?? "0"), 10) || 0;
+          snapshot.yearlyCents = parseInt(String(session.metadata?.yearly_cents ?? "0"), 10) || 0;
+          snapshot.billingInterval = billingInterval;
+
+          await ensureSubscriptionSeedV2(orgId, {
+            stripeCustomerId: customerId,
+            stripeSubscriptionId: subscriptionId,
+            billingInterval,
+            status: v2Status,
+            currentPeriodEnd: v2PeriodEnd,
+            snapshot,
+          });
+
+          // grantAdminRole resolves the creator from payment_attempts; safer than
+          // trusting metadata.creator_id directly. Skip if no attempt id.
+          if (v2AttemptId) {
+            const granted = await grantAdminRole(orgId, v2AttemptId);
+            if (!granted) {
+              console.error("[stripe-webhook] org_v2 admin grant failed", {
+                eventId: maskPII(event.id),
+                organizationId: maskPII(orgId),
+              });
+              return NextResponse.json(
+                { error: "org_v2 admin grant failed - will retry" },
+                { status: 500 },
+              );
+            }
+            await updatePaymentAttemptStatus(supabase, {
+              paymentAttemptId: v2AttemptId,
+              status: "succeeded",
+              checkoutSessionId: session.id,
+              organizationId: orgId,
+            });
+          } else {
+            // No payment_attempt_id -> creator from metadata fallback (legacy path).
+            await supabase
+              .from("user_organization_roles")
+              .upsert(
+                { user_id: creatorId, organization_id: orgId, role: "admin", status: "active" },
+                { onConflict: "organization_id,user_id" },
+              );
+          }
+
+          debugLog("stripe-webhook", "org_v2 provisioned:", maskPII(orgId));
+          break;
+        }
+
+        // v2 self-serve enterprise signup. Same precedence reasoning as org_v2.
+        if (session.metadata?.type === "enterprise_v2") {
+          const v2AttemptId =
+            (session.metadata?.payment_attempt_id as string | undefined) ?? null;
+
+          if (v2AttemptId) {
+            const { data: priorAttempt } = await supabase
+              .from("payment_attempts")
+              .select("status")
+              .eq("id", v2AttemptId)
+              .maybeSingle();
+            if (priorAttempt?.status === "succeeded") {
+              debugLog("stripe-webhook", "enterprise_v2 attempt already succeeded; skipping");
+              break;
+            }
+          }
+
+          if (session.payment_status !== "paid") {
+            debugLog("stripe-webhook", "enterprise_v2 completed without payment; skipping");
+            break;
+          }
+
+          const enterpriseSlug = (session.metadata?.enterprise_slug as string | undefined) ?? null;
+          const enterpriseName = (session.metadata?.enterprise_name as string | undefined) ?? null;
+          const enterpriseDescription =
+            (session.metadata?.enterprise_description as string | undefined) ?? null;
+          const billingContactEmail =
+            (session.metadata?.billing_contact_email as string | undefined) ?? null;
+          const billingInterval =
+            session.metadata?.billing_interval === "month" ? "month" : "year";
+
+          if (!enterpriseSlug || !enterpriseName) {
+            console.error("[stripe-webhook] enterprise_v2 missing required metadata", {
+              eventId: maskPII(event.id),
+              sessionId: maskPII(session.id),
+            });
+            if (v2AttemptId) {
+              await updatePaymentAttemptStatus(supabase, {
+                paymentAttemptId: v2AttemptId,
+                status: "failed",
+                lastError: "missing_required_metadata",
+              });
+            }
+            return NextResponse.json(
+              { error: "enterprise_v2 provisioning failed - missing metadata" },
+              { status: 500 },
+            );
+          }
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let { data: enterprise } = await (supabase as any)
+            .from("enterprises")
+            .select("*")
+            .eq("slug", enterpriseSlug)
+            .maybeSingle();
+
+          if (!enterprise) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const { data: created, error: insertError } = await (supabase as any)
+              .from("enterprises")
+              .insert({
+                name: enterpriseName,
+                slug: enterpriseSlug,
+                description: enterpriseDescription || null,
+                billing_contact_email: billingContactEmail || null,
+              })
+              .select()
+              .single();
+
+            if (insertError || !created) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const { data: retry } = await (supabase as any)
+                .from("enterprises")
+                .select("*")
+                .eq("slug", enterpriseSlug)
+                .maybeSingle();
+              if (!retry) {
+                if (v2AttemptId) {
+                  await updatePaymentAttemptStatus(supabase, {
+                    paymentAttemptId: v2AttemptId,
+                    status: "failed",
+                    lastError: insertError?.message || "enterprise_insert_failed",
+                  });
+                }
+                return NextResponse.json(
+                  { error: "enterprise_v2 provisioning failed - will retry" },
+                  { status: 500 },
+                );
+              }
+              enterprise = retry;
+            } else {
+              enterprise = created;
+            }
+          }
+
+          let snapshot: Record<string, unknown> = {};
+          const rawSnapshot = session.metadata?.quote_snapshot;
+          if (typeof rawSnapshot === "string" && rawSnapshot.length > 0) {
+            try {
+              const parsed = JSON.parse(rawSnapshot);
+              if (parsed && typeof parsed === "object") {
+                snapshot = parsed as Record<string, unknown>;
+              }
+            } catch {
+              // ignore
+            }
+          }
+          snapshot.tier = "enterprise";
+          snapshot.actives = parseInt(String(session.metadata?.actives ?? "0"), 10) || 0;
+          snapshot.alumni = parseInt(String(session.metadata?.alumni ?? "0"), 10) || 0;
+          snapshot.subOrgs = parseInt(String(session.metadata?.sub_orgs ?? "0"), 10) || 0;
+          snapshot.monthlyCents = parseInt(String(session.metadata?.monthly_cents ?? "0"), 10) || 0;
+          snapshot.yearlyCents = parseInt(String(session.metadata?.yearly_cents ?? "0"), 10) || 0;
+          snapshot.billingInterval = billingInterval;
+
+          let enterpriseStatus = "active";
+          let enterprisePeriodEnd: string | null = null;
+          if (subscriptionId) {
+            try {
+              const subscription = await stripeClient.subscriptions.retrieve(subscriptionId);
+              enterpriseStatus = normalizeSubscriptionStatus(subscription);
+              enterprisePeriodEnd = extractSubscriptionPeriodEndIso(subscription);
+            } catch (error) {
+              console.error("[stripe-webhook] enterprise_v2 subscription retrieve failed", error);
+            }
+          }
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const { error: subErr } = await (supabase as any)
+            .from("enterprise_subscriptions")
+            .upsert(
+              {
+                enterprise_id: enterprise.id,
+                stripe_customer_id: customerId,
+                stripe_subscription_id: subscriptionId,
+                billing_interval: billingInterval,
+                pricing_model_version: "v2",
+                pricing_v2_snapshot: snapshot,
+                status: enterpriseStatus,
+                current_period_end: enterprisePeriodEnd,
+                updated_at: new Date().toISOString(),
+              },
+              { onConflict: "enterprise_id" },
+            );
+
+          if (subErr) {
+            console.error("[stripe-webhook] enterprise_v2 subscription upsert failed", subErr);
+            if (v2AttemptId) {
+              await updatePaymentAttemptStatus(supabase, {
+                paymentAttemptId: v2AttemptId,
+                status: "failed",
+                lastError: subErr.message || "subscription_upsert_failed",
+              });
+            }
+            return NextResponse.json(
+              { error: "enterprise_v2 subscription provisioning failed" },
+              { status: 500 },
+            );
+          }
+
+          const ownerUserId = await resolveCreatorFromPaymentAttempt(v2AttemptId);
+          if (!ownerUserId) {
+            console.error("[stripe-webhook] enterprise_v2 owner grant failed - no creator in payment_attempts", {
+              eventId: maskPII(event.id),
+              enterpriseId: maskPII(enterprise.id),
+            });
+            return NextResponse.json(
+              { error: "enterprise_v2 owner grant failed - will retry" },
+              { status: 500 },
+            );
+          }
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await (supabase as any)
+            .from("user_enterprise_roles")
+            .upsert(
+              { user_id: ownerUserId, enterprise_id: enterprise.id, role: "owner" },
+              { onConflict: "user_id,enterprise_id" },
+            );
+
+          if (v2AttemptId) {
+            await updatePaymentAttemptStatus(supabase, {
+              paymentAttemptId: v2AttemptId,
+              status: "succeeded",
+              checkoutSessionId: session.id,
+              metadataPatch: { provisioned_enterprise_id: enterprise.id },
+            });
+          }
+
+          debugLog("stripe-webhook", "enterprise_v2 provisioned:", enterprise.id);
+          break;
+        }
 
         // v2 dynamic-quote test slice. Must stay above the enterprise + generic
         // subscription branches: those branches require an org_id and would 500

--- a/src/app/app/create-enterprise/page.tsx
+++ b/src/app/app/create-enterprise/page.tsx
@@ -5,91 +5,16 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import { Button, Input, Card } from "@/components/ui";
+import { Button, Input, Card, Textarea, InlineBanner } from "@/components/ui";
 import { useIdempotencyKey } from "@/hooks";
 import {
-  ENTERPRISE_SEAT_PRICING,
-  ALUMNI_BUCKET_PRICING,
-} from "@/types/enterprise";
-import { isSalesLed, getFreeSubOrgCount } from "@/lib/enterprise/pricing";
-
-const MIN_SEATS = 1;
-const MAX_SEATS = 100;
-
-const createEnterpriseSchema = z.object({
-  name: z
-    .string()
-    .min(2, "Name must be at least 2 characters")
-    .max(100, "Name must be less than 100 characters"),
-  slug: z
-    .string()
-    .min(2, "Slug must be at least 2 characters")
-    .max(50, "Slug must be less than 50 characters")
-    .regex(
-      /^[a-z0-9-]+$/,
-      "Slug can only contain lowercase letters, numbers, and hyphens",
-    ),
-  billingContactEmail: z.string().email("Invalid email address"),
-  seatQuantity: z.number().min(MIN_SEATS).max(MAX_SEATS),
-  alumniBucketQuantity: z.number().min(1).max(5),
-  billingInterval: z.enum(["month", "year"]),
-});
-
-type CreateEnterpriseForm = z.infer<typeof createEnterpriseSchema>;
-
-const ALUMNI_BUCKET_OPTIONS = [
-  {
-    buckets: 1,
-    capacity: ALUMNI_BUCKET_PRICING.capacityPerBucket,
-    monthlyPrice: ALUMNI_BUCKET_PRICING.monthlyCentsPerBucket / 100,
-    yearlyPrice: ALUMNI_BUCKET_PRICING.yearlyCentsPerBucket / 100,
-    description: "0 - 2,500 alumni",
-  },
-  {
-    buckets: 2,
-    capacity: ALUMNI_BUCKET_PRICING.capacityPerBucket * 2,
-    monthlyPrice: (ALUMNI_BUCKET_PRICING.monthlyCentsPerBucket * 2) / 100,
-    yearlyPrice: (ALUMNI_BUCKET_PRICING.yearlyCentsPerBucket * 2) / 100,
-    description: "2,501 - 5,000 alumni",
-  },
-  {
-    buckets: 3,
-    capacity: ALUMNI_BUCKET_PRICING.capacityPerBucket * 3,
-    monthlyPrice: (ALUMNI_BUCKET_PRICING.monthlyCentsPerBucket * 3) / 100,
-    yearlyPrice: (ALUMNI_BUCKET_PRICING.yearlyCentsPerBucket * 3) / 100,
-    description: "5,001 - 7,500 alumni",
-  },
-  {
-    buckets: 4,
-    capacity: ALUMNI_BUCKET_PRICING.capacityPerBucket * 4,
-    monthlyPrice: (ALUMNI_BUCKET_PRICING.monthlyCentsPerBucket * 4) / 100,
-    yearlyPrice: (ALUMNI_BUCKET_PRICING.yearlyCentsPerBucket * 4) / 100,
-    description: "7,501 - 10,000 alumni",
-  },
-  {
-    buckets: 5,
-    capacity: null,
-    monthlyPrice: null,
-    yearlyPrice: null,
-    description: "10,000+ alumni (Contact Sales)",
-  },
-] as const;
-
-function calculateSeatPrice(
-  quantity: number,
-  bucketQuantity: number,
-): { totalCentsYearly: number; billableOrgs: number; freeOrgs: number } {
-  const freeCount = getFreeSubOrgCount(bucketQuantity);
-  const freeOrgs = Math.min(quantity, freeCount);
-  const billableOrgs = Math.max(0, quantity - freeCount);
-  const totalCentsYearly = billableOrgs * ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsYearly;
-
-  return { totalCentsYearly, billableOrgs, freeOrgs };
-}
+  createEnterpriseV2Schema,
+  type CreateEnterpriseV2Form,
+} from "@/lib/schemas/organization-v2";
+import { quote, isSelfServeSalesLed } from "@/lib/pricing-v2";
 
 function formatCents(cents: number): string {
-  return `$${(cents / 100).toLocaleString()}`;
+  return `$${(cents / 100).toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
 }
 
 export default function CreateEnterprisePage() {
@@ -103,35 +28,69 @@ export default function CreateEnterprisePage() {
     watch,
     setValue,
     formState: { errors },
-  } = useForm<CreateEnterpriseForm>({
-    resolver: zodResolver(createEnterpriseSchema),
+  } = useForm<CreateEnterpriseV2Form>({
+    resolver: zodResolver(createEnterpriseV2Schema),
     defaultValues: {
       name: "",
       slug: "",
+      description: "",
+      primaryColor: "#5b21b6",
       billingContactEmail: "",
-      seatQuantity: 3, // Default to free tier
-      alumniBucketQuantity: 1,
+      actives: 0,
+      alumni: 0,
+      subOrgs: 1,
       billingInterval: "year",
     },
   });
 
-  const { name, slug, billingContactEmail, seatQuantity, alumniBucketQuantity, billingInterval } = watch();
+  const {
+    name,
+    slug,
+    description,
+    primaryColor,
+    billingContactEmail,
+    actives,
+    alumni,
+    subOrgs,
+    billingInterval,
+  } = watch();
+
+  const q = useMemo(
+    () =>
+      quote({
+        tier: "enterprise",
+        actives: actives || 0,
+        alumni: alumni || 0,
+        subOrgs: subOrgs || 0,
+      }),
+    [actives, alumni, subOrgs],
+  );
+  const salesLed = isSelfServeSalesLed({
+    tier: "enterprise",
+    actives: actives || 0,
+    alumni: alumni || 0,
+    subOrgs: subOrgs || 0,
+  });
+  const displayCents = billingInterval === "year" ? q.yearlyCents : q.monthlyCents;
+  const intervalLabel = billingInterval === "year" ? "/yr" : "/mo";
 
   const fingerprint = useMemo(
     () =>
       JSON.stringify({
         name: name?.trim() || "",
         slug: slug?.trim() || "",
+        description: description?.trim() || "",
+        primaryColor: primaryColor || "",
         billingContactEmail: billingContactEmail?.trim() || "",
-        seatQuantity,
-        alumniBucketQuantity,
+        actives: actives || 0,
+        alumni: alumni || 0,
+        subOrgs: subOrgs || 0,
         billingInterval,
       }),
-    [name, slug, billingContactEmail, seatQuantity, alumniBucketQuantity, billingInterval],
+    [actives, alumni, billingContactEmail, billingInterval, description, name, primaryColor, slug, subOrgs],
   );
-
   const { idempotencyKey } = useIdempotencyKey({
-    storageKey: "create-enterprise-checkout",
+    storageKey: "create-enterprise-v2-checkout",
     fingerprint,
   });
 
@@ -146,10 +105,9 @@ export default function CreateEnterprisePage() {
     setValue("slug", generatedSlug);
   };
 
-  const onSubmit = async (data: CreateEnterpriseForm) => {
+  const onSubmit = async (data: CreateEnterpriseV2Form) => {
     setIsLoading(true);
     setError(null);
-
     if (!idempotencyKey) {
       setError("Preparing checkout... please try again.");
       setIsLoading(false);
@@ -157,33 +115,28 @@ export default function CreateEnterprisePage() {
     }
 
     try {
-      const response = await fetch("/api/stripe/create-enterprise-checkout", {
+      const response = await fetch("/api/stripe/create-enterprise-v2-checkout", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: data.name,
           slug: data.slug,
-          billingContactEmail: data.billingContactEmail,
+          description: data.description ?? "",
+          primaryColor: data.primaryColor,
           billingInterval: data.billingInterval,
-          alumniBucketQuantity: data.alumniBucketQuantity,
-          subOrgQuantity: data.seatQuantity,
+          actives: data.actives,
+          alumni: data.alumni,
+          subOrgs: data.subOrgs,
+          billingContactEmail: data.billingContactEmail,
           idempotencyKey,
         }),
       });
 
       const responseData = await response.json();
-
-      if (!response.ok) {
-        throw new Error(responseData.error || "Unable to start checkout");
-      }
+      if (!response.ok) throw new Error(responseData.error || "Unable to start checkout");
 
       if (responseData.mode === "sales") {
         router.push(`/app?enterprise=${data.slug}&billing=pending-sales`);
-        return;
-      }
-
-      if (responseData.pending) {
-        router.push(`/app?enterprise=${data.slug}&billing=pending`);
         return;
       }
 
@@ -192,7 +145,6 @@ export default function CreateEnterprisePage() {
         window.location.href = checkoutUrl as string;
         return;
       }
-
       throw new Error("Missing checkout URL");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
@@ -200,93 +152,46 @@ export default function CreateEnterprisePage() {
     }
   };
 
-  const handleSeatChange = (delta: number) => {
-    const newValue = Math.max(
-      MIN_SEATS,
-      Math.min(MAX_SEATS, seatQuantity + delta),
-    );
-    setValue("seatQuantity", newValue);
-  };
-
-  const seatPricing = calculateSeatPrice(seatQuantity, alumniBucketQuantity);
-  const selectedBucket = ALUMNI_BUCKET_OPTIONS.find((opt) => opt.buckets === alumniBucketQuantity);
-  const isContactSales = isSalesLed(alumniBucketQuantity);
-
-  const alumniMonthlyPrice = selectedBucket?.monthlyPrice ?? 0;
-  const alumniYearlyPrice = selectedBucket?.yearlyPrice ?? 0;
-
-  const seatMonthlyPrice = seatPricing.billableOrgs * (ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsMonthly / 100);
-  const seatYearlyPrice = seatPricing.totalCentsYearly / 100;
-
-  const totalMonthly = alumniMonthlyPrice + seatMonthlyPrice;
-  const totalYearly = alumniYearlyPrice + seatYearlyPrice;
-
-  const displayTotal = billingInterval === "month" ? totalMonthly : totalYearly;
-  const displayInterval = billingInterval === "month" ? "/mo" : "/yr";
+  const submitDisabled = !salesLed && displayCents <= 0;
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
       <header className="border-b border-border bg-card">
         <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
           <Link href="/app">
             <h1 className="text-2xl font-bold text-foreground">
               Team<span className="text-purple-500">Network</span>
-              <span className="ml-2 text-sm font-normal text-muted-foreground">
-                Enterprise
-              </span>
+              <span className="ml-2 text-sm font-normal text-muted-foreground">Enterprise</span>
             </h1>
           </Link>
           <form action="/auth/signout" method="POST">
-            <Button variant="ghost" size="sm" type="submit">
-              Sign Out
-            </Button>
+            <Button variant="ghost" size="sm" type="submit">Sign Out</Button>
           </form>
         </div>
       </header>
 
-      {/* Main Content */}
       <main className="w-full max-w-4xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
         <div className="mb-8">
-          <Link
-            href="/app"
-            className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1"
-          >
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M15.75 19.5L8.25 12l7.5-7.5"
-              />
+          <Link href="/app" className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1">
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
             </svg>
             Back to Dashboard
           </Link>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          {/* Form */}
           <div className="lg:col-span-2">
             <Card className="p-8">
               <div className="mb-8">
-                <h2 className="text-2xl font-bold text-foreground mb-2">
-                  Create Enterprise Account
-                </h2>
+                <h2 className="text-2xl font-bold text-foreground mb-2">Create Enterprise Account</h2>
                 <p className="text-muted-foreground">
-                  Manage multiple organizations under one roof with pooled
-                  alumni quotas and unified billing.
+                  Manage multiple organizations under one roof with shared billing.
                 </p>
               </div>
 
               {error && (
-                <div className="mb-6 p-4 rounded-xl bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 text-sm">
-                  {error}
-                </div>
+                <InlineBanner variant="error" className="mb-6">{error}</InlineBanner>
               )}
 
               <form onSubmit={handleSubmit(onSubmit)}>
@@ -296,11 +201,8 @@ export default function CreateEnterprisePage() {
                     type="text"
                     placeholder="e.g., Acme Athletics, State University"
                     error={errors.name?.message}
-                    {...register("name", {
-                      onChange: (e) => handleNameChange(e.target.value),
-                    })}
+                    {...register("name", { onChange: (e) => handleNameChange(e.target.value) })}
                   />
-
                   <Input
                     label="URL Slug"
                     type="text"
@@ -309,13 +211,17 @@ export default function CreateEnterprisePage() {
                     error={errors.slug?.message}
                     {...register("slug", {
                       onChange: (e) => {
-                        e.target.value = e.target.value
-                          .toLowerCase()
-                          .replace(/[^a-z0-9-]/g, "");
+                        e.target.value = e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "");
                       },
                     })}
                   />
-
+                  <Textarea
+                    label="Description"
+                    placeholder="Tell people about your enterprise..."
+                    rows={3}
+                    error={errors.description?.message}
+                    {...register("description")}
+                  />
                   <Input
                     label="Billing Contact Email"
                     type="email"
@@ -324,302 +230,128 @@ export default function CreateEnterprisePage() {
                     {...register("billingContactEmail")}
                   />
 
-                  {/* Billing Interval Toggle */}
-                  <div className="space-y-3 p-5 rounded-xl border border-border bg-card">
-                    <div>
-                      <h3 className="text-base font-semibold text-foreground">
-                        Billing Frequency
-                      </h3>
-                      <p className="text-sm text-muted-foreground mt-1">
-                        Choose monthly or yearly billing
-                      </p>
-                    </div>
-
-                    <div className="flex gap-3">
-                      <button
-                        type="button"
-                        onClick={() => setValue("billingInterval", "month")}
-                        className={`flex-1 p-3 rounded-lg border transition-all ${
-                          billingInterval === "month"
-                            ? "border-purple-500 bg-purple-50 dark:bg-purple-900/20"
-                            : "border-border hover:border-muted-foreground"
-                        }`}
-                      >
-                        <p className="font-semibold text-foreground">Monthly</p>
-                        <p className="text-xs text-muted-foreground">Billed monthly</p>
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setValue("billingInterval", "year")}
-                        className={`flex-1 p-3 rounded-lg border transition-all ${
-                          billingInterval === "year"
-                            ? "border-purple-500 bg-purple-50 dark:bg-purple-900/20"
-                            : "border-border hover:border-muted-foreground"
-                        }`}
-                      >
-                        <p className="font-semibold text-foreground">Yearly</p>
-                        <p className="text-xs text-muted-foreground">Save 17%</p>
-                      </button>
-                    </div>
-                  </div>
-
-                  {/* Section 1: Enterprise-Managed Org Seats */}
-                  <div className="space-y-4 p-5 rounded-xl border border-border bg-card">
-                    <div>
-                      <h3 className="text-base font-semibold text-foreground">
-                        Enterprise-Managed Organizations
-                      </h3>
-                      <p className="text-sm text-muted-foreground mt-1">
-                        How many organizations do you need to manage?
-                      </p>
-                    </div>
-
-                    {/* Free tier callout */}
-                    <div className="p-3 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
-                      <p className="text-sm text-green-800 dark:text-green-200">
-                        <span className="font-semibold">First {getFreeSubOrgCount(alumniBucketQuantity)} organizations are FREE! (3 per alumni bucket)</span>
-                        <span className="block mt-1 text-green-700 dark:text-green-300">
-                          ${(ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsYearly / 100).toFixed(0)}/year for each additional organization
-                        </span>
-                      </p>
-                    </div>
-
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-2">Brand Color</label>
                     <div className="flex items-center gap-4">
-                      <div className="flex items-center border border-border rounded-xl">
-                        <button
-                          type="button"
-                          onClick={() => handleSeatChange(-1)}
-                          disabled={seatQuantity <= MIN_SEATS}
-                          className="px-4 py-3 text-lg font-medium text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed rounded-l-xl"
-                        >
-                          -
-                        </button>
-                        <input
-                          type="number"
-                          min={MIN_SEATS}
-                          max={MAX_SEATS}
-                          value={seatQuantity}
-                          onChange={(e) => {
-                            const val = parseInt(e.target.value, 10);
-                            if (
-                              !isNaN(val) &&
-                              val >= MIN_SEATS &&
-                              val <= MAX_SEATS
-                            ) {
-                              setValue("seatQuantity", val);
-                            }
-                          }}
-                          className="w-16 text-center py-3 text-lg font-semibold bg-transparent border-x border-border focus:outline-none"
-                        />
-                        <button
-                          type="button"
-                          onClick={() => handleSeatChange(1)}
-                          disabled={seatQuantity >= MAX_SEATS}
-                          className="px-4 py-3 text-lg font-medium text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed rounded-r-xl"
-                        >
-                          +
-                        </button>
-                      </div>
-                      <div className="text-sm text-muted-foreground">
-                        {seatQuantity <= getFreeSubOrgCount(alumniBucketQuantity) ? (
-                          <span className="text-green-600 dark:text-green-400 font-medium">
-                            Free!
-                          </span>
-                        ) : (
-                          <span>
-                            {seatQuantity - getFreeSubOrgCount(alumniBucketQuantity)} paid @ {formatCents(ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsYearly)}/yr each
-                          </span>
-                        )}
-                      </div>
+                      <input
+                        type="color"
+                        value={primaryColor}
+                        onChange={(e) => setValue("primaryColor", e.target.value)}
+                        className="h-12 w-20 rounded-xl border border-border cursor-pointer"
+                      />
+                      <Input
+                        type="text"
+                        placeholder="#5b21b6"
+                        className="flex-1"
+                        error={errors.primaryColor?.message}
+                        {...register("primaryColor")}
+                      />
                     </div>
                   </div>
 
-                  {/* Section 2: Alumni Bucket Selector */}
-                  <div className="space-y-4 p-5 rounded-xl border border-border bg-card">
-                    <div>
-                      <h3 className="text-base font-semibold text-foreground">
-                        Alumni Bucket Size
-                      </h3>
-                      <p className="text-sm text-muted-foreground mt-1">
-                        Each bucket provides 2,500 alumni capacity (minimum 1 bucket required)
-                      </p>
-                    </div>
-
-                    <div className="grid gap-3">
-                      {ALUMNI_BUCKET_OPTIONS.map((option) => {
-                        const isSelected = alumniBucketQuantity === option.buckets;
-                        const isContactSales = option.buckets === 5;
-
-                        return (
-                          <button
-                            key={option.buckets}
-                            type="button"
-                            onClick={() => setValue("alumniBucketQuantity", option.buckets)}
-                            className={`text-left p-4 rounded-xl border transition-all ${
-                              isSelected
-                                ? "border-purple-500 bg-purple-50 dark:bg-purple-900/20"
-                                : "border-border hover:border-muted-foreground"
-                            }`}
-                          >
-                            <div className="flex items-center justify-between">
-                              <div>
-                                <p className="font-semibold text-foreground">
-                                  Bucket {option.buckets}
-                                </p>
-                                <p className="text-sm text-muted-foreground">
-                                  {option.description}
-                                </p>
-                              </div>
-                              <div className="text-right">
-                                {isContactSales ? (
-                                  <p className="text-sm font-medium text-purple-600 dark:text-purple-400">
-                                    Contact Sales
-                                  </p>
-                                ) : (
-                                  <>
-                                    <p className="font-medium text-foreground">
-                                      ${billingInterval === "month" ? option.monthlyPrice : option.yearlyPrice}{displayInterval}
-                                    </p>
-                                    <p className="text-xs text-muted-foreground">
-                                      {option.capacity?.toLocaleString()} alumni
-                                    </p>
-                                  </>
-                                )}
-                              </div>
-                            </div>
-                          </button>
-                        );
-                      })}
+                  <div className="space-y-3 p-5 rounded-xl border border-border bg-card">
+                    <h3 className="text-base font-semibold text-foreground">Billing Frequency</h3>
+                    <div className="flex gap-3">
+                      {(["month", "year"] as const).map((interval) => (
+                        <button
+                          key={interval}
+                          type="button"
+                          onClick={() => setValue("billingInterval", interval)}
+                          className={`flex-1 p-3 rounded-lg border ${
+                            billingInterval === interval
+                              ? "border-purple-500 bg-purple-50 dark:bg-purple-900/20"
+                              : "border-border hover:border-muted-foreground"
+                          }`}
+                        >
+                          <p className="font-semibold text-foreground">
+                            {interval === "month" ? "Monthly" : "Yearly"}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {interval === "month" ? "Billed monthly" : "Save 17%"}
+                          </p>
+                        </button>
+                      ))}
                     </div>
                   </div>
+
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                    <Input
+                      label="Active Members"
+                      type="number"
+                      min={0}
+                      error={errors.actives?.message}
+                      {...register("actives", { valueAsNumber: true })}
+                    />
+                    <Input
+                      label="Alumni"
+                      type="number"
+                      min={0}
+                      error={errors.alumni?.message}
+                      {...register("alumni", { valueAsNumber: true })}
+                    />
+                    <Input
+                      label="Sub-Organizations"
+                      type="number"
+                      min={0}
+                      error={errors.subOrgs?.message}
+                      {...register("subOrgs", { valueAsNumber: true })}
+                    />
+                  </div>
+
+                  {salesLed && (
+                    <InlineBanner variant="warning">
+                      Your size qualifies for custom enterprise pricing. We&apos;ll reach out to finalize the plan; no payment is collected now.
+                    </InlineBanner>
+                  )}
 
                   <div className="flex gap-4 pt-4">
                     <Link href="/app" className="flex-1">
-                      <Button
-                        type="button"
-                        variant="secondary"
-                        className="w-full"
-                      >
-                        Cancel
-                      </Button>
+                      <Button type="button" variant="secondary" className="w-full">Cancel</Button>
                     </Link>
-                    {isContactSales ? (
-                      <Button
-                        type="submit"
-                        className="flex-1"
-                        isLoading={isLoading}
-                      >
-                        Contact Sales
-                      </Button>
-                    ) : (
-                      <Button
-                        type="submit"
-                        className="flex-1"
-                        isLoading={isLoading}
-                      >
-                        Continue to Checkout
-                      </Button>
-                    )}
+                    <Button type="submit" className="flex-1" isLoading={isLoading} disabled={submitDisabled}>
+                      {salesLed ? "Contact Sales" : "Continue to Checkout"}
+                    </Button>
                   </div>
                 </div>
               </form>
             </Card>
           </div>
 
-          {/* Pricing Summary */}
           <div className="lg:col-span-1">
             <Card className="p-6 sticky top-8">
-              <h3 className="font-semibold text-foreground mb-4">
-                Order Summary
-              </h3>
-
-              <div className="space-y-3 text-sm">
-                {/* Alumni buckets */}
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Alumni buckets</span>
-                  <span className="text-foreground font-medium">
-                    {isContactSales
-                      ? "Contact Sales"
-                      : `${alumniBucketQuantity} × $${billingInterval === "month" ? (ALUMNI_BUCKET_PRICING.monthlyCentsPerBucket / 100) : (ALUMNI_BUCKET_PRICING.yearlyCentsPerBucket / 100)}${displayInterval}`}
-                  </span>
-                </div>
-                <div className="flex justify-between text-xs">
-                  <span className="text-muted-foreground pl-4">Capacity</span>
-                  <span className="text-muted-foreground">
-                    {isContactSales
-                      ? "Custom"
-                      : `${(alumniBucketQuantity * ALUMNI_BUCKET_PRICING.capacityPerBucket).toLocaleString()} alumni`}
-                  </span>
-                </div>
-
-                <div className="border-t border-border my-2"></div>
-
-                {/* Organizations */}
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Organizations</span>
-                  <span className="text-foreground font-medium">
-                    {seatQuantity}
-                  </span>
-                </div>
-                <div className="flex justify-between text-xs">
-                  <span className="text-muted-foreground pl-4">Free</span>
-                  <span className="text-green-600 dark:text-green-400 font-medium">
-                    {seatPricing.freeOrgs}
-                  </span>
-                </div>
-                {seatPricing.billableOrgs > 0 && (
-                  <div className="flex justify-between text-xs">
-                    <span className="text-muted-foreground pl-4">Paid</span>
-                    <span className="text-foreground font-medium">
-                      {seatPricing.billableOrgs} × ${billingInterval === "month" ? (ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsMonthly / 100) : (ENTERPRISE_SEAT_PRICING.pricePerAdditionalCentsYearly / 100)}{displayInterval}
-                    </span>
-                  </div>
+              <h3 className="font-semibold text-foreground mb-4">Order Summary</h3>
+              <div className="space-y-2 text-sm">
+                {salesLed ? (
+                  <p className="text-muted-foreground">
+                    Custom quote — sales will tailor a plan for your size.
+                  </p>
+                ) : (
+                  <>
+                    <div className="flex justify-between text-muted-foreground">
+                      <span>Platform base</span>
+                      <span>{formatCents(q.breakdown.platformBaseCents)}/mo</span>
+                    </div>
+                    <div className="flex justify-between text-muted-foreground">
+                      <span>Active members ({actives || 0})</span>
+                      <span>{formatCents(q.breakdown.activeMonthlyCents)}/mo</span>
+                    </div>
+                    <div className="flex justify-between text-muted-foreground">
+                      <span>Alumni ({alumni || 0})</span>
+                      <span>{formatCents(q.breakdown.alumniMonthlyCents)}/mo</span>
+                    </div>
+                    <div className="flex justify-between text-muted-foreground">
+                      <span>Sub-orgs ({q.breakdown.subOrgsBilled})</span>
+                      <span>{formatCents(q.breakdown.subOrgMonthlyCents)}/mo</span>
+                    </div>
+                    <div className="border-t border-border my-2" />
+                    <div className="flex justify-between text-lg">
+                      <span className="font-semibold text-foreground">Total</span>
+                      <span className="font-bold text-foreground">
+                        {formatCents(displayCents)}{intervalLabel}
+                      </span>
+                    </div>
+                  </>
                 )}
-
-                <div className="border-t border-border pt-3 mt-3">
-                  <div className="flex justify-between text-lg">
-                    <span className="font-semibold text-foreground">Total</span>
-                    <span className="font-bold text-foreground">
-                      {isContactSales ? "Contact Sales" : `$${displayTotal.toFixed(2)}${displayInterval}`}
-                    </span>
-                  </div>
-                  {!isContactSales && (
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Alumni buckets: ${billingInterval === "month" ? alumniMonthlyPrice : alumniYearlyPrice}
-                      {seatPricing.billableOrgs > 0 && ` + Organizations: $${billingInterval === "month" ? seatMonthlyPrice : seatYearlyPrice}`}
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              <div className="mt-4 p-3 rounded-lg bg-muted/50 text-sm">
-                <p className="text-muted-foreground">
-                  {isContactSales ? (
-                    "Custom alumni quota — our sales team will tailor a plan for your needs"
-                  ) : (
-                    <>
-                      Pooled alumni quota of{" "}
-                      <span className="font-medium text-foreground">
-                        {(alumniBucketQuantity * ALUMNI_BUCKET_PRICING.capacityPerBucket).toLocaleString()}
-                      </span>{" "}
-                      alumni across all enterprise-managed organizations
-                    </>
-                  )}
-                </p>
-              </div>
-
-              <div className="mt-6 p-4 rounded-xl bg-purple-50 dark:bg-purple-900/20">
-                <h4 className="font-medium text-purple-800 dark:text-purple-200 mb-2">
-                  Enterprise Benefits
-                </h4>
-                <ul className="text-xs text-purple-700 dark:text-purple-300 space-y-1">
-                  <li>3 free organizations per alumni bucket</li>
-                  <li>Pooled alumni quota across organizations</li>
-                  <li>Unified billing for all sub-orgs</li>
-                  <li>Centralized admin dashboard</li>
-                  <li>Adopt existing organizations</li>
-                  <li>Priority support</li>
-                </ul>
               </div>
             </Card>
           </div>

--- a/src/app/app/create-org/page.tsx
+++ b/src/app/app/create-org/page.tsx
@@ -1,28 +1,20 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Button, Input, Card, Textarea, Select, InlineBanner, ToggleSwitch } from "@/components/ui";
+import { Button, Input, Card, Textarea, InlineBanner } from "@/components/ui";
 import { FeedbackButton } from "@/components/feedback";
 import { useIdempotencyKey } from "@/hooks";
-import { createOrgSchema, type CreateOrgForm } from "@/lib/schemas/organization";
-import { ORG_TRIAL_DAYS, isOrgFreeTrialSelectable } from "@/lib/subscription/org-trial";
-import {
-  BASE_PRICES,
-  ALUMNI_ADD_ON_PRICES,
-  ALUMNI_BUCKET_LABELS,
-  getTotalPrice,
-  formatPrice,
-} from "@/lib/pricing";
-import type { AlumniBucket } from "@/types/database";
+import { createOrgV2Schema, type CreateOrgV2Form } from "@/lib/schemas/organization-v2";
+import { quote, isSelfServeSalesLed } from "@/lib/pricing-v2";
 
-const ALUMNI_OPTIONS = (Object.entries(ALUMNI_BUCKET_LABELS) as [AlumniBucket, string][]).map(
-  ([value, label]) => ({ value, label }),
-);
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+}
 
 export default function CreateOrgPage() {
   const router = useRouter();
@@ -38,29 +30,35 @@ export default function CreateOrgPage() {
     setValue,
     trigger,
     formState: { errors },
-  } = useForm<CreateOrgForm>({
-    resolver: zodResolver(createOrgSchema),
+  } = useForm<CreateOrgV2Form>({
+    resolver: zodResolver(createOrgV2Schema),
     defaultValues: {
       name: "",
       slug: "",
       description: "",
       primaryColor: "#1e3a5f",
       billingInterval: "month",
-      alumniBucket: "none",
-      withTrial: false,
+      actives: 0,
+      alumni: 0,
     },
   });
 
   const formValues = watch();
-  const { name, slug, primaryColor, billingInterval, alumniBucket, withTrial } = formValues;
-  const trialEligible = isOrgFreeTrialSelectable({ billingInterval, alumniBucket });
-  const effectiveWithTrial = trialEligible && Boolean(withTrial);
+  const { name, slug, primaryColor, billingInterval, actives, alumni } = formValues;
 
-  useEffect(() => {
-    if (!trialEligible && withTrial) {
-      setValue("withTrial", false);
-    }
-  }, [setValue, trialEligible, withTrial]);
+  const q = useMemo(
+    () => quote({ tier: "single", actives: actives || 0, alumni: alumni || 0 }),
+    [actives, alumni],
+  );
+  const salesLed = isSelfServeSalesLed({
+    tier: "single",
+    actives: actives || 0,
+    alumni: alumni || 0,
+  });
+  const monthlyCents = q.monthlyCents;
+  const yearlyCents = q.yearlyCents;
+  const displayCents = billingInterval === "year" ? yearlyCents : monthlyCents;
+  const intervalLabel = billingInterval === "year" ? "/yr" : "/mo";
 
   const fingerprint = useMemo(
     () =>
@@ -70,20 +68,18 @@ export default function CreateOrgPage() {
         description: formValues.description?.trim() || "",
         primaryColor: primaryColor || "",
         billingInterval,
-        alumniBucket,
-        withTrial: effectiveWithTrial,
+        actives: actives || 0,
+        alumni: alumni || 0,
       }),
-    [alumniBucket, billingInterval, formValues.description, effectiveWithTrial, name, primaryColor, slug],
+    [actives, alumni, billingInterval, formValues.description, name, primaryColor, slug],
   );
   const { idempotencyKey } = useIdempotencyKey({
-    storageKey: "create-org-checkout",
+    storageKey: "create-org-v2-checkout",
     fingerprint,
   });
 
-  // Auto-generate slug from name
   const handleNameChange = (value: string) => {
     setValue("name", value);
-    // Generate slug: lowercase, replace spaces with hyphens, remove special chars
     const generatedSlug = value
       .toLowerCase()
       .replace(/[^a-z0-9\s-]/g, "")
@@ -94,13 +90,11 @@ export default function CreateOrgPage() {
   };
 
   const handleNext = async () => {
-    const valid = await trigger(["name", "slug"]);
-    if (valid) {
-      setStep(2);
-    }
+    const valid = await trigger(["name", "slug", "primaryColor"]);
+    if (valid) setStep(2);
   };
 
-  const onSubmit = async (data: CreateOrgForm) => {
+  const onSubmit = async (data: CreateOrgV2Form) => {
     setIsLoading(true);
     setError(null);
     setInfoMessage(null);
@@ -111,38 +105,35 @@ export default function CreateOrgPage() {
     }
 
     try {
-      const response = await fetch("/api/stripe/create-org-checkout", {
+      const response = await fetch("/api/stripe/create-org-v2-checkout", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: data.name,
           slug: data.slug,
-          description: data.description,
+          description: data.description ?? "",
           primaryColor: data.primaryColor,
           billingInterval: data.billingInterval,
-          alumniBucket: data.alumniBucket,
-          withTrial: effectiveWithTrial,
+          actives: data.actives,
+          alumni: data.alumni,
           idempotencyKey,
         }),
       });
 
       const responseData = await response.json();
-
-      if (!response.ok) {
-        throw new Error(responseData.error || "Unable to start checkout");
-      }
+      if (!response.ok) throw new Error(responseData.error || "Unable to start checkout");
 
       if (responseData.mode === "sales") {
-        setInfoMessage("Thank you! We will contact you to finalize a custom alumni plan.");
+        setInfoMessage("Thank you! We will contact you to finalize a custom plan.");
         router.push(`/app?org=${data.slug}&billing=pending-sales`);
         return;
       }
 
-      if (responseData.url) {
-        window.location.href = responseData.url as string;
+      const checkoutUrl = responseData.checkoutUrl ?? responseData.url;
+      if (checkoutUrl) {
+        window.location.href = checkoutUrl as string;
         return;
       }
-
       throw new Error("Missing checkout URL");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
@@ -150,17 +141,10 @@ export default function CreateOrgPage() {
     }
   };
 
-  // Dynamic pricing summary
-  const basePrice = BASE_PRICES[billingInterval];
-  const alumniAddon =
-    alumniBucket !== "none" && alumniBucket !== "5000+"
-      ? ALUMNI_ADD_ON_PRICES[alumniBucket][billingInterval]
-      : null;
-  const totalPrice = getTotalPrice(billingInterval, alumniBucket);
+  const submitDisabled = !salesLed && displayCents <= 0;
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
       <header className="border-b border-border bg-card/80 backdrop-blur-sm">
         <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
           <Link href="/app">
@@ -173,14 +157,11 @@ export default function CreateOrgPage() {
             </h1>
           </Link>
           <form action="/auth/signout" method="POST">
-            <Button variant="ghost" size="sm" type="submit">
-              Sign Out
-            </Button>
+            <Button variant="ghost" size="sm" type="submit">Sign Out</Button>
           </form>
         </div>
       </header>
 
-      {/* Main Content */}
       <main className="w-full max-w-2xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
         <div className="mb-8">
           <Link href="/app" className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1">
@@ -193,16 +174,14 @@ export default function CreateOrgPage() {
 
         <Card className="p-8">
           <div className="mb-8">
-            <p className="text-sm font-medium text-muted-foreground mb-1">
-              Step {step} of 2
-            </p>
+            <p className="text-sm font-medium text-muted-foreground mb-1">Step {step} of 2</p>
             <h2 className="text-2xl font-bold text-foreground mb-2">
               {step === 1 ? "Your Organization" : "Plan & Billing"}
             </h2>
             <p className="text-muted-foreground">
               {step === 1
-                ? "Set up your team, club, or group. You\u2019ll be the admin and can invite members later."
-                : "Choose your billing plan and alumni access level."}
+                ? "Set up your team, club, or group. You’ll be the admin and can invite members later."
+                : "Tell us about your size — pricing scales with your active members and alumni."}
             </p>
           </div>
 
@@ -215,15 +194,10 @@ export default function CreateOrgPage() {
             </InlineBanner>
           )}
           {infoMessage && (
-            <InlineBanner variant="success" className="mb-6">
-              {infoMessage}
-            </InlineBanner>
+            <InlineBanner variant="success" className="mb-6">{infoMessage}</InlineBanner>
           )}
 
           <form onSubmit={handleSubmit(onSubmit)}>
-            <input type="hidden" {...register("withTrial")} />
-
-            {/* Step 1: Your Organization */}
             {step === 1 && (
               <div className="space-y-6">
                 <Input
@@ -231,11 +205,8 @@ export default function CreateOrgPage() {
                   type="text"
                   placeholder="e.g., Stanford Crew, The Whiffenpoofs"
                   error={errors.name?.message}
-                  {...register("name", {
-                    onChange: (e) => handleNameChange(e.target.value),
-                  })}
+                  {...register("name", { onChange: (e) => handleNameChange(e.target.value) })}
                 />
-
                 <Input
                   label="URL Slug"
                   type="text"
@@ -248,7 +219,6 @@ export default function CreateOrgPage() {
                     },
                   })}
                 />
-
                 <Textarea
                   label="Description"
                   placeholder="Tell people about your organization..."
@@ -256,11 +226,8 @@ export default function CreateOrgPage() {
                   error={errors.description?.message}
                   {...register("description")}
                 />
-
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
-                    Brand Color
-                  </label>
+                  <label className="block text-sm font-medium text-foreground mb-2">Brand Color</label>
                   <div className="flex items-center gap-4">
                     <input
                       type="color"
@@ -280,24 +247,17 @@ export default function CreateOrgPage() {
                     This color will be used for your organization&apos;s branding
                   </p>
                 </div>
-
                 <div className="flex gap-4 pt-4">
                   <Link href="/app" className="flex-1">
-                    <Button type="button" variant="secondary" className="w-full">
-                      Cancel
-                    </Button>
+                    <Button type="button" variant="secondary" className="w-full">Cancel</Button>
                   </Link>
-                  <Button type="button" className="flex-1" onClick={handleNext}>
-                    Next
-                  </Button>
+                  <Button type="button" className="flex-1" onClick={handleNext}>Next</Button>
                 </div>
               </div>
             )}
 
-            {/* Step 2: Plan & Billing */}
             {step === 2 && (
               <div className="space-y-6">
-                {/* Billing Interval */}
                 <div className="space-y-2">
                   <p className="text-sm font-medium text-foreground">Billing Interval</p>
                   <div className="flex gap-2">
@@ -312,88 +272,68 @@ export default function CreateOrgPage() {
                             : "border-border bg-muted text-foreground"
                         }`}
                       >
-                        {interval === "month" ? "Monthly" : "Yearly (save 2 months)"}
+                        {interval === "month" ? "Monthly" : "Yearly (save 17%)"}
                       </button>
                     ))}
                   </div>
                 </div>
 
-                {/* Alumni Access */}
-                <Select
-                  label="Alumni Access"
-                  options={ALUMNI_OPTIONS}
-                  error={errors.alumniBucket?.message}
-                  {...register("alumniBucket")}
-                />
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Input
+                    label="Active Members"
+                    type="number"
+                    min={0}
+                    error={errors.actives?.message}
+                    {...register("actives", { valueAsNumber: true })}
+                  />
+                  <Input
+                    label="Alumni"
+                    type="number"
+                    min={0}
+                    error={errors.alumni?.message}
+                    {...register("alumni", { valueAsNumber: true })}
+                  />
+                </div>
 
-                {/* Dynamic Pricing Summary */}
                 <div className="rounded-xl border border-border bg-muted/40 p-4 text-sm space-y-2">
                   <p className="font-semibold text-foreground">Pricing Summary</p>
-                  {totalPrice !== null ? (
+                  {salesLed ? (
+                    <p className="text-muted-foreground">
+                      Custom quote &mdash; we&apos;ll contact you to finalize pricing for your network size.
+                    </p>
+                  ) : displayCents > 0 ? (
                     <>
                       <div className="flex justify-between text-muted-foreground">
-                        <span>Active Team</span>
-                        <span>{formatPrice(basePrice, billingInterval)}</span>
+                        <span>Active members ({actives || 0})</span>
+                        <span>{formatCents(q.breakdown.activeMonthlyCents)}/mo</span>
                       </div>
-                      {alumniAddon !== null && (
-                        <div className="flex justify-between text-muted-foreground">
-                          <span>Alumni ({ALUMNI_BUCKET_LABELS[alumniBucket]})</span>
-                          <span>+{formatPrice(alumniAddon, billingInterval)}</span>
-                        </div>
-                      )}
+                      <div className="flex justify-between text-muted-foreground">
+                        <span>Alumni ({alumni || 0})</span>
+                        <span>{formatCents(q.breakdown.alumniMonthlyCents)}/mo</span>
+                      </div>
                       <div className="border-t border-border my-1" />
                       <div className="flex justify-between font-medium text-foreground">
                         <span>Total</span>
-                        <span>{formatPrice(totalPrice, billingInterval)}</span>
+                        <span>{formatCents(displayCents)}{intervalLabel}</span>
                       </div>
                     </>
                   ) : (
                     <p className="text-muted-foreground">
-                      Custom quote &mdash; we&apos;ll reach out to discuss pricing for your alumni network.
+                      Add active members or alumni to see pricing.
                     </p>
                   )}
                 </div>
 
-                {/* 5000+ warning */}
-                {alumniBucket === "5000+" && (
+                {salesLed && (
                   <InlineBanner variant="warning">
-                    For 5,000+ alumni, we will contact you with custom pricing. No payment is collected now and the org will remain pending_sales.
+                    With {alumni?.toLocaleString()} alumni, we will contact you with custom pricing. No payment is collected now and the org remains pending_sales.
                   </InlineBanner>
                 )}
 
-                {/* Trial toggle */}
-                {trialEligible && (
-                  <div className="rounded-xl border border-border bg-muted/40 p-4 text-sm space-y-3">
-                    <div className="flex items-center justify-between">
-                      <div className="space-y-1 pr-4">
-                        <p className="font-medium text-foreground">
-                          {ORG_TRIAL_DAYS}-day free trial
-                        </p>
-                        <p className="text-muted-foreground">
-                          Your card is collected now. Billing starts when the trial ends unless you cancel.
-                        </p>
-                      </div>
-                      <ToggleSwitch
-                        checked={effectiveWithTrial}
-                        onChange={(checked) => setValue("withTrial", checked)}
-                        label={`Enable ${ORG_TRIAL_DAYS}-day free trial`}
-                      />
-                    </div>
-                    {effectiveWithTrial && (
-                      <p className="text-emerald-600 dark:text-emerald-400">
-                        Trial selected. Your organization will be active immediately, and the first charge will happen after {ORG_TRIAL_DAYS} days.
-                      </p>
-                    )}
-                  </div>
-                )}
-
-                {/* Action buttons */}
                 <div className="flex gap-4 pt-4">
-                  <Button type="button" variant="secondary" className="flex-1" onClick={() => setStep(1)}>
-                    Back
-                  </Button>
-                  <Button type="submit" className="flex-1" isLoading={isLoading}>
-                    {effectiveWithTrial ? `Start ${ORG_TRIAL_DAYS}-Day Free Trial` : "Create Organization"}
+                  <Button type="button" variant="secondary" className="flex-1" onClick={() => setStep(1)}>Back</Button>
+                  <Button type="submit" className="flex-1" isLoading={isLoading} disabled={submitDisabled}>
+                    {salesLed ? "Contact Sales" : "Create Organization"}
                   </Button>
                 </div>
               </div>

--- a/src/lib/payments/enterprise-v2-checkout-fingerprint.ts
+++ b/src/lib/payments/enterprise-v2-checkout-fingerprint.ts
@@ -1,0 +1,25 @@
+export function buildEnterpriseV2CheckoutFingerprintPayload(params: {
+  userId: string;
+  slug: string;
+  billingInterval: "month" | "year";
+  actives: number;
+  alumni: number;
+  subOrgs: number;
+  monthlyCents: number;
+  yearlyCents: number;
+  billingContactEmail: string;
+}): Record<string, unknown> {
+  return {
+    v: 1,
+    flow: "enterprise_v2_checkout",
+    userId: params.userId,
+    slug: params.slug,
+    billingInterval: params.billingInterval,
+    actives: params.actives,
+    alumni: params.alumni,
+    subOrgs: params.subOrgs,
+    monthlyCents: params.monthlyCents,
+    yearlyCents: params.yearlyCents,
+    billingContactEmail: params.billingContactEmail,
+  };
+}

--- a/src/lib/payments/org-v2-checkout-fingerprint.ts
+++ b/src/lib/payments/org-v2-checkout-fingerprint.ts
@@ -1,0 +1,23 @@
+export function buildOrgV2CheckoutFingerprintPayload(params: {
+  userId: string;
+  slug: string;
+  billingInterval: "month" | "year";
+  actives: number;
+  alumni: number;
+  monthlyCents: number;
+  yearlyCents: number;
+  primaryColor: string;
+}): Record<string, unknown> {
+  return {
+    v: 1,
+    flow: "org_v2_checkout",
+    userId: params.userId,
+    slug: params.slug,
+    billingInterval: params.billingInterval,
+    actives: params.actives,
+    alumni: params.alumni,
+    monthlyCents: params.monthlyCents,
+    yearlyCents: params.yearlyCents,
+    primaryColor: params.primaryColor,
+  };
+}

--- a/src/lib/pricing-v2.ts
+++ b/src/lib/pricing-v2.ts
@@ -28,6 +28,21 @@ export interface QuoteResult {
 export const SALES_LED_ALUMNI_THRESHOLD = 100_000;
 export const YEARLY_DISCOUNT_FACTOR = 0.83;
 
+// New-org / new-enterprise self-serve signup gates to sales much earlier
+// than the public calculator's 100k cap. Matches the v1 UX precedent
+// (>5000 alumni → sales-led on /app/create-org). Enterprise tier also
+// caps sub-orgs.
+export const SELF_SERVE_ALUMNI_LIMIT = 5_000;
+export const SELF_SERVE_SUB_ORG_LIMIT = 25;
+
+export function isSelfServeSalesLed(input: QuoteInput): boolean {
+  const alumni = Math.max(0, Math.floor(input.alumni));
+  const subOrgs = Math.max(0, Math.floor(input.subOrgs ?? 0));
+  if (alumni > SELF_SERVE_ALUMNI_LIMIT) return true;
+  if (input.tier === "enterprise" && subOrgs > SELF_SERVE_SUB_ORG_LIMIT) return true;
+  return false;
+}
+
 const ENTERPRISE_PLATFORM_BASE_CENTS = 25_000;
 const SUB_ORG_FIRST_TIER_CENTS = 2_000;
 const SUB_ORG_SECOND_TIER_CENTS = 1_500;

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -15,6 +15,7 @@ export * from "./content";
 
 // Organization schemas
 export * from "./organization";
+export * from "./organization-v2";
 
 // Schedule schemas
 export * from "./schedule";

--- a/src/lib/schemas/organization-v2.ts
+++ b/src/lib/schemas/organization-v2.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { baseSchemas, safeString, optionalSafeString, hexColorSchema } from "./common";
+import { subscriptionIntervalSchema } from "./organization";
+
+const v2Count = (max: number) => z.number().int().min(0).max(max);
+
+export const createOrgV2Schema = z
+  .object({
+    name: safeString(120),
+    slug: baseSchemas.slug,
+    description: optionalSafeString(800),
+    primaryColor: hexColorSchema,
+    billingInterval: subscriptionIntervalSchema,
+    actives: v2Count(1_000_000),
+    alumni: v2Count(1_000_000),
+    idempotencyKey: baseSchemas.idempotencyKey.optional(),
+    paymentAttemptId: baseSchemas.uuid.optional(),
+  })
+  .strict();
+export type CreateOrgV2Form = z.infer<typeof createOrgV2Schema>;
+
+export const createEnterpriseV2Schema = z
+  .object({
+    name: safeString(120),
+    slug: baseSchemas.slug,
+    description: optionalSafeString(800),
+    primaryColor: hexColorSchema,
+    billingInterval: subscriptionIntervalSchema,
+    actives: v2Count(1_000_000),
+    alumni: v2Count(1_000_000),
+    subOrgs: v2Count(1_000),
+    billingContactEmail: baseSchemas.email,
+    idempotencyKey: baseSchemas.idempotencyKey.optional(),
+    paymentAttemptId: baseSchemas.uuid.optional(),
+  })
+  .strict();
+export type CreateEnterpriseV2Form = z.infer<typeof createEnterpriseV2Schema>;

--- a/src/lib/stripe/org-provisioner.ts
+++ b/src/lib/stripe/org-provisioner.ts
@@ -150,6 +150,57 @@ export function createOrgProvisioner({ supabase, debugLog }: OrgProvisionerDeps)
     }
   };
 
+  const ensureSubscriptionSeedV2 = async (
+    orgId: string,
+    params: {
+      stripeCustomerId: string | null;
+      stripeSubscriptionId: string | null;
+      billingInterval: SubscriptionInterval;
+      status: string;
+      currentPeriodEnd: string | null;
+      snapshot: Record<string, unknown>;
+    },
+  ) => {
+    const { data: existing, error: existingError } = await orgSubs()
+      .select("id")
+      .eq("organization_id", orgId)
+      .maybeSingle();
+
+    if (existingError) {
+      throw new Error(`[ensureSubscriptionSeedV2] Existence check failed: ${existingError.message}`);
+    }
+
+    const basePayload = {
+      pricing_model_version: "v2",
+      pricing_v2_snapshot: params.snapshot,
+      base_plan_interval: params.billingInterval,
+      alumni_bucket: "none",
+      alumni_plan_interval: null,
+      is_trial: false,
+      stripe_customer_id: params.stripeCustomerId,
+      stripe_subscription_id: params.stripeSubscriptionId,
+      status: params.status,
+      current_period_end: params.currentPeriodEnd,
+    };
+
+    if (existing?.id) {
+      const { error } = await orgSubs()
+        .update({ ...basePayload, updated_at: new Date().toISOString() })
+        .eq("organization_id", orgId);
+      if (error) {
+        throw new Error(`Failed to seed v2 subscription row: ${error.message}`);
+      }
+    } else {
+      const { error } = await orgSubs().insert({
+        organization_id: orgId,
+        ...basePayload,
+      });
+      if (error) {
+        throw new Error(`Failed to create v2 subscription row: ${error.message}`);
+      }
+    }
+  };
+
   const ensureSubscriptionSeed = async (orgId: string, metadata: OrgMetadata) => {
     const baseInterval = metadata.baseInterval || "month";
     const alumniBucket = metadata.alumniBucket || "none";
@@ -318,6 +369,7 @@ export function createOrgProvisioner({ supabase, debugLog }: OrgProvisionerDeps)
     ensureOrganizationFromMetadata,
     grantAdminRole,
     ensureSubscriptionSeed,
+    ensureSubscriptionSeedV2,
     resolveOrgForSubscriptionFlow,
     validateOrgOwnsStripeResource,
   };

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2268,6 +2268,8 @@ export type Database = {
           id: string
           price_per_sub_org_cents: number | null
           pricing_model: string | null
+          pricing_model_version: string
+          pricing_v2_snapshot: Json | null
           status: string
           stripe_customer_id: string | null
           stripe_subscription_id: string | null
@@ -2284,6 +2286,8 @@ export type Database = {
           id?: string
           price_per_sub_org_cents?: number | null
           pricing_model?: string | null
+          pricing_model_version?: string
+          pricing_v2_snapshot?: Json | null
           status?: string
           stripe_customer_id?: string | null
           stripe_subscription_id?: string | null
@@ -2300,6 +2304,8 @@ export type Database = {
           id?: string
           price_per_sub_org_cents?: number | null
           pricing_model?: string | null
+          pricing_model_version?: string
+          pricing_v2_snapshot?: Json | null
           status?: string
           stripe_customer_id?: string | null
           stripe_subscription_id?: string | null
@@ -4863,6 +4869,8 @@ export type Database = {
           media_storage_quota_bytes: number | null
           organization_id: string
           parents_bucket: string
+          pricing_model_version: string
+          pricing_v2_snapshot: Json | null
           status: string
           stripe_customer_id: string | null
           stripe_subscription_id: string | null
@@ -4880,6 +4888,8 @@ export type Database = {
           media_storage_quota_bytes?: number | null
           organization_id: string
           parents_bucket?: string
+          pricing_model_version?: string
+          pricing_v2_snapshot?: Json | null
           status?: string
           stripe_customer_id?: string | null
           stripe_subscription_id?: string | null
@@ -4897,6 +4907,8 @@ export type Database = {
           media_storage_quota_bytes?: number | null
           organization_id?: string
           parents_bucket?: string
+          pricing_model_version?: string
+          pricing_v2_snapshot?: Json | null
           status?: string
           stripe_customer_id?: string | null
           stripe_subscription_id?: string | null

--- a/supabase/migrations/20260429120000_pricing_v2_subscription_columns.sql
+++ b/supabase/migrations/20260429120000_pricing_v2_subscription_columns.sql
@@ -1,0 +1,24 @@
+-- Pricing v2: discriminator + snapshot columns on subscription tables.
+--
+-- v1 and v2 subscriptions coexist. Existing rows backfill to 'v1'. New v2
+-- signups (org_v2 / enterprise_v2 webhook branches) write 'v2' plus the
+-- pure quote() inputs + breakdown so we can audit, reprice, or migrate
+-- later without parsing Stripe metadata.
+
+ALTER TABLE organization_subscriptions
+  ADD COLUMN IF NOT EXISTS pricing_model_version text NOT NULL DEFAULT 'v1'
+    CHECK (pricing_model_version IN ('v1', 'v2')),
+  ADD COLUMN IF NOT EXISTS pricing_v2_snapshot jsonb;
+
+ALTER TABLE enterprise_subscriptions
+  ADD COLUMN IF NOT EXISTS pricing_model_version text NOT NULL DEFAULT 'v1'
+    CHECK (pricing_model_version IN ('v1', 'v2')),
+  ADD COLUMN IF NOT EXISTS pricing_v2_snapshot jsonb;
+
+-- Backfill is implicit via DEFAULT 'v1'. No-op for already-existing rows
+-- because PostgreSQL fills the new column with the default value at ALTER time.
+
+COMMENT ON COLUMN organization_subscriptions.pricing_model_version IS 'v1 = legacy bucket pricing; v2 = per-user slab pricing.';
+COMMENT ON COLUMN organization_subscriptions.pricing_v2_snapshot IS 'Snapshot of v2 quote() inputs + breakdown at subscription creation. Null for v1 rows.';
+COMMENT ON COLUMN enterprise_subscriptions.pricing_model_version IS 'v1 = legacy bucket pricing; v2 = per-user slab pricing.';
+COMMENT ON COLUMN enterprise_subscriptions.pricing_v2_snapshot IS 'Snapshot of v2 quote() inputs + breakdown at subscription creation. Null for v1 rows.';

--- a/tests/pricing-v2.test.ts
+++ b/tests/pricing-v2.test.ts
@@ -1,7 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 
-import { quote, SALES_LED_ALUMNI_THRESHOLD } from "@/lib/pricing-v2";
+import {
+  quote,
+  SALES_LED_ALUMNI_THRESHOLD,
+  isSelfServeSalesLed,
+  SELF_SERVE_ALUMNI_LIMIT,
+  SELF_SERVE_SUB_ORG_LIMIT,
+} from "@/lib/pricing-v2";
 
 describe("pricing-v2 quote() — pinned scenarios", () => {
   it("single org: 200 actives + 1,200 alumni → $320/mo, $3,187.20/yr", () => {
@@ -85,5 +91,69 @@ describe("pricing-v2 quote() — edges", () => {
     assert.strictEqual(q.monthlyCents, 0);
     assert.strictEqual(q.breakdown.subOrgMonthlyCents, 0);
     assert.strictEqual(q.breakdown.subOrgsBilled, 0);
+  });
+});
+
+describe("pricing-v2 isSelfServeSalesLed()", () => {
+  it("single tier at limit not sales-led", () => {
+    assert.strictEqual(
+      isSelfServeSalesLed({ tier: "single", actives: 100, alumni: SELF_SERVE_ALUMNI_LIMIT }),
+      false,
+    );
+  });
+
+  it("single tier above limit sales-led", () => {
+    assert.strictEqual(
+      isSelfServeSalesLed({ tier: "single", actives: 100, alumni: SELF_SERVE_ALUMNI_LIMIT + 1 }),
+      true,
+    );
+  });
+
+  it("enterprise tier at sub-org cap not sales-led", () => {
+    assert.strictEqual(
+      isSelfServeSalesLed({
+        tier: "enterprise",
+        actives: 100,
+        alumni: 1_000,
+        subOrgs: SELF_SERVE_SUB_ORG_LIMIT,
+      }),
+      false,
+    );
+  });
+
+  it("enterprise tier above sub-org cap sales-led", () => {
+    assert.strictEqual(
+      isSelfServeSalesLed({
+        tier: "enterprise",
+        actives: 100,
+        alumni: 1_000,
+        subOrgs: SELF_SERVE_SUB_ORG_LIMIT + 1,
+      }),
+      true,
+    );
+  });
+
+  it("enterprise alumni overflow trumps small sub-org count", () => {
+    assert.strictEqual(
+      isSelfServeSalesLed({
+        tier: "enterprise",
+        actives: 0,
+        alumni: SELF_SERVE_ALUMNI_LIMIT + 1,
+        subOrgs: 0,
+      }),
+      true,
+    );
+  });
+
+  it("single tier ignores subOrgs for sales-led check", () => {
+    assert.strictEqual(
+      isSelfServeSalesLed({
+        tier: "single",
+        actives: 0,
+        alumni: 0,
+        subOrgs: SELF_SERVE_SUB_ORG_LIMIT + 100,
+      }),
+      false,
+    );
   });
 });

--- a/tests/routes/stripe/v2-checkout-routes.test.ts
+++ b/tests/routes/stripe/v2-checkout-routes.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readSource(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+describe("v2 Stripe checkout routes", () => {
+  const orgRoute = readSource("src/app/api/stripe/create-org-v2-checkout/route.ts");
+  const enterpriseRoute = readSource("src/app/api/stripe/create-enterprise-v2-checkout/route.ts");
+
+  it("org v2 route validates auth, schema, slug collision, sales mode, checkout metadata, and idempotency", () => {
+    assert.match(orgRoute, /if \(!user\)[\s\S]*Unauthorized/);
+    assert.match(orgRoute, /validateJson\(req, createOrgV2Schema/);
+    assert.match(orgRoute, /serviceSupabase[\s\S]*\.from\("organizations"\)[\s\S]*\.eq\("slug", slug\)/);
+    assert.match(orgRoute, /Slug is already taken/);
+    assert.match(orgRoute, /isSelfServeSalesLed\(\{ tier: "single"/);
+    assert.match(orgRoute, /return respond\(\{ mode: "sales", organizationSlug: org\.slug \}\)/);
+    assert.match(orgRoute, /flowType: "org_v2_checkout"/);
+    assert.match(orgRoute, /type: "org_v2"/);
+    assert.match(orgRoute, /payment_attempt_id: claimedAttempt\.id/);
+    assert.match(orgRoute, /stripe\.checkout\.sessions\.create/);
+    assert.match(orgRoute, /success_url: `\$\{origin\}\/app\?org=\$\{slug\}&checkout=success`/);
+    assert.match(orgRoute, /cancel_url: `\$\{origin\}\/app\/create-org\?checkout=cancel`/);
+  });
+
+  it("enterprise v2 route validates auth, schema, slug collision, sales mode, checkout metadata, and idempotency", () => {
+    assert.match(enterpriseRoute, /if \(!user\)[\s\S]*Unauthorized/);
+    assert.match(enterpriseRoute, /validateJson\(req, createEnterpriseV2Schema/);
+    assert.match(enterpriseRoute, /\.from\("enterprises"\)[\s\S]*\.eq\("slug", slug\)/);
+    assert.match(enterpriseRoute, /\.from\("organizations"\)[\s\S]*\.eq\("slug", slug\)/);
+    assert.match(enterpriseRoute, /Slug is already taken/);
+    assert.match(enterpriseRoute, /isSelfServeSalesLed\(\{ tier: "enterprise"/);
+    assert.match(enterpriseRoute, /return respond\(\{ mode: "sales", enterpriseSlug: ent\.slug \}\)/);
+    assert.match(enterpriseRoute, /flowType: "enterprise_v2_checkout"/);
+    assert.match(enterpriseRoute, /type: "enterprise_v2"/);
+    assert.match(enterpriseRoute, /payment_attempt_id: claimedAttempt\.id/);
+    assert.match(enterpriseRoute, /stripe\.checkout\.sessions\.create/);
+    assert.match(enterpriseRoute, /success_url: `\$\{origin\}\/app\?enterprise=\$\{slug\}&checkout=success`/);
+    assert.match(enterpriseRoute, /cancel_url: `\$\{origin\}\/app\/create-enterprise\?checkout=cancel`/);
+  });
+});

--- a/tests/routes/stripe/webhook-v2-security.test.ts
+++ b/tests/routes/stripe/webhook-v2-security.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const source = readFileSync(join(process.cwd(), "src/app/api/stripe/webhook/handler.ts"), "utf8");
+const enterpriseV2Block = source.slice(
+  source.indexOf('if (session.metadata?.type === "enterprise_v2")'),
+  source.indexOf('// v2 dynamic-quote test slice'),
+);
+
+describe("stripe webhook enterprise_v2 security", () => {
+  it("resolves enterprise owner from payment_attempts, not creator_id metadata", () => {
+    assert.match(enterpriseV2Block, /resolveCreatorFromPaymentAttempt\(v2AttemptId\)/);
+    assert.doesNotMatch(enterpriseV2Block, /metadata\?\.creator_id/);
+    assert.match(enterpriseV2Block, /user_id: ownerUserId/);
+  });
+
+  it("retrieves Stripe subscription status and current period end", () => {
+    assert.match(enterpriseV2Block, /stripeClient\.subscriptions\.retrieve\(subscriptionId\)/);
+    assert.match(enterpriseV2Block, /enterpriseStatus = normalizeSubscriptionStatus\(subscription\)/);
+    assert.match(enterpriseV2Block, /enterprisePeriodEnd = extractSubscriptionPeriodEndIso\(subscription\)/);
+    assert.match(enterpriseV2Block, /status: enterpriseStatus/);
+    assert.match(enterpriseV2Block, /current_period_end: enterprisePeriodEnd/);
+  });
+});

--- a/tests/schemas/organization-v2.test.ts
+++ b/tests/schemas/organization-v2.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createOrgV2Schema,
+  createEnterpriseV2Schema,
+} from "@/lib/schemas/organization-v2";
+
+const validOrg = {
+  name: "Test Org",
+  slug: "test-org",
+  description: "An org",
+  primaryColor: "#1e3a5f",
+  billingInterval: "month" as const,
+  actives: 100,
+  alumni: 500,
+};
+
+const validEnt = {
+  ...validOrg,
+  subOrgs: 5,
+  billingContactEmail: "billing@example.com",
+};
+
+describe("createOrgV2Schema", () => {
+  it("accepts minimal valid payload", () => {
+    const r = createOrgV2Schema.safeParse(validOrg);
+    assert.ok(r.success);
+  });
+
+  it("accepts zero actives + zero alumni (route handles totalCents)", () => {
+    const r = createOrgV2Schema.safeParse({ ...validOrg, actives: 0, alumni: 0 });
+    assert.ok(r.success);
+  });
+
+  it("rejects missing actives", () => {
+    const { actives: _drop, ...rest } = validOrg;
+    void _drop;
+    const r = createOrgV2Schema.safeParse(rest);
+    assert.ok(!r.success);
+  });
+
+  it("rejects actives over cap", () => {
+    const r = createOrgV2Schema.safeParse({ ...validOrg, actives: 2_000_000 });
+    assert.ok(!r.success);
+  });
+
+  it("rejects negative alumni", () => {
+    const r = createOrgV2Schema.safeParse({ ...validOrg, alumni: -1 });
+    assert.ok(!r.success);
+  });
+
+  it("rejects bad slug", () => {
+    const r = createOrgV2Schema.safeParse({ ...validOrg, slug: "Bad Slug!" });
+    assert.ok(!r.success);
+  });
+
+  it("rejects bad hex color", () => {
+    const r = createOrgV2Schema.safeParse({ ...validOrg, primaryColor: "blue" });
+    assert.ok(!r.success);
+  });
+
+  it("rejects unknown fields (strict)", () => {
+    const r = createOrgV2Schema.safeParse({ ...validOrg, monthlyCents: 9999 });
+    assert.ok(!r.success);
+  });
+
+  it("accepts optional idempotencyKey", () => {
+    const r = createOrgV2Schema.safeParse({
+      ...validOrg,
+      idempotencyKey: "11111111-1111-4111-8111-111111111111",
+    });
+    assert.ok(r.success);
+  });
+});
+
+describe("createEnterpriseV2Schema", () => {
+  it("accepts minimal valid enterprise payload", () => {
+    const r = createEnterpriseV2Schema.safeParse(validEnt);
+    assert.ok(r.success);
+  });
+
+  it("rejects subOrgs over cap", () => {
+    const r = createEnterpriseV2Schema.safeParse({ ...validEnt, subOrgs: 1_001 });
+    assert.ok(!r.success);
+  });
+
+  it("rejects bad billing email", () => {
+    const r = createEnterpriseV2Schema.safeParse({
+      ...validEnt,
+      billingContactEmail: "not-an-email",
+    });
+    assert.ok(!r.success);
+  });
+
+  it("rejects missing subOrgs", () => {
+    const { subOrgs: _drop, ...rest } = validEnt;
+    void _drop;
+    const r = createEnterpriseV2Schema.safeParse(rest);
+    assert.ok(!r.success);
+  });
+});


### PR DESCRIPTION
## Summary
- Cuts new-customer signup flows (`/app/create-org`, `/app/create-enterprise`) over to pricing v2 (per-user model). v1 routes, v1 pricing modules, and existing v1 customer subscriptions are untouched.
- Adds two new self-serve checkout routes that recompute `quote()` server-side, snapshot v2 inputs into Stripe + `payment_attempts.metadata`, and create Stripe sessions with inline `price_data` against `STRIPE_PRODUCT_ID_DYNAMIC`.
- Webhook gets `org_v2` and `enterprise_v2` short-circuits ahead of the generic `mode === "subscription"` branch. Both provision org/enterprise + admin/owner role + `*_subscriptions` row with `pricing_model_version='v2'` and a JSON snapshot. Enterprise owner is resolved from `payment_attempts.user_id` (not trusted from metadata), and subscription `status` + `current_period_end` are pulled from Stripe.
- Sales-led path preserved at v1 thresholds (alumni > 5000 for org; alumni > 5000 OR sub-orgs > 25 for enterprise) — pre-creates the row with `status='pending_sales'` and skips Stripe.
- UI replaces v1 `alumniBucket` / `seatQuantity` / `alumniBucketQuantity` inputs with free-form actives + alumni (+ subOrgs for enterprise). v1 trial toggle removed in v2. Distinct localStorage idempotency keys.

## Risk
- Webhook precedence: v2 short-circuits sit above the generic `mode === "subscription"` branch with an explicit comment. Wrong order would clobber v2 state with v1 column defaults.
- Sales-led pre-creation creates org rows that never see Stripe — same pattern as v1 today.
- v1 webhook branches and v1 routes remain functional for in-flight sessions; cleanup deferred to a follow-up after prod soak.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] New unit tests pass: `tests/pricing-v2.test.ts`, `tests/schemas/organization-v2.test.ts`
- [x] New route + webhook security tests pass: `tests/routes/stripe/v2-checkout-routes.test.ts`, `tests/routes/stripe/webhook-v2-security.test.ts`
- [ ] Manual: create-org happy path → Stripe Checkout → org provisioned with `pricing_model_version='v2'`, snapshot, admin role
- [ ] Manual: create-org alumni > 5000 → sales-led, no Stripe call, `status='pending_sales'`
- [ ] Manual: create-enterprise happy path → enterprise provisioned with v2 columns + owner role
- [ ] Manual: create-enterprise sub-orgs > 25 → sales-led
- [ ] Manual: duplicate slug returns 409 before Stripe
- [ ] Manual: replay same idempotency key returns same checkout URL

## Rollout
1. Migration `pricing_model_version` + `pricing_v2_snapshot` already shipped (prior commit).
2. Deploy this branch.
3. Stripe dashboard sanity check after first v2 prod signup: subscription product = dynamic v2 product, line item is `price_data` (not a saved Price), session metadata includes `type: org_v2` / `enterprise_v2`.
4. Monitor: `select pricing_model_version, count(*) from organization_subscriptions group by 1`.

## Rollback
- Revert this PR. v1 routes still work; UI link reversion restores prior signup. Existing v2 subscriptions created in the soak window keep billing on inline `price_data` independent of code.