### PR TITLE
test: realign source-grep assertions with helper-extracted routes

### DIFF
--- a/tests/mentorship-admin-remind-route.test.ts
+++ b/tests/mentorship-admin-remind-route.test.ts
@@ -23,8 +23,20 @@ test("route is dynamic + nodejs runtime", () => {
 });
 
 test("route requires admin role with active status", () => {
-  assert.match(routeSource, /role\?.role !== "admin"/);
-  assert.match(routeSource, /role\?.status !== "active"/);
+  // Role + active-status check is delegated to the shared helper. Assert the
+  // helper is imported and gates the 403 branch on its return value.
+  assert.match(
+    routeSource,
+    /from\s+"@\/lib\/auth\/require-active-admin"/,
+  );
+  assert.match(
+    routeSource,
+    /requireActiveOrgAdmin\(\s*supabase\s*,\s*user\.id\s*,\s*organizationId\s*\)/,
+  );
+  assert.match(
+    routeSource,
+    /!\(await requireActiveOrgAdmin[\s\S]*?status:\s*403/,
+  );
 });
 
 test("route enforces 24h rate-limit window", () => {

--- a/tests/security/telemetry-user-id-forgery.test.ts
+++ b/tests/security/telemetry-user-id-forgery.test.ts
@@ -10,15 +10,17 @@ const routePath = join(repoRoot, "src", "app", "api", "telemetry", "error", "rou
 const schemaPath = join(repoRoot, "src", "lib", "schemas", "telemetry.ts");
 
 describe("POST /api/telemetry/error trusts session, not body", () => {
-  it("derives user_id from supabase.auth.getUser, not the request body", () => {
+  it("derives user_id from the trusted-user helper, not the request body", () => {
     const src = readFileSync(routePath, "utf8");
+    // The auth.getUser() call lives inside resolveTrustedUserId. Verify the
+    // route imports + invokes that helper rather than re-inlining the call.
     assert.ok(
-      src.includes("supabaseAuth.auth.getUser()"),
-      "Route must call supabase auth.getUser() to derive trusted user id",
+      /from\s+"@\/lib\/telemetry\/trusted-user"/.test(src),
+      "Route must import resolveTrustedUserId from the trusted-user helper",
     );
     assert.ok(
-      /const\s+trustedUserId\s*=/.test(src),
-      "Route must compute a trustedUserId",
+      /const\s+trustedUserId\s*=\s*await\s+resolveTrustedUserId\s*\(/.test(src),
+      "Route must compute trustedUserId via resolveTrustedUserId(...)",
     );
     assert.ok(
       /const\s+user_id\s*=\s*trustedUserId/.test(src),


### PR DESCRIPTION
## Summary

Two source-grep tests fail on main with no actual route regression — the routes were refactored to call shared helpers, but the tests still grep for the inline shape.

- `tests/mentorship-admin-remind-route.test.ts` — was greping inline `role !== "admin"`; route now uses `requireActiveOrgAdmin` (commit `bcaf1a8f`).
- `tests/security/telemetry-user-id-forgery.test.ts` — was greping inline `supabaseAuth.auth.getUser()`; route now uses `resolveTrustedUserId`, which lives in `src/lib/telemetry/trusted-user.ts` and contains the `auth.getUser()` call.

Both tests now assert the helper is imported + invoked. The behavioral simulator suite in the mentorship test is untouched.

## Why

Unblocks PR #190 (next-intl security bump) and any other PR landing on main, since these failures otherwise gate `Test (fast)` and `Test (unit)` red.

## Test plan

- [x] `node --import ./tests/register-ts-loader.mjs --test tests/mentorship-admin-remind-route.test.ts tests/security/telemetry-user-id-forgery.test.ts` — 18/18 pass locally