### PR TITLE
fix(mobile): stop lock screen flickering on notification tap

### DIFF
--- a/apps/mobile/src/contexts/BiometricLockContext.tsx
+++ b/apps/mobile/src/contexts/BiometricLockContext.tsx
@@ -58,7 +58,14 @@ export function BiometricLockProvider({ children }: PropsWithChildren) {
   const [enabled, setEnabled] = useState(false);
   const [isResolving, setIsResolving] = useState(true);
   const [isLocked, setIsLocked] = useState(false);
-  const [appState, setAppState] = useState<AppStateStatus>(AppState.currentState);
+  // Backgrounded state drives the privacy overlay. We only setState when the
+  // boolean actually flips (active <-> not-active), so the Face ID system
+  // dialog's rapid inactive↔active churn doesn't re-render the entire
+  // children tree mid-prompt — that re-render was the source of the lock
+  // screen flicker on notification tap.
+  const [isBackgrounded, setIsBackgrounded] = useState(
+    AppState.currentState !== "active",
+  );
   const lastBackgroundedAtRef = useRef<number | null>(null);
   // Read inside the AppState handler so the listener can stay stable across
   // enable/disable toggles. Avoids a race where re-subscribing drops the
@@ -87,10 +94,18 @@ export function BiometricLockProvider({ children }: PropsWithChildren) {
   // deps; reads `enabled` via a ref to stay stable across toggles.
   useEffect(() => {
     const handler = (next: AppStateStatus) => {
-      setAppState(next);
+      const nextBackgrounded = next !== "active";
+      // Only setState on a transition, not on every event. iOS fires
+      // inactive→inactive duplicates around system prompts.
+      setIsBackgrounded((prev) => (prev === nextBackgrounded ? prev : nextBackgrounded));
       if (!enabledRef.current) return;
       if (next === "background" || next === "inactive") {
-        lastBackgroundedAtRef.current = Date.now();
+        // Don't overwrite an existing timestamp — the system biometric
+        // prompt cycles inactive→active→inactive and we want the original
+        // background time, not the prompt's transient inactive.
+        if (lastBackgroundedAtRef.current == null) {
+          lastBackgroundedAtRef.current = Date.now();
+        }
         return;
       }
       if (next === "active") {
@@ -105,7 +120,7 @@ export function BiometricLockProvider({ children }: PropsWithChildren) {
     return () => sub.remove();
   }, []);
 
-  const showPrivacyOverlay = enabled && appState !== "active";
+  const showPrivacyOverlay = enabled && isBackgrounded;
 
   const lock = useCallback(() => setIsLocked(true), []);
 

--- a/apps/mobile/src/hooks/usePushNotifications.ts
+++ b/apps/mobile/src/hooks/usePushNotifications.ts
@@ -12,6 +12,7 @@ import {
   type NotificationData,
 } from "@/lib/notifications";
 import { captureException } from "@/lib/analytics";
+import { useBiometricLock } from "@/contexts/BiometricLockContext";
 
 interface UsePushNotificationsOptions {
   userId: string | null;
@@ -33,31 +34,49 @@ export function usePushNotifications({
   const lastTokenRef = useRef<string | null>(null);
   const hasHandledColdLaunchRef = useRef(false);
   const lastHandledNotificationIdRef = useRef<string | null>(null);
+  const pendingRouteRef = useRef<string | null>(null);
 
-  // Handle notification response (user tapped on notification). De-duped by
-  // request identifier so the cold-launch path and the live response listener
-  // can't both fire for the same tap, and so effect re-runs that surface the
-  // persisted cold-launch response don't navigate twice.
-  const handleNotificationResponse = useCallback(
-    (response: Notifications.NotificationResponse) => {
-      try {
-        const id = response.notification.request.identifier;
-        if (id && lastHandledNotificationIdRef.current === id) return;
-        lastHandledNotificationIdRef.current = id ?? null;
+  const { isLocked } = useBiometricLock();
+  const isLockedRef = useRef(isLocked);
+  isLockedRef.current = isLocked;
 
-        const data = response.notification.request.content.data as unknown as NotificationData;
-        const route = getNotificationRoute(data);
+  // Stable handler: subscribed once, reads `isLocked` via ref so router
+  // identity changes don't tear down + re-subscribe the listener (which on
+  // rapid auth/nav re-renders caused duplicate response handling).
+  const handlerRef = useRef<(response: Notifications.NotificationResponse) => void>(() => {});
+  handlerRef.current = (response: Notifications.NotificationResponse) => {
+    try {
+      const id = response.notification.request.identifier;
+      if (id && lastHandledNotificationIdRef.current === id) return;
+      lastHandledNotificationIdRef.current = id ?? null;
 
-        if (route) {
-          router.push(route as any);
-        }
-      } catch (error) {
-        console.error("Error handling notification response:", error);
-        captureException(error as Error, { context: "handleNotificationResponse" });
+      const data = response.notification.request.content.data as unknown as NotificationData;
+      const route = getNotificationRoute(data);
+      if (!route) return;
+
+      // Defer routing while the biometric lock screen is up. Navigating
+      // behind the LockScreen overlay caused the underlying screen to mount
+      // mid-Face-ID prompt, producing the visible flicker. We replay the
+      // route once the lock clears.
+      if (isLockedRef.current) {
+        pendingRouteRef.current = route;
+        return;
       }
-    },
-    [router]
-  );
+      router.push(route as any);
+    } catch (error) {
+      console.error("Error handling notification response:", error);
+      captureException(error as Error, { context: "handleNotificationResponse" });
+    }
+  };
+
+  // Flush any pending notification route once the lock clears.
+  useEffect(() => {
+    if (isLocked) return;
+    const pending = pendingRouteRef.current;
+    if (!pending) return;
+    pendingRouteRef.current = null;
+    router.push(pending as any);
+  }, [isLocked, router]);
 
   // Register for push notifications
   const register = useCallback(async () => {
@@ -136,9 +155,12 @@ export function usePushNotifications({
       });
     });
 
-    // Listen for user interaction with notifications
+    // Listen for user interaction with notifications. Subscribe with a stable
+    // wrapper that reads the latest handler via ref — otherwise router
+    // identity changes would re-subscribe per render and cause duplicate
+    // response handling on rapid nav.
     responseListener.current = Notifications.addNotificationResponseReceivedListener(
-      handleNotificationResponse
+      (response) => handlerRef.current(response)
     );
 
     // Handle notification tap when app launches from a quit state. Expo
@@ -148,7 +170,7 @@ export function usePushNotifications({
       hasHandledColdLaunchRef.current = true;
       Notifications.getLastNotificationResponseAsync().then((response) => {
         if (response) {
-          handleNotificationResponse(response);
+          handlerRef.current(response);
         }
       });
     }
@@ -169,7 +191,7 @@ export function usePushNotifications({
       pushTokenListener.current?.remove();
       appStateSubscription.remove();
     };
-  }, [userId, enabled, register, handleNotificationResponse]);
+  }, [userId, enabled, register]);
 
   // Handle logout - unregister token
   useEffect(() => {


### PR DESCRIPTION
## Problem
Tapping a push notification with biometric lock enabled causes the LockScreen to strobe. Reported via TestFlight screenshot.

## Root cause (three compounding issues)

1. **Routing fires while locked.** `usePushNotifications.handleNotificationResponse` called `router.push()` the moment a tap was processed, regardless of `isLocked`. The deep-link target mounted **behind** the LockScreen overlay and ran its full data-fetch cycle mid-Face-ID prompt.

2. **Provider re-renders on every AppState change.** `BiometricLockProvider` did `setAppState(next)` on every event. The Face ID system dialog cycles `active → inactive → active`, so the provider re-rendered three times mid-prompt.

3. **Response listener re-subscribes per render.** Effect deps included `handleNotificationResponse`, whose identity changed with `router` — every nav tore down and re-added the listener, letting the same response dispatch twice.

## Fixes

- **`usePushNotifications`**: queue the route in a ref while `isLocked` is true, replay on unlock. Subscribe the response listener once via a stable ref-reading wrapper.
- **`BiometricLockContext`**: collapse `appState` to `isBackgrounded` boolean, only `setState` on actual transitions. Preserve the original background timestamp instead of overwriting with transient prompt inactives (also fixes a latent relock-skip edge case).

## Test plan
- [ ] TestFlight build → tap chat push from lock screen → solid LockScreen until Face ID succeeds, then routes once with no flicker
- [ ] Tap from foreground (no lock) → routes immediately, no regression
- [ ] Tap with biometric off → no LockScreen, routes normally
- [ ] Background app >5 min, foreground → still locks correctly