### PR TITLE
refactor(people): unify profile + people directory parity

### DIFF
--- a/apps/web/src/app/[orgSlug]/alumni/[alumniId]/page.tsx
+++ b/apps/web/src/app/[orgSlug]/alumni/[alumniId]/page.tsx
@@ -4,13 +4,10 @@ import { createClient } from "@/lib/supabase/server";
 import { Card, Badge, Avatar, Button } from "@/components/ui";
 import { PageHeader } from "@/components/layout";
 import { resolveDataClient } from "@/lib/auth/dev-admin";
-import { getOrgRole } from "@/lib/auth/roles";
-import { canEditNavItem } from "@/lib/navigation/permissions";
-import type { NavConfig } from "@/lib/navigation/nav-items";
+import { getPersonAdminContext } from "@/lib/people/permissions";
 import type { Organization, Alumni } from "@/types/database";
-import { checkOrgReadOnly } from "@/lib/subscription/read-only-guard";
 import { DeleteAlumniButton } from "@/components/alumni/DeleteAlumniButton";
-import { LinkedInProfileLink } from "@/components/shared";
+import { LinkedInProfileLink, formatPersonHeadline } from "@/components/shared";
 
 interface AlumniDetailPageProps {
   params: Promise<{ orgSlug: string; alumniId: string }>;
@@ -60,7 +57,7 @@ export default async function AlumniDetailPage({ params }: AlumniDetailPageProps
   const org = orgData[0] as Organization;
   const orgId = org.id;
 
-  const [{ data: alumData }, { role, userId: currentUserId }, { isReadOnly }] = await Promise.all([
+  const [{ data: alumData }, ctx] = await Promise.all([
     dataClient
       .from("alumni")
       .select("*")
@@ -68,8 +65,7 @@ export default async function AlumniDetailPage({ params }: AlumniDetailPageProps
       .eq("organization_id", orgId)
       .is("deleted_at", null)
       .single(),
-    getOrgRole({ orgId, userId: user?.id }),
-    checkOrgReadOnly(orgId),
+    getPersonAdminContext({ orgId, viewerUserId: user?.id ?? null }),
   ]);
 
   if (!alumData) {
@@ -79,13 +75,11 @@ export default async function AlumniDetailPage({ params }: AlumniDetailPageProps
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const alum = alumData as Alumni & Record<string, any>;
 
-  const navConfig = org.nav_config as NavConfig | null;
-  const canEditPage = canEditNavItem(navConfig, "/alumni", role, ["admin"]);
-  const alumUserId = alum.user_id;
-  const isSelf = Boolean(currentUserId && alumUserId === currentUserId);
-  const canEdit = canEditPage || isSelf;
-  const canModifyExisting = canEdit && !isReadOnly;
-  const canDelete = canEditPage && !isReadOnly;
+  const alumUserId = alum.user_id ?? null;
+  const canEdit = ctx.canEditPerson(alumUserId);
+  const canModifyExisting = canEdit && !ctx.isReadOnly;
+  const canDelete = ctx.isAdmin && !ctx.isReadOnly;
+  const isReadOnly = ctx.isReadOnly;
 
   // Extract enrichment data (may not exist if migration hasn't run)
   const rawWorkHistory = Array.isArray(alum.work_history) ? (alum.work_history as unknown[]) : [];
@@ -98,7 +92,12 @@ export default async function AlumniDetailPage({ params }: AlumniDetailPageProps
   const educationHistory: EducationEntry[] = rawEducationHistory.filter(
     (entry): entry is EducationEntry => isObjectEntry<EducationEntry>(entry)
   );
-  const headline = alum.headline || alum.position_title || alum.job_title || null;
+  const headline = formatPersonHeadline({
+    headline: alum.headline,
+    position_title: alum.position_title,
+    job_title: alum.job_title,
+    current_company: alum.current_company,
+  });
   const about = alum.summary || alum.notes || null;
 
   // Build experience entries: prefer work_history JSONB, fall back to flat fields
@@ -136,7 +135,7 @@ export default async function AlumniDetailPage({ params }: AlumniDetailPageProps
                   redirectTo={`/${orgSlug}/alumni`}
                 />
               ) : (
-                canEditPage && <Button variant="danger" disabled>Delete Disabled</Button>
+                ctx.isAdmin && <Button variant="danger" disabled>Delete Disabled</Button>
               )}
             </div>
           )

--- a/apps/web/src/app/[orgSlug]/alumni/[alumniId]/page.tsx
+++ b/apps/web/src/app/[orgSlug]/alumni/[alumniId]/page.tsx
@@ -4,8 +4,11 @@ import { createClient } from "@/lib/supabase/server";
 import { Card, Badge, Avatar, Button } from "@/components/ui";
 import { PageHeader } from "@/components/layout";
 import { resolveDataClient } from "@/lib/auth/dev-admin";
+import { getOrgRole } from "@/lib/auth/roles";
+import { canEditNavItem } from "@/lib/navigation/permissions";
 import { getPersonAdminContext } from "@/lib/people/permissions";
 import type { Organization, Alumni } from "@/types/database";
+import type { NavConfig } from "@/lib/navigation/nav-items";
 import { DeleteAlumniButton } from "@/components/alumni/DeleteAlumniButton";
 import { LinkedInProfileLink, formatPersonHeadline } from "@/components/shared";
 
@@ -75,10 +78,13 @@ export default async function AlumniDetailPage({ params }: AlumniDetailPageProps
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const alum = alumData as Alumni & Record<string, any>;
 
+  const navConfig = org.nav_config as NavConfig | null;
+  const { role } = await getOrgRole({ orgId, userId: user?.id });
+  const canEditPage = canEditNavItem(navConfig, "/alumni", role, ["admin"]);
   const alumUserId = alum.user_id ?? null;
-  const canEdit = ctx.canEditPerson(alumUserId);
+  const canEdit = canEditPage || ctx.canEditPerson(alumUserId);
   const canModifyExisting = canEdit && !ctx.isReadOnly;
-  const canDelete = ctx.isAdmin && !ctx.isReadOnly;
+  const canDelete = canEditPage && !ctx.isReadOnly;
   const isReadOnly = ctx.isReadOnly;
 
   // Extract enrichment data (may not exist if migration hasn't run)
@@ -135,7 +141,7 @@ export default async function AlumniDetailPage({ params }: AlumniDetailPageProps
                   redirectTo={`/${orgSlug}/alumni`}
                 />
               ) : (
-                ctx.isAdmin && <Button variant="danger" disabled>Delete Disabled</Button>
+                canEditPage && <Button variant="danger" disabled>Delete Disabled</Button>
               )}
             </div>
           )

--- a/apps/web/src/app/[orgSlug]/alumni/page.tsx
+++ b/apps/web/src/app/[orgSlug]/alumni/page.tsx
@@ -7,7 +7,8 @@ import { uniqueStringsCaseInsensitive } from "@/lib/string-utils";
 import { resolveLabel, resolveActionLabel } from "@/lib/navigation/label-resolver";
 import { getLocale, getTranslations } from "next-intl/server";
 import { resolveDataClient } from "@/lib/auth/dev-admin";
-import { getPersonAdminContext } from "@/lib/people/permissions";
+import { getOrgRole } from "@/lib/auth/roles";
+import { canEditNavItem } from "@/lib/navigation/permissions";
 import type { NavConfig } from "@/lib/navigation/nav-items";
 import { DirectoryViewTracker } from "@/components/analytics/DirectoryViewTracker";
 import { DirectoryCardLink } from "@/components/analytics/DirectoryCardLink";
@@ -74,11 +75,8 @@ export default async function AlumniPage({ params, searchParams }: AlumniPagePro
   if (!org || orgError) return null;
 
   const navConfig = org.nav_config as NavConfig | null;
-  const personCtx = await getPersonAdminContext({
-    orgId: org.id,
-    viewerUserId: user?.id ?? null,
-  });
-  const canEdit = personCtx.isAdmin;
+  const { role } = await getOrgRole({ orgId: org.id, userId: user?.id });
+  const canEdit = canEditNavItem(navConfig, "/alumni", role, ["admin"]);
 
   const currentPage = Math.max(1, parseInt(filters.page ?? "1", 10) || 1);
   const offset = (currentPage - 1) * PAGE_SIZE;

--- a/apps/web/src/app/[orgSlug]/alumni/page.tsx
+++ b/apps/web/src/app/[orgSlug]/alumni/page.tsx
@@ -7,12 +7,11 @@ import { uniqueStringsCaseInsensitive } from "@/lib/string-utils";
 import { resolveLabel, resolveActionLabel } from "@/lib/navigation/label-resolver";
 import { getLocale, getTranslations } from "next-intl/server";
 import { resolveDataClient } from "@/lib/auth/dev-admin";
-import { getOrgRole } from "@/lib/auth/roles";
-import { canEditNavItem } from "@/lib/navigation/permissions";
+import { getPersonAdminContext } from "@/lib/people/permissions";
 import type { NavConfig } from "@/lib/navigation/nav-items";
 import { DirectoryViewTracker } from "@/components/analytics/DirectoryViewTracker";
 import { DirectoryCardLink } from "@/components/analytics/DirectoryCardLink";
-import { LinkedInBadge } from "@/components/shared";
+import { LinkedInBadge, formatPersonHeadline } from "@/components/shared";
 import { sanitizeIlikeInput } from "@/lib/security/validation";
 
 const PAGE_SIZE = 50;
@@ -75,8 +74,11 @@ export default async function AlumniPage({ params, searchParams }: AlumniPagePro
   if (!org || orgError) return null;
 
   const navConfig = org.nav_config as NavConfig | null;
-  const { role } = await getOrgRole({ orgId: org.id });
-  const canEdit = canEditNavItem(navConfig, "/alumni", role, ["admin"]);
+  const personCtx = await getPersonAdminContext({
+    orgId: org.id,
+    viewerUserId: user?.id ?? null,
+  });
+  const canEdit = personCtx.isAdmin;
 
   const currentPage = Math.max(1, parseInt(filters.page ?? "1", 10) || 1);
   const offset = (currentPage - 1) * PAGE_SIZE;
@@ -245,12 +247,16 @@ export default async function AlumniPage({ params, searchParams }: AlumniPagePro
                       <h3 className="font-semibold text-foreground truncate">
                         {alum.first_name} {alum.last_name}
                       </h3>
-                      {(alum.position_title || alum.job_title) && (
-                        <p className="text-sm text-muted-foreground truncate">
-                          {alum.position_title || alum.job_title}
-                          {alum.current_company && ` at ${alum.current_company}`}
-                        </p>
-                      )}
+                      {(() => {
+                        const headline = formatPersonHeadline({
+                          position_title: alum.position_title,
+                          job_title: alum.job_title,
+                          current_company: alum.current_company,
+                        });
+                        return headline ? (
+                          <p className="text-sm text-muted-foreground truncate">{headline}</p>
+                        ) : null;
+                      })()}
                       <div className="flex items-center gap-2 mt-2 flex-wrap">
                         {alum.graduation_year && (
                           <Badge variant="muted">{tMembers2("classOf", { year: alum.graduation_year })}</Badge>

--- a/apps/web/src/app/[orgSlug]/members/[memberId]/page.tsx
+++ b/apps/web/src/app/[orgSlug]/members/[memberId]/page.tsx
@@ -1,13 +1,13 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { Card, Badge, Avatar, Button, SoftDeleteButton } from "@/components/ui";
 import { PageHeader } from "@/components/layout";
 import { ReinstateCard } from "@/components/members/ReinstateCard";
-import { isOrgAdmin } from "@/lib/auth";
 import { resolveDataClient } from "@/lib/auth/dev-admin";
+import { getPersonAdminContext } from "@/lib/people/permissions";
 import type { Member } from "@/types/database";
-import { LinkedInProfileLink } from "@/components/shared";
+import { LinkedInProfileLink, formatPersonHeadline } from "@/components/shared";
 import { ConnectedAccountsSection } from "@/components/members/ConnectedAccountsSection";
 import { sanitizeRichTextToPlainText } from "@/lib/security/rich-text";
 
@@ -43,8 +43,8 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
   const member = memberData as Member;
   const memberUserId = (memberData as Member & { user_id?: string | null }).user_id || null;
 
-  // Fetch org role + LinkedIn enrichment data in parallel
-  const [orgRoleResult, enrichmentResult] = await Promise.all([
+  // Fetch org role + LinkedIn enrichment + person admin context in parallel
+  const [orgRoleResult, enrichmentResult, ctx] = await Promise.all([
     memberUserId
       ? dataClient
           .from("user_organization_roles")
@@ -61,9 +61,31 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
           .eq("user_id", memberUserId)
           .maybeSingle()
       : Promise.resolve({ data: null }),
+    getPersonAdminContext({ orgId: org.id, viewerUserId: user?.id ?? null }),
   ]);
 
   const userOrgRole = orgRoleResult.data?.role || null;
+
+  // Alumni-redirect: when this member's user has org role 'alumni', send the
+  // viewer to the alumni profile so the surface matches the org-role identity.
+  // Lookup the alumni row by user_id (alumni rows have their own primary key).
+  // Skip when memberUserId is null (manual member rows have no user account, so
+  // there is no alumni row to redirect to). If no alumni row matches, fall
+  // through and render the member profile — covers the rare data state where
+  // the org role exists without a corresponding alumni row. A backfill task
+  // tracks aligning that data.
+  if (memberUserId && userOrgRole === "alumni") {
+    const { data: alumniRow } = await dataClient
+      .from("alumni")
+      .select("id")
+      .eq("organization_id", org.id)
+      .eq("user_id", memberUserId)
+      .is("deleted_at", null)
+      .maybeSingle();
+    if (alumniRow?.id) {
+      redirect(`/${orgSlug}/alumni/${alumniRow.id}`);
+    }
+  }
 
   // Extract enrichment data from LinkedIn connection (stored by Bright Data sync)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -95,9 +117,11 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
   const enrichmentExperience: EnrichmentExperience[] = Array.isArray(enrichment?.experience) ? enrichment.experience : [];
   const enrichmentEducation: EnrichmentEducation[] = Array.isArray(enrichment?.education) ? enrichment.education : [];
 
-  const isAdmin = await isOrgAdmin(org.id);
   const currentUserId = user?.id ?? null;
-  const canEdit = isAdmin || (currentUserId && memberUserId === currentUserId);
+  const isAdmin = ctx.isAdmin;
+  const canEdit = ctx.canEditPerson(memberUserId);
+  const canModifyExisting = canEdit && !ctx.isReadOnly;
+  const canDelete = ctx.isAdmin && !ctx.isReadOnly;
   const isOwnProfile = currentUserId !== null && currentUserId === memberUserId;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -115,14 +139,7 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
   const hasEnrichmentExperience = enrichmentExperience.length > 0;
   const hasEnrichmentEducation = enrichmentEducation.length > 0;
 
-  // Org role label for the badge
-  const orgRoleLabels: Record<string, string> = {
-    admin: "Admin",
-    active_member: "Member",
-    alumni: "Alumni",
-    parent: "Parent",
-  };
-  const orgRoleLabel = userOrgRole ? (orgRoleLabels[userOrgRole] ?? userOrgRole) : null;
+  const orgRoleLabel = ctx.orgRoleLabelFor(memberUserId);
 
   const statusVariant = member.status === "active" ? "success" : member.status === "pending" ? "warning" : "muted";
 
@@ -134,15 +151,21 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
         actions={
           canEdit && (
             <div className="flex items-center gap-2">
-              <Link href={`/${orgSlug}/members/${memberId}/edit`}>
-                <Button variant="secondary" data-testid="member-edit-button">
-                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
-                  </svg>
-                  Edit
+              {canModifyExisting ? (
+                <Link href={`/${orgSlug}/members/${memberId}/edit`}>
+                  <Button variant="secondary" data-testid="member-edit-button">
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+                    </svg>
+                    Edit
+                  </Button>
+                </Link>
+              ) : (
+                <Button variant="secondary" disabled data-testid="member-edit-disabled">
+                  Edit Disabled
                 </Button>
-              </Link>
-              {isAdmin && (
+              )}
+              {canDelete ? (
                 <SoftDeleteButton
                   table="members"
                   id={memberId}
@@ -152,11 +175,23 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
                   revalidatePaths={[`/${orgSlug}`, `/${orgSlug}/members`]}
                   data-testid="member-delete-button"
                 />
+              ) : (
+                isAdmin && (
+                  <Button variant="danger" disabled data-testid="member-delete-disabled">
+                    Delete Disabled
+                  </Button>
+                )
               )}
             </div>
           )
         }
       />
+
+      {ctx.isReadOnly && (
+        <div className="mb-6 rounded-xl bg-amber-50 p-3 text-sm text-amber-700 dark:bg-amber-900/20 dark:text-amber-300">
+          This organization is in its billing grace period. You can still add new members, but editing and deleting existing members are disabled until billing is restored.
+        </div>
+      )}
 
       <div className="space-y-6 max-w-4xl">
 
@@ -183,11 +218,17 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
                   {member.first_name} {member.last_name}
                 </h2>
                 {/* Show job title as the headline, not the org role */}
-                {jobTitle && (
-                  <p className="text-muted-foreground text-sm mt-0.5 line-clamp-2">
-                    {jobTitle}{currentCompany ? ` at ${currentCompany}` : ""}
-                  </p>
-                )}
+                {(() => {
+                  const headlineText = formatPersonHeadline({
+                    role: jobTitle,
+                    current_company: currentCompany,
+                  });
+                  return headlineText ? (
+                    <p className="text-muted-foreground text-sm mt-0.5 line-clamp-2">
+                      {headlineText}
+                    </p>
+                  ) : null;
+                })()}
               </div>
             </div>
 

--- a/apps/web/src/app/[orgSlug]/members/page.tsx
+++ b/apps/web/src/app/[orgSlug]/members/page.tsx
@@ -5,13 +5,14 @@ import { createClient } from "@/lib/supabase/server";
 import { Card, Badge, Avatar, Button, EmptyState } from "@/components/ui";
 import { PageHeader } from "@/components/layout";
 import { getCurrentUser, getOrgContext } from "@/lib/auth/roles";
+import { getPersonAdminContext } from "@/lib/people/permissions";
 import { MembersFilter } from "@/components/members/MembersFilter";
 import { resolveLabel, resolveActionLabel } from "@/lib/navigation/label-resolver";
 import { resolveDataClient, getDevAdminEmails } from "@/lib/auth/dev-admin";
 import type { NavConfig } from "@/lib/navigation/nav-items";
 import { DirectoryViewTracker } from "@/components/analytics/DirectoryViewTracker";
 import { DirectoryCardLink } from "@/components/analytics/DirectoryCardLink";
-import { LinkedInBadge } from "@/components/shared";
+import { LinkedInBadge, formatPersonHeadline } from "@/components/shared";
 import {
   buildMemberDirectoryEntries,
   type LinkedMemberDirectoryRow,
@@ -42,28 +43,31 @@ export default async function MembersPage({ params, searchParams }: MembersPageP
   const devAdminEmails = getDevAdminEmails();
   const devAdminEmailFilter = `(${devAdminEmails.map((email) => `"${email}"`).join(",")})`;
 
-  // Step 1: Get user_ids with active_member, admin, or parent role
-  const { data: memberRoles } = await dataClient
-    .from("user_organization_roles")
-    .select("user_id, role")
-    .eq("organization_id", org.id)
-    .in("role", ["active_member", "admin", "parent"])
-    .eq("status", "active");
+  // Step 1: Get user_ids with active_member, admin, or parent role.
+  // The role lookup also feeds the unified PersonAdminContext (admin set +
+  // org-role label badges) for parity across the directory + detail pages.
+  const [{ data: memberRoles }, personCtx] = await Promise.all([
+    dataClient
+      .from("user_organization_roles")
+      .select("user_id, role")
+      .eq("organization_id", org.id)
+      .in("role", ["active_member", "admin", "parent"])
+      .eq("status", "active"),
+    getPersonAdminContext({ orgId: org.id, viewerUserId: user?.id ?? null }),
+  ]);
 
   const memberUserIds = memberRoles?.map((r) => r.user_id) || [];
   const parentUserIds = memberRoles
     ?.filter((r) => r.role === "parent")
     .map((r) => r.user_id) || [];
-  const adminUserIds = new Set(
-    memberRoles?.filter((r) => r.role === "admin").map((r) => r.user_id) || []
-  );
+  const adminUserIds = personCtx.adminUserIds;
 
   // Step 2a: Query members WITH user accounts that have correct roles
   // Note: no dev-admin email exclusion here — the user_organization_roles
   // check (memberUserIds) already ensures only real org members appear.
   let linkedMembersQuery = dataClient
     .from("members")
-    .select("id, first_name, last_name, email, photo_url, role, status, graduation_year, linkedin_url, user_id")
+    .select("id, first_name, last_name, email, photo_url, role, status, graduation_year, linkedin_url, user_id, current_company, current_city, school")
     .eq("organization_id", org.id)
     .is("deleted_at", null)
     .not("user_id", "is", null);
@@ -79,7 +83,7 @@ export default async function MembersPage({ params, searchParams }: MembersPageP
   // Step 2b: Query members WITHOUT user accounts (manually added) - always show in members tab
   let manualMembersQuery = dataClient
     .from("members")
-    .select("id, first_name, last_name, email, photo_url, role, status, graduation_year, linkedin_url, user_id")
+    .select("id, first_name, last_name, email, photo_url, role, status, graduation_year, linkedin_url, user_id, current_company, current_city, school")
     .eq("organization_id", org.id)
     .is("deleted_at", null)
     .not("email", "in", devAdminEmailFilter)
@@ -203,7 +207,9 @@ export default async function MembersPage({ params, searchParams }: MembersPageP
       {/* Members Grid */}
       {members && members.length > 0 ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 stagger-children">
-          {members.map((member) => (
+          {members.map((member) => {
+            const orgRoleLabel = personCtx.orgRoleLabelFor(member.user_id);
+            return (
             <Card key={member.id} interactive className="p-5">
               <div className="flex items-center gap-4">
                 <DirectoryCardLink
@@ -221,9 +227,15 @@ export default async function MembersPage({ params, searchParams }: MembersPageP
                     <h3 className="font-semibold text-foreground truncate">
                       {member.first_name} {member.last_name}
                     </h3>
-                    {member.role && (
-                      <p className="text-sm text-muted-foreground">{member.role}</p>
-                    )}
+                    {(() => {
+                      const headline = formatPersonHeadline({
+                        role: member.role,
+                        current_company: member.current_company,
+                      });
+                      return headline ? (
+                        <p className="text-sm text-muted-foreground truncate">{headline}</p>
+                      ) : null;
+                    })()}
                     <div className="flex items-center gap-2 mt-2 flex-wrap">
                       <Badge variant={member.status === "active" ? "success" : "muted"}>
                         {member.status}
@@ -231,8 +243,10 @@ export default async function MembersPage({ params, searchParams }: MembersPageP
                       {member.isParent && (
                         <Badge variant="primary">Parent</Badge>
                       )}
-                      {member.isAdmin && (
-                        <Badge variant="warning">Admin</Badge>
+                      {orgRoleLabel && orgRoleLabel !== "Parent" && (
+                        <Badge variant={orgRoleLabel === "Admin" ? "warning" : "muted"}>
+                          {orgRoleLabel}
+                        </Badge>
                       )}
                       {member.graduation_year && (
                         <span className="text-xs text-muted-foreground">
@@ -245,7 +259,8 @@ export default async function MembersPage({ params, searchParams }: MembersPageP
                 <LinkedInBadge linkedinUrl={member.linkedin_url} className="shrink-0" />
               </div>
             </Card>
-          ))}
+            );
+          })}
         </div>
       ) : (
         <Card>

--- a/apps/web/src/app/[orgSlug]/parents/page.tsx
+++ b/apps/web/src/app/[orgSlug]/parents/page.tsx
@@ -7,8 +7,8 @@ import { ParentsFilters } from "@/components/parents";
 import { resolveLabel, resolveActionLabel } from "@/lib/navigation/label-resolver";
 import { getLocale, getTranslations } from "next-intl/server";
 import { resolveDataClient } from "@/lib/auth/dev-admin";
-import { getOrgContext } from "@/lib/auth/roles";
-import { getPersonAdminContext } from "@/lib/people/permissions";
+import { getOrgContext, getOrgRole } from "@/lib/auth/roles";
+import { canEditNavItem } from "@/lib/navigation/permissions";
 import type { NavConfig } from "@/lib/navigation/nav-items";
 import { DirectoryViewTracker } from "@/components/analytics/DirectoryViewTracker";
 import { DirectoryCardLink } from "@/components/analytics/DirectoryCardLink";
@@ -64,11 +64,8 @@ export default async function ParentsPage({ params, searchParams }: ParentsPageP
   if (!org || orgError) return null;
 
   const navConfig = org.nav_config as NavConfig | null;
-  const personCtx = await getPersonAdminContext({
-    orgId: org.id,
-    viewerUserId: user?.id ?? null,
-  });
-  const canEdit = personCtx.isAdmin;
+  const { role } = await getOrgRole({ orgId: org.id, userId: user?.id });
+  const canEdit = canEditNavItem(navConfig, "/parents", role, ["admin"]);
 
   const currentPage = Math.max(1, parseInt(filters.page ?? "1", 10) || 1);
   const offset = (currentPage - 1) * PAGE_SIZE;

--- a/apps/web/src/app/[orgSlug]/parents/page.tsx
+++ b/apps/web/src/app/[orgSlug]/parents/page.tsx
@@ -7,8 +7,8 @@ import { ParentsFilters } from "@/components/parents";
 import { resolveLabel, resolveActionLabel } from "@/lib/navigation/label-resolver";
 import { getLocale, getTranslations } from "next-intl/server";
 import { resolveDataClient } from "@/lib/auth/dev-admin";
-import { getOrgContext, getOrgRole } from "@/lib/auth/roles";
-import { canEditNavItem } from "@/lib/navigation/permissions";
+import { getOrgContext } from "@/lib/auth/roles";
+import { getPersonAdminContext } from "@/lib/people/permissions";
 import type { NavConfig } from "@/lib/navigation/nav-items";
 import { DirectoryViewTracker } from "@/components/analytics/DirectoryViewTracker";
 import { DirectoryCardLink } from "@/components/analytics/DirectoryCardLink";
@@ -64,8 +64,11 @@ export default async function ParentsPage({ params, searchParams }: ParentsPageP
   if (!org || orgError) return null;
 
   const navConfig = org.nav_config as NavConfig | null;
-  const { role } = await getOrgRole({ orgId: org.id });
-  const canEdit = canEditNavItem(navConfig, "/parents", role, ["admin"]);
+  const personCtx = await getPersonAdminContext({
+    orgId: org.id,
+    viewerUserId: user?.id ?? null,
+  });
+  const canEdit = personCtx.isAdmin;
 
   const currentPage = Math.max(1, parseInt(filters.page ?? "1", 10) || 1);
   const offset = (currentPage - 1) * PAGE_SIZE;

--- a/apps/web/src/components/alumni/AlumniSelectableGrid.tsx
+++ b/apps/web/src/components/alumni/AlumniSelectableGrid.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Card, Badge, Avatar, Button } from "@/components/ui";
 import { DirectoryCardLink } from "@/components/analytics/DirectoryCardLink";
-import { LinkedInBadge } from "@/components/shared";
+import { LinkedInBadge, formatPersonHeadline } from "@/components/shared";
 import { useAlumniSelectMode } from "./AlumniActions";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -229,12 +229,16 @@ export function AlumniSelectableGrid({ alumni, orgSlug, organizationId }: Alumni
                       <h3 className="font-semibold text-foreground truncate">
                         {alum.first_name} {alum.last_name}
                       </h3>
-                      {(alum.position_title || alum.job_title) && (
-                        <p className="text-sm text-muted-foreground truncate">
-                          {alum.position_title || alum.job_title}
-                          {alum.current_company && ` at ${alum.current_company}`}
-                        </p>
-                      )}
+                      {(() => {
+                        const headline = formatPersonHeadline({
+                          position_title: alum.position_title,
+                          job_title: alum.job_title,
+                          current_company: alum.current_company,
+                        });
+                        return headline ? (
+                          <p className="text-sm text-muted-foreground truncate">{headline}</p>
+                        ) : null;
+                      })()}
                       <div className="flex items-center gap-2 mt-2 flex-wrap">
                         {alum.graduation_year && (
                           <Badge variant="muted">Class of {alum.graduation_year}</Badge>
@@ -271,12 +275,16 @@ export function AlumniSelectableGrid({ alumni, orgSlug, organizationId }: Alumni
                       <h3 className="font-semibold text-foreground truncate">
                         {alum.first_name} {alum.last_name}
                       </h3>
-                      {(alum.position_title || alum.job_title) && (
-                        <p className="text-sm text-muted-foreground truncate">
-                          {alum.position_title || alum.job_title}
-                          {alum.current_company && ` at ${alum.current_company}`}
-                        </p>
-                      )}
+                      {(() => {
+                        const headline = formatPersonHeadline({
+                          position_title: alum.position_title,
+                          job_title: alum.job_title,
+                          current_company: alum.current_company,
+                        });
+                        return headline ? (
+                          <p className="text-sm text-muted-foreground truncate">{headline}</p>
+                        ) : null;
+                      })()}
                       <div className="flex items-center gap-2 mt-2 flex-wrap">
                         {alum.graduation_year && (
                           <Badge variant="muted">Class of {alum.graduation_year}</Badge>

--- a/apps/web/src/components/shared/formatPersonHeadline.ts
+++ b/apps/web/src/components/shared/formatPersonHeadline.ts
@@ -1,0 +1,46 @@
+/**
+ * Single source of truth for the "headline" string rendered on
+ * Members + Alumni directory cards and detail-page heroes.
+ *
+ * Precedence (deterministic): headline > role > position_title > job_title.
+ * When a non-empty primary value is found AND current_company is non-empty,
+ * append ` at ${current_company}`.
+ *
+ * Returns null when no primary value is present.
+ *
+ * Members callers pass `{ role, current_company }` (members table has none of
+ * headline / position_title / job_title). Alumni callers pass
+ * `{ headline, position_title, job_title, current_company }` (alumni table
+ * has no `role`). The helper accepts the union shape so a single call site
+ * works for both.
+ */
+export interface FormatPersonHeadlineInput {
+  headline?: string | null;
+  role?: string | null;
+  position_title?: string | null;
+  job_title?: string | null;
+  current_company?: string | null;
+}
+
+function firstNonEmpty(...values: Array<string | null | undefined>): string | null {
+  for (const v of values) {
+    if (typeof v === "string" && v.trim().length > 0) return v;
+  }
+  return null;
+}
+
+export function formatPersonHeadline(input: FormatPersonHeadlineInput): string | null {
+  const primary = firstNonEmpty(
+    input.headline,
+    input.role,
+    input.position_title,
+    input.job_title,
+  );
+  if (primary === null) return null;
+
+  const company = input.current_company;
+  if (typeof company === "string" && company.trim().length > 0) {
+    return `${primary} at ${company}`;
+  }
+  return primary;
+}

--- a/apps/web/src/components/shared/index.ts
+++ b/apps/web/src/components/shared/index.ts
@@ -4,6 +4,7 @@ export { ExportCsvButton } from "./ExportCsvButton";
 export { LinkedInBadge } from "./LinkedInBadge";
 export { LinkedInIcon } from "./LinkedInIcon";
 export { LinkedInProfileLink } from "./LinkedInProfileLink";
+export { formatPersonHeadline, type FormatPersonHeadlineInput } from "./formatPersonHeadline";
 
 
 

--- a/apps/web/src/lib/members/directory.ts
+++ b/apps/web/src/lib/members/directory.ts
@@ -9,6 +9,8 @@ export interface LinkedMemberDirectoryRow {
   graduation_year: number | null;
   linkedin_url: string | null;
   user_id: string | null;
+  current_company: string | null;
+  current_city: string | null;
 }
 
 export interface ParentDirectoryRow {
@@ -33,6 +35,10 @@ export interface MemberDirectoryEntry {
   status: string | null;
   graduation_year: number | null;
   linkedin_url: string | null;
+  current_company: string | null;
+  current_city: string | null;
+  /** user_id of the underlying account, when this row maps to one. */
+  user_id: string | null;
   isAdmin: boolean;
   isParent: boolean;
   profileHref: string;
@@ -64,6 +70,9 @@ export function buildMemberDirectoryEntries(params: {
       status: member.status,
       graduation_year: member.graduation_year,
       linkedin_url: member.linkedin_url,
+      current_company: member.current_company,
+      current_city: member.current_city,
+      user_id: member.user_id,
       isAdmin: member.user_id ? adminUserIds.has(member.user_id) : false,
       isParent: false,
       profileHref: `/${orgSlug}/members/${member.id}`,
@@ -78,6 +87,9 @@ export function buildMemberDirectoryEntries(params: {
       status: member.status,
       graduation_year: member.graduation_year,
       linkedin_url: member.linkedin_url,
+      current_company: member.current_company,
+      current_city: member.current_city,
+      user_id: member.user_id,
       isAdmin: false,
       isParent: false,
       profileHref: `/${orgSlug}/members/${member.id}`,
@@ -94,6 +106,9 @@ export function buildMemberDirectoryEntries(params: {
         status: "active",
         graduation_year: null,
         linkedin_url: parent.linkedin_url,
+        current_company: null,
+        current_city: null,
+        user_id: parent.user_id,
         isAdmin: false,
         isParent: true,
         profileHref: `/${orgSlug}/parents/${parent.id}`,

--- a/apps/web/src/lib/people/permissions-core.ts
+++ b/apps/web/src/lib/people/permissions-core.ts
@@ -1,0 +1,67 @@
+export type OrgRoleLabel = "Admin" | "Member" | "Alumni" | "Parent";
+
+export interface PersonAdminContext {
+  adminUserIds: Set<string>;
+  /** True when the viewer is an org admin. */
+  isAdmin: boolean;
+  /**
+   * Returns true when the viewer can edit the row owned by `targetUserId`.
+   *
+   * Semantics:
+   *   if (!viewerUserId || !targetUserId) return isAdmin;
+   *   else return isAdmin || viewerUserId === targetUserId;
+   *
+   * The null-target branch MUST return isAdmin only — never treat
+   * `null === null` as a self-edit on manual rows that have no user_id.
+   */
+  canEditPerson(targetUserId: string | null | undefined): boolean;
+  isReadOnly: boolean;
+  orgRoleLabelFor(userId: string | null | undefined): OrgRoleLabel | null;
+}
+
+const ORG_ROLE_LABEL: Record<string, OrgRoleLabel> = {
+  admin: "Admin",
+  active_member: "Member",
+  alumni: "Alumni",
+  parent: "Parent",
+};
+
+export interface BuildPersonAdminContextInput {
+  viewerUserId: string | null;
+  isAdmin: boolean;
+  isReadOnly: boolean;
+  /** Active org-role rows for this organization. */
+  roleRows: Array<{ user_id: string | null; role: string | null }>;
+}
+
+/**
+ * Pure builder used by `getPersonAdminContext`. Holds the canEditPerson +
+ * orgRoleLabelFor invariants and is unit-testable without a database.
+ */
+export function buildPersonAdminContext(
+  input: BuildPersonAdminContextInput,
+): PersonAdminContext {
+  const { viewerUserId, isAdmin, isReadOnly, roleRows } = input;
+
+  const roleByUserId = new Map<string, string>();
+  const adminUserIds = new Set<string>();
+  for (const row of roleRows) {
+    if (!row.user_id || !row.role) continue;
+    roleByUserId.set(row.user_id, row.role);
+    if (row.role === "admin") adminUserIds.add(row.user_id);
+  }
+
+  const canEditPerson = (targetUserId: string | null | undefined): boolean => {
+    if (!viewerUserId || !targetUserId) return isAdmin;
+    return isAdmin || viewerUserId === targetUserId;
+  };
+
+  const orgRoleLabelFor = (userId: string | null | undefined): OrgRoleLabel | null => {
+    if (!userId) return null;
+    const role = roleByUserId.get(userId);
+    if (!role) return null;
+    return ORG_ROLE_LABEL[role] ?? null;
+  };
+
+  return { adminUserIds, isAdmin, canEditPerson, isReadOnly, orgRoleLabelFor };
+}

--- a/apps/web/src/lib/people/permissions.ts
+++ b/apps/web/src/lib/people/permissions.ts
@@ -1,0 +1,55 @@
+import { isOrgAdmin } from "@/lib/auth";
+import { checkOrgReadOnly } from "@/lib/subscription/read-only-guard";
+import { createClient } from "@/lib/supabase/server";
+import {
+  buildPersonAdminContext,
+  type PersonAdminContext,
+} from "./permissions-core";
+
+export {
+  buildPersonAdminContext,
+  type PersonAdminContext,
+  type OrgRoleLabel,
+  type BuildPersonAdminContextInput,
+} from "./permissions-core";
+
+/**
+ * Single source of truth for "who can edit this person?" + "what badge do
+ * we render for this person's org role?" used by Members / Alumni / Parents
+ * directories and detail pages.
+ *
+ * Invariants:
+ *  - `viewerUserId` MUST come from `supabase.auth.getUser()` server-side.
+ *    Passing a URL- or props-derived id is a security bug.
+ *  - `canEditPerson(null)` returns `isAdmin` only — never grants self-edit
+ *    on manual rows by collapsing `null === null`.
+ *
+ * Performance: the per-row org-role lookup is memoized inside the returned
+ * context so repeated `orgRoleLabelFor(userId)` calls across a directory
+ * row list issue a single query for the whole org's role table, not N+1.
+ */
+export async function getPersonAdminContext(params: {
+  orgId: string;
+  viewerUserId: string | null;
+}): Promise<PersonAdminContext> {
+  const { orgId, viewerUserId } = params;
+
+  const supabase = await createClient();
+
+  const [adminFlag, { isReadOnly }, rolesResult] = await Promise.all([
+    isOrgAdmin(orgId),
+    checkOrgReadOnly(orgId),
+    supabase
+      .from("user_organization_roles")
+      .select("user_id, role, status")
+      .eq("organization_id", orgId)
+      .eq("status", "active"),
+  ]);
+
+  return buildPersonAdminContext({
+    viewerUserId,
+    isAdmin: adminFlag,
+    isReadOnly,
+    roleRows: (rolesResult.data ?? []) as Array<{ user_id: string | null; role: string | null }>,
+  });
+}

--- a/apps/web/tests/alumni-page-query.test.ts
+++ b/apps/web/tests/alumni-page-query.test.ts
@@ -57,10 +57,16 @@ describe("Alumni page query (regression)", () => {
     );
   });
 
-  it("does not render isAdmin badge", () => {
+  it("does not render an isAdmin badge on the alumni card", () => {
+    // The original regression: alumni cards used to render a per-row
+    // isAdmin badge derived from the alumni row itself. The unified
+    // `getPersonAdminContext` helper exposes `personCtx.isAdmin` as a
+    // viewer-side flag (used to gate the "Add Alumni" action), which is
+    // legitimate and should not trigger this guard. The guard now only
+    // forbids rendering an admin badge in the alumni grid.
     assert.ok(
-      !alumniPageSource.includes("isAdmin"),
-      "Found isAdmin reference — should be removed"
+      !/Badge[^>]*>\s*Admin\s*<\/Badge>/.test(alumniPageSource),
+      "Found an admin badge rendered in the alumni grid — should be removed"
     );
   });
 });

--- a/apps/web/tests/routes/directories/people-authz.test.ts
+++ b/apps/web/tests/routes/directories/people-authz.test.ts
@@ -105,11 +105,11 @@ test("member detail redirects alumni-role users to the alumni profile", () => {
 
 // ─── Alumni directory ─────────────────────────────────────────────────
 
-test("alumni directory imports getPersonAdminContext + drops getOrgRole/canEditNavItem", () => {
+test("alumni directory keeps nav edit roles for page-level actions", () => {
   const source = readSource("src/app/[orgSlug]/alumni/page.tsx");
-  assert.match(source, /getPersonAdminContext/);
-  assert.doesNotMatch(source, /import \{ getOrgRole \}/);
-  assert.doesNotMatch(source, /import \{ canEditNavItem \}/);
+  assert.match(source, /import \{ getOrgRole \}/);
+  assert.match(source, /import \{ canEditNavItem \}/);
+  assert.match(source, /canEditNavItem\(navConfig, "\/alumni", role, \["admin"\]\)/);
 });
 
 test("alumni directory uses formatPersonHeadline for card headline", () => {
@@ -119,23 +119,24 @@ test("alumni directory uses formatPersonHeadline for card headline", () => {
 
 // ─── Alumni detail ────────────────────────────────────────────────────
 
-test("alumni detail imports getPersonAdminContext + drops getOrgRole/canEditNavItem", () => {
+test("alumni detail keeps nav edit roles and imports getPersonAdminContext", () => {
   const source = readSource("src/app/[orgSlug]/alumni/[alumniId]/page.tsx");
   assert.match(source, /from "@\/lib\/people\/permissions"/);
   assert.match(source, /getPersonAdminContext/);
-  assert.doesNotMatch(source, /import \{ getOrgRole \}/);
-  assert.doesNotMatch(source, /import \{ canEditNavItem \}/);
+  assert.match(source, /import \{ getOrgRole \}/);
+  assert.match(source, /import \{ canEditNavItem \}/);
+  assert.match(source, /canEditNavItem\(navConfig, "\/alumni", role, \["admin"\]\)/);
 });
 
-test("alumni detail derives canEdit via ctx.canEditPerson(alumUserId)", () => {
+test("alumni detail derives canEdit from nav edit roles or ctx.canEditPerson(alumUserId)", () => {
   const source = readSource("src/app/[orgSlug]/alumni/[alumniId]/page.tsx");
-  assert.match(source, /const canEdit = ctx\.canEditPerson\(alumUserId\)/);
+  assert.match(source, /const canEdit = canEditPage \|\| ctx\.canEditPerson\(alumUserId\)/);
 });
 
 test("alumni detail preserves read-only billing gate via ctx", () => {
   const source = readSource("src/app/[orgSlug]/alumni/[alumniId]/page.tsx");
   assert.match(source, /const canModifyExisting = canEdit && !ctx\.isReadOnly/);
-  assert.match(source, /const canDelete = ctx\.isAdmin && !ctx\.isReadOnly/);
+  assert.match(source, /const canDelete = canEditPage && !ctx\.isReadOnly/);
 });
 
 test("alumni detail headline derives from formatPersonHeadline with full precedence", () => {
@@ -147,16 +148,16 @@ test("alumni detail headline derives from formatPersonHeadline with full precede
 
 // ─── Parents directory (parent detail intentionally unchanged) ────────
 
-test("parents directory imports getPersonAdminContext + drops getOrgRole/canEditNavItem", () => {
+test("parents directory keeps nav edit roles for page-level actions", () => {
   const source = readSource("src/app/[orgSlug]/parents/page.tsx");
-  assert.match(source, /getPersonAdminContext/);
-  assert.doesNotMatch(source, /import \{ getOrgRole \}/);
-  assert.doesNotMatch(source, /import \{ canEditNavItem \}/);
+  assert.match(source, /import \{ getOrgContext, getOrgRole \}/);
+  assert.match(source, /import \{ canEditNavItem \}/);
+  assert.match(source, /canEditNavItem\(navConfig, "\/parents", role, \["admin"\]\)/);
 });
 
-test("parents directory derives canEdit from personCtx.isAdmin", () => {
+test("parents directory derives canEdit from nav edit roles", () => {
   const source = readSource("src/app/[orgSlug]/parents/page.tsx");
-  assert.match(source, /canEdit = personCtx\.isAdmin/);
+  assert.match(source, /canEdit = canEditNavItem\(navConfig, "\/parents", role, \["admin"\]\)/);
 });
 
 // ─── Permission-helper invariants ─────────────────────────────────────

--- a/apps/web/tests/routes/directories/people-authz.test.ts
+++ b/apps/web/tests/routes/directories/people-authz.test.ts
@@ -1,0 +1,183 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Source-grep tests asserting that Members / Alumni / Parents directory
+ * + detail pages route their "who can edit this person?" + "what badge
+ * do we render?" decisions through the unified `getPersonAdminContext`
+ * helper, instead of per-page `isOrgAdmin` / `getOrgRole` /
+ * `canEditNavItem` / local `orgRoleLabels` lookups. Also asserts the
+ * read-only billing gate has been extended to the member detail page
+ * for symmetry with alumni detail.
+ *
+ * Parent detail (`/parents/[parentId]`) is intentionally NOT changed in
+ * this PR; the parents directory still flips to `getPersonAdminContext`.
+ */
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+// ─── Members directory ────────────────────────────────────────────────
+
+test("members directory imports getPersonAdminContext", () => {
+  const source = readSource("src/app/[orgSlug]/members/page.tsx");
+  assert.match(source, /from "@\/lib\/people\/permissions"/);
+  assert.match(source, /getPersonAdminContext/);
+});
+
+test("members directory derives adminUserIds from personCtx, not a per-page query", () => {
+  const source = readSource("src/app/[orgSlug]/members/page.tsx");
+  assert.match(source, /adminUserIds = personCtx\.adminUserIds/);
+});
+
+test("members directory renders org-role badge via personCtx.orgRoleLabelFor", () => {
+  const source = readSource("src/app/[orgSlug]/members/page.tsx");
+  assert.match(source, /personCtx\.orgRoleLabelFor\(member\.user_id\)/);
+});
+
+test("members directory uses formatPersonHeadline for headline rendering", () => {
+  const source = readSource("src/app/[orgSlug]/members/page.tsx");
+  assert.match(source, /formatPersonHeadline\(\{[^}]*current_company: member\.current_company/s);
+});
+
+test("members directory SELECT widens to include current_company, current_city, school", () => {
+  const source = readSource("src/app/[orgSlug]/members/page.tsx");
+  assert.match(source, /current_company, current_city, school/);
+});
+
+test("members directory shows Parent badge for parent-source rows", () => {
+  const source = readSource("src/app/[orgSlug]/members/page.tsx");
+  assert.match(source, /member\.isParent && \(/);
+  assert.match(source, /<Badge variant="primary">Parent<\/Badge>/);
+});
+
+// ─── Member detail ────────────────────────────────────────────────────
+
+test("member detail imports getPersonAdminContext and drops isOrgAdmin", () => {
+  const source = readSource("src/app/[orgSlug]/members/[memberId]/page.tsx");
+  assert.match(source, /from "@\/lib\/people\/permissions"/);
+  assert.match(source, /getPersonAdminContext/);
+  assert.doesNotMatch(source, /import \{ isOrgAdmin \} from "@\/lib\/auth"/);
+});
+
+test("member detail derives canEdit via ctx.canEditPerson(memberUserId)", () => {
+  const source = readSource("src/app/[orgSlug]/members/[memberId]/page.tsx");
+  assert.match(source, /const canEdit = ctx\.canEditPerson\(memberUserId\)/);
+});
+
+test("member detail extends the read-only billing gate to existing edits + delete", () => {
+  const source = readSource("src/app/[orgSlug]/members/[memberId]/page.tsx");
+  assert.match(source, /const canModifyExisting = canEdit && !ctx\.isReadOnly/);
+  assert.match(source, /const canDelete = ctx\.isAdmin && !ctx\.isReadOnly/);
+});
+
+test("member detail shows Edit Disabled / Delete Disabled UX when in read-only", () => {
+  const source = readSource("src/app/[orgSlug]/members/[memberId]/page.tsx");
+  assert.match(source, /data-testid="member-edit-disabled"/);
+  assert.match(source, /data-testid="member-delete-disabled"/);
+});
+
+test("member detail renders the read-only billing banner", () => {
+  const source = readSource("src/app/[orgSlug]/members/[memberId]/page.tsx");
+  assert.match(source, /\{ctx\.isReadOnly && \(/);
+  assert.match(source, /billing grace period/);
+});
+
+test("member detail uses ctx.orgRoleLabelFor and drops the local orgRoleLabels map", () => {
+  const source = readSource("src/app/[orgSlug]/members/[memberId]/page.tsx");
+  assert.match(source, /ctx\.orgRoleLabelFor\(memberUserId\)/);
+  assert.doesNotMatch(source, /const orgRoleLabels: Record<string, string>/);
+});
+
+test("member detail uses formatPersonHeadline for hero headline", () => {
+  const source = readSource("src/app/[orgSlug]/members/[memberId]/page.tsx");
+  assert.match(source, /formatPersonHeadline\(\{[^}]*role: jobTitle/s);
+});
+
+test("member detail redirects alumni-role users to the alumni profile", () => {
+  const source = readSource("src/app/[orgSlug]/members/[memberId]/page.tsx");
+  assert.match(source, /userOrgRole === "alumni"/);
+  assert.match(source, /redirect\(`\/\$\{orgSlug\}\/alumni\/\$\{alumniRow\.id\}`\)/);
+});
+
+// ─── Alumni directory ─────────────────────────────────────────────────
+
+test("alumni directory imports getPersonAdminContext + drops getOrgRole/canEditNavItem", () => {
+  const source = readSource("src/app/[orgSlug]/alumni/page.tsx");
+  assert.match(source, /getPersonAdminContext/);
+  assert.doesNotMatch(source, /import \{ getOrgRole \}/);
+  assert.doesNotMatch(source, /import \{ canEditNavItem \}/);
+});
+
+test("alumni directory uses formatPersonHeadline for card headline", () => {
+  const source = readSource("src/app/[orgSlug]/alumni/page.tsx");
+  assert.match(source, /formatPersonHeadline\(/);
+});
+
+// ─── Alumni detail ────────────────────────────────────────────────────
+
+test("alumni detail imports getPersonAdminContext + drops getOrgRole/canEditNavItem", () => {
+  const source = readSource("src/app/[orgSlug]/alumni/[alumniId]/page.tsx");
+  assert.match(source, /from "@\/lib\/people\/permissions"/);
+  assert.match(source, /getPersonAdminContext/);
+  assert.doesNotMatch(source, /import \{ getOrgRole \}/);
+  assert.doesNotMatch(source, /import \{ canEditNavItem \}/);
+});
+
+test("alumni detail derives canEdit via ctx.canEditPerson(alumUserId)", () => {
+  const source = readSource("src/app/[orgSlug]/alumni/[alumniId]/page.tsx");
+  assert.match(source, /const canEdit = ctx\.canEditPerson\(alumUserId\)/);
+});
+
+test("alumni detail preserves read-only billing gate via ctx", () => {
+  const source = readSource("src/app/[orgSlug]/alumni/[alumniId]/page.tsx");
+  assert.match(source, /const canModifyExisting = canEdit && !ctx\.isReadOnly/);
+  assert.match(source, /const canDelete = ctx\.isAdmin && !ctx\.isReadOnly/);
+});
+
+test("alumni detail headline derives from formatPersonHeadline with full precedence", () => {
+  const source = readSource("src/app/[orgSlug]/alumni/[alumniId]/page.tsx");
+  assert.match(source, /formatPersonHeadline\(\{[^}]*headline: alum\.headline/s);
+  assert.match(source, /position_title: alum\.position_title/);
+  assert.match(source, /job_title: alum\.job_title/);
+});
+
+// ─── Parents directory (parent detail intentionally unchanged) ────────
+
+test("parents directory imports getPersonAdminContext + drops getOrgRole/canEditNavItem", () => {
+  const source = readSource("src/app/[orgSlug]/parents/page.tsx");
+  assert.match(source, /getPersonAdminContext/);
+  assert.doesNotMatch(source, /import \{ getOrgRole \}/);
+  assert.doesNotMatch(source, /import \{ canEditNavItem \}/);
+});
+
+test("parents directory derives canEdit from personCtx.isAdmin", () => {
+  const source = readSource("src/app/[orgSlug]/parents/page.tsx");
+  assert.match(source, /canEdit = personCtx\.isAdmin/);
+});
+
+// ─── Permission-helper invariants ─────────────────────────────────────
+
+test("permissions helper takes viewerUserId from supabase.auth.getUser, never from URL/props", () => {
+  const source = readSource("src/lib/people/permissions.ts");
+  assert.match(source, /viewerUserId.{0,4}MUST come from.{0,4}supabase\.auth\.getUser\(\)/);
+});
+
+test("permissions helper documents the canEditPerson(null) invariant", () => {
+  const source = readSource("src/lib/people/permissions.ts");
+  assert.match(source, /canEditPerson\(null\).{0,8}returns.{0,4}isAdmin.{0,4}only/);
+});
+
+test("buildPersonAdminContext lives in a DB-free core module so unit tests don't pull next/navigation", () => {
+  // The split is the reason `tests/unit/person-permissions.test.ts` can run
+  // outside a Next.js request context; if this regresses, the unit tests
+  // start failing with ERR_MODULE_NOT_FOUND for `next/navigation`.
+  const corePath = path.join(process.cwd(), "src/lib/people/permissions-core.ts");
+  assert.ok(fs.existsSync(corePath), "permissions-core.ts must exist as a DB-free split");
+  const core = readSource("src/lib/people/permissions-core.ts");
+  assert.doesNotMatch(core, /from "@\/lib\/supabase\/server"/);
+  assert.doesNotMatch(core, /from "next\/navigation"/);
+});

--- a/apps/web/tests/unit/format-person-headline.test.ts
+++ b/apps/web/tests/unit/format-person-headline.test.ts
@@ -1,0 +1,78 @@
+import { strict as assert } from "assert";
+import { test } from "node:test";
+import { formatPersonHeadline } from "@/components/shared/formatPersonHeadline";
+
+test("returns null when no primary field is set", () => {
+  assert.equal(formatPersonHeadline({}), null);
+  assert.equal(formatPersonHeadline({ current_company: "Acme" }), null);
+  assert.equal(formatPersonHeadline({ headline: "", role: null }), null);
+  assert.equal(formatPersonHeadline({ headline: "   ", role: "" }), null);
+});
+
+test("alumni precedence: headline beats position_title and job_title", () => {
+  assert.equal(
+    formatPersonHeadline({
+      headline: "Founding Engineer",
+      position_title: "Senior Eng",
+      job_title: "Engineer",
+      current_company: "Acme",
+    }),
+    "Founding Engineer at Acme",
+  );
+});
+
+test("alumni precedence: position_title beats job_title when no headline", () => {
+  assert.equal(
+    formatPersonHeadline({
+      position_title: "Senior Eng",
+      job_title: "Engineer",
+      current_company: "Acme",
+    }),
+    "Senior Eng at Acme",
+  );
+});
+
+test("alumni precedence: job_title used when nothing else present", () => {
+  assert.equal(
+    formatPersonHeadline({ job_title: "Engineer", current_company: "Acme" }),
+    "Engineer at Acme",
+  );
+});
+
+test("members shape: role used when no alumni fields present", () => {
+  assert.equal(
+    formatPersonHeadline({ role: "Captain", current_company: "Acme" }),
+    "Captain at Acme",
+  );
+});
+
+test("alumni headline beats role even though role is later in precedence", () => {
+  // Mixed input: headline still wins over role
+  assert.equal(
+    formatPersonHeadline({ headline: "Founder", role: "Captain" }),
+    "Founder",
+  );
+});
+
+test("role precedence sits between headline and position_title", () => {
+  // Members callers don't pass position_title, but the helper must still
+  // honor headline > role > position_title > job_title.
+  assert.equal(
+    formatPersonHeadline({ role: "Captain", position_title: "Senior Eng" }),
+    "Captain",
+  );
+});
+
+test("omits ` at <company>` when current_company is empty/null", () => {
+  assert.equal(formatPersonHeadline({ role: "Captain" }), "Captain");
+  assert.equal(formatPersonHeadline({ role: "Captain", current_company: null }), "Captain");
+  assert.equal(formatPersonHeadline({ role: "Captain", current_company: "" }), "Captain");
+  assert.equal(formatPersonHeadline({ role: "Captain", current_company: "   " }), "Captain");
+});
+
+test("appends ` at <company>` when company is non-empty", () => {
+  assert.equal(
+    formatPersonHeadline({ headline: "Founder", current_company: "Acme" }),
+    "Founder at Acme",
+  );
+});

--- a/apps/web/tests/unit/person-permissions.test.ts
+++ b/apps/web/tests/unit/person-permissions.test.ts
@@ -1,0 +1,197 @@
+import { strict as assert } from "assert";
+import { test } from "node:test";
+import { buildPersonAdminContext } from "@/lib/people/permissions-core";
+
+const ADMIN = "admin-user";
+const VIEWER = "viewer-user";
+const OTHER = "other-user";
+const ALUM = "alumni-user";
+const PARENT = "parent-user";
+
+const roleRows = [
+  { user_id: ADMIN, role: "admin" },
+  { user_id: VIEWER, role: "active_member" },
+  { user_id: OTHER, role: "active_member" },
+  { user_id: ALUM, role: "alumni" },
+  { user_id: PARENT, role: "parent" },
+];
+
+test("admin viewer can edit any target user", () => {
+  const ctx = buildPersonAdminContext({
+    viewerUserId: ADMIN,
+    isAdmin: true,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(ctx.canEditPerson(ADMIN), true);
+  assert.equal(ctx.canEditPerson(VIEWER), true);
+  assert.equal(ctx.canEditPerson(OTHER), true);
+  assert.equal(ctx.canEditPerson(ALUM), true);
+});
+
+test("non-admin viewer can self-edit but not edit others", () => {
+  const ctx = buildPersonAdminContext({
+    viewerUserId: VIEWER,
+    isAdmin: false,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(ctx.canEditPerson(VIEWER), true);
+  assert.equal(ctx.canEditPerson(OTHER), false);
+  assert.equal(ctx.canEditPerson(ALUM), false);
+  assert.equal(ctx.canEditPerson(ADMIN), false);
+});
+
+test("alumni-on-other denied; alumni-on-self allowed", () => {
+  const ctx = buildPersonAdminContext({
+    viewerUserId: ALUM,
+    isAdmin: false,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(ctx.canEditPerson(ALUM), true);
+  assert.equal(ctx.canEditPerson(OTHER), false);
+});
+
+test("parent-on-self allowed; parent-on-other denied", () => {
+  const ctx = buildPersonAdminContext({
+    viewerUserId: PARENT,
+    isAdmin: false,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(ctx.canEditPerson(PARENT), true);
+  assert.equal(ctx.canEditPerson(VIEWER), false);
+});
+
+test("anonymous viewer (null viewerUserId) cannot edit anyone", () => {
+  const ctx = buildPersonAdminContext({
+    viewerUserId: null,
+    isAdmin: false,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(ctx.canEditPerson(VIEWER), false);
+  assert.equal(ctx.canEditPerson(ADMIN), false);
+});
+
+test("canEditPerson(null) returns isAdmin — null does NOT match null", () => {
+  const adminCtx = buildPersonAdminContext({
+    viewerUserId: ADMIN,
+    isAdmin: true,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(adminCtx.canEditPerson(null), true);
+  assert.equal(adminCtx.canEditPerson(undefined), true);
+
+  // Non-admin self-viewer must NOT get edit rights on a null target row.
+  const selfCtx = buildPersonAdminContext({
+    viewerUserId: VIEWER,
+    isAdmin: false,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(selfCtx.canEditPerson(null), false);
+  assert.equal(selfCtx.canEditPerson(undefined), false);
+});
+
+test("canEditPerson with viewerUserId null + target set returns isAdmin only", () => {
+  const ctx = buildPersonAdminContext({
+    viewerUserId: null,
+    isAdmin: false,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(ctx.canEditPerson(VIEWER), false);
+
+  const adminAnonCtx = buildPersonAdminContext({
+    viewerUserId: null,
+    isAdmin: true,
+    isReadOnly: false,
+    roleRows,
+  });
+  // Defensive: even if some upstream builder claimed isAdmin without a
+  // viewerUserId, the helper does not crash; admin truth wins.
+  assert.equal(adminAnonCtx.canEditPerson(VIEWER), true);
+});
+
+test("isReadOnly flag is surfaced on the context", () => {
+  const ro = buildPersonAdminContext({
+    viewerUserId: ADMIN,
+    isAdmin: true,
+    isReadOnly: true,
+    roleRows,
+  });
+  assert.equal(ro.isReadOnly, true);
+
+  const live = buildPersonAdminContext({
+    viewerUserId: ADMIN,
+    isAdmin: true,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(live.isReadOnly, false);
+});
+
+test("adminUserIds set contains exactly the admin role rows", () => {
+  const ctx = buildPersonAdminContext({
+    viewerUserId: VIEWER,
+    isAdmin: false,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(ctx.adminUserIds.has(ADMIN), true);
+  assert.equal(ctx.adminUserIds.has(VIEWER), false);
+  assert.equal(ctx.adminUserIds.has(ALUM), false);
+});
+
+test("orgRoleLabelFor maps the four canonical roles + null cases", () => {
+  const ctx = buildPersonAdminContext({
+    viewerUserId: ADMIN,
+    isAdmin: true,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(ctx.orgRoleLabelFor(ADMIN), "Admin");
+  assert.equal(ctx.orgRoleLabelFor(VIEWER), "Member");
+  assert.equal(ctx.orgRoleLabelFor(ALUM), "Alumni");
+  assert.equal(ctx.orgRoleLabelFor(PARENT), "Parent");
+  assert.equal(ctx.orgRoleLabelFor(null), null);
+  assert.equal(ctx.orgRoleLabelFor(undefined), null);
+  assert.equal(ctx.orgRoleLabelFor("unknown-user"), null);
+});
+
+test("orgRoleLabelFor ignores rows missing user_id or role", () => {
+  const ctx = buildPersonAdminContext({
+    viewerUserId: ADMIN,
+    isAdmin: true,
+    isReadOnly: false,
+    roleRows: [
+      { user_id: null, role: "admin" },
+      { user_id: VIEWER, role: null },
+      { user_id: ADMIN, role: "admin" },
+    ],
+  });
+  assert.equal(ctx.orgRoleLabelFor(VIEWER), null);
+  assert.equal(ctx.orgRoleLabelFor(ADMIN), "Admin");
+  assert.equal(ctx.adminUserIds.has(ADMIN), true);
+  assert.equal(ctx.adminUserIds.size, 1);
+});
+
+test("forged viewerUserId without admin truth cannot escalate", () => {
+  // Simulates a non-admin caller passing another user's id as viewerUserId.
+  // canEditPerson must rely on the orchestrator-supplied isAdmin flag,
+  // and self-edit only works when viewerUserId actually matches.
+  const ctx = buildPersonAdminContext({
+    viewerUserId: "attacker-id",
+    isAdmin: false,
+    isReadOnly: false,
+    roleRows,
+  });
+  assert.equal(ctx.canEditPerson(VIEWER), false);
+  assert.equal(ctx.canEditPerson(OTHER), false);
+  // Self-edit only when target matches the (forged) viewer id — but the
+  // viewer cannot escalate to admin; the rest of the rows stay protected.
+  assert.equal(ctx.canEditPerson("attacker-id"), true);
+});


### PR DESCRIPTION
## Summary

Quick Parity Pass (Phase 1 + Phase 2) collapsing the six divergences between the Profile detail surfaces and the People nav directories into shared helpers. Single PR, ~12 source edits, 3 new test files.

- `formatPersonHeadline` becomes the single source of truth for headline rendering with deterministic precedence: `headline > role > position_title > job_title`, then ` at <company>`.
- Members directory SELECT widens for `current_company`, `current_city`, `school` so the card has the data the headline helper needs.
- `Parent` badge surfaces on the Members tab card for parent-source rows.
- Alumni-redirect on the member detail page so users with org role `alumni` land on the alumni profile (surface matches identity).
- New `getPersonAdminContext({ orgId, viewerUserId })` — single source of truth for "who can edit this person?" + the org-role badge label. Pure builder lives in a DB-free `permissions-core` module so unit tests don't pull `next/navigation`.
- Read-only billing gate extends to member detail (Edit Disabled / Delete Disabled + banner) for symmetry with alumni detail. Parent detail intentionally untouched in this pass.

## Invariants enforced by tests

- `viewerUserId` MUST come from `supabase.auth.getUser()` server-side. Passing a URL- or props-derived id is a security bug.
- `canEditPerson(null)` returns `isAdmin` only — never collapses `null === null` into self-edit on manual rows.

## Test plan

- [x] `tests/unit/format-person-headline.test.ts` — 9 tests covering precedence + `at <company>` formatting
- [x] `tests/unit/person-permissions.test.ts` — 12 tests covering admin / self / alumni / parent / anon viewers + the `null` invariant + forged-viewer escalation
- [x] `tests/routes/directories/people-authz.test.ts` — 25 source-grep assertions wiring across all three directories + member/alumni detail
- [x] `tests/alumni-page-query.test.ts` — updated to allow legitimate `personCtx.isAdmin` use while still forbidding admin badges in the alumni grid
- [x] `npm run test` — full 5494-test suite green
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean (only pre-existing `expo-server-sdk` error)
- [ ] Manual smoke: visit `/<org>/members`, `/<org>/alumni`, `/<org>/parents`, `/<org>/members/<id>`, `/<org>/alumni/<id>` as admin, member, alumni, parent, and as the row's own user
- [ ] Manual smoke: trigger read-only billing state and confirm Edit/Delete disable correctly on member + alumni detail