### PR TITLE
docs(claude): split CLAUDE.md for monorepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,149 +1,70 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working anywhere in this repository. App-specific guidance lives in nested `CLAUDE.md` files (`apps/web/CLAUDE.md`, `apps/mobile/CLAUDE.md`).
+
+## Repository Layout
+
+This is a **Bun + Turborepo monorepo**. Package manager is `bun@1.3.6`, Node ≥22.
+
+```
+apps/
+├── web/                # @teammeet/web — Next.js 15 App Router (the primary product)
+└── mobile/             # @teammeet/mobile — Expo / React Native client
+packages/
+├── core/               # @teammeet/core — shared business logic
+├── types/              # @teammeet/types — shared TypeScript types
+├── validation/         # @teammeet/validation — shared Zod schemas
+└── supabase/           # @teammeet/supabase — shared Supabase helpers
+supabase/               # Migrations, config, seeds (symlinked from apps/web/supabase)
+docs/                   # Cross-cutting docs (agent/, db/, stripe-donations.md, ...)
+turbo.json              # Pipeline config + globalPassThroughEnv allowlist
+```
+
+Workspaces are declared in root `package.json` (`apps/*`, `packages/*`). Internal deps use `workspace:*`.
 
 ## Commands
 
-### Development
+Run from repo root unless noted. Turbo handles task orchestration and caching.
+
+### Top-level
 ```bash
-npm run dev          # Start Next.js dev server at localhost:3000
-npm run build        # Build production application
-npm run start        # Start production server
-npm run lint         # Run ESLint
-npm run gen:types    # Regenerate Supabase TypeScript types (writes to src/types/database.ts)
+bun install              # Install all workspaces
+bun dev                  # Dev server for @teammeet/web (alias: bun run dev:web)
+bun run dev:mobile       # Start Expo for @teammeet/mobile
+bun run build            # Build all packages/apps
+bun run build:web        # Build only @teammeet/web
+bun run lint             # Lint all workspaces except mobile
+bun run typecheck        # tsc --noEmit across workspaces
+bun run test             # Run tests for @teammeet/web
+bun run test:e2e         # Playwright e2e for web
+bun run format           # Prettier write
+bun run format:check     # Prettier check
 ```
 
-### Testing
+### Per-workspace
+Use `--filter`:
 ```bash
-npm run test            # Run unit + security + payment + route suites
-npm run test:unit       # Run focused unit/integration suites
-npm run test:security   # Run security-specific tests
-npm run test:payments   # Test payment idempotency and Stripe webhooks
-npm run test:routes     # Run route simulation suites
-npm run test:schedules  # Test schedule domain verification and enrollment
-npm run test:e2e        # Run Playwright end-to-end tests
+turbo run build --filter=@teammeet/web
+turbo run typecheck --filter=@teammeet/core
 ```
 
-Single test file: `node --import ./tests/register-ts-loader.mjs --test tests/your-test.test.ts`.
-
-### Stripe Webhook Testing (Local)
-```bash
-stripe listen --forward-to localhost:3000/api/stripe/webhook
-stripe listen --forward-connect-to localhost:3000/api/stripe/webhook-connect
-```
-
-## Architecture
-
-### Tech Stack
-- **Framework**: Next.js 14 with App Router (TypeScript, React 18)
-- **Database**: Supabase (PostgreSQL with RLS policies)
-- **Authentication**: Supabase Auth with SSR
-- **Payments**: Stripe (subscriptions + Stripe Connect for donations)
-- **Email**: Resend
-- **Styling**: Tailwind CSS
-
-### Multi-Tenant SaaS Architecture
-Organizations are first-class entities identified by slugs (e.g., `/[orgSlug]/members`). Middleware validates organization access on every request.
-
-### Project Structure
-```
-src/
-├── app/                    # Next.js App Router
-│   ├── [orgSlug]/          # Dynamic org-scoped routes (calendar, chat, discussions, feed, forms, jobs, media, parents, philanthropy, etc.)
-│   ├── app/                # Platform routes (/app/join, /app/create-org, /app/create-enterprise)
-│   ├── auth/               # Auth flows (login, signup, callback)
-│   ├── api/                # API routes (Stripe webhooks, org APIs, enterprise APIs)
-│   ├── enterprise/         # Enterprise dashboard routes
-│   └── settings/           # User settings (notifications)
-├── components/             # Reusable UI components (ui/, layout/, feedback/, skeletons/)
-├── lib/                    # Business logic and utilities
-│   ├── auth/               # Role-based auth utilities
-│   ├── supabase/           # Supabase client wrappers (server, client, middleware, service)
-│   ├── payments/           # Payment idempotency & event handling
-│   ├── security/           # Rate limiting, validation
-│   ├── enterprise/         # Enterprise quota, pricing, adoption
-│   ├── navigation/         # Navigation configuration
-│   ├── schedule-connectors/ # External schedule importers (ICS, HTML parsers)
-│   ├── schedule-security/  # Domain allowlist, SSRF protection
-│   └── schemas/            # Zod validation schemas by domain (see index.ts for full list)
-├── types/
-│   └── database.ts         # Generated Supabase types
-└── middleware.ts           # Global auth/routing middleware
-
-supabase/migrations/        # Database migrations
-tests/                      # Test files (unit, routes/, e2e/, fixtures/)
-docs/agent/                 # AI agent architecture & feature docs
-```
-
-### Supabase Client Wrappers
-Use the appropriate wrapper for each context:
-- `lib/supabase/server.ts` — Server Components (uses cookies)
-- `lib/supabase/client.ts` — Client Components (browser)
-- `lib/supabase/middleware.ts` — Middleware (edge runtime)
-- `lib/supabase/service.ts` — Admin operations (service role key)
-
-### Role-Based Access Control
-Four roles: **admin** (full access), **active_member** (most features), **alumni** (read-only), **parent** (selected features, requires org flag). Role normalization: `member` → `active_member`, `viewer` → `alumni`.
-
-### Middleware Request Flow
-Every request flows through `src/middleware.ts`:
-1. Parse auth cookies and validate JWT
-2. Refresh session if needed
-3. Check if route is public vs. protected
-4. Validate org membership for `[orgSlug]` routes
-5. Redirect revoked users to `/app` with error
-6. Enforce canonical domain
-
-Public routes: `/`, `/demos`, `/terms`, `/privacy`, `/app/parents-join`, `/auth/*`. Bypassed: Stripe webhooks, `/api/auth/validate-age`, `/api/telemetry/error`. Org existence gating finalized in `src/app/[orgSlug]/layout.tsx`.
-
-## Key Architectural Patterns
-
-### Payment Idempotency System
-Client generates stable `idempotency_key` (localStorage) → server creates `payment_attempts` row with unique constraint → duplicate requests return existing attempt/checkout URL → webhooks deduplicated via `stripe_events(event_id unique)`. States: `initiated`, `processing`, `succeeded`, `failed`. Files: `src/lib/payments/idempotency.ts`, `src/lib/payments/stripe-events.ts`.
-
-### Soft Delete Pattern
-Most tables use `deleted_at` timestamp. Always filter: `.is("deleted_at", null)` when querying.
-
-### Stripe Connect Donations
-Funds route directly to org's connected Stripe account, never touching the app. See `docs/stripe-donations.md`.
-
-### Schedule Domain Allowlist & Security
-External schedule URLs validated before import to prevent SSRF. Domain statuses: `denied` → `pending` → `active` / `blocked`. Files: `src/lib/schedule-security/allowlist.ts`, `safe-fetch.ts`, `verifyAndEnroll.ts`.
-
-### AI Agent
-Architecture, pipeline, and feature docs live in `docs/agent/`. When modifying AI agent code (`src/lib/ai/`, `src/app/api/ai/`, `src/app/[orgSlug]/chat/`), update the relevant doc in `docs/agent/` to reflect structural changes, new features, or revised taxonomy.
-
-### Schema Validation
-Centralized Zod schemas in `src/lib/schemas/` — see `index.ts` for all available domains. Usage: `import { schemaName } from "@/lib/schemas"`.
+Or `cd` into the workspace and use its scripts. See `apps/web/CLAUDE.md` and `apps/mobile/CLAUDE.md` for app-specific commands (single-test invocations, Stripe webhook listeners, Expo prebuild, etc.).
 
 ## Environment Variables
 
-Required variables validated at build time in `next.config.mjs` — see that file for the complete list. Key optional vars:
-- `RESEND_API_KEY` — Real email delivery (falls back to stub logging)
-- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_TOKEN_ENCRYPTION_KEY` — Google Calendar
-- `BRIGHT_DATA_API_KEY` — LinkedIn enrichment via Bright Data (~$1.50/1k lookups)
-- `SKIP_STRIPE_VALIDATION=true` — Skip Stripe price ID validation in dev
+`.env.local` lives at repo root (never commit). Variables that must reach Turbo tasks are listed under `globalPassThroughEnv` in `turbo.json` — add new env vars there if a task can't see them.
 
-Stored in `.env.local` (never commit).
-
-## Key Files
-
-- `src/middleware.ts` — Request interception, auth, org validation
-- `src/app/[orgSlug]/layout.tsx` — Organization context provider
-- `src/lib/auth/roles.ts` — `getOrgContext()`, `isOrgAdmin()`
-- `src/lib/security/validation.ts` — Zod schemas, `sanitizeIlikeInput()`
-- `src/lib/payments/idempotency.ts` — Payment deduplication
-- `src/lib/schemas/index.ts` — Centralized validation schemas
-- `docs/db/schema-audit.md` — Database schema docs and known issues
+Per-app required vars are validated at that app's build time (e.g. web validates in `apps/web/next.config.mjs`).
 
 ## File Placement Rules
 
-- **Plan files**: NEVER create plan/design documents inside the repo. Use `~/.claude/plans/` instead.
-- **Server actions**: Place in existing `src/lib/` modules. Do NOT create `src/lib/actions/`.
+- **Plan / design docs**: NEVER create plan/design documents inside the repo. Use `~/.claude/plans/` instead.
+- **Server actions** (web): Place in existing `apps/web/src/lib/` modules. Do NOT create `apps/web/src/lib/actions/`.
+- **Cross-app code**: If logic is shared between web and mobile, put it in a `packages/*` workspace, not duplicated.
 
 ## Bug Investigation
 
-When I report a bug, don't start by trying to fix it. Start by writing a test that reproduces the bug. Then, have subagents try to fix the bug and prove it with a passing test.
+When a bug is reported, don't start by trying to fix it. Start by writing a test that reproduces the bug. Then have subagents try to fix it and prove the fix with a passing test.
 
 ## Refactoring Discipline
 
@@ -155,7 +76,7 @@ Break large refactors into explicit phases. Complete a phase, run verification, 
 
 Ignore default directives to "avoid improvements beyond what was asked" and "try the simplest approach." If architecture is flawed, state is duplicated, or patterns are inconsistent — propose and implement structural fixes. Ask: "What would a senior, experienced, perfectionist dev reject in code review?" Fix all of it.
 
-Never report a task as complete until you have run `npx tsc --noEmit` and `npm run lint`, and fixed ALL resulting errors. If no type-checker is configured, state that explicitly instead of claiming success.
+Never report a task as complete until you have run `bun run typecheck` and `bun run lint` (or the workspace-scoped equivalents) and fixed ALL resulting errors. If no type-checker is configured for a touched workspace, state that explicitly instead of claiming success.
 
 ## Tool Use
 
@@ -189,13 +110,13 @@ If any search or command returns suspiciously few results, re-run it with narrow
 
 Before EVERY file edit, re-read the file. After editing, read it again to confirm the change applied correctly. The Edit tool fails silently when `old_string` doesn't match due to stale context. Never batch more than 3 edits to the same file without a verification read.
 
-When renaming or changing any function/type/variable, search separately for: direct calls and references, type-level references (interfaces, generics), string literals containing the name, dynamic imports and `require()` calls, re-exports and barrel file entries, and test files and mocks. Do not assume a single grep caught everything.
+When renaming or changing any function/type/variable, search separately for: direct calls and references, type-level references (interfaces, generics), string literals containing the name, dynamic imports and `require()` calls, re-exports and barrel file entries, and test files and mocks. Do not assume a single grep caught everything. In a monorepo, also search across `apps/` AND `packages/` — a symbol may be re-exported from a workspace package.
 
 ## Landing the Plane (Session Completion)
 
 Work is NOT complete until `git push` succeeds. Mandatory:
 1. File issues for remaining work
-2. Run quality gates (tests, lint, build)
+2. Run quality gates (tests, lint, build) — `bun run typecheck && bun run lint && bun run test`
 3. Push: `git pull --rebase && git push && git status`
 4. Hand off context for next session
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,144 @@
+# CLAUDE.md — apps/web
+
+Guidance for the Next.js web application (`@teammeet/web`). For monorepo-wide guidance see the root `CLAUDE.md`.
+
+## Commands
+
+Run from `apps/web/` (or via `turbo run <task> --filter=@teammeet/web` from the repo root).
+
+### Development
+```bash
+bun run dev          # Start Next.js dev server at localhost:3000
+bun run build        # Build production application
+bun run start        # Start production server
+bun run lint         # Run ESLint
+bun run typecheck    # tsc --noEmit
+bun run gen:types    # Regenerate Supabase TypeScript types (writes to src/types/database.ts)
+```
+
+From the repo root: `bun dev` (web), `bun run build:web`, `bun run lint`, `bun run typecheck`.
+
+### Testing
+```bash
+bun run test            # Orphan check + fast suites
+bun run test:unit       # Focused unit/integration suites
+bun run test:security   # Security-specific tests
+bun run test:payments   # Payment idempotency + Stripe webhooks
+bun run test:routes     # Route simulation suites
+bun run test:schedules  # Schedule domain verification + enrollment
+bun run test:e2e        # Playwright end-to-end tests
+```
+
+Single test file: `node --import ./tests/register-ts-loader.mjs --test tests/your-test.test.ts`.
+
+### Stripe Webhook Testing (Local)
+```bash
+stripe listen --forward-to localhost:3000/api/stripe/webhook
+stripe listen --forward-connect-to localhost:3000/api/stripe/webhook-connect
+```
+
+## Architecture
+
+### Tech Stack
+- **Framework**: Next.js 15 with App Router (TypeScript, React 18)
+- **Database**: Supabase (PostgreSQL with RLS policies)
+- **Authentication**: Supabase Auth with SSR
+- **Payments**: Stripe (subscriptions + Stripe Connect for donations)
+- **Email**: Resend
+- **Styling**: Tailwind CSS
+
+### Multi-Tenant SaaS Architecture
+Organizations are first-class entities identified by slugs (e.g., `/[orgSlug]/members`). Middleware validates organization access on every request.
+
+### Project Structure
+Paths below are relative to `apps/web/`.
+```
+src/
+├── app/                    # Next.js App Router
+│   ├── [orgSlug]/          # Dynamic org-scoped routes (calendar, chat, discussions, feed, forms, jobs, media, parents, philanthropy, etc.)
+│   ├── app/                # Platform routes (/app/join, /app/create-org, /app/create-enterprise)
+│   ├── auth/               # Auth flows (login, signup, callback)
+│   ├── api/                # API routes (Stripe webhooks, org APIs, enterprise APIs)
+│   ├── enterprise/         # Enterprise dashboard routes
+│   └── settings/           # User settings (notifications)
+├── components/             # Reusable UI components (ui/, layout/, feedback/, skeletons/)
+├── lib/                    # Business logic and utilities
+│   ├── auth/               # Role-based auth utilities
+│   ├── supabase/           # Supabase client wrappers (server, client, middleware, service)
+│   ├── payments/           # Payment idempotency & event handling
+│   ├── security/           # Rate limiting, validation
+│   ├── enterprise/         # Enterprise quota, pricing, adoption
+│   ├── navigation/         # Navigation configuration
+│   ├── schedule-connectors/ # External schedule importers (ICS, HTML parsers)
+│   ├── schedule-security/  # Domain allowlist, SSRF protection
+│   └── schemas/            # Zod validation schemas by domain (see index.ts for full list)
+├── types/
+│   └── database.ts         # Generated Supabase types
+└── middleware.ts           # Global auth/routing middleware
+
+supabase/                   # Symlink → repo-root supabase/ (migrations, config, seeds)
+tests/                      # Test files (unit, routes/, e2e/, fixtures/)
+```
+
+Shared monorepo packages consumed via workspace deps: `@teammeet/core`, `@teammeet/types`, `@teammeet/validation`. AI agent docs live at repo-root `docs/agent/`.
+
+### Supabase Client Wrappers
+Use the appropriate wrapper for each context:
+- `lib/supabase/server.ts` — Server Components (uses cookies)
+- `lib/supabase/client.ts` — Client Components (browser)
+- `lib/supabase/middleware.ts` — Middleware (edge runtime)
+- `lib/supabase/service.ts` — Admin operations (service role key)
+
+### Role-Based Access Control
+Four roles: **admin** (full access), **active_member** (most features), **alumni** (read-only), **parent** (selected features, requires org flag). Role normalization: `member` → `active_member`, `viewer` → `alumni`.
+
+### Middleware Request Flow
+Every request flows through `src/middleware.ts`:
+1. Parse auth cookies and validate JWT
+2. Refresh session if needed
+3. Check if route is public vs. protected
+4. Validate org membership for `[orgSlug]` routes
+5. Redirect revoked users to `/app` with error
+6. Enforce canonical domain
+
+Public routes: `/`, `/demos`, `/terms`, `/privacy`, `/app/parents-join`, `/auth/*`. Bypassed: Stripe webhooks, `/api/auth/validate-age`, `/api/telemetry/error`. Org existence gating finalized in `src/app/[orgSlug]/layout.tsx`.
+
+## Key Architectural Patterns
+
+### Payment Idempotency System
+Client generates stable `idempotency_key` (localStorage) → server creates `payment_attempts` row with unique constraint → duplicate requests return existing attempt/checkout URL → webhooks deduplicated via `stripe_events(event_id unique)`. States: `initiated`, `processing`, `succeeded`, `failed`. Files: `src/lib/payments/idempotency.ts`, `src/lib/payments/stripe-events.ts`.
+
+### Soft Delete Pattern
+Most tables use `deleted_at` timestamp. Always filter: `.is("deleted_at", null)` when querying.
+
+### Stripe Connect Donations
+Funds route directly to org's connected Stripe account, never touching the app. See `docs/stripe-donations.md` (repo root).
+
+### Schedule Domain Allowlist & Security
+External schedule URLs validated before import to prevent SSRF. Domain statuses: `denied` → `pending` → `active` / `blocked`. Files: `src/lib/schedule-security/allowlist.ts`, `safe-fetch.ts`, `verifyAndEnroll.ts`.
+
+### AI Agent
+Architecture, pipeline, and feature docs live in repo-root `docs/agent/`. When modifying AI agent code (`src/lib/ai/`, `src/app/api/ai/`, `src/app/[orgSlug]/chat/`), update the relevant doc in `docs/agent/` to reflect structural changes, new features, or revised taxonomy.
+
+### Schema Validation
+Centralized Zod schemas in `src/lib/schemas/` — see `index.ts` for all available domains. Usage: `import { schemaName } from "@/lib/schemas"`. Cross-app schemas live in `@teammeet/validation`.
+
+## Environment Variables
+
+Required variables validated at build time in `next.config.mjs` — see that file for the complete list. Key optional vars:
+- `RESEND_API_KEY` — Real email delivery (falls back to stub logging)
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_TOKEN_ENCRYPTION_KEY` — Google Calendar
+- `BRIGHT_DATA_API_KEY` — LinkedIn enrichment via Bright Data (~$1.50/1k lookups)
+- `SKIP_STRIPE_VALIDATION=true` — Skip Stripe price ID validation in dev
+
+Stored in `.env.local` at repo root (never commit). Vars surfaced to Turbo via `globalPassThroughEnv` in `turbo.json`.
+
+## Key Files
+
+- `src/middleware.ts` — Request interception, auth, org validation
+- `src/app/[orgSlug]/layout.tsx` — Organization context provider
+- `src/lib/auth/roles.ts` — `getOrgContext()`, `isOrgAdmin()`
+- `src/lib/security/validation.ts` — Zod schemas, `sanitizeIlikeInput()`
+- `src/lib/payments/idempotency.ts` — Payment deduplication
+- `src/lib/schemas/index.ts` — Centralized validation schemas
+- `../../docs/db/schema-audit.md` — Database schema docs and known issues


### PR DESCRIPTION
## Summary
- Split root `CLAUDE.md` into a monorepo-level overview (Bun + Turborepo, workspace layout, cross-cutting rules)
- Move web-app-specific guidance into `apps/web/CLAUDE.md`
- Add `apps/web/AGENTS.md` symlink to mirror the root convention

## Changes
- `CLAUDE.md`: 171 → 70 lines, now describes the monorepo (apps/, packages/, turbo, bun)
- `apps/web/CLAUDE.md`: new — original web guidance (Next.js commands, tech stack, payment idempotency, schedule security, etc.)
- `apps/web/AGENTS.md`: new symlink → `CLAUDE.md`

## Risk
Docs-only. No behavior changes.

## Test plan
- [ ] Skim root CLAUDE.md reads as monorepo entry point
- [ ] Skim apps/web/CLAUDE.md retains web-specific patterns (idempotency, RLS, schedule allowlist, etc.)