### PR TITLE
fix(api): accept Bearer auth on mobile API routes

### DIFF
--- a/src/app/api/stripe/create-org-v2-checkout/route.ts
+++ b/src/app/api/stripe/create-org-v2-checkout/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { stripe } from "@/lib/stripe";
 import { getStripeOrigin } from "@/lib/stripe-origin";
-import { createClient } from "@/lib/supabase/server";
+import { createAuthenticatedApiClient } from "@/lib/supabase/api";
 import { createServiceClient } from "@/lib/supabase/service";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import {
@@ -30,11 +30,21 @@ import { createOrgV2Schema } from "@/lib/schemas/organization-v2";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": process.env.MOBILE_CORS_ORIGIN ?? "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "authorization, content-type",
+  "Access-Control-Max-Age": "86400",
+};
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: CORS_HEADERS });
+}
+
 export async function POST(req: Request) {
   try {
-    const supabase = await createClient();
+    const { supabase, user } = await createAuthenticatedApiClient(req);
     const serviceSupabase = createServiceClient();
-    const { data: { user } } = await supabase.auth.getUser();
 
     const rateLimit = checkRateLimit(req, {
       userId: user?.id ?? null,
@@ -48,7 +58,10 @@ export async function POST(req: Request) {
     }
 
     const respond = (payload: unknown, status = 200) =>
-      NextResponse.json(payload, { status, headers: rateLimit.headers });
+      NextResponse.json(payload, {
+        status,
+        headers: { ...rateLimit.headers, ...CORS_HEADERS },
+      });
 
     if (!user) {
       return respond({ error: "Unauthorized" }, 401);
@@ -137,7 +150,7 @@ export async function POST(req: Request) {
         }
         const message = error instanceof Error ? error.message : "Unable to start checkout";
         console.error("[create-org-v2-checkout] sales-led error:", message);
-        return buildCheckoutErrorResponse(error, { headers: rateLimit.headers });
+        return buildCheckoutErrorResponse(error, { headers: { ...rateLimit.headers, ...CORS_HEADERS } });
       }
     }
 
@@ -313,7 +326,7 @@ export async function POST(req: Request) {
       }
 
       console.error("[create-org-v2-checkout] error:", { errorClass, lastError });
-      return buildCheckoutErrorResponse(error, { headers: rateLimit.headers });
+      return buildCheckoutErrorResponse(error, { headers: { ...rateLimit.headers, ...CORS_HEADERS } });
     }
   } catch (error) {
     if (error instanceof ValidationError) {

--- a/src/lib/supabase/api.ts
+++ b/src/lib/supabase/api.ts
@@ -1,0 +1,40 @@
+import { createServerClient } from "@supabase/ssr";
+import type { User } from "@supabase/supabase-js";
+import { createClient } from "./server";
+import { getSupabaseBrowserEnv } from "./config";
+import type { ServerSupabase } from "./types";
+
+/**
+ * Build a request-scoped Supabase client honoring either Bearer token (mobile)
+ * or cookies (web). Returns `user: null` on missing/invalid auth — callers
+ * should respond 401 in that case.
+ */
+export async function createAuthenticatedApiClient(
+  req: Request,
+): Promise<{ supabase: ServerSupabase; user: User | null }> {
+  const auth = req.headers.get("authorization");
+  const match = auth?.match(/^Bearer (.+)$/);
+
+  if (match) {
+    const token = match[1];
+    const { supabaseUrl, supabaseAnonKey } = getSupabaseBrowserEnv();
+    const client = createServerClient(supabaseUrl, supabaseAnonKey, {
+      cookies: {
+        getAll: () => [],
+        setAll: () => {},
+      },
+      global: {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    });
+    const { data, error } = await client.auth.getUser(token);
+    return {
+      supabase: client as unknown as ServerSupabase,
+      user: error ? null : data.user,
+    };
+  }
+
+  const supabase = await createClient();
+  const { data } = await supabase.auth.getUser();
+  return { supabase, user: data.user };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -143,6 +143,35 @@ export async function middleware(request: NextRequest) {
     );
   }
 
+  // Bearer / CORS branch for /api/* (mobile clients).
+  // Web requests don't send Bearer + don't send OPTIONS preflights to same-origin
+  // POSTs, so this is provably unreachable from the existing web flow.
+  if (pathname.startsWith("/api/")) {
+    if (request.method === "OPTIONS") {
+      return NextResponse.next({ request: { headers: request.headers } });
+    }
+    const authHeader = request.headers.get("authorization");
+    const bearerMatch = authHeader?.match(/^Bearer (eyJ|sb_)/);
+    if (bearerMatch) {
+      const token = authHeader!.slice("Bearer ".length);
+      const tokenClient = createServerClient(supabaseUrl, supabaseAnonKey, {
+        cookies: {
+          getAll: () => [],
+          setAll: () => {},
+        },
+        global: { headers: { Authorization: `Bearer ${token}` } },
+      });
+      const { data, error } = await tokenClient.auth.getUser(token);
+      if (error || !data.user) {
+        return NextResponse.json(
+          { error: "Unauthorized", message: "Authentication required" },
+          { status: 401 },
+        );
+      }
+      return NextResponse.next({ request: { headers: request.headers } });
+    }
+  }
+
   const response = NextResponse.next({
     request: {
       headers: request.headers,

--- a/tests/routes/stripe/v2-checkout-routes.test.ts
+++ b/tests/routes/stripe/v2-checkout-routes.test.ts
@@ -42,6 +42,39 @@ describe("v2 Stripe checkout routes", () => {
     assert.match(enterpriseRoute, /cancel_url: `\$\{origin\}\/app\/create-enterprise\?checkout=cancel`/);
   });
 
+  it("org v2 route accepts Bearer auth via createAuthenticatedApiClient and exposes CORS preflight", () => {
+    assert.match(orgRoute, /createAuthenticatedApiClient/);
+    assert.doesNotMatch(
+      orgRoute,
+      /from "@\/lib\/supabase\/server"/,
+      "v2 org route should no longer import cookie-only createClient",
+    );
+    assert.match(orgRoute, /export async function OPTIONS\(/);
+    assert.match(orgRoute, /Access-Control-Allow-Origin/);
+    assert.match(orgRoute, /Access-Control-Allow-Headers.*authorization/i);
+    assert.match(
+      orgRoute,
+      /headers: \{ \.\.\.rateLimit\.headers, \.\.\.CORS_HEADERS \}/,
+      "respond() must merge CORS_HEADERS into success/error JSON",
+    );
+  });
+
+  it("middleware accepts Bearer tokens for /api/* and short-circuits OPTIONS", () => {
+    const mw = readSource("src/middleware.ts");
+    assert.match(mw, /pathname\.startsWith\("\/api\/"\)/);
+    assert.match(mw, /request\.method === "OPTIONS"/);
+    assert.match(mw, /\^Bearer \(eyJ\|sb_\)/);
+    assert.match(mw, /tokenClient\.auth\.getUser\(token\)/);
+  });
+
+  it("createAuthenticatedApiClient prefers Bearer token, falls back to cookie client", () => {
+    const api = readSource("src/lib/supabase/api.ts");
+    assert.match(api, /\^Bearer \(\.\+\)\$/);
+    assert.match(api, /Authorization: `Bearer \$\{token\}`/);
+    assert.match(api, /createClient\(\)/);
+    assert.match(api, /auth\.getUser\(token\)/);
+  });
+
   it("v2 routes route catch-block errors through buildCheckoutErrorResponse (no generic 400 mask)", () => {
     for (const route of [orgRoute, enterpriseRoute]) {
       assert.match(route, /buildCheckoutErrorResponse\(error/);


### PR DESCRIPTION
## Summary
- Add `createAuthenticatedApiClient(req)`: Bearer-aware Supabase client; cookie fallback unchanged.
- Middleware: scoped Bearer branch for `/api/*` (gated on `Bearer (eyJ|sb_)` prefix) + `OPTIONS` short-circuit. Web cookie flow byte-identical when no Bearer header is present.
- v2 org checkout (`/api/stripe/create-org-v2-checkout`): swap auth helper, add `OPTIONS` handler + CORS headers (`MOBILE_CORS_ORIGIN`, defaults to `*`).

## Out of scope (mobile must follow up)
Mobile (`apps/mobile/src/lib/web-api.ts`) currently posts to deprecated v1 (`create-org-checkout`). This PR fixes v2 only. **Mobile production signup remains broken until a mobile-repo PR bumps the call to v2.** Recommended sequencing: land+deploy this PR → mobile PR → mobile release.

## Risk
Touches `src/middleware.ts` — global blast radius. Mitigations:
- Bearer branch gated on `pathname.startsWith("/api/")` AND `Authorization: Bearer (eyJ|sb_)` prefix → web traffic skips it entirely.
- OPTIONS short-circuit only fires on `OPTIONS` method (web POSTs are same-origin, no preflight).
- Cookie path returns from the same `createServerClient` block as before; no behavior change.
- CORS headers additive (browsers ignore `Access-Control-Allow-*` on same-origin responses).

## Test plan
- [x] `npm run lint`
- [x] `npm run test:routes` (1751 pass, +3 new)
- [x] `npm run test:payments` (11 pass)
- [x] `npm run test:unit` (3489 pass)
- [ ] Manual web smoke: log in, hit v2 checkout, confirm Stripe redirect.
- [ ] Manual mobile smoke (after mobile PR ships).

## Env
- `MOBILE_CORS_ORIGIN` (optional) — tightens `Access-Control-Allow-Origin`. Defaults to `*` because native clients send no Origin.