### PR TITLE
feat(engagement): streaks, badges, weekly digest, quiet hours, re-engagement

### DIFF
--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/menu.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/menu.tsx
@@ -40,6 +40,7 @@ import { useThemedStyles } from "@/hooks/useThemedStyles";
 import { APP_CHROME } from "@/lib/chrome";
 import { SPACING, RADIUS, SHADOWS } from "@/lib/design-tokens";
 import { TYPOGRAPHY } from "@/lib/typography";
+import { StreakChip } from "@/components/profile/StreakChip";
 
 interface Organization {
   id: string;
@@ -59,7 +60,7 @@ interface MenuItem {
 const STALE_TIME_MS = 30_000; // 30 seconds
 
 export default function MenuScreen() {
-  const { orgSlug } = useOrg();
+  const { orgSlug, orgId } = useOrg();
   const router = useRouter();
   const navigation = useNavigation();
   const { user } = useAuth();
@@ -648,6 +649,9 @@ export default function MenuScreen() {
               </View>
               <ChevronRight size={20} color={neutral.secondary} />
             </Pressable>
+            <View style={{ paddingHorizontal: SPACING.md, paddingBottom: SPACING.sm }}>
+              <StreakChip userId={user?.id ?? null} organizationId={orgId} />
+            </View>
           </View>
 
           {/* Updates Section */}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -23,6 +23,7 @@ import { setGlobalShowToast } from "@/components/ui/Toast";
 import AuthLoadingScreen from "@/components/AuthLoadingScreen";
 import { init as initAnalytics, identify, reset as resetAnalytics, captureException, hydrateEnabled } from "@/lib/analytics";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
+import { useActivityHeartbeat } from "@/hooks/useActivityHeartbeat";
 import { useScreenTracking } from "@/hooks/useScreenTracking";
 import { useSupabaseAppState } from "@/hooks/useSupabaseAppState";
 import { parseTeammeetUrl, routeIntent } from "@/lib/deep-link";
@@ -141,6 +142,9 @@ function RootLayoutInner() {
     userId: session?.user?.id ?? null,
     enabled: true,
   });
+
+  // Bump users.last_active_at on sign-in + every foreground.
+  useActivityHeartbeat(session?.user?.id ?? null);
 
   // Hide splash screen once fonts are loaded
   useEffect(() => {

--- a/apps/mobile/src/components/profile/StreakChip.tsx
+++ b/apps/mobile/src/components/profile/StreakChip.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { Flame } from "lucide-react-native";
+import { useThemedStyles } from "@/hooks/useThemedStyles";
+import { TYPOGRAPHY } from "@/lib/typography";
+import { SPACING, RADIUS } from "@/lib/design-tokens";
+import { useMemberStreak } from "@/hooks/useMemberStreak";
+
+interface StreakChipProps {
+  userId: string | null;
+  organizationId: string | null;
+}
+
+/**
+ * Compact pill showing the current attendance streak (consecutive weeks with
+ * ≥1 checked-in event). Renders nothing when the user hasn't started a
+ * streak yet — chip should celebrate, not nag.
+ */
+export function StreakChip({ userId, organizationId }: StreakChipProps) {
+  const { streak } = useMemberStreak(userId, organizationId);
+  const styles = useThemedStyles((n) => ({
+    chip: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      gap: 6,
+      backgroundColor: n.surface,
+      borderColor: n.border,
+      borderWidth: 1,
+      borderCurve: "continuous" as const,
+      borderRadius: RADIUS.full,
+      paddingHorizontal: SPACING.sm,
+      paddingVertical: 6,
+      alignSelf: "flex-start" as const,
+    },
+    label: {
+      ...TYPOGRAPHY.labelMedium,
+      color: n.foreground,
+    },
+    longest: {
+      ...TYPOGRAPHY.caption,
+      color: n.muted,
+    },
+  }));
+
+  if (!streak || streak.currentWeeks === 0) return null;
+
+  return (
+    <View style={styles.chip}>
+      <Flame size={14} color="#f97316" />
+      <Text style={styles.label}>
+        {streak.currentWeeks}-week streak
+      </Text>
+      {streak.longestWeeks > streak.currentWeeks ? (
+        <Text style={styles.longest}>(best: {streak.longestWeeks})</Text>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/settings/SettingsNotificationsSection.tsx
+++ b/apps/mobile/src/components/settings/SettingsNotificationsSection.tsx
@@ -43,6 +43,11 @@ export function SettingsNotificationsSection({ orgId }: Props) {
   const [discussionPush, setDiscussionPush] = useState(false);
   const [mentorshipPush, setMentorshipPush] = useState(false);
   const [donationPush, setDonationPush] = useState(false);
+  const [digestPush, setDigestPush] = useState(true);
+  const [reengagementPush, setReengagementPush] = useState(true);
+  const [quietHoursTimezone, setQuietHoursTimezone] = useState("UTC");
+  const [quietHoursStart, setQuietHoursStart] = useState("21:00");
+  const [quietHoursEnd, setQuietHoursEnd] = useState("07:00");
 
   useEffect(() => {
     if (prefs) {
@@ -58,8 +63,27 @@ export function SettingsNotificationsSection({ orgId }: Props) {
       setDiscussionPush(prefs.discussion_push_enabled);
       setMentorshipPush(prefs.mentorship_push_enabled);
       setDonationPush(prefs.donation_push_enabled);
+      setDigestPush(prefs.digest_push_enabled);
+      setReengagementPush(prefs.reengagement_push_enabled);
+      setQuietHoursStart(prefs.quiet_hours_start.slice(0, 5));
+      setQuietHoursEnd(prefs.quiet_hours_end.slice(0, 5));
+      setQuietHoursTimezone(prefs.quiet_hours_timezone);
+
+      // First-launch timezone capture: when the saved timezone is the UTC
+      // default but the device knows better, persist the device tz so quiet
+      // hours apply to the user's actual local time.
+      if (prefs.quiet_hours_timezone === "UTC") {
+        try {
+          const deviceTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+          if (deviceTz && deviceTz !== "UTC") {
+            void updatePrefs({ quiet_hours_timezone: deviceTz });
+          }
+        } catch {
+          // Older RN runtimes may not expose Intl — skip silently.
+        }
+      }
     }
-  }, [prefs]);
+  }, [prefs, updatePrefs]);
 
   const handleSaveNotifications = async () => {
     await updatePrefs({
@@ -75,6 +99,11 @@ export function SettingsNotificationsSection({ orgId }: Props) {
       discussion_push_enabled: discussionPush,
       mentorship_push_enabled: mentorshipPush,
       donation_push_enabled: donationPush,
+      digest_push_enabled: digestPush,
+      reengagement_push_enabled: reengagementPush,
+      quiet_hours_start: quietHoursStart,
+      quiet_hours_end: quietHoursEnd,
+      quiet_hours_timezone: quietHoursTimezone,
     });
   };
 
@@ -407,6 +436,43 @@ export function SettingsNotificationsSection({ orgId }: Props) {
                   trackColor={{ false: colors.border, true: colors.primaryLight }}
                   thumbColor={donationPush ? colors.primary : colors.card}
                 />
+              </View>
+
+              <View style={[styles.switchRow, !pushEnabled && { opacity: 0.5 }]}>
+                <View style={styles.switchInfo}>
+                  <Text style={styles.switchLabel}>Weekly digest</Text>
+                  <Text style={styles.switchHint}>Sunday recap of the week's activity</Text>
+                </View>
+                <Switch
+                  value={digestPush}
+                  onValueChange={setDigestPush}
+                  disabled={!pushEnabled}
+                  trackColor={{ false: colors.border, true: colors.primaryLight }}
+                  thumbColor={digestPush ? colors.primary : colors.card}
+                />
+              </View>
+
+              <View style={[styles.switchRow, !pushEnabled && { opacity: 0.5 }]}>
+                <View style={styles.switchInfo}>
+                  <Text style={styles.switchLabel}>Re-engagement</Text>
+                  <Text style={styles.switchHint}>Occasional nudge if you've been away</Text>
+                </View>
+                <Switch
+                  value={reengagementPush}
+                  onValueChange={setReengagementPush}
+                  disabled={!pushEnabled}
+                  trackColor={{ false: colors.border, true: colors.primaryLight }}
+                  thumbColor={reengagementPush ? colors.primary : colors.card}
+                />
+              </View>
+
+              <View style={[styles.switchRow, !pushEnabled && { opacity: 0.5 }]}>
+                <View style={styles.switchInfo}>
+                  <Text style={styles.switchLabel}>Quiet hours</Text>
+                  <Text style={styles.switchHint}>
+                    Digest + re-engagement pushes deferred {quietHoursStart}–{quietHoursEnd} ({quietHoursTimezone})
+                  </Text>
+                </View>
               </View>
 
               <Pressable

--- a/apps/mobile/src/hooks/useActivityHeartbeat.ts
+++ b/apps/mobile/src/hooks/useActivityHeartbeat.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { AppState, type AppStateStatus } from "react-native";
+import { supabase } from "@/lib/supabase";
+
+/**
+ * Bumps `users.last_active_at` for the signed-in user via the
+ * `record_user_activity` RPC. Server-side debounced to 60s so we can call it
+ * liberally — once on mount (sign-in) and once on every app-foreground.
+ *
+ * Powers DAU + the re-engagement-sweep cron's "inactive ≥7d" gate.
+ */
+async function fireHeartbeat(): Promise<void> {
+  try {
+    // Cast: `record_user_activity` is a new RPC not yet in the generated
+    // Database types. Regenerate via `bun run gen:types` after the migration
+    // is applied to remove the cast.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (supabase as any).rpc("record_user_activity");
+  } catch {
+    // Silent — heartbeat failure shouldn't break the app.
+  }
+}
+
+export function useActivityHeartbeat(userId: string | null): void {
+  useEffect(() => {
+    if (!userId) return;
+
+    void fireHeartbeat();
+
+    const handler = (state: AppStateStatus) => {
+      if (state !== "active") return;
+      void fireHeartbeat();
+    };
+    const sub = AppState.addEventListener("change", handler);
+    return () => sub.remove();
+  }, [userId]);
+}

--- a/apps/mobile/src/hooks/useMemberStreak.ts
+++ b/apps/mobile/src/hooks/useMemberStreak.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState, useRef } from "react";
+import { supabase } from "@/lib/supabase";
+import * as sentry from "@/lib/analytics/sentry";
+
+export interface MemberStreak {
+  currentWeeks: number;
+  longestWeeks: number;
+}
+
+/**
+ * Reads the calling user's per-org streak from `member_streaks`. Updated by
+ * the daily streaks-recompute cron, so this hook just reads — no realtime
+ * needed.
+ */
+export function useMemberStreak(
+  userId: string | null,
+  organizationId: string | null,
+): { streak: MemberStreak | null; loading: boolean } {
+  const [streak, setStreak] = useState<MemberStreak | null>(null);
+  const [loading, setLoading] = useState(true);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!userId || !organizationId) {
+      setStreak(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    void (async () => {
+      try {
+        // Cast: member_streaks isn't in the generated Database types yet.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data, error } = await (supabase as any)
+          .from("member_streaks")
+          .select("current_weeks, longest_weeks")
+          .eq("user_id", userId)
+          .eq("organization_id", organizationId)
+          .maybeSingle();
+        if (error) throw error;
+        if (!isMountedRef.current) return;
+        setStreak(
+          data
+            ? {
+                currentWeeks: data.current_weeks,
+                longestWeeks: data.longest_weeks,
+              }
+            : { currentWeeks: 0, longestWeeks: 0 },
+        );
+      } catch (err) {
+        sentry.captureException(err as Error, { context: "useMemberStreak" });
+      } finally {
+        if (isMountedRef.current) setLoading(false);
+      }
+    })();
+  }, [userId, organizationId]);
+
+  return { streak, loading };
+}

--- a/apps/mobile/src/hooks/useNotificationPreferences.ts
+++ b/apps/mobile/src/hooks/useNotificationPreferences.ts
@@ -21,6 +21,13 @@ export interface NotificationPreferences {
   discussion_push_enabled: boolean;
   mentorship_push_enabled: boolean;
   donation_push_enabled: boolean;
+  // Phase B: digest + re-engagement controls. Quiet hours window is
+  // local-time per the user's selected timezone.
+  digest_push_enabled: boolean;
+  reengagement_push_enabled: boolean;
+  quiet_hours_start: string; // 'HH:MM' or 'HH:MM:SS'
+  quiet_hours_end: string;
+  quiet_hours_timezone: string;
 }
 
 const DEFAULT_PUSH_CATEGORIES = {
@@ -33,6 +40,11 @@ const DEFAULT_PUSH_CATEGORIES = {
   discussion_push_enabled: false,
   mentorship_push_enabled: false,
   donation_push_enabled: false,
+  digest_push_enabled: true,
+  reengagement_push_enabled: true,
+  quiet_hours_start: "21:00",
+  quiet_hours_end: "07:00",
+  quiet_hours_timezone: "UTC",
 } as const;
 
 interface UseNotificationPreferencesReturn {
@@ -61,6 +73,11 @@ const SELECT_COLUMNS = [
   "discussion_push_enabled",
   "mentorship_push_enabled",
   "donation_push_enabled",
+  "digest_push_enabled",
+  "reengagement_push_enabled",
+  "quiet_hours_start",
+  "quiet_hours_end",
+  "quiet_hours_timezone",
 ].join(",");
 
 type PrefRow = {
@@ -77,6 +94,11 @@ type PrefRow = {
   discussion_push_enabled: boolean | null;
   mentorship_push_enabled: boolean | null;
   donation_push_enabled: boolean | null;
+  digest_push_enabled: boolean | null;
+  reengagement_push_enabled: boolean | null;
+  quiet_hours_start: string | null;
+  quiet_hours_end: string | null;
+  quiet_hours_timezone: string | null;
 };
 
 function rowToPrefs(row: PrefRow): NotificationPreferences {
@@ -100,6 +122,15 @@ function rowToPrefs(row: PrefRow): NotificationPreferences {
       row.mentorship_push_enabled ?? DEFAULT_PUSH_CATEGORIES.mentorship_push_enabled,
     donation_push_enabled:
       row.donation_push_enabled ?? DEFAULT_PUSH_CATEGORIES.donation_push_enabled,
+    digest_push_enabled:
+      row.digest_push_enabled ?? DEFAULT_PUSH_CATEGORIES.digest_push_enabled,
+    reengagement_push_enabled:
+      row.reengagement_push_enabled ?? DEFAULT_PUSH_CATEGORIES.reengagement_push_enabled,
+    quiet_hours_start:
+      row.quiet_hours_start ?? DEFAULT_PUSH_CATEGORIES.quiet_hours_start,
+    quiet_hours_end: row.quiet_hours_end ?? DEFAULT_PUSH_CATEGORIES.quiet_hours_end,
+    quiet_hours_timezone:
+      row.quiet_hours_timezone ?? DEFAULT_PUSH_CATEGORIES.quiet_hours_timezone,
   };
 }
 
@@ -251,8 +282,20 @@ export function useNotificationPreferences(
         "discussion_push_enabled",
         "mentorship_push_enabled",
         "donation_push_enabled",
+        "digest_push_enabled",
+        "reengagement_push_enabled",
       ] as const;
       for (const key of pushCategoryKeys) {
+        if (key in updates) {
+          writePayload[key] = updates[key] ?? prefs?.[key] ?? DEFAULT_PUSH_CATEGORIES[key];
+        }
+      }
+      const quietHoursKeys = [
+        "quiet_hours_start",
+        "quiet_hours_end",
+        "quiet_hours_timezone",
+      ] as const;
+      for (const key of quietHoursKeys) {
         if (key in updates) {
           writePayload[key] = updates[key] ?? prefs?.[key] ?? DEFAULT_PUSH_CATEGORIES[key];
         }

--- a/apps/web/src/app/api/cron/notification-dispatch/route.ts
+++ b/apps/web/src/app/api/cron/notification-dispatch/route.ts
@@ -4,6 +4,7 @@ import { validateCronAuth } from "@/lib/security/cron-auth";
 import { sendPush, type PushType } from "@/lib/notifications/push";
 import type { NotificationCategory } from "@/lib/notifications";
 import type { NotificationAudience } from "@/types/database";
+import { maybeDeferForQuietHours } from "@/lib/notifications/quiet-hours";
 
 /**
  * Notification dispatch cron worker — drains the `notification_jobs` queue
@@ -98,6 +99,27 @@ export async function GET(request: Request) {
         // Live Activity / APNs not handled in this port. Mark failed so the
         // row doesn't keep re-leasing.
         throw new Error(`unsupported kind=${job.kind} (Live Activity not yet ported to main)`);
+      }
+
+      // Quiet-hours gate for digest/reengagement single-target pushes.
+      const deferTo = await maybeDeferForQuietHours({
+        supabase: service,
+        category: job.category,
+        organizationId: job.organization_id,
+        targetUserIds: job.target_user_ids,
+      });
+      if (deferTo) {
+        await svc
+          .from("notification_jobs")
+          .update({
+            status: "pending",
+            scheduled_for: deferTo,
+            leased_at: null,
+            last_error: "deferred for quiet hours",
+          })
+          .eq("id", job.id);
+        results.push({ id: job.id, status: "deferred" });
+        continue;
       }
 
       // Resolve orgSlug for deep-link routing.

--- a/apps/web/src/app/api/cron/reengagement-sweep/route.ts
+++ b/apps/web/src/app/api/cron/reengagement-sweep/route.ts
@@ -1,0 +1,185 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { validateCronAuth } from "@/lib/security/cron-auth";
+
+/**
+ * Daily re-engagement sweep.
+ *
+ * For each user who:
+ *   - has not been active in the past 7 days (users.last_active_at), AND
+ *   - belongs to ≥1 org with reengagement_push_enabled=true (the per-(user,org)
+ *     pref), AND
+ *   - has pending activity in that org (≥1 upcoming event in the next 14d
+ *     OR ≥1 announcement created in the past 14d)
+ *
+ * Enqueue ONE notification_jobs row, throttled to once per 14 days per user
+ * via the `data.last_reengagement_at` lookup against past notifications.
+ *
+ * The actual delivery time defers to quiet hours via the dispatcher's
+ * quiet-hours gate; we just enqueue with scheduled_for=now().
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+const DORMANT_DAYS = 7;
+const THROTTLE_DAYS = 14;
+const ACTIVITY_HORIZON_DAYS = 14;
+
+export async function GET(request: Request) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const service = createServiceClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const svc = service as any;
+
+  const dormantSince = new Date(
+    Date.now() - DORMANT_DAYS * 24 * 3600 * 1000,
+  ).toISOString();
+  const throttleSince = new Date(
+    Date.now() - THROTTLE_DAYS * 24 * 3600 * 1000,
+  ).toISOString();
+  const upcomingHorizon = new Date(
+    Date.now() + ACTIVITY_HORIZON_DAYS * 24 * 3600 * 1000,
+  ).toISOString();
+
+  // 1. Candidates: dormant users.
+  const { data: dormantUsers, error: dormantErr } = await svc
+    .from("users")
+    .select("id, name, last_active_at")
+    .or(`last_active_at.is.null,last_active_at.lt.${dormantSince}`)
+    .limit(5000);
+
+  if (dormantErr) {
+    return NextResponse.json(
+      { success: false, error: dormantErr.message },
+      { status: 500 },
+    );
+  }
+
+  const userIds = ((dormantUsers ?? []) as Array<{ id: string }>).map((u) => u.id);
+  if (userIds.length === 0) {
+    return NextResponse.json({ success: true, enqueued: 0 });
+  }
+
+  // 2. Throttle: skip users who already got a re-engagement push within
+  // THROTTLE_DAYS. notifications.category='reengagement'.
+  const { data: recent } = await svc
+    .from("notifications")
+    .select("user_id")
+    .eq("category", "reengagement")
+    .gte("created_at", throttleSince)
+    .in("user_id", userIds);
+  const recentlyNotified = new Set(
+    ((recent ?? []) as Array<{ user_id: string }>).map((r) => r.user_id),
+  );
+  const eligibleUserIds = userIds.filter((id) => !recentlyNotified.has(id));
+
+  if (eligibleUserIds.length === 0) {
+    return NextResponse.json({ success: true, enqueued: 0 });
+  }
+
+  // 3. For each eligible user, find an org they belong to with
+  // reengagement_push_enabled=true and pending activity. Pick the first such
+  // org to send for (don't spam multiple pushes to one user even if they're
+  // in several orgs).
+  const { data: prefs } = await svc
+    .from("notification_preferences")
+    .select("user_id, organization_id")
+    .eq("reengagement_push_enabled", true)
+    .in("user_id", eligibleUserIds);
+
+  const userOrgs = new Map<string, string[]>();
+  for (const p of (prefs ?? []) as Array<{
+    user_id: string;
+    organization_id: string;
+  }>) {
+    const list = userOrgs.get(p.user_id) ?? [];
+    list.push(p.organization_id);
+    userOrgs.set(p.user_id, list);
+  }
+
+  // Aggregate org-side pending activity once.
+  const allOrgIds = Array.from(
+    new Set(Array.from(userOrgs.values()).flat()),
+  );
+  const orgsWithActivity = new Set<string>();
+
+  if (allOrgIds.length > 0) {
+    const [{ data: upcomingEvents }, { data: recentAnns }] = await Promise.all([
+      svc
+        .from("events")
+        .select("organization_id")
+        .in("organization_id", allOrgIds)
+        .is("deleted_at", null)
+        .gte("start_date", new Date().toISOString())
+        .lte("start_date", upcomingHorizon),
+      svc
+        .from("announcements")
+        .select("organization_id")
+        .in("organization_id", allOrgIds)
+        .is("deleted_at", null)
+        .gte(
+          "created_at",
+          new Date(
+            Date.now() - ACTIVITY_HORIZON_DAYS * 24 * 3600 * 1000,
+          ).toISOString(),
+        ),
+    ]);
+    for (const r of (upcomingEvents ?? []) as Array<{ organization_id: string }>) {
+      orgsWithActivity.add(r.organization_id);
+    }
+    for (const r of (recentAnns ?? []) as Array<{ organization_id: string }>) {
+      orgsWithActivity.add(r.organization_id);
+    }
+  }
+
+  // 4. Build jobs.
+  const orgNames = new Map<string, string>();
+  if (allOrgIds.length > 0) {
+    const { data: orgs } = await svc
+      .from("organizations")
+      .select("id, name")
+      .in("id", allOrgIds);
+    for (const o of (orgs ?? []) as Array<{ id: string; name: string }>) {
+      orgNames.set(o.id, o.name);
+    }
+  }
+
+  const jobs: Array<Record<string, unknown>> = [];
+  for (const userId of eligibleUserIds) {
+    const userOrgList = userOrgs.get(userId) ?? [];
+    const target = userOrgList.find((o) => orgsWithActivity.has(o));
+    if (!target) continue;
+    const orgName = orgNames.get(target) ?? "your team";
+    jobs.push({
+      organization_id: target,
+      kind: "standard",
+      priority: 7,
+      audience: null,
+      target_user_ids: [userId],
+      category: "reengagement",
+      push_type: "reengagement",
+      push_resource_id: null,
+      title: `${orgName} has updates for you`,
+      body: "There's new activity since you last checked in. Tap to catch up.",
+      data: { reengagement: true },
+      status: "pending",
+      scheduled_for: new Date().toISOString(),
+    });
+  }
+
+  if (jobs.length === 0) {
+    return NextResponse.json({ success: true, enqueued: 0 });
+  }
+
+  const { error: insertErr } = await svc.from("notification_jobs").insert(jobs);
+  if (insertErr) {
+    return NextResponse.json(
+      { success: false, error: insertErr.message },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ success: true, enqueued: jobs.length });
+}

--- a/apps/web/src/app/api/cron/streaks-recompute/route.ts
+++ b/apps/web/src/app/api/cron/streaks-recompute/route.ts
@@ -1,0 +1,267 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { validateCronAuth } from "@/lib/security/cron-auth";
+
+/**
+ * Daily streak recompute + badge evaluation.
+ *
+ * For every (user, org) with at least one event_rsvps row checked-in within
+ * the past 365 days, derive:
+ *   - current_weeks: count of consecutive ISO weeks ending in the most recent
+ *     calendar week (Mon UTC) where the user had ≥1 checked-in attendance.
+ *   - longest_weeks: the all-time max (never decreases).
+ *
+ * Then evaluate seeded badges: streak milestones, events_attended, workouts.
+ * Inserts into member_badges; ON CONFLICT DO NOTHING means re-runs are
+ * idempotent.
+ *
+ * Designed for orgs with up to ~5k members. For larger scale, the SELECT
+ * should move to a SQL CTE; this version processes per (org, user) in JS for
+ * readability. Acceptable while we're in the ten-of-thousands rows range.
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // streak recompute is bounded but can be slow.
+
+interface BadgeRow {
+  id: string;
+  slug: string;
+  criteria: { kind: string; threshold?: number };
+}
+
+interface RsvpRow {
+  user_id: string;
+  organization_id: string;
+  checked_in_at: string;
+}
+
+interface WorkoutRow {
+  user_id: string;
+  organization_id: string;
+}
+
+function isoWeekStart(d: Date): Date {
+  // Monday 00:00:00 UTC of the week containing d.
+  const utc = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+  const day = utc.getUTCDay() || 7; // Sun=7
+  utc.setUTCDate(utc.getUTCDate() - (day - 1));
+  return utc;
+}
+
+function weekKey(d: Date): string {
+  return isoWeekStart(d).toISOString().slice(0, 10);
+}
+
+export async function GET(request: Request) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const service = createServiceClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const svc = service as any;
+
+  // 1. Pull all checked-in RSVPs over the last 365 days. The qualifying
+  // signal is `status='attending' AND checked_in_at IS NOT NULL`.
+  const since = new Date(Date.now() - 365 * 24 * 3600 * 1000).toISOString();
+  const { data: rsvps, error: rsvpErr } = await svc
+    .from("event_rsvps")
+    .select("user_id, organization_id, checked_in_at")
+    .eq("status", "attending")
+    .not("checked_in_at", "is", null)
+    .gte("checked_in_at", since)
+    .limit(100_000);
+
+  if (rsvpErr) {
+    return NextResponse.json(
+      { success: false, error: rsvpErr.message },
+      { status: 500 },
+    );
+  }
+
+  // 2. Bucket weeks per (user, org).
+  const weeksByPair = new Map<string, Set<string>>();
+  for (const r of (rsvps ?? []) as RsvpRow[]) {
+    const key = `${r.user_id}::${r.organization_id}`;
+    const wk = weekKey(new Date(r.checked_in_at));
+    let set = weeksByPair.get(key);
+    if (!set) {
+      set = new Set();
+      weeksByPair.set(key, set);
+    }
+    set.add(wk);
+  }
+
+  // 3. Compute streaks. current_weeks = consecutive weeks ending in current
+  // week. If current week missing, the streak ends last week (so a Sunday
+  // run still counts on Monday).
+  const thisWeek = weekKey(new Date());
+  const lastWeek = weekKey(new Date(Date.now() - 7 * 24 * 3600 * 1000));
+
+  const upserts: Array<{
+    user_id: string;
+    organization_id: string;
+    current_weeks: number;
+    longest_weeks: number;
+    last_qualifying_week_start: string | null;
+    last_recomputed_at: string;
+  }> = [];
+
+  for (const [key, weeks] of weeksByPair) {
+    const [user_id, organization_id] = key.split("::");
+    const sortedDesc = Array.from(weeks).sort().reverse();
+
+    let current = 0;
+    let cursor = weeks.has(thisWeek)
+      ? thisWeek
+      : weeks.has(lastWeek)
+        ? lastWeek
+        : null;
+    while (cursor && weeks.has(cursor)) {
+      current += 1;
+      const prev = new Date(cursor + "T00:00:00Z");
+      prev.setUTCDate(prev.getUTCDate() - 7);
+      cursor = weekKey(prev);
+    }
+
+    // Longest: scan sorted weeks for max run.
+    let longest = 0;
+    let run = 0;
+    let prevWk: string | null = null;
+    for (const wk of sortedDesc.slice().reverse()) {
+      if (prevWk === null) {
+        run = 1;
+      } else {
+        const expected = new Date(prevWk + "T00:00:00Z");
+        expected.setUTCDate(expected.getUTCDate() + 7);
+        run = weekKey(expected) === wk ? run + 1 : 1;
+      }
+      longest = Math.max(longest, run);
+      prevWk = wk;
+    }
+
+    upserts.push({
+      user_id,
+      organization_id,
+      current_weeks: current,
+      longest_weeks: longest,
+      last_qualifying_week_start: sortedDesc[0] ?? null,
+      last_recomputed_at: new Date().toISOString(),
+    });
+  }
+
+  // 4. Upsert. We don't decrease longest_weeks here — Postgres-side guard via
+  // the on-conflict update preserving the larger value.
+  if (upserts.length > 0) {
+    // Read existing longest values to honor the "never decreases" invariant.
+    const userIds = Array.from(new Set(upserts.map((u) => u.user_id)));
+    const orgIds = Array.from(new Set(upserts.map((u) => u.organization_id)));
+    const { data: existing } = await svc
+      .from("member_streaks")
+      .select("user_id, organization_id, longest_weeks")
+      .in("user_id", userIds)
+      .in("organization_id", orgIds);
+    const existingMap = new Map<string, number>();
+    for (const e of (existing ?? []) as Array<{
+      user_id: string;
+      organization_id: string;
+      longest_weeks: number;
+    }>) {
+      existingMap.set(`${e.user_id}::${e.organization_id}`, e.longest_weeks);
+    }
+    for (const u of upserts) {
+      const key = `${u.user_id}::${u.organization_id}`;
+      const prior = existingMap.get(key) ?? 0;
+      if (prior > u.longest_weeks) u.longest_weeks = prior;
+    }
+
+    const { error: upsertErr } = await svc
+      .from("member_streaks")
+      .upsert(upserts, { onConflict: "user_id,organization_id" });
+    if (upsertErr) {
+      return NextResponse.json(
+        { success: false, error: upsertErr.message },
+        { status: 500 },
+      );
+    }
+  }
+
+  // 5. Badge evaluation. Pull catalog + (per pair) total attended events +
+  // workouts logged. Insert any newly-earned rows; ON CONFLICT DO NOTHING.
+  const { data: badges } = await svc
+    .from("badges")
+    .select("id, slug, criteria");
+  const badgeRows = (badges ?? []) as BadgeRow[];
+
+  const eventsAttended = new Map<string, number>();
+  for (const r of (rsvps ?? []) as RsvpRow[]) {
+    const k = `${r.user_id}::${r.organization_id}`;
+    eventsAttended.set(k, (eventsAttended.get(k) ?? 0) + 1);
+  }
+
+  // Workouts logged: any row in workout_logs counts.
+  const { data: wRows } = await svc
+    .from("workout_logs")
+    .select("user_id, organization_id");
+  const workoutsLogged = new Map<string, number>();
+  for (const w of (wRows ?? []) as WorkoutRow[]) {
+    const k = `${w.user_id}::${w.organization_id}`;
+    workoutsLogged.set(k, (workoutsLogged.get(k) ?? 0) + 1);
+  }
+
+  const awards: Array<{
+    user_id: string;
+    organization_id: string;
+    badge_id: string;
+  }> = [];
+  for (const upsert of upserts) {
+    const k = `${upsert.user_id}::${upsert.organization_id}`;
+    const ea = eventsAttended.get(k) ?? 0;
+    const wl = workoutsLogged.get(k) ?? 0;
+    for (const b of badgeRows) {
+      const c = b.criteria;
+      let earned = false;
+      if (c.kind === "streak_weeks" && (c.threshold ?? 0) > 0) {
+        earned = upsert.longest_weeks >= (c.threshold ?? 0);
+      } else if (c.kind === "events_attended" && (c.threshold ?? 0) > 0) {
+        earned = ea >= (c.threshold ?? 0);
+      } else if (c.kind === "workouts_logged" && (c.threshold ?? 0) > 0) {
+        earned = wl >= (c.threshold ?? 0);
+      }
+      if (earned) {
+        awards.push({
+          user_id: upsert.user_id,
+          organization_id: upsert.organization_id,
+          badge_id: b.id,
+        });
+      }
+    }
+  }
+
+  if (awards.length > 0) {
+    // Use upsert with onConflict: ignore — Supabase doesn't expose ON CONFLICT
+    // DO NOTHING directly, but ignoreDuplicates on the unique key works.
+    const { error: awardErr } = await svc
+      .from("member_badges")
+      .upsert(awards, {
+        onConflict: "user_id,organization_id,badge_id",
+        ignoreDuplicates: true,
+      });
+    if (awardErr) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `streaks ok, badges failed: ${awardErr.message}`,
+          streaks: upserts.length,
+        },
+        { status: 500 },
+      );
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    streaksUpserted: upserts.length,
+    badgeAwards: awards.length,
+  });
+}

--- a/apps/web/src/app/api/cron/weekly-digest/route.ts
+++ b/apps/web/src/app/api/cron/weekly-digest/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { validateCronAuth } from "@/lib/security/cron-auth";
+
+/**
+ * Weekly digest fan-out.
+ *
+ * Schedule: every hour. For each (user, org) where digest_push_enabled=true
+ * AND the user's current local time is Sunday 18:00 in their quiet-hours
+ * timezone, build a one-line summary of the past week's activity and enqueue
+ * a notification_jobs row delivered immediately.
+ *
+ * The "current local time === Sun 18:00" gate runs in SQL so we don't have to
+ * read every preference row per hour and convert in JS.
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+interface PrefRow {
+  user_id: string;
+  organization_id: string;
+}
+
+export async function GET(request: Request) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const service = createServiceClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const svc = service as any;
+
+  // 1. Find recipients: enabled + currently Sun 18:00 local.
+  // Wrap the timezone math in an RPC-style query via raw SQL? Supabase JS
+  // doesn't expose ad-hoc SQL on the public client. We approximate with a
+  // narrower SELECT then filter in JS — small enough at MVP scale.
+  const { data: prefs, error: prefErr } = await svc
+    .from("notification_preferences")
+    .select("user_id, organization_id, quiet_hours_timezone")
+    .eq("digest_push_enabled", true);
+
+  if (prefErr) {
+    return NextResponse.json(
+      { success: false, error: prefErr.message },
+      { status: 500 },
+    );
+  }
+
+  const now = new Date();
+  const recipients: PrefRow[] = [];
+  for (const p of (prefs ?? []) as Array<{
+    user_id: string;
+    organization_id: string;
+    quiet_hours_timezone: string;
+  }>) {
+    try {
+      const fmt = new Intl.DateTimeFormat("en-US", {
+        timeZone: p.quiet_hours_timezone,
+        weekday: "short",
+        hour: "2-digit",
+        hour12: false,
+      });
+      const parts = fmt.formatToParts(now);
+      const wk = parts.find((x) => x.type === "weekday")?.value ?? "";
+      const hr = parseInt(
+        parts.find((x) => x.type === "hour")?.value ?? "-1",
+        10,
+      );
+      if (wk === "Sun" && hr === 18) {
+        recipients.push({
+          user_id: p.user_id,
+          organization_id: p.organization_id,
+        });
+      }
+    } catch {
+      // Invalid timezone string — skip rather than crash the cron.
+    }
+  }
+
+  if (recipients.length === 0) {
+    return NextResponse.json({ success: true, enqueued: 0 });
+  }
+
+  // 2. For each org, fetch this-past-week aggregates once and reuse for all
+  // recipients in that org.
+  const sinceIso = new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString();
+  const orgIds = Array.from(new Set(recipients.map((r) => r.organization_id)));
+
+  const orgStats = new Map<
+    string,
+    { events: number; announcements: number; discussions: number }
+  >();
+
+  for (const orgId of orgIds) {
+    const [{ count: events }, { count: announcements }, { count: discussions }] =
+      await Promise.all([
+        svc
+          .from("events")
+          .select("id", { count: "exact", head: true })
+          .eq("organization_id", orgId)
+          .is("deleted_at", null)
+          .gte("created_at", sinceIso),
+        svc
+          .from("announcements")
+          .select("id", { count: "exact", head: true })
+          .eq("organization_id", orgId)
+          .is("deleted_at", null)
+          .gte("created_at", sinceIso),
+        svc
+          .from("discussion_threads")
+          .select("id", { count: "exact", head: true })
+          .eq("organization_id", orgId)
+          .gte("created_at", sinceIso),
+      ]);
+    orgStats.set(orgId, {
+      events: events ?? 0,
+      announcements: announcements ?? 0,
+      discussions: discussions ?? 0,
+    });
+  }
+
+  // 3. Build + insert notification_jobs rows.
+  const orgNames = new Map<string, string>();
+  const { data: orgs } = await svc
+    .from("organizations")
+    .select("id, name")
+    .in("id", orgIds);
+  for (const o of (orgs ?? []) as Array<{ id: string; name: string }>) {
+    orgNames.set(o.id, o.name);
+  }
+
+  const jobs = recipients
+    .map((r) => {
+      const stats = orgStats.get(r.organization_id);
+      const orgName = orgNames.get(r.organization_id) ?? "your team";
+      if (!stats) return null;
+      const total = stats.events + stats.announcements + stats.discussions;
+      if (total === 0) return null; // nothing to digest
+      const parts: string[] = [];
+      if (stats.events) parts.push(`${stats.events} event${stats.events === 1 ? "" : "s"}`);
+      if (stats.announcements)
+        parts.push(`${stats.announcements} update${stats.announcements === 1 ? "" : "s"}`);
+      if (stats.discussions)
+        parts.push(`${stats.discussions} discussion${stats.discussions === 1 ? "" : "s"}`);
+      return {
+        organization_id: r.organization_id,
+        kind: "standard",
+        priority: 5,
+        audience: null,
+        target_user_ids: [r.user_id],
+        category: "digest",
+        push_type: "digest",
+        push_resource_id: null,
+        title: `This week in ${orgName}`,
+        body: parts.join(", ") + ".",
+        data: { digest: true },
+        status: "pending",
+        scheduled_for: new Date().toISOString(),
+      };
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null);
+
+  if (jobs.length === 0) {
+    return NextResponse.json({ success: true, enqueued: 0, recipients: recipients.length });
+  }
+
+  const { error: insertErr } = await svc.from("notification_jobs").insert(jobs);
+  if (insertErr) {
+    return NextResponse.json(
+      { success: false, error: insertErr.message, recipients: recipients.length },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    enqueued: jobs.length,
+    recipients: recipients.length,
+  });
+}

--- a/apps/web/src/lib/notifications/quiet-hours.ts
+++ b/apps/web/src/lib/notifications/quiet-hours.ts
@@ -1,0 +1,107 @@
+/**
+ * Quiet-hours gate for the notification dispatcher.
+ *
+ * Categories that respect quiet hours: digest, reengagement. Transactional
+ * categories (chat, event_reminder, announcement, mention) bypass — if you
+ * @-mention me at 11pm I'd rather be pinged than wait until morning.
+ *
+ * Logic:
+ *   1. For single-target pushes in a respecting category, look up the
+ *      user's quiet_hours_{start,end,timezone} on notification_preferences
+ *      scoped to the job's organization.
+ *   2. If `now` falls inside the local-time window, compute the next
+ *      quiet_hours_end as a UTC ISO string and return it as the deferred
+ *      scheduled_for.
+ *   3. Otherwise return null — caller proceeds with normal dispatch.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const RESPECTING_CATEGORIES = new Set(["digest", "reengagement"]);
+
+interface QuietHoursPref {
+  quiet_hours_start: string; // 'HH:MM:SS' or 'HH:MM'
+  quiet_hours_end: string;
+  quiet_hours_timezone: string;
+}
+
+function parseHM(value: string): { h: number; m: number } {
+  const [h, m] = value.split(":");
+  return { h: parseInt(h, 10) || 0, m: parseInt(m ?? "0", 10) || 0 };
+}
+
+/** Returns local hour:minute in given IANA timezone for `now`. */
+function localHM(now: Date, tz: string): { h: number; m: number } {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(now);
+  const h = parseInt(parts.find((x) => x.type === "hour")?.value ?? "0", 10);
+  const m = parseInt(parts.find((x) => x.type === "minute")?.value ?? "0", 10);
+  return { h, m };
+}
+
+function isInsideWindow(
+  now: Date,
+  pref: QuietHoursPref,
+): { inside: boolean; minutesUntilEnd: number } {
+  const start = parseHM(pref.quiet_hours_start);
+  const end = parseHM(pref.quiet_hours_end);
+  const cur = localHM(now, pref.quiet_hours_timezone);
+
+  const startMin = start.h * 60 + start.m;
+  const endMin = end.h * 60 + end.m;
+  const curMin = cur.h * 60 + cur.m;
+
+  // Window may wrap midnight (start > end). Default 21:00–07:00 wraps.
+  const wraps = startMin > endMin;
+  const inside = wraps
+    ? curMin >= startMin || curMin < endMin
+    : curMin >= startMin && curMin < endMin;
+  if (!inside) return { inside: false, minutesUntilEnd: 0 };
+
+  const minutesUntilEnd = wraps
+    ? curMin >= startMin
+      ? 24 * 60 - curMin + endMin
+      : endMin - curMin
+    : endMin - curMin;
+  return { inside: true, minutesUntilEnd };
+}
+
+/**
+ * Returns an ISO string for `scheduled_for` if the job should be deferred,
+ * or null if it should proceed now.
+ */
+export async function maybeDeferForQuietHours(args: {
+  supabase: SupabaseClient;
+  category: string | null | undefined;
+  organizationId: string;
+  targetUserIds: string[] | null;
+  now?: Date;
+}): Promise<string | null> {
+  const { supabase, category, organizationId, targetUserIds } = args;
+  if (!category || !RESPECTING_CATEGORIES.has(category)) return null;
+  if (!targetUserIds || targetUserIds.length !== 1) return null;
+
+  const userId = targetUserIds[0];
+  const now = args.now ?? new Date();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const svc = supabase as any;
+  const { data: pref } = await svc
+    .from("notification_preferences")
+    .select("quiet_hours_start, quiet_hours_end, quiet_hours_timezone")
+    .eq("user_id", userId)
+    .eq("organization_id", organizationId)
+    .maybeSingle();
+
+  if (!pref) return null;
+  const result = isInsideWindow(now, pref as QuietHoursPref);
+  if (!result.inside) return null;
+
+  const deferTo = new Date(now.getTime() + result.minutesUntilEnd * 60 * 1000);
+  return deferTo.toISOString();
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -64,6 +64,18 @@
     {
       "path": "/api/cron/notification-dispatch",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/streaks-recompute",
+      "schedule": "0 9 * * *"
+    },
+    {
+      "path": "/api/cron/weekly-digest",
+      "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/reengagement-sweep",
+      "schedule": "0 10 * * *"
     }
   ]
 }

--- a/supabase/migrations/20260508130000_engagement_phase_b_schema.sql
+++ b/supabase/migrations/20260508130000_engagement_phase_b_schema.sql
@@ -1,0 +1,70 @@
+-- =============================================================================
+-- Engagement Phase B: schema for streaks, badges, digest, and quiet hours.
+-- =============================================================================
+-- Adds:
+--   - users.last_active_at — bumped on auth-bound activity. Drives DAU + the
+--     re-engagement-sweep cron's "inactive ≥7d" gate.
+--   - notification_preferences.quiet_hours_{start,end,timezone} — local-time
+--     window the dispatcher must defer to. Default 21:00–07:00 in UTC; mobile
+--     overrides the timezone on first launch.
+--   - notification_preferences.digest_push_enabled — gates the weekly digest.
+--   - notification_preferences.reengagement_push_enabled — gates the
+--     re-engagement sweep so dormant users can opt out without losing other
+--     transactional pushes.
+--   - public.record_user_activity() RPC — debounced server-side write so any
+--     authenticated client can heartbeat without RLS-policy churn.
+-- =============================================================================
+
+-- 1. users.last_active_at
+alter table public.users
+  add column if not exists last_active_at timestamptz;
+
+create index if not exists users_last_active_at_idx
+  on public.users (last_active_at);
+
+comment on column public.users.last_active_at is
+  'Updated by record_user_activity() on auth-bound activity. Drives DAU + reengagement cron.';
+
+-- 2. quiet hours + new push toggles on notification_preferences
+alter table public.notification_preferences
+  add column if not exists quiet_hours_start time not null default '21:00',
+  add column if not exists quiet_hours_end time not null default '07:00',
+  add column if not exists quiet_hours_timezone text not null default 'UTC',
+  add column if not exists digest_push_enabled boolean not null default true,
+  add column if not exists reengagement_push_enabled boolean not null default true;
+
+comment on column public.notification_preferences.quiet_hours_start is
+  'Local-time start of the user''s do-not-disturb window. Dispatcher defers digests/re-engagement pushes during this window.';
+comment on column public.notification_preferences.quiet_hours_end is
+  'Local-time end of the user''s do-not-disturb window.';
+comment on column public.notification_preferences.quiet_hours_timezone is
+  'IANA timezone (e.g. America/New_York). Mobile sets this on first launch.';
+
+-- 3. record_user_activity() RPC — debounced heartbeat.
+-- Only writes if the existing last_active_at is NULL or older than 60s, so a
+-- chatty client can call this freely without thrashing the row.
+create or replace function public.record_user_activity()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+begin
+  if v_uid is null then
+    return;
+  end if;
+
+  update public.users
+     set last_active_at = now()
+   where id = v_uid
+     and (last_active_at is null or last_active_at < now() - interval '60 seconds');
+end;
+$$;
+
+revoke all on function public.record_user_activity() from public;
+grant execute on function public.record_user_activity() to authenticated;
+
+comment on function public.record_user_activity() is
+  'Debounced heartbeat (60s) bumping users.last_active_at for the calling user. Safe to call on every authenticated request.';

--- a/supabase/migrations/20260508130001_member_streaks.sql
+++ b/supabase/migrations/20260508130001_member_streaks.sql
@@ -1,0 +1,68 @@
+-- =============================================================================
+-- member_streaks — per-(user, org) attendance streaks.
+-- =============================================================================
+-- "Attendance" is qualifying weekly activity:
+--   - any event_rsvps row where status='attending' AND checked_in_at IS NOT NULL
+--     in a given ISO week counts that week as qualifying.
+-- A streak is the count of consecutive qualifying weeks ending in the most
+-- recent calendar week (Mon-Sun, UTC). Missing a week resets `current_weeks`
+-- to 0; longest_weeks never decreases.
+--
+-- Recompute is performed by /api/cron/streaks-recompute daily.
+-- =============================================================================
+
+create table if not exists public.member_streaks (
+  user_id uuid not null references public.users(id) on delete cascade,
+  organization_id uuid not null references public.organizations(id) on delete cascade,
+  current_weeks integer not null default 0,
+  longest_weeks integer not null default 0,
+  last_qualifying_week_start date,
+  last_recomputed_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, organization_id)
+);
+
+create index if not exists member_streaks_org_current_idx
+  on public.member_streaks (organization_id, current_weeks desc);
+
+create index if not exists member_streaks_org_longest_idx
+  on public.member_streaks (organization_id, longest_weeks desc);
+
+alter table public.member_streaks enable row level security;
+
+-- Members of the org can see streaks for that org. The leaderboard surface
+-- queries by organization_id; RLS gates by org membership rather than per-row.
+drop policy if exists member_streaks_select_same_org on public.member_streaks;
+create policy member_streaks_select_same_org
+  on public.member_streaks
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.members m
+      where m.organization_id = public.member_streaks.organization_id
+        and m.user_id = auth.uid()
+        and m.deleted_at is null
+    )
+  );
+
+-- Writes are service-role only (the cron). Clients never directly write streak
+-- rows — they're always derived from RSVPs.
+
+create or replace function public.tg_member_streaks_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists member_streaks_updated_at on public.member_streaks;
+create trigger member_streaks_updated_at
+  before update on public.member_streaks
+  for each row execute function public.tg_member_streaks_updated_at();
+
+comment on table public.member_streaks is
+  'Per-(user,org) attendance streak. Recomputed daily by /api/cron/streaks-recompute. longest_weeks never decreases.';

--- a/supabase/migrations/20260508130002_badges.sql
+++ b/supabase/migrations/20260508130002_badges.sql
@@ -1,0 +1,77 @@
+-- =============================================================================
+-- badges + member_badges — earnable achievements per (user, org).
+-- =============================================================================
+-- The `badges` table is a small, mostly-read seed table; rows are added
+-- intentionally by migrations rather than admin UI. Eligibility is evaluated
+-- by /api/cron/streaks-recompute and ad-hoc evaluators (so a brand-new badge
+-- can be backfilled by editing the cron's evaluator list).
+-- =============================================================================
+
+create table if not exists public.badges (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  title text not null,
+  description text not null,
+  icon text not null, -- lucide-react-native / lucide-react icon name
+  -- Free-form criteria for the cron's evaluator: e.g.
+  --   { "kind": "streak_weeks", "threshold": 4 }
+  --   { "kind": "events_attended", "threshold": 10 }
+  --   { "kind": "first_workout" }
+  criteria jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.member_badges (
+  user_id uuid not null references public.users(id) on delete cascade,
+  organization_id uuid not null references public.organizations(id) on delete cascade,
+  badge_id uuid not null references public.badges(id) on delete cascade,
+  earned_at timestamptz not null default now(),
+  primary key (user_id, organization_id, badge_id)
+);
+
+create index if not exists member_badges_org_user_idx
+  on public.member_badges (organization_id, user_id);
+
+create index if not exists member_badges_user_recent_idx
+  on public.member_badges (user_id, earned_at desc);
+
+alter table public.badges enable row level security;
+alter table public.member_badges enable row level security;
+
+-- Anyone authenticated can read the badge catalog.
+drop policy if exists badges_select_all on public.badges;
+create policy badges_select_all
+  on public.badges for select to authenticated using (true);
+
+-- Members of the org can see who-earned-what for that org (powers profile
+-- pages + leaderboards).
+drop policy if exists member_badges_select_same_org on public.member_badges;
+create policy member_badges_select_same_org
+  on public.member_badges
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.members m
+      where m.organization_id = public.member_badges.organization_id
+        and m.user_id = auth.uid()
+        and m.deleted_at is null
+    )
+  );
+
+-- Inserts/updates/deletes are service-role only (the cron evaluator).
+
+-- =============================================================================
+-- Seed initial badge catalog.
+-- =============================================================================
+-- Five starter badges that the cron can evaluate today. More can be added by
+-- adding rows + extending the evaluator list in /api/cron/streaks-recompute.
+
+insert into public.badges (slug, title, description, icon, criteria) values
+  ('first-event',   'First Event',     'Attended your first event.',                 'calendar-check', '{"kind":"events_attended","threshold":1}'::jsonb),
+  ('event-regular', 'Event Regular',   'Attended 10 events.',                         'calendar-heart', '{"kind":"events_attended","threshold":10}'::jsonb),
+  ('streak-month',  'On a Roll',       '4-week attendance streak.',                   'flame',          '{"kind":"streak_weeks","threshold":4}'::jsonb),
+  ('streak-season', 'Stayed the Course','12-week attendance streak.',                 'medal',          '{"kind":"streak_weeks","threshold":12}'::jsonb),
+  ('first-workout', 'First Workout',   'Logged your first workout.',                  'dumbbell',       '{"kind":"workouts_logged","threshold":1}'::jsonb)
+on conflict (slug) do nothing;


### PR DESCRIPTION
## Summary

Phase B of the retention plan. Three new crons + schema + a quiet-hours dispatcher gate that converts one-off pushes into a daily engagement loop. Targets DAU.

## What ships

**Schema (3 migrations)**
- `users.last_active_at` + `record_user_activity()` RPC (60s server-debounced heartbeat).
- `notification_preferences`: `quiet_hours_{start,end,timezone}` (defaults 21:00–07:00 UTC; mobile overrides timezone on first launch), `digest_push_enabled`, `reengagement_push_enabled`.
- `member_streaks` table — per-(user, org) consecutive-week attendance, `longest_weeks` invariant never decreases.
- `badges` + `member_badges` + 5 seed badges (first-event, event-regular, streak-month, streak-season, first-workout). RLS scoped by org membership.

**Crons + dispatcher gate**
- `/api/cron/streaks-recompute` (daily 09:00 UTC) — derives streaks from `event_rsvps.checked_in_at`; awards badges per `criteria` JSON.
- `/api/cron/weekly-digest` (hourly) — for each user currently at Sunday 18:00 in their local timezone, builds a 1-line week recap and enqueues a job. Skips orgs with zero activity.
- `/api/cron/reengagement-sweep` (daily 10:00 UTC) — finds users dormant ≥7d with pending org activity, throttled to 1/14d via `notifications` history.
- `notification-dispatch` — new quiet-hours gate defers `digest` / `reengagement` single-target jobs falling inside the user's local DND window. Transactional categories (chat, event_reminder, announcement) bypass.

**Mobile**
- `useActivityHeartbeat` fires `record_user_activity` on sign-in + every foreground.
- `StreakChip` on the menu tab — renders only when current streak > 0 (celebrate, not nag).
- Settings: digest + re-engagement toggles + quiet-hours window display. Auto-captures device IANA timezone when the saved pref is still UTC.

## Scope cuts (deferred)

- Web parity for the streak chip + per-user badge grid (data path is built; web UI in a follow-up).
- Per-org leaderboards page (web + mobile) — depends on this PR's `member_streaks` data; lands in PR-B2.
- Quiet-hours time-of-day picker (currently displays the window read-only; toggles only). Picker can land in PR-B2.
- Web side `record_user_activity` heartbeat (current PR is mobile-only; web needs middleware tap).

## Required env

No new env vars. CRON_SECRET unchanged.

## Test plan

- [ ] Apply 3 migrations to staging DB
- [ ] `bun run typecheck && bun run lint` (passing — verified)
- [ ] Mobile: sign in → query `users.last_active_at` updates within 60s
- [ ] Mobile: foreground app → `last_active_at` updates again (debounce holds inside 60s)
- [ ] Manually `POST /api/cron/streaks-recompute` with CRON_SECRET → `member_streaks` populated
- [ ] Set a test user's quiet hours to `now`–`now+1h` → enqueue a digest → dispatcher defers via `last_error="deferred for quiet hours"`
- [ ] Set a test user's `last_active_at` to 8d ago → run reengagement-sweep → see job enqueued

## Post-Deploy Monitoring & Validation

- **Logs**: `[notification-dispatch]` — `deferred for quiet hours` should appear sparingly (digest/reengagement only)
- **Metrics**:
  - `SELECT count(*) FROM users WHERE last_active_at > now() - interval '24 hours';` — DAU baseline
  - `SELECT count(*) FROM member_streaks WHERE current_weeks > 0;` — engaged users
  - `SELECT count(*) FROM member_badges;` — should grow over time
- **Healthy signals**: weekly digest cron returns `enqueued: N>0` on Sundays; reengagement enqueued count stays low (most users active)
- **Failure signals**: notification_jobs piling up `failed` for `digest`/`reengagement` → check dispatcher logs; stale streak rows → check streaks-recompute cron
- **Rollback**: revert PR; migrations are additive only (no destructive drops) so revert is safe
- **Owner / window**: @cicconel11, 14-day post-deploy

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.46.0