### PR TITLE
fix(auth): drop caller-supplied identity from claim_alumni_profiles RPC

### DIFF
--- a/src/app/auth/claim/ClaimAccountClient.tsx
+++ b/src/app/auth/claim/ClaimAccountClient.tsx
@@ -149,7 +149,7 @@ function ClaimFormComponent({ captchaSiteKey }: ClaimAccountClientProps) {
     }
 
     try {
-      const { orgs } = await claimAlumniProfile(pendingEmail);
+      const { orgs } = await claimAlumniProfile();
 
       if (orgs.length === 0) {
         router.push(buildJoinFallbackUrl());

--- a/src/lib/auth/claim-flow.ts
+++ b/src/lib/auth/claim-flow.ts
@@ -11,9 +11,6 @@ export interface ClaimAlumniResult {
   orgs: ClaimedOrg[];
 }
 
-// Per-instance rate limit. The OTP step is already captcha-gated, but the
-// server action is also a public POST surface to authenticated users — cap
-// invocations to prevent burst abuse if the entry path is bypassed.
 declare global {
   // eslint-disable-next-line no-var
   var __claimAlumniRateLimit: Map<string, { count: number; resetAt: number }> | undefined;
@@ -22,7 +19,6 @@ const claimRateStore = globalThis.__claimAlumniRateLimit ?? new Map();
 globalThis.__claimAlumniRateLimit = claimRateStore;
 const CLAIM_WINDOW_MS = 60_000;
 const CLAIM_LIMIT_PER_USER = 10;
-const CLAIM_EMAIL_MAX_LEN = 254; // RFC 5321 max email length
 
 function consumeClaimRate(userId: string): boolean {
   const now = Date.now();
@@ -38,18 +34,10 @@ function consumeClaimRate(userId: string): boolean {
 
 // Server action: after OTP verify, grant org membership for every imported
 // alumni row matching the session user's verified email. Wraps RPC
-// claim_alumni_profiles. Caller branches on orgs.length for redirect.
-export async function claimAlumniProfile(
-  verifiedEmail: string,
-): Promise<ClaimAlumniResult> {
-  const trimmed = (verifiedEmail ?? "").trim();
-  if (trimmed === "") {
-    throw new Error("verifiedEmail is required");
-  }
-  if (trimmed.length > CLAIM_EMAIL_MAX_LEN) {
-    throw new Error("verifiedEmail too long");
-  }
-
+// claim_alumni_profiles which derives subject + email from auth.uid()
+// server-side — no caller-supplied identity. Caller branches on orgs.length
+// for redirect.
+export async function claimAlumniProfile(): Promise<ClaimAlumniResult> {
   const supabase = await createClient();
   const {
     data: { user },
@@ -58,10 +46,6 @@ export async function claimAlumniProfile(
 
   if (userError || !user) {
     throw new Error("Not authenticated");
-  }
-
-  if (!user.email || user.email.toLowerCase() !== trimmed.toLowerCase()) {
-    throw new Error("Email does not match session user");
   }
 
   // Defense-in-depth: only proceed if the email has actually been verified
@@ -76,10 +60,7 @@ export async function claimAlumniProfile(
     throw new Error("Too many claim attempts. Please retry shortly.");
   }
 
-  const { data, error } = await supabase.rpc("claim_alumni_profiles", {
-    p_user_id: user.id,
-    p_email: trimmed,
-  });
+  const { data, error } = await supabase.rpc("claim_alumni_profiles");
 
   if (error) {
     console.error("[claimAlumniProfile] rpc error", {

--- a/supabase/migrations/20261105000000_claim_alumni_profiles_no_args.sql
+++ b/supabase/migrations/20261105000000_claim_alumni_profiles_no_args.sql
@@ -1,0 +1,65 @@
+-- Harden claim_alumni_profiles by removing caller-supplied parameters.
+--
+-- Prior signature claim_alumni_profiles(p_user_id uuid, p_email text) accepted
+-- both values from the client. Even though it verified
+-- lower(auth.users.email WHERE id=p_user_id) = lower(p_email), an authenticated
+-- attacker who knew another user's id + email could trigger the RPC for that
+-- victim. Memberships still landed on the victim (no privilege escalation),
+-- but the cross-user input surface was unnecessary.
+--
+-- New signature claim_alumni_profiles() takes no arguments and derives the
+-- subject from auth.uid() + auth.users.email. SECURITY DEFINER is preserved
+-- so the function can read alumni rows + insert UORs across orgs the caller
+-- has no membership in (RLS would otherwise block).
+
+DROP FUNCTION IF EXISTS public.claim_alumni_profiles(uuid, text);
+
+CREATE OR REPLACE FUNCTION public.claim_alumni_profiles()
+RETURNS TABLE (out_organization_id uuid, out_slug text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_email text;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  SELECT email INTO v_email FROM auth.users WHERE id = v_user_id;
+
+  IF v_email IS NULL OR btrim(v_email) = '' THEN
+    RAISE EXCEPTION 'auth user has no email';
+  END IF;
+
+  INSERT INTO public.user_organization_roles (user_id, organization_id, role, status)
+  SELECT
+    v_user_id,
+    a.organization_id,
+    'alumni'::public.user_role,
+    'active'::public.membership_status
+  FROM public.alumni a
+  WHERE a.user_id IS NULL
+    AND a.deleted_at IS NULL
+    AND a.email IS NOT NULL
+    AND lower(a.email) = lower(v_email)
+  ON CONFLICT (user_id, organization_id) DO NOTHING;
+
+  RETURN QUERY
+  SELECT DISTINCT o.id, o.slug
+  FROM public.user_organization_roles uor
+  JOIN public.organizations o ON o.id = uor.organization_id
+  JOIN public.alumni a ON a.organization_id = uor.organization_id
+  WHERE uor.user_id = v_user_id
+    AND uor.status = 'active'
+    AND a.deleted_at IS NULL
+    AND a.email IS NOT NULL
+    AND lower(a.email) = lower(v_email)
+    AND (a.user_id = v_user_id OR a.user_id IS NULL);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_alumni_profiles() FROM public;
+GRANT EXECUTE ON FUNCTION public.claim_alumni_profiles() TO authenticated;

--- a/tests/claim-flow-grants-from-alumni.test.ts
+++ b/tests/claim-flow-grants-from-alumni.test.ts
@@ -69,8 +69,8 @@ test("claim client invokes claimAlumniProfile after OTP verify", () => {
   );
   assert.match(
     src,
-    /claimAlumniProfile\s*\(\s*pendingEmail/,
-    "Claim client must call claimAlumniProfile with the verified email after OTP verify.",
+    /claimAlumniProfile\s*\(\s*\)/,
+    "Claim client must call claimAlumniProfile after OTP verify; subject + email derived server-side from session.",
   );
 });
 
@@ -156,12 +156,12 @@ test("claim-flow rejects unauthenticated callers", () => {
   );
 });
 
-test("claim-flow validates verifiedEmail matches session user", () => {
+test("claim-flow requires verified email on session user", () => {
   const src = readClaimFlow();
   assert.match(
     src,
-    /Email does not match session user/,
-    "Server action must reject email-mismatch before invoking RPC.",
+    /Email not verified/,
+    "Server action must reject sessions whose email_confirmed_at is unset.",
   );
 });
 


### PR DESCRIPTION
## Summary

Hardens `claim_alumni_profiles` RPC by removing caller-supplied `p_user_id` and `p_email` parameters. RPC derives subject + email from `auth.uid()` + `auth.users` server-side, eliminating the cross-user input surface flagged in security review.

Prior signature accepted both values from the client and verified `lower(auth.users.email WHERE id=p_user_id) = lower(p_email)`. An authenticated attacker who knew another user's id + email could invoke the RPC for that victim. Memberships still landed on the victim (no privilege escalation), but the input surface was unnecessary.

Note: PR 190 (the next-intl deps bump) was the originally-requested target, but it merged before these commits could land. Opening this against main as the next-best path. The 3 commits were also pushed to `claude/task-a-LsyGO` for traceability but that PR is closed.

## Changes

- `supabase/migrations/20261105000000_claim_alumni_profiles_no_args.sql` — drops two-arg signature, redefines as `claim_alumni_profiles()` with `auth.uid()` derivation. `SECURITY DEFINER` + `search_path=''` preserved. `EXECUTE` granted to `authenticated`.
- `src/lib/auth/claim-flow.ts` — server action drops `verifiedEmail` parameter. `email_confirmed_at` gate + per-user rate limit preserved.
- `src/app/auth/claim/ClaimAccountClient.tsx` — calls `claimAlumniProfile()` no args.
- `tests/claim-flow-grants-from-alumni.test.ts` — invariant tests aligned to no-arg shape and `email_confirmed_at` gate.

## Risk

Low. RPC behavior unchanged for legitimate callers (session matches subject). Migration drops the old function signature; no production code paths still call the two-arg form.

## Test plan

- [x] `node --import ./tests/register-ts-loader.mjs --test tests/claim-flow-grants-from-alumni.test.ts` — 13/13 pass
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean (one pre-existing unrelated `expo-server-sdk` resolution warning)

## Rollout / rollback

Rollout: standard migration apply. Rollback: revert migration; restore prior two-arg function from `20261104000000_claim_alumni_profiles_rpc.sql`.