### PR TITLE
fix(notifications): accept mobile Bearer tokens in /api/notifications/send

### DIFF
--- a/apps/web/src/app/api/notifications/send/route.ts
+++ b/apps/web/src/app/api/notifications/send/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { Resend } from "resend";
 import { z } from "zod";
-import { createClient } from "@/lib/supabase/server";
+import { createAuthenticatedApiClient } from "@/lib/supabase/api";
 import { createServiceClient } from "@/lib/supabase/service";
 import { sendNotificationBlast, sendEmail as sendEmailStub } from "@/lib/notifications";
 import type { EmailParams, NotificationResult, NotificationCategory } from "@/lib/notifications";
@@ -175,12 +175,8 @@ async function sendEmailWithFallback(to: string, subject: string, bodyText: stri
 export async function POST(request: Request) {
   let respond: ((payload: unknown, status?: number) => ReturnType<typeof NextResponse.json>) | null = null;
   try {
-    const supabase = await createClient();
+    const { supabase, user } = await createAuthenticatedApiClient(request);
     const service = createServiceClient();
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
 
     const rateLimit = checkRateLimit(request, {
       userId: user?.id ?? null,


### PR DESCRIPTION
## Summary

- Mobile-originated announcements weren't producing push or email notifications. Web-originated ones worked.
- Root cause: `/api/notifications/send` used `createClient()` (cookies-only). Mobile sends `Authorization: Bearer <token>`, so `auth.getUser()` returned `null` and the route bailed with 401. The mobile client surfaced "Failed to send notification" as a toast.
- Fix: swap to the existing `createAuthenticatedApiClient(request)` helper in `apps/web/src/lib/supabase/api.ts`, which accepts both Bearer (mobile) and cookies (web).

## Test plan

- [ ] Vercel preview: create an announcement on mobile with "Send notification" → push arrives on a second device, email arrives for members
- [ ] Vercel preview: create an announcement on web → still works (cookie path unchanged)
- [ ] Confirm 401 path still triggers when no auth header / cookies are present