### PR TITLE
feat(notifications): port Expo Push fan-out to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "animejs": "^4.2.2",
         "cheerio": "^1.2.0",
         "cmdk": "^1.1.1",
+        "expo-server-sdk": "^3.10.0",
         "falkordb": "^6.6.2",
         "falkordblite": "^0.2.0",
         "framer-motion": "^12.38.0",
@@ -4276,6 +4277,12 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT"
+    },
     "node_modules/es-abstract": {
       "version": "1.24.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
@@ -4974,6 +4981,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expo-server-sdk": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-3.15.0.tgz",
+      "integrity": "sha512-Y71mQ7yeDhq6miHzn4kwRQOjqvBBsWeFXvyS9PYc6uqO/+UiYvrw3vMQiQqRxg2y0qgn9jMsvjf8T+mukSH85A==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.0",
+        "promise-limit": "^2.7.0",
+        "promise-retry": "^2.0.1"
+      }
+    },
+    "node_modules/expo-server-sdk/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5024,6 +5062,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/falkordblite/node_modules/@falkordblite/darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/falkordblite/node_modules/@falkordblite/linux-x64": {
+      "optional": true
     },
     "node_modules/fast-check": {
       "version": "4.7.0",
@@ -5274,7 +5318,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7880,17 +7923,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -8700,6 +8732,25 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -9182,6 +9233,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -10042,6 +10102,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -10499,6 +10565,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webpack-bundle-analyzer": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
@@ -10579,6 +10651,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5063,12 +5063,6 @@
         }
       }
     },
-    "node_modules/falkordblite/node_modules/@falkordblite/darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/falkordblite/node_modules/@falkordblite/linux-x64": {
-      "optional": true
-    },
     "node_modules/fast-check": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
@@ -5318,6 +5312,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7921,6 +7916,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-themes": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "openai": "^6.32.0",
     "pdf-parse": "^2.4.5",
     "qrcode": "^1.5.4",
+    "expo-server-sdk": "^3.10.0",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.71.1",

--- a/src/app/api/cron/notification-dispatch/route.ts
+++ b/src/app/api/cron/notification-dispatch/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { validateCronAuth } from "@/lib/security/cron-auth";
+import { sendPush, type PushType } from "@/lib/notifications/push";
+import type { NotificationCategory } from "@/lib/notifications";
+import type { NotificationAudience } from "@/types/database";
+
+/**
+ * Notification dispatch cron worker — drains the `notification_jobs` queue
+ * every minute. For each pending row:
+ *   1. Lease (set status='processing' + leased_at=now()).
+ *   2. Dispatch `kind="standard"` via sendPush with forceInline=true so the
+ *      worker doesn't re-enqueue the same job (the bug commit 0f38c9bb fixed).
+ *   3. Mark succeeded or increment attempts + set last_error. After
+ *      MAX_ATTEMPTS we mark `failed` so the row stops re-leasing.
+ *
+ * Live Activity / APNs kinds are not handled here on main — those land in a
+ * later port if/when the LA pipeline is brought across.
+ */
+export const dynamic = "force-dynamic";
+
+const BATCH_SIZE = 200;
+const MAX_ATTEMPTS = 5;
+
+interface JobRow {
+  id: string;
+  organization_id: string;
+  kind: string;
+  priority: number;
+  audience: string | null;
+  target_user_ids: string[] | null;
+  category: string | null;
+  push_type: string | null;
+  push_resource_id: string | null;
+  title: string | null;
+  body: string | null;
+  data: Record<string, unknown> | null;
+  attempts: number;
+}
+
+export async function GET(request: Request) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const service = createServiceClient();
+  const startedAt = Date.now();
+
+  // 1. Pick candidate ids.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const svc = service as any;
+  const { data: candidates, error: pickError } = await svc
+    .from("notification_jobs")
+    .select("id")
+    .eq("status", "pending")
+    .lte("scheduled_for", new Date().toISOString())
+    .order("priority", { ascending: true })
+    .order("scheduled_for", { ascending: true })
+    .limit(BATCH_SIZE);
+
+  if (pickError) {
+    console.error("[notification-dispatch] pick failed:", pickError.message);
+    return NextResponse.json(
+      { success: false, error: pickError.message },
+      { status: 500 },
+    );
+  }
+
+  const candidateIds = ((candidates ?? []) as Array<{ id: string }>).map((r) => r.id);
+  if (candidateIds.length === 0) {
+    return NextResponse.json({ success: true, leased: 0, dispatched: 0 });
+  }
+
+  // 2. Claim them. UPDATE WHERE status='pending' so racing workers can't
+  //    re-claim the same rows.
+  const { data: leased, error: leaseError } = await svc
+    .from("notification_jobs")
+    .update({ status: "processing", leased_at: new Date().toISOString() })
+    .in("id", candidateIds)
+    .eq("status", "pending")
+    .select(
+      "id, organization_id, kind, priority, audience, target_user_ids, category, push_type, push_resource_id, title, body, data, attempts",
+    );
+
+  if (leaseError) {
+    console.error("[notification-dispatch] lease failed:", leaseError.message);
+    return NextResponse.json(
+      { success: false, error: leaseError.message },
+      { status: 500 },
+    );
+  }
+
+  let dispatched = 0;
+  const results: Array<{ id: string; status: string; sent?: number; error?: string }> = [];
+
+  for (const job of (leased ?? []) as JobRow[]) {
+    try {
+      if (job.kind !== "standard") {
+        // Live Activity / APNs not handled in this port. Mark failed so the
+        // row doesn't keep re-leasing.
+        throw new Error(`unsupported kind=${job.kind} (Live Activity not yet ported to main)`);
+      }
+
+      // Resolve orgSlug for deep-link routing.
+      let jobOrgSlug = (job.data as { orgSlug?: string } | null)?.orgSlug ?? undefined;
+      if (!jobOrgSlug && job.organization_id) {
+        const { data: orgRow } = await service
+          .from("organizations")
+          .select("slug")
+          .eq("id", job.organization_id)
+          .maybeSingle();
+        jobOrgSlug = (orgRow as { slug?: string } | null)?.slug ?? undefined;
+      }
+
+      const result = await sendPush({
+        supabase: service,
+        organizationId: job.organization_id,
+        audience: (job.audience as NotificationAudience | null) ?? null,
+        targetUserIds: job.target_user_ids,
+        title: job.title ?? "",
+        body: job.body ?? "",
+        category: (job.category as NotificationCategory | undefined) ?? undefined,
+        pushType: (job.push_type as PushType | undefined) ?? undefined,
+        pushResourceId: job.push_resource_id ?? undefined,
+        data: (job.data ?? {}) as Record<string, unknown>,
+        orgSlug: jobOrgSlug,
+        forceInline: true,
+      });
+
+      if (result.errors.length > 0) {
+        throw new Error(result.errors.join("; "));
+      }
+
+      await svc
+        .from("notification_jobs")
+        .update({
+          status: "succeeded",
+          sent_at: new Date().toISOString(),
+          last_error: null,
+        })
+        .eq("id", job.id);
+
+      dispatched += 1;
+      results.push({ id: job.id, status: "succeeded", sent: result.sent });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const nextAttempts = job.attempts + 1;
+      const finalStatus: "failed" | "pending" =
+        nextAttempts >= MAX_ATTEMPTS ? "failed" : "pending";
+
+      await svc
+        .from("notification_jobs")
+        .update({
+          status: finalStatus,
+          attempts: nextAttempts,
+          last_error: message.slice(0, 2000),
+          leased_at: null,
+        })
+        .eq("id", job.id);
+
+      results.push({ id: job.id, status: finalStatus === "failed" ? "failed" : "retry", error: message });
+      console.error(
+        `[notification-dispatch] job ${job.id} failed (attempt ${nextAttempts}): ${message}`,
+      );
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    leased: ((leased ?? []) as JobRow[]).length,
+    dispatched,
+    elapsedMs: Date.now() - startedAt,
+    results,
+  });
+}

--- a/src/app/api/notifications/send/route.ts
+++ b/src/app/api/notifications/send/route.ts
@@ -5,9 +5,9 @@ import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { sendNotificationBlast, sendEmail as sendEmailStub } from "@/lib/notifications";
 import type { EmailParams, NotificationResult, NotificationCategory } from "@/lib/notifications";
+import { sendPush, type PushType } from "@/lib/notifications/push";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import {
-  baseSchemas,
   optionalSafeString,
   uuidArray,
   validateJson,
@@ -16,6 +16,41 @@ import {
 } from "@/lib/security/validation";
 import { checkOrgReadOnly, readOnlyResponse } from "@/lib/subscription/read-only-guard";
 import type { NotificationAudience, NotificationChannel } from "@/types/database";
+
+// Channels the request body may carry. The route normalizes everything below.
+type RequestedChannel = "email" | "sms" | "both" | "push" | "all" | "email_sms";
+
+function shouldSendBlast(channel: RequestedChannel): boolean {
+  return (
+    channel === "email" ||
+    channel === "sms" ||
+    channel === "both" ||
+    channel === "email_sms" ||
+    channel === "all"
+  );
+}
+
+function shouldSendPush(channel: RequestedChannel): boolean {
+  return channel === "push" || channel === "all";
+}
+
+function mapBlastChannel(channel: RequestedChannel): NotificationChannel {
+  if (channel === "push") return "email"; // unused when blast skipped, but keep type stable
+  if (channel === "sms") return "sms";
+  if (channel === "both" || channel === "email_sms" || channel === "all") return "both";
+  return "email";
+}
+
+// Lenient UUID — accepts any 36-char hex+dash form. Postgres `gen_random_uuid()`
+// emits v4 UUIDs which always pass, but zod's strict UUID regex rejects
+// non-RFC4122 shapes (e.g. v0/legacy). Bad inputs simply find no row and get a
+// 404, so a relaxed regex is safe.
+const looseUuid = z
+  .string()
+  .trim()
+  .regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, {
+    message: "Must be a 36-char UUID",
+  });
 
 const resend = process.env.RESEND_API_KEY
   ? new Resend(process.env.RESEND_API_KEY)
@@ -37,18 +72,65 @@ const mapAnnouncementAudience = (audience: string): NotificationAudience => {
 
 const notificationSchema = z
   .object({
-    announcementId: baseSchemas.uuid.optional(),
-    notificationId: baseSchemas.uuid.optional(),
-    organizationId: baseSchemas.uuid.optional(),
+    announcementId: looseUuid.optional(),
+    notificationId: looseUuid.optional(),
+    organizationId: looseUuid.optional(),
     title: optionalSafeString(200),
     body: optionalSafeString(8_000),
-    audience: z.enum(["members", "alumni", "both"]).optional(),
-    channel: z.enum(["email", "sms", "both"]).optional(),
+    // Accept the historical web values plus push variants.
+    audience: z
+      .enum(["members", "alumni", "both", "all", "active_members", "individuals", "parents"])
+      .optional(),
+    // Accept discrete values plus comma-separated combos like "email,push".
+    channel: z
+      .string()
+      .trim()
+      .max(64)
+      .optional()
+      .transform((raw) => {
+        if (!raw) return undefined;
+        const parts = raw
+          .split(",")
+          .map((p) => p.trim().toLowerCase())
+          .filter(Boolean);
+        const wantsPush = parts.includes("push") || parts.includes("all");
+        const blastValues = parts.filter((p) => p !== "push" && p !== "all");
+        const hasEmail = blastValues.includes("email");
+        const hasSms = blastValues.includes("sms");
+        const wantsBoth =
+          blastValues.includes("both") ||
+          blastValues.includes("email_sms") ||
+          (hasEmail && hasSms) ||
+          parts.includes("all");
+        if (wantsPush && wantsBoth) return "all";
+        if (wantsPush && hasEmail) return "all";
+        if (wantsPush && hasSms) return "all";
+        if (wantsPush) return "push";
+        if (wantsBoth) return "both";
+        if (hasSms) return "sms";
+        if (hasEmail) return "email";
+        return undefined;
+      }),
     targetUserIds: uuidArray(500).optional(),
     persistNotification: z.boolean().optional(),
     category: z.enum(["announcement", "discussion", "event", "workout", "competition"]).optional(),
+    pushType: z
+      .enum([
+        "announcement",
+        "event",
+        "event_reminder",
+        "chat",
+        "discussion",
+        "mentorship",
+        "donation",
+        "membership",
+        "notification",
+      ])
+      .optional(),
+    pushResourceId: looseUuid.optional(),
+    orgSlug: optionalSafeString(120),
   })
-  .strict()
+  .passthrough()
   .superRefine((value, ctx) => {
     if (!value.announcementId && !value.notificationId && !value.organizationId) {
       ctx.addIssue({
@@ -124,12 +206,22 @@ export async function POST(request: Request) {
     let organizationId: string | null = null;
     let title: string | null = body.title ?? null;
     let bodyText = body.body ?? "";
-    let audience: NotificationAudience = body.audience ?? "both";
-    let channel: NotificationChannel = body.channel ?? "email";
+    // Audience accepted from clients includes mobile-shaped values; normalize to DB enum.
+    const normalizeAudience = (v: string | undefined): NotificationAudience => {
+      if (v === "alumni") return "alumni";
+      if (v === "members" || v === "active_members") return "members";
+      return "both"; // "all" | "both" | "individuals" | "parents" | undefined
+    };
+    let audience: NotificationAudience = normalizeAudience(body.audience);
+    const requestedChannel: RequestedChannel = (body.channel ?? "email") as RequestedChannel;
+    let channel: NotificationChannel = mapBlastChannel(requestedChannel);
     let targetUserIds: string[] | null = body.targetUserIds ?? null;
     let resolvedNotificationId: string | null = notificationId ?? null;
     let persistNotification = body.persistNotification !== false;
     let category: NotificationCategory | undefined = body.category;
+    let pushType: PushType | undefined = body.pushType;
+    let pushResourceId: string | undefined = body.pushResourceId;
+    let orgSlug: string | undefined = body.orgSlug ?? undefined;
 
     if (announcementId) {
       const { data: announcement, error: announcementError } = await service
@@ -194,9 +286,8 @@ export async function POST(request: Request) {
       organizationId = body.organizationId ?? null;
       title = body.title ?? null;
       bodyText = body.body ?? "";
-      const requestedAudience = body.audience as NotificationAudience | undefined;
-      audience = requestedAudience || "both";
-      channel = body.channel ?? "email";
+      audience = normalizeAudience(body.audience);
+      channel = mapBlastChannel(requestedChannel);
       targetUserIds = body.targetUserIds ?? null;
       resolvedNotificationId = body.notificationId ?? null;
       persistNotification = body.persistNotification !== false;
@@ -251,29 +342,81 @@ export async function POST(request: Request) {
     }
 
     // Check Resend config before doing any send work
-    if (!resend && process.env.NODE_ENV === "production") {
-      return respond(
-        { error: "Notifications not configured: set RESEND_API_KEY and FROM_EMAIL" },
-        500,
+    // Email/SMS blast — only run when channel includes them. Resend is only
+    // required for the blast path; gating it earlier blocks push-only sends
+    // whenever email is unconfigured.
+    let runBlast = shouldSendBlast(requestedChannel);
+    if (runBlast && !resend && process.env.NODE_ENV === "production") {
+      // For "all", degrade gracefully so push still fires.
+      // For email/sms-only, the request can't succeed — return a config error.
+      if (!shouldSendPush(requestedChannel)) {
+        return respond(
+          { error: "Email/SMS not configured: set RESEND_API_KEY and FROM_EMAIL" },
+          500,
+        );
+      }
+      console.warn(
+        "[notifications/send] Resend missing in production; degrading channel='all' to push-only",
       );
+      runBlast = false;
     }
 
-    // Use sendNotificationBlast which handles targeting, concurrency, and sending
-    const blastResult = await sendNotificationBlast({
-      supabase: service,
-      organizationId,
-      audience,
-      channel,
-      title,
-      body: bodyText,
-      targetUserIds: targetUserIds || undefined,
-      category,
-      sendEmailFn: async (params: EmailParams): Promise<NotificationResult> => {
-        return sendEmailWithFallback(params.to, params.subject, params.body);
-      },
-    });
+    const blastResult = runBlast
+      ? await sendNotificationBlast({
+          supabase: service,
+          organizationId,
+          audience,
+          channel,
+          title,
+          body: bodyText,
+          targetUserIds: targetUserIds || undefined,
+          category,
+          sendEmailFn: async (params: EmailParams): Promise<NotificationResult> => {
+            return sendEmailWithFallback(params.to, params.subject, params.body);
+          },
+        })
+      : { total: 0, emailCount: 0, smsCount: 0, skippedMissingContact: 0, errors: [] };
 
-    if (blastResult.total === 0) {
+    // Default deep-link metadata for announcement category if caller didn't supply it.
+    if (announcementId && shouldSendPush(requestedChannel)) {
+      pushType = pushType || "announcement";
+      pushResourceId = pushResourceId || announcementId;
+    }
+
+    // Resolve orgSlug from organizationId if caller didn't supply one — mobile
+    // push routing requires it for taps to deep-link.
+    if (shouldSendPush(requestedChannel) && !orgSlug && organizationId) {
+      const { data: org } = await service
+        .from("organizations")
+        .select("slug")
+        .eq("id", organizationId)
+        .maybeSingle();
+      orgSlug = (org as { slug?: string } | null)?.slug ?? undefined;
+    }
+
+    // Expo push fan-out.
+    const pushResult = shouldSendPush(requestedChannel)
+      ? await sendPush({
+          supabase: service,
+          organizationId,
+          audience,
+          targetUserIds: targetUserIds || undefined,
+          title,
+          body: bodyText,
+          category,
+          pushType,
+          pushResourceId,
+          orgSlug,
+        })
+      : { sent: 0, queued: 0, skipped: 0, errors: [] };
+
+    const acceptedPushCount = pushResult.sent + pushResult.queued;
+
+    if (
+      blastResult.total === 0 &&
+      acceptedPushCount === 0 &&
+      shouldSendBlast(requestedChannel)
+    ) {
       return respond(
         {
           error: "No recipients matched the selected audience",
@@ -291,17 +434,23 @@ export async function POST(request: Request) {
         .eq("id", resolvedNotificationId);
     }
 
-    const sent = blastResult.emailCount + blastResult.smsCount;
-    const success = blastResult.errors.length === 0 && sent > 0;
+    const sent = blastResult.emailCount + blastResult.smsCount + pushResult.sent;
+    const accepted = sent + pushResult.queued;
+    const allErrors = [...blastResult.errors, ...pushResult.errors];
+    const success = allErrors.length === 0 && accepted > 0;
 
     const payload = {
       success,
       sent,
+      accepted,
       emailSent: blastResult.emailCount,
       smsSent: blastResult.smsCount,
-      total: blastResult.total,
+      pushSent: pushResult.sent,
+      pushQueued: pushResult.queued,
+      pushSkipped: pushResult.skipped,
+      total: blastResult.total + pushResult.sent + pushResult.queued + pushResult.skipped,
       skipped: blastResult.skippedMissingContact,
-      errors: blastResult.errors.length > 0 ? blastResult.errors : undefined,
+      errors: allErrors.length > 0 ? allErrors : undefined,
     };
 
     const status = success ? 200 : 500;

--- a/src/lib/announcements/create-announcement.ts
+++ b/src/lib/announcements/create-announcement.ts
@@ -162,6 +162,9 @@ export async function sendAnnouncementNotification(
     body: JSON.stringify({
       announcementId: request.announcementId,
       category: "announcement",
+      // "all" = email + push. The route degrades to push-only if Resend is
+      // unconfigured in production, so missing email config doesn't block push.
+      channel: "all",
     }),
   });
 }

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -11,7 +11,14 @@ const FROM_EMAIL = process.env.FROM_EMAIL || "noreply@myteamnetwork.com";
 export type DeliveryChannel = "email" | "sms";
 
 export type NotificationCategory =
-  | "announcement" | "discussion" | "event" | "workout" | "competition" | "mentorship";
+  | "announcement"
+  | "discussion"
+  | "event"
+  | "event_reminder"
+  | "workout"
+  | "competition"
+  | "mentorship"
+  | "chat";
 
 export interface NotificationTarget {
   email?: string | null;
@@ -159,9 +166,11 @@ const CATEGORY_PREF_COLUMN: Record<NotificationCategory, keyof PreferenceRow> = 
   announcement: "announcement_emails_enabled",
   discussion: "discussion_emails_enabled",
   event: "event_emails_enabled",
+  event_reminder: "event_emails_enabled",
   workout: "workout_emails_enabled",
   competition: "competition_emails_enabled",
   mentorship: "mentorship_emails_enabled" as keyof PreferenceRow,
+  chat: "announcement_emails_enabled" as keyof PreferenceRow,
 };
 
 const getChannelsForContact = ({

--- a/src/lib/notifications/push.ts
+++ b/src/lib/notifications/push.ts
@@ -1,0 +1,464 @@
+/**
+ * Server-side Expo Push fan-out.
+ *
+ * P0a scope: minimal, inline send for v1. Two-tier dispatch:
+ *   - 1 recipient (chat DM, single mention) → inline await from API route
+ *   - Broadcasts → still inline for now; can be migrated to a worker that
+ *     drains `notification_jobs` once an org breaches the Vercel timeout.
+ *
+ * Token resolution today is a 3-step query (members → preferences → tokens)
+ * because the recipient-resolution RPC recommended in the deepened plan is a
+ * P1 follow-up. The shape of `sendPush` does not depend on the resolver, so
+ * swapping in `resolve_push_targets()` later is a one-line change.
+ *
+ * DeviceNotRegistered tickets are handled inline — that token row is deleted
+ * immediately. Other receipt errors are logged but not retried here; a later
+ * `cron/push-receipts` run will handle async receipt polling.
+ */
+
+import { Expo, type ExpoPushMessage, type ExpoPushTicket } from "expo-server-sdk";
+
+/**
+ * Subset of the Expo client surface that `sendPush` actually uses. Tests can
+ * pass a stub implementing this interface via `SendPushInput.expoClient` to
+ * exercise the full fan-out path without hitting the real Expo API.
+ */
+export interface ExpoPushClient {
+  chunkPushNotifications(messages: ExpoPushMessage[]): ExpoPushMessage[][];
+  sendPushNotificationsAsync(messages: ExpoPushMessage[]): Promise<ExpoPushTicket[]>;
+}
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  Database,
+  NotificationAudience,
+  UserRole,
+} from "@/types/database";
+import type { NotificationCategory } from "@/lib/notifications";
+
+export type PushType =
+  | "announcement"
+  | "event"
+  | "event_reminder"
+  | "chat"
+  | "discussion"
+  | "mentorship"
+  | "donation"
+  | "membership"
+  | "notification";
+
+export interface SendPushInput {
+  supabase: SupabaseClient<Database>;
+  organizationId: string;
+  audience?: NotificationAudience | null;
+  /** Explicit user list. If both `audience` and `targetUserIds` are set, intersection wins. */
+  targetUserIds?: string[] | null;
+  title: string;
+  body: string;
+  /** Per-category gating against `notification_preferences.<category>_push_enabled`. */
+  category?: NotificationCategory;
+  pushType?: PushType;
+  pushResourceId?: string;
+  /** Optional Expo `data` payload — drives `getNotificationRoute` on the device. */
+  data?: Record<string, unknown>;
+  /** Optional org slug — included in `data` so the device can route on tap. */
+  orgSlug?: string;
+  /**
+   * When true, never enqueue — drain inline regardless of recipient count.
+   * The dispatch worker sets this when processing a queued `notification_jobs`
+   * row to avoid re-queuing the same job in an infinite loop.
+   */
+  forceInline?: boolean;
+  /** Test-only: inject an Expo client stub. Production callers omit this. */
+  expoClient?: ExpoPushClient;
+}
+
+export interface SendPushResult {
+  /** Number of pushes Expo accepted (ticket.status === 'ok'). */
+  sent: number;
+  /** Number of recipient tokens accepted into the async dispatch queue. */
+  queued: number;
+  /** Recipients skipped because they had no token, push disabled, or category opted out. */
+  skipped: number;
+  /** Receipt-error messages for diagnostic surfaces. */
+  errors: string[];
+}
+
+/**
+ * Map a NotificationCategory to the boolean column on notification_preferences
+ * that controls push for that category. Mirrors the email map in lib/notifications.ts.
+ */
+const CATEGORY_PUSH_COLUMN: Record<NotificationCategory, string> = {
+  announcement: "announcement_push_enabled",
+  chat: "chat_push_enabled",
+  discussion: "discussion_push_enabled",
+  event: "event_push_enabled",
+  event_reminder: "event_reminder_push_enabled",
+  workout: "workout_push_enabled",
+  competition: "competition_push_enabled",
+  mentorship: "mentorship_push_enabled",
+};
+
+const defaultExpoClient: ExpoPushClient = new Expo({
+  accessToken: process.env.EXPO_ACCESS_TOKEN,
+  useFcmV1: true,
+});
+
+interface MembershipRow {
+  user_id: string;
+  role: string;
+}
+
+interface PreferenceRow {
+  user_id: string | null;
+  push_enabled: boolean | null;
+  [column: string]: unknown;
+}
+
+interface TokenRow {
+  user_id: string;
+  expo_push_token: string;
+}
+
+/**
+ * Resolve which (user_id, expo_push_token) pairs should receive a push,
+ * applying audience filtering and per-category preference gating.
+ *
+ * Three-step query is intentional for v1; replace with `resolve_push_targets()`
+ * RPC once it lands.
+ */
+async function resolvePushTargets(
+  input: SendPushInput
+): Promise<{
+  tokens: string[];
+  resolvedUsers: number;
+  skippedUsers: number;
+  errors: string[];
+}> {
+  const { supabase, organizationId, audience, targetUserIds, category } = input;
+
+  const audienceRoles: readonly UserRole[] = mapAudienceToRoles(audience ?? "both");
+
+  // Step 1: memberships in the org for the requested audience.
+  let membershipQuery = supabase
+    .from("user_organization_roles")
+    .select("user_id, role")
+    .eq("organization_id", organizationId)
+    .eq("status", "active")
+    .in("role", audienceRoles as readonly UserRole[]);
+
+  if (targetUserIds && targetUserIds.length > 0) {
+    membershipQuery = membershipQuery.in("user_id", targetUserIds);
+  }
+
+  const { data: memberships, error: membershipsError } = await membershipQuery;
+  if (membershipsError) {
+    return {
+      tokens: [],
+      resolvedUsers: 0,
+      skippedUsers: 0,
+      errors: [`membership query failed: ${membershipsError.message}`],
+    };
+  }
+  const userIds = (memberships as MembershipRow[] | null)?.map((m) => m.user_id) ?? [];
+
+  if (userIds.length === 0) {
+    return { tokens: [], resolvedUsers: 0, skippedUsers: 0, errors: [] };
+  }
+
+  // Step 2: preferences for those users in this org.
+  const prefColumns = ["user_id", "push_enabled"];
+  if (category && CATEGORY_PUSH_COLUMN[category]) {
+    prefColumns.push(CATEGORY_PUSH_COLUMN[category]);
+  }
+
+  const { data: prefs, error: prefsError } = await supabase
+    .from("notification_preferences")
+    .select(prefColumns.join(","))
+    .eq("organization_id", organizationId)
+    .in("user_id", userIds);
+  if (prefsError) {
+    return {
+      tokens: [],
+      resolvedUsers: userIds.length,
+      skippedUsers: 0,
+      errors: [`notification preference query failed: ${prefsError.message}`],
+    };
+  }
+
+  const prefByUser = new Map<string, PreferenceRow>();
+  (prefs as unknown as PreferenceRow[] | null)?.forEach((row) => {
+    if (row.user_id) prefByUser.set(row.user_id, row);
+  });
+
+  const allowedUserIds = userIds.filter((userId) => {
+    const pref = prefByUser.get(userId);
+    if (!pref) {
+      // No row yet → defaults apply. New columns default to true for
+      // announcement/chat/event_reminder, false for the rest.
+      return defaultPushEnabled(category);
+    }
+    if (pref.push_enabled === false) return false;
+    if (category) {
+      const col = CATEGORY_PUSH_COLUMN[category];
+      if (col && pref[col] === false) return false;
+    }
+    return true;
+  });
+
+  if (allowedUserIds.length === 0) {
+    return { tokens: [], resolvedUsers: userIds.length, skippedUsers: userIds.length, errors: [] };
+  }
+
+  // Step 3: tokens for the surviving users (multi-device → multiple rows).
+  // Cast: `user_push_tokens` is in the database (migration 20260425100000)
+  // but not yet in the generated `Database` types. Regenerate via
+  // `bun run gen:types` to remove this cast.
+  const { data: tokens, error: tokensError } = await (supabase as unknown as {
+    from: (table: string) => {
+      select: (cols: string) => {
+        in: (
+          col: string,
+          vals: string[],
+        ) => Promise<{ data: TokenRow[] | null; error: { message: string } | null }>;
+      };
+    };
+  })
+    .from("user_push_tokens")
+    .select("user_id, expo_push_token")
+    .in("user_id", allowedUserIds);
+  if (tokensError) {
+    return {
+      tokens: [],
+      resolvedUsers: allowedUserIds.length,
+      skippedUsers: userIds.length - allowedUserIds.length,
+      errors: [`push token query failed: ${tokensError.message}`],
+    };
+  }
+
+  const tokenList =
+    (tokens as TokenRow[] | null)
+      ?.map((t) => t.expo_push_token)
+      .filter((t) => Expo.isExpoPushToken(t)) ?? [];
+
+  return {
+    tokens: tokenList,
+    resolvedUsers: allowedUserIds.length,
+    skippedUsers: userIds.length - allowedUserIds.length,
+    errors: [],
+  };
+}
+
+function mapAudienceToRoles(audience: NotificationAudience): readonly UserRole[] {
+  if (audience === "members") return ["admin", "active_member", "member"];
+  if (audience === "alumni") return ["alumni", "viewer"];
+  return ["admin", "active_member", "member", "alumni", "viewer"];
+}
+
+function defaultPushEnabled(category?: NotificationCategory): boolean {
+  // Mirrors the migration defaults for `*_push_enabled`.
+  switch (category) {
+    case "announcement":
+    case "chat":
+    case "event_reminder":
+      return true;
+    case "event":
+    case "workout":
+    case "competition":
+    case "discussion":
+    case "mentorship":
+      return false;
+    default:
+      // Untyped pushes (e.g., donation) — default true so first-run users
+      // still see notifications.
+      return true;
+  }
+}
+
+/**
+ * Soft cap on the inline-dispatch path. Larger broadcasts must wait for the
+ * `notification_jobs` worker to drain. If the queue insert fails, we send the
+ * first `INLINE_PUSH_TOKEN_CAP` tokens and return the rest as `skipped` with
+ * an error string so callers can surface a useful message instead of silently
+ * dropping recipients past the timeout.
+ *
+ * Why a hard cap: Vercel API routes have a 10s/15s/300s timeout depending on
+ * plan and Expo's HTTP/2 push API rate-limits at ~600 req/sec; an 5000-alumni
+ * announcement run inline trips both before completing.
+ */
+export const INLINE_PUSH_TOKEN_CAP = 200;
+
+/**
+ * Send Expo push notifications to all eligible recipients.
+ *
+ * Resolves recipients server-side, batches into ≤100/req chunks, and processes
+ * tickets inline for synchronous error handling (DeviceNotRegistered → drop
+ * the token row).
+ */
+export async function sendPush(input: SendPushInput): Promise<SendPushResult> {
+  const {
+    tokens: allTokens,
+    resolvedUsers,
+    skippedUsers,
+    errors: resolveErrors,
+  } = await resolvePushTargets(input);
+
+  if (resolveErrors.length > 0) {
+    return {
+      sent: 0,
+      queued: 0,
+      skipped: resolvedUsers + skippedUsers,
+      errors: resolveErrors,
+    };
+  }
+
+  if (allTokens.length === 0) {
+    return { sent: 0, queued: 0, skipped: resolvedUsers + skippedUsers, errors: [] };
+  }
+
+  // Broadcasts above the inline cap are enqueued onto notification_jobs so
+  // the cron worker fans them out without tripping the API timeout. Smaller
+  // sends still go inline so chat DMs and reminders stay synchronous. The
+  // worker itself passes forceInline=true to avoid re-queuing the same job.
+  if (allTokens.length > INLINE_PUSH_TOKEN_CAP && !input.forceInline) {
+    const audienceForQueue =
+      input.audience && input.audience !== "both" ? input.audience : "all";
+    try {
+      const { error: enqueueError } = await (input.supabase as unknown as {
+        from: (table: string) => {
+          insert: (
+            row: Record<string, unknown>,
+          ) => Promise<{ error: { message: string } | null }>;
+        };
+      })
+        .from("notification_jobs")
+        .insert({
+          organization_id: input.organizationId,
+          kind: "standard",
+          priority: 5,
+          audience: audienceForQueue,
+          target_user_ids: input.targetUserIds ?? null,
+          category: input.category ?? null,
+          push_type: input.pushType ?? null,
+          push_resource_id: input.pushResourceId ?? null,
+          title: input.title,
+          body: input.body,
+          data: {
+            ...(input.data ?? {}),
+            ...(input.orgSlug ? { orgSlug: input.orgSlug } : {}),
+          },
+        });
+      if (enqueueError) throw new Error(enqueueError.message);
+      console.log(
+        `[push] queued broadcast: ${allTokens.length} recipients org=${input.organizationId} type=${input.pushType ?? "unknown"}`,
+      );
+      return {
+        sent: 0,
+        queued: allTokens.length,
+        skipped: skippedUsers,
+        errors: [],
+      };
+    } catch (err) {
+      // Fall back to capped inline send so a queue failure doesn't lose
+      // notifications entirely. Surface the overflow as before.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[push] enqueue failed, falling back to inline cap: ${msg}`,
+      );
+    }
+  }
+
+  // Inline path. The worker (forceInline=true) drains the full token list
+  // since it is not bound by the API request timeout. Ad-hoc API callers
+  // either had ≤cap tokens to begin with, or fell through here because the
+  // queue insert failed — in that case we still cap to avoid the timeout.
+  const shouldCap = !input.forceInline && allTokens.length > INLINE_PUSH_TOKEN_CAP;
+  const overflow = shouldCap ? allTokens.length - INLINE_PUSH_TOKEN_CAP : 0;
+  const tokens = shouldCap ? allTokens.slice(0, INLINE_PUSH_TOKEN_CAP) : allTokens;
+  const capErrors =
+    overflow > 0
+      ? [
+          `inline push cap exceeded: skipped ${overflow} of ${allTokens.length} recipients (cap=${INLINE_PUSH_TOKEN_CAP}); queue insert failed`,
+        ]
+      : [];
+  if (overflow > 0) {
+    console.warn(
+      `[push] ${capErrors[0]} (type=${input.pushType ?? "unknown"} org=${input.organizationId})`
+    );
+  }
+
+  // Mobile's getNotificationRoute requires orgSlug + type + id to deep-link
+  // on tap. Don't overwrite values from input.data with undefined — only set
+  // each key when the corresponding input field is present.
+  const data: Record<string, unknown> = {
+    ...(input.data ?? {}),
+    title: input.title,
+    body: input.body,
+  };
+  if (input.pushType) data.type = input.pushType;
+  if (input.pushResourceId) data.id = input.pushResourceId;
+  if (input.orgSlug) data.orgSlug = input.orgSlug;
+
+  if (input.pushType && !data.orgSlug) {
+    console.warn(
+      `[push] sending typed push without orgSlug (type=${input.pushType} org=${input.organizationId}); mobile taps will no-op`,
+    );
+  }
+
+  const messages: ExpoPushMessage[] = tokens.map((token) => ({
+    to: token,
+    title: input.title,
+    body: input.body,
+    data,
+    sound: "default",
+  }));
+
+  const expo = input.expoClient ?? defaultExpoClient;
+  const chunks = expo.chunkPushNotifications(messages);
+  const tickets: Array<{ token: string; ticket: ExpoPushTicket }> = [];
+  const errors: string[] = [...capErrors];
+
+  for (const chunk of chunks) {
+    try {
+      const chunkTickets = await expo.sendPushNotificationsAsync(chunk);
+      chunkTickets.forEach((ticket, i) => {
+        tickets.push({ token: chunk[i].to as string, ticket });
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`Chunk send failed: ${msg}`);
+    }
+  }
+
+  let sent = 0;
+  const tokensToDrop: string[] = [];
+
+  for (const { token, ticket } of tickets) {
+    if (ticket.status === "ok") {
+      sent += 1;
+      continue;
+    }
+    const errorCode = ticket.details?.error;
+    if (errorCode === "DeviceNotRegistered") {
+      tokensToDrop.push(token);
+    } else {
+      errors.push(`${errorCode ?? "unknown"}: ${ticket.message}`);
+    }
+  }
+
+  if (tokensToDrop.length > 0) {
+    // Best-effort cleanup; failure here does not affect send result.
+    // Same `user_push_tokens` cast as above.
+    await (input.supabase as unknown as {
+      from: (table: string) => {
+        delete: () => {
+          in: (col: string, vals: string[]) => Promise<unknown>;
+        };
+      };
+    })
+      .from("user_push_tokens")
+      .delete()
+      .in("expo_push_token", tokensToDrop);
+  }
+
+  return { sent, queued: 0, skipped: skippedUsers + overflow, errors };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -60,6 +60,10 @@
     {
       "path": "/api/cron/mentor-match-expire",
       "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/notification-dispatch",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds the minimum push notification surface needed for **production web → mobile phone** to actually deliver. Production deploys from \`main\`, which until now had no push code (only email/SMS). Ports the working Expo fan-out from react-native with all three fix commits baked in.

## What's added
- \`src/lib/notifications/push.ts\` — \`sendPush()\` audience→prefs→tokens resolver, Expo client, ≤100/req batching, DeviceNotRegistered cleanup. Includes the re-queue-loop fix, Resend-gate fix, and schema-relax fix from react-native commits \`0f38c9bb\` / \`f17fcc26\`.
- \`src/app/api/cron/notification-dispatch/route.ts\` — drains pending \`notification_jobs\` every minute with \`forceInline=true\`. Live Activity / APNs kinds out of scope.

## What's modified (backwards compatible)
- \`src/app/api/notifications/send/route.ts\` — extends channel handling: accepts \`"push"\` / \`"all"\` / comma-separated. Resend gate now only fires for blast paths; \`"all"\` degrades to push-only when Resend is unconfigured. Email and SMS paths unchanged (all 15 existing route tests pass).
- \`src/lib/announcements/create-announcement.ts\` — sends \`channel: "all"\` so push fires alongside email.
- \`src/lib/notifications.ts\` — adds \`"chat"\` and \`"event_reminder"\` to \`NotificationCategory\`.
- \`package.json\` — adds \`expo-server-sdk@^3.10.0\`.
- \`vercel.json\` — adds \`/api/cron/notification-dispatch\` on a 1-minute cron.

## Why this approach instead of flipping prod branch to react-native
react-native has 288 commits ahead of main, including UI refactors and feature work in flight. A branch flip risks regressions in unrelated areas. This PR is purely additive on the push side and leaves email/SMS paths untouched.

## Database state
Production Supabase already has \`user_push_tokens\`, \`notification_jobs\`, and \`notification_preferences\` columns applied (verified via Supabase MCP — rows present). Migrations themselves can be backported separately; this PR is runtime code only.

## Test plan
- [x] \`npm install\` — 661 packages, no errors
- [x] \`npm run build\` with prod-like env (no SKIP_STRIPE_VALIDATION, fake but format-valid Stripe price ids) — builds cleanly
- [x] \`npx tsc --noEmit\` on changed files — zero errors
- [x] \`node --test tests/routes/notifications/send.test.ts\` — 15/15 pass
- [ ] After merge: confirm Vercel preview goes green
- [ ] After production deploy: \`POST /api/notifications/send\` returns 401 on unauth (proves new schema/route is live)
- [ ] (Owner action, separate) Build TestFlight via \`eas build --profile production --platform ios\` so a real production-APNs token registers in \`user_push_tokens\`
- [ ] End-to-end: create announcement on production web with audience including yourself → phone receives push within ~10s