### PR TITLE
fix(payments): address pricing-v2 code review findings

### DIFF
--- a/src/app/api/stripe/create-custom-quote-checkout/route.ts
+++ b/src/app/api/stripe/create-custom-quote-checkout/route.ts
@@ -113,7 +113,6 @@ export async function POST(req: Request) {
 
       const attemptMetadata: Record<string, unknown> = {
         pricing_model_version: "v2",
-        flow_type_v2: "dynamic_quote_checkout",
         tier,
         billing_interval: billingInterval,
         actives,

--- a/src/app/api/stripe/create-custom-quote-checkout/route.ts
+++ b/src/app/api/stripe/create-custom-quote-checkout/route.ts
@@ -17,10 +17,13 @@ import {
   ensurePaymentAttempt,
   hashFingerprint,
   hasStripeResource,
-  IdempotencyConflictError,
   updatePaymentAttempt,
   waitForExistingStripeResource,
 } from "@/lib/payments/idempotency";
+import {
+  buildCheckoutErrorResponse,
+  extractErrorMessage,
+} from "@/lib/payments/stripe-error";
 import { buildDynamicQuoteCheckoutFingerprintPayload } from "@/lib/payments/dynamic-quote-checkout-fingerprint";
 import { quote } from "@/lib/pricing-v2";
 
@@ -243,15 +246,7 @@ export async function POST(req: Request) {
         paymentAttemptId: claimedAttempt.id,
       });
     } catch (error) {
-      if (error instanceof IdempotencyConflictError) {
-        return respond({ error: error.message }, 409);
-      }
-
-      const stripeErr = error as {
-        message?: string;
-        raw?: { message?: string };
-      };
-      const lastError = stripeErr?.message || stripeErr?.raw?.message || "checkout_failed";
+      const lastError = extractErrorMessage(error);
 
       if (resolvedAttemptId) {
         const errorUpdate: { last_error: string; status?: string } = { last_error: lastError };
@@ -262,8 +257,8 @@ export async function POST(req: Request) {
         await serviceSupabase.from("payment_attempts").update(errorUpdate as any).eq("id", resolvedAttemptId);
       }
 
-      const message = error instanceof Error ? error.message : "Unable to create checkout session";
-      return respond({ error: message }, 400);
+      console.error("[create-custom-quote-checkout] error:", lastError);
+      return buildCheckoutErrorResponse(error, { headers: rateLimit.headers });
     }
   } catch (error) {
     if (error instanceof ValidationError) {

--- a/src/app/api/stripe/create-enterprise-v2-checkout/route.ts
+++ b/src/app/api/stripe/create-enterprise-v2-checkout/route.ts
@@ -182,7 +182,6 @@ export async function POST(req: Request) {
       );
 
       const attemptMetadata: Record<string, unknown> = {
-        flow_type_v2: "enterprise_v2_checkout",
         pricing_model_version: "v2",
         tier: "enterprise",
         slug,

--- a/src/app/api/stripe/create-enterprise-v2-checkout/route.ts
+++ b/src/app/api/stripe/create-enterprise-v2-checkout/route.ts
@@ -59,7 +59,6 @@ export async function POST(req: Request) {
       name,
       slug,
       description,
-      primaryColor,
       billingInterval,
       actives,
       alumni,
@@ -275,7 +274,6 @@ export async function POST(req: Request) {
         enterprise_name: name.slice(0, 200),
         enterprise_slug: slug,
         enterprise_description: (description || "").slice(0, 500),
-        enterprise_primary_color: primaryColor,
         billing_contact_email: billingContactEmail,
       } as const;
 

--- a/src/app/api/stripe/create-org-v2-checkout/route.ts
+++ b/src/app/api/stripe/create-org-v2-checkout/route.ts
@@ -165,7 +165,6 @@ export async function POST(req: Request) {
       );
 
       const attemptMetadata: Record<string, unknown> = {
-        flow_type_v2: "org_v2_checkout",
         pricing_model_version: "v2",
         tier: "single",
         slug,

--- a/src/app/api/stripe/create-org-v2-checkout/route.ts
+++ b/src/app/api/stripe/create-org-v2-checkout/route.ts
@@ -129,9 +129,11 @@ export async function POST(req: Request) {
         return respond({ mode: "sales", organizationSlug: org.slug });
       } catch (error) {
         if (orgId) {
-          await supabase.from("organization_subscriptions").delete().eq("organization_id", orgId);
-          await supabase.from("user_organization_roles").delete().eq("organization_id", orgId).eq("user_id", user.id);
-          await supabase.from("organizations").delete().eq("id", orgId);
+          // Use service client uniformly so cleanup is not partially blocked
+          // by RLS if any single delete races with policy evaluation.
+          await serviceSupabase.from("organization_subscriptions").delete().eq("organization_id", orgId);
+          await serviceSupabase.from("user_organization_roles").delete().eq("organization_id", orgId).eq("user_id", user.id);
+          await serviceSupabase.from("organizations").delete().eq("id", orgId);
         }
         const message = error instanceof Error ? error.message : "Unable to start checkout";
         console.error("[create-org-v2-checkout] sales-led error:", message);

--- a/src/app/api/stripe/webhook/handler.ts
+++ b/src/app/api/stripe/webhook/handler.ts
@@ -622,9 +622,15 @@ export async function handleStripeWebhookPost(
             );
           }
 
-          const ownerUserId = await resolveCreatorFromPaymentAttempt(v2AttemptId);
+          let ownerUserId = await resolveCreatorFromPaymentAttempt(v2AttemptId);
           if (!ownerUserId) {
-            console.error("[stripe-webhook] enterprise_v2 owner grant failed - no creator in payment_attempts", {
+            // Fallback to metadata.creator_id when payment_attempts has no row.
+            // Mirrors the org_v2 branch above so a missing/lost attempt id does
+            // not orphan the enterprise without an owner.
+            ownerUserId = (session.metadata?.creator_id as string | undefined) ?? null;
+          }
+          if (!ownerUserId) {
+            console.error("[stripe-webhook] enterprise_v2 owner grant failed - no creator in payment_attempts or metadata", {
               eventId: maskPII(event.id),
               enterpriseId: maskPII(enterprise.id),
             });

--- a/src/app/api/stripe/webhook/handler.ts
+++ b/src/app/api/stripe/webhook/handler.ts
@@ -622,15 +622,9 @@ export async function handleStripeWebhookPost(
             );
           }
 
-          let ownerUserId = await resolveCreatorFromPaymentAttempt(v2AttemptId);
+          const ownerUserId = await resolveCreatorFromPaymentAttempt(v2AttemptId);
           if (!ownerUserId) {
-            // Fallback to metadata.creator_id when payment_attempts has no row.
-            // Mirrors the org_v2 branch above so a missing/lost attempt id does
-            // not orphan the enterprise without an owner.
-            ownerUserId = (session.metadata?.creator_id as string | undefined) ?? null;
-          }
-          if (!ownerUserId) {
-            console.error("[stripe-webhook] enterprise_v2 owner grant failed - no creator in payment_attempts or metadata", {
+            console.error("[stripe-webhook] enterprise_v2 owner grant failed - no creator in payment_attempts", {
               eventId: maskPII(event.id),
               enterpriseId: maskPII(enterprise.id),
             });

--- a/src/app/api/stripe/webhook/handler.ts
+++ b/src/app/api/stripe/webhook/handler.ts
@@ -405,7 +405,7 @@ export async function handleStripeWebhookPost(
           if (typeof rawSnapshot === "string" && rawSnapshot.length > 0) {
             try {
               const parsed = JSON.parse(rawSnapshot);
-              if (parsed && typeof parsed === "object") {
+              if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
                 snapshot = parsed as Record<string, unknown>;
               }
             } catch {
@@ -562,7 +562,7 @@ export async function handleStripeWebhookPost(
           if (typeof rawSnapshot === "string" && rawSnapshot.length > 0) {
             try {
               const parsed = JSON.parse(rawSnapshot);
-              if (parsed && typeof parsed === "object") {
+              if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
                 snapshot = parsed as Record<string, unknown>;
               }
             } catch {

--- a/src/lib/payments/stripe-error.ts
+++ b/src/lib/payments/stripe-error.ts
@@ -19,7 +19,9 @@ export function classifyCheckoutError(error: unknown): StripeErrorClass {
   const type = e?.type || e?.name || e?.raw?.type || "";
   if (typeof type === "string" && type.startsWith("Stripe")) return "stripe";
   if (typeof e?.raw?.type === "string" && e.raw.type.endsWith("_error")) return "stripe";
-  if (e?.requestId || e?.raw?.requestId || e?.statusCode || e?.raw?.statusCode) return "stripe";
+  // requestId is Stripe-specific (req_*); statusCode alone is not — many
+  // non-Stripe errors carry a statusCode and should fall through to "internal".
+  if (e?.requestId || e?.raw?.requestId) return "stripe";
   return "internal";
 }
 

--- a/src/lib/payments/stripe-error.ts
+++ b/src/lib/payments/stripe-error.ts
@@ -11,7 +11,7 @@ type ErrLike = {
   raw?: { code?: string; message?: string; requestId?: string; statusCode?: number; type?: string };
 };
 
-export type StripeErrorClass = "stripe" | "idempotency" | "internal";
+type StripeErrorClass = "stripe" | "idempotency" | "internal";
 
 export function classifyCheckoutError(error: unknown): StripeErrorClass {
   if (error instanceof IdempotencyConflictError) return "idempotency";
@@ -35,7 +35,7 @@ function isVerboseDev() {
   return true;
 }
 
-export type CheckoutErrorBody = {
+type CheckoutErrorBody = {
   error: string;
   detail?: string;
   errorClass?: StripeErrorClass;


### PR DESCRIPTION
## Summary

Addresses 8 actionable findings from the multi-reviewer code review on the pricing-v2 dynamic-quote checkout slice (org + enterprise + custom-quote). One reviewer finding (creator_id fallback for enterprise_v2 owner) was implemented then reverted after it conflicted with an existing security test.

## Changes

Each commit is one logical change:

- `aef2fd13` chore(payments): drop unused exports from stripe-error helper
- `41228bbf` chore(payments): drop unread flow_type_v2 metadata from v2 checkout routes
- `0ebe7a09` chore(payments): drop dead enterprise_primary_color metadata round-trip
- `0b9c7e48` fix(payments): route custom-quote checkout errors through buildCheckoutErrorResponse (P1 — was returning generic 400)
- `3d595fbe` fix(stripe-webhook): reject array payloads in v2 quote_snapshot parse
- `01f93768` fix(stripe-webhook): fall back to creator_id metadata for enterprise_v2 owner grant
- `fd4b98c0` fix(payments): use service client consistently in sales-led cleanup (avoids RLS asymmetry between insert + delete on org_v2 cleanup path)
- `ebbc7f23` fix(payments): tighten stripe-error detection in classifyCheckoutError (statusCode alone no longer routes to "stripe" / 502)
- `55d8437b` revert(stripe-webhook): drop creator_id fallback for enterprise_v2 owner — `01f93768` contradicted `tests/routes/stripe/webhook-v2-security.test.ts`, which deliberately enforces "resolves enterprise owner from payment_attempts, not creator_id metadata". Trusting metadata.creator_id would let anyone able to set session metadata claim the enterprise owner role.

## Risk

Low. Each commit is a small targeted fix with no schema or contract changes. The webhook handler change (P2 array guard) is defense-in-depth — current code already only accepts shaped objects via subsequent property assignment, but failing loud on array input is safer.

The error-class tightening (`ebbc7f23`) changes some failures that were 502 to now be 500. Callers parsing `errorClass` see "internal" instead of "stripe" for non-Stripe errors that happened to have a statusCode. No production caller depends on the old behavior.

## Test plan

- [x] `npx tsc --noEmit` clean for touched files
- [x] `npm run test:routes` — 1748/1748 pass (includes `webhook-v2-security.test.ts`)
- [x] `npm run test:payments` — 11/11 pass
- [x] `npm run test:unit` — 3483/3484 pass (1 pre-existing auth-i18n failure unrelated to this branch)
- [ ] Manual: `/app/create-org` checkout flow returns proper status code on Stripe error
- [ ] Manual: `/app/create-enterprise` sales-led cleanup leaves no orphan rows on rollback

## Rollback

`git revert <commit>` per logical change. Each commit is independently revertable.