### PR TITLE
feat(engagement): live activities + streaks/badges/digest + reactions/mentions/presence

### DIFF
--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -1,8 +1,10 @@
 .expo/
-ios/
-android/
-ios.bak-*/
-android.bak-*/
+# Anchored: only ignores the prebuild output at apps/mobile/{ios,android}, not
+# `modules/<name>/ios/` source folders that ship with local Expo modules.
+/ios/
+/android/
+/ios.bak-*/
+/android.bak-*/
 dist/
 .env.local
 .claude/skills/

--- a/apps/mobile/__tests__/lib/mentions.test.ts
+++ b/apps/mobile/__tests__/lib/mentions.test.ts
@@ -1,0 +1,69 @@
+import {
+  buildMentionMarker,
+  extractMentionedUserIds,
+  parseMentionMarkers,
+  renderMentionPlainText,
+} from "@/lib/mentions";
+
+describe("mentions", () => {
+  const userA = "11111111-1111-1111-1111-111111111111";
+  const userB = "22222222-2222-2222-2222-222222222222";
+
+  describe("extractMentionedUserIds", () => {
+    it("returns ids in stable order with duplicates removed", () => {
+      const body = `hey [@${userA}|Alice] and [@${userB}|Bob], also [@${userA}|Alice] again`;
+      expect(extractMentionedUserIds(body)).toEqual([userA, userB]);
+    });
+
+    it("returns empty array when no markers present", () => {
+      expect(extractMentionedUserIds("just prose with @nonsense")).toEqual([]);
+    });
+
+    it("ignores invalid uuid patterns", () => {
+      expect(extractMentionedUserIds("[@not-a-uuid|Name]")).toEqual([]);
+    });
+
+    it("normalizes case to lowercase", () => {
+      const upper = userA.toUpperCase();
+      expect(extractMentionedUserIds(`[@${upper}|Alice]`)).toEqual([userA]);
+    });
+  });
+
+  describe("parseMentionMarkers", () => {
+    it("preserves order and display name per occurrence", () => {
+      const body = `[@${userA}|Alice] [@${userB}|Bob]`;
+      expect(parseMentionMarkers(body)).toEqual([
+        { userId: userA, displayName: "Alice" },
+        { userId: userB, displayName: "Bob" },
+      ]);
+    });
+  });
+
+  describe("renderMentionPlainText", () => {
+    it("substitutes markers with @DisplayName", () => {
+      const body = `hi [@${userA}|Alice] and [@${userB}|Bob]`;
+      expect(renderMentionPlainText(body)).toBe("hi @Alice and @Bob");
+    });
+
+    it("leaves prose with stray @ untouched", () => {
+      expect(renderMentionPlainText("email me @ alice@example.com")).toBe(
+        "email me @ alice@example.com",
+      );
+    });
+  });
+
+  describe("buildMentionMarker", () => {
+    it("strips brackets from display names so the parser stays unambiguous", () => {
+      expect(buildMentionMarker(userA, "Alice [Admin]")).toBe(
+        `[@${userA}|Alice Admin]`,
+      );
+    });
+  });
+
+  describe("round-trip", () => {
+    it("buildMentionMarker → extractMentionedUserIds yields the original id", () => {
+      const marker = buildMentionMarker(userA, "Alice");
+      expect(extractMentionedUserIds(marker)).toEqual([userA]);
+    });
+  });
+});

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/members.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/members.tsx
@@ -14,6 +14,7 @@ import { useFocusEffect, useRouter, useNavigation } from "expo-router";
 import { ArrowUpDown, Users, Search } from "lucide-react-native";
 import { useMemberDirectory, type DirectoryMember } from "@/hooks/useMemberDirectory";
 import { useOrg } from "@/contexts/OrgContext";
+import { usePresence } from "@/contexts/PresenceContext";
 import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
 import { useThemedStyles } from "@/hooks/useThemedStyles";
 import { useNetwork } from "@/contexts/NetworkContext";
@@ -39,6 +40,7 @@ export default function MembersScreen() {
   const { orgSlug, orgId, orgName, orgLogoUrl } = useOrg();
   // Use orgId from context for data hook (eliminates redundant org fetch)
   const { members, loading, error, refetch, refetchIfStale } = useMemberDirectory(orgId);
+  const { isOnline } = usePresence();
   const { neutral, semantic } = useAppColorScheme();
   const { isOffline } = useNetwork();
   const [refreshing, setRefreshing] = useState(false);
@@ -275,10 +277,11 @@ export default function MembersScreen() {
           chips={chips}
           onPress={() => handleMemberPress(item)}
           colors={directoryColors}
+          online={isOnline(item.user_id)}
         />
       );
     },
-    [handleMemberPress, directoryColors]
+    [handleMemberPress, directoryColors, isOnline]
   );
 
   const roleOptions: { value: RoleFilter; label: string }[] = [

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/menu.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/menu.tsx
@@ -40,6 +40,7 @@ import { useThemedStyles } from "@/hooks/useThemedStyles";
 import { APP_CHROME } from "@/lib/chrome";
 import { SPACING, RADIUS, SHADOWS } from "@/lib/design-tokens";
 import { TYPOGRAPHY } from "@/lib/typography";
+import { StreakChip } from "@/components/profile/StreakChip";
 
 interface Organization {
   id: string;
@@ -59,7 +60,7 @@ interface MenuItem {
 const STALE_TIME_MS = 30_000; // 30 seconds
 
 export default function MenuScreen() {
-  const { orgSlug } = useOrg();
+  const { orgSlug, orgId } = useOrg();
   const router = useRouter();
   const navigation = useNavigation();
   const { user } = useAuth();
@@ -648,6 +649,9 @@ export default function MenuScreen() {
               </View>
               <ChevronRight size={20} color={neutral.secondary} />
             </Pressable>
+            <View style={{ paddingHorizontal: SPACING.md, paddingBottom: SPACING.sm }}>
+              <StreakChip userId={user?.id ?? null} organizationId={orgId} />
+            </View>
           </View>
 
           {/* Updates Section */}

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,10 +1,13 @@
 import { AppDrawer } from "@/navigation/AppDrawer";
 import { OrgProvider } from "@/contexts/OrgContext";
+import { PresenceProvider } from "@/contexts/PresenceContext";
 
 export default function AppLayout() {
   return (
     <OrgProvider>
-      <AppDrawer />
+      <PresenceProvider>
+        <AppDrawer />
+      </PresenceProvider>
     </OrgProvider>
   );
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -23,6 +23,7 @@ import { setGlobalShowToast } from "@/components/ui/Toast";
 import AuthLoadingScreen from "@/components/AuthLoadingScreen";
 import { init as initAnalytics, identify, reset as resetAnalytics, captureException, hydrateEnabled } from "@/lib/analytics";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
+import { useActivityHeartbeat } from "@/hooks/useActivityHeartbeat";
 import { useScreenTracking } from "@/hooks/useScreenTracking";
 import { useSupabaseAppState } from "@/hooks/useSupabaseAppState";
 import { parseTeammeetUrl, routeIntent } from "@/lib/deep-link";
@@ -141,6 +142,9 @@ function RootLayoutInner() {
     userId: session?.user?.id ?? null,
     enabled: true,
   });
+
+  // Bump users.last_active_at on sign-in + every foreground.
+  useActivityHeartbeat(session?.user?.id ?? null);
 
   // Hide splash screen once fonts are loaded
   useEffect(() => {

--- a/apps/mobile/modules/live-activity/ios/EventActivityAttributes.swift
+++ b/apps/mobile/modules/live-activity/ios/EventActivityAttributes.swift
@@ -1,0 +1,65 @@
+// EventActivityAttributes.swift
+// LiveActivity (RN module)
+//
+// IMPORTANT: This file MUST stay byte-identical to
+// `apps/mobile/targets/widget/EventActivityAttributes.swift`.
+// The widget target compiles its own copy so that the SwiftUI views can
+// reference the type without importing the host module. The RN bridge
+// compiles a second copy here so that `LiveActivityModule.swift` can
+// instantiate `Activity<EventActivityAttributes>` without a cross-target
+// header dependency that CocoaPods sandboxing forbids.
+//
+// If you change one, change the other. A drift between the two struct
+// definitions corrupts ActivityKit payloads and crashes the widget at
+// runtime. Consider extracting both into a shared Swift Package once
+// `@bacons/apple-targets` adds first-class SPM support.
+
+import ActivityKit
+import Foundation
+
+@available(iOS 16.1, *)
+public struct EventActivityAttributes: ActivityAttributes {
+    public typealias EventStatus = ContentState
+
+    public struct ContentState: Codable, Hashable {
+        public var checkedInCount: Int
+        public var totalAttending: Int
+        public var isCheckedIn: Bool
+        public var status: String
+        public var startsAt: Date
+        public var endsAt: Date
+
+        public init(
+            checkedInCount: Int,
+            totalAttending: Int,
+            isCheckedIn: Bool,
+            status: String,
+            startsAt: Date,
+            endsAt: Date
+        ) {
+            self.checkedInCount = checkedInCount
+            self.totalAttending = totalAttending
+            self.isCheckedIn = isCheckedIn
+            self.status = status
+            self.startsAt = startsAt
+            self.endsAt = endsAt
+        }
+    }
+
+    public var eventId: String
+    public var orgSlug: String
+    public var orgName: String
+    public var eventTitle: String
+
+    public init(
+        eventId: String,
+        orgSlug: String,
+        orgName: String,
+        eventTitle: String
+    ) {
+        self.eventId = eventId
+        self.orgSlug = orgSlug
+        self.orgName = orgName
+        self.eventTitle = eventTitle
+    }
+}

--- a/apps/mobile/modules/live-activity/ios/LiveActivity.podspec
+++ b/apps/mobile/modules/live-activity/ios/LiveActivity.podspec
@@ -1,0 +1,28 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'LiveActivity'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.license        = 'MIT'
+  s.author         = 'TeamMeet'
+  s.homepage       = 'https://www.myteamnetwork.com'
+  s.platforms      = { :ios => '17.0' }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  # Source files: the bridge module + a local copy of the
+  # ActivityAttributes struct. The widget extension target compiles its
+  # own copy from `targets/widget/EventActivityAttributes.swift`. The two
+  # files MUST stay byte-identical; see the header comment in each.
+  s.source_files = "**/*.{h,m,swift}"
+end

--- a/apps/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/apps/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -1,0 +1,216 @@
+// LiveActivityModule.swift
+// TeamMeet
+//
+// Expo Modules bridge for iOS Live Activities (ActivityKit).
+//
+// Exposes four async functions to JS:
+//   - isSupported() -> bool
+//   - start(args)   -> { activityId, pushToken } | null
+//   - update(activityId, contentState)
+//   - end(activityId, contentState?, dismissalPolicy?)
+//
+// And one event:
+//   - onPushTokenUpdate { activityId, pushToken }
+//
+// The widget extension target ships EventActivityAttributes; this module is in
+// the host app target. Both reference the same Swift struct via the file
+// being included in both targets at build time (Xcode shared compilation).
+
+import ActivityKit
+import ExpoModulesCore
+
+public class LiveActivityModule: Module {
+    private var pushTokenObservers: [String: Task<Void, Never>] = [:]
+
+    public func definition() -> ModuleDefinition {
+        Name("LiveActivityModule")
+
+        Events("onPushTokenUpdate", "onActivityStateChange")
+
+        AsyncFunction("isSupported") { () -> Bool in
+            if #available(iOS 16.1, *) {
+                return ActivityAuthorizationInfo().areActivitiesEnabled
+            }
+            return false
+        }
+
+        AsyncFunction("start") { (args: [String: Any]) async throws -> [String: String]? in
+            guard #available(iOS 17.0, *) else {
+                throw LiveActivityError.unsupportedOSVersion
+            }
+            guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+                throw LiveActivityError.notAuthorized
+            }
+
+            guard
+                let eventId = args["eventId"] as? String,
+                let orgSlug = args["orgSlug"] as? String,
+                let orgName = args["orgName"] as? String,
+                let eventTitle = args["eventTitle"] as? String,
+                let stateRaw = args["contentState"] as? [String: Any]
+            else {
+                throw LiveActivityError.invalidArguments
+            }
+
+            let attributes = EventActivityAttributes(
+                eventId: eventId,
+                orgSlug: orgSlug,
+                orgName: orgName,
+                eventTitle: eventTitle
+            )
+            let state = try Self.parseContentState(stateRaw)
+            let staleDateRaw = args["staleDate"] as? Double
+            let staleDate = staleDateRaw.map { Date(timeIntervalSince1970: $0) }
+
+            let activity = try Activity.request(
+                attributes: attributes,
+                content: .init(state: state, staleDate: staleDate),
+                pushType: .token
+            )
+
+            let activityId = activity.id
+            self.observePushToken(for: activity)
+
+            // Wait briefly for the first token so the host app can register
+            // it with the server before returning. If APNs is slow we fall
+            // back to nil and the JS side relies on the onPushTokenUpdate
+            // event for late delivery.
+            let initialToken = await Self.firstToken(activity, timeoutSeconds: 5)
+            return [
+                "activityId": activityId,
+                "pushToken": initialToken ?? "",
+            ]
+        }
+
+        AsyncFunction("update") { (activityId: String, stateRaw: [String: Any]) async throws -> Void in
+            guard #available(iOS 16.2, *) else { return }
+            let state = try Self.parseContentState(stateRaw)
+            for activity in Activity<EventActivityAttributes>.activities where activity.id == activityId {
+                await activity.update(.init(state: state, staleDate: nil))
+            }
+        }
+
+        AsyncFunction("end") { (activityId: String, finalStateRaw: [String: Any]?, policyRaw: String?) async throws -> Void in
+            guard #available(iOS 16.2, *) else { return }
+            let policy: ActivityUIDismissalPolicy = {
+                switch policyRaw {
+                case "immediate": return .immediate
+                case "default": return .default
+                default: return .immediate
+                }
+            }()
+            for activity in Activity<EventActivityAttributes>.activities where activity.id == activityId {
+                let content: ActivityContent<EventActivityAttributes.ContentState>?
+                if let finalStateRaw {
+                    let state = try Self.parseContentState(finalStateRaw)
+                    content = .init(state: state, staleDate: nil)
+                } else {
+                    content = nil
+                }
+                await activity.end(content, dismissalPolicy: policy)
+                self.cancelTokenObserver(activityId: activityId)
+            }
+        }
+
+        AsyncFunction("endAll") { (policyRaw: String?) async throws -> Void in
+            guard #available(iOS 16.2, *) else { return }
+            let policy: ActivityUIDismissalPolicy = policyRaw == "default" ? .default : .immediate
+            for activity in Activity<EventActivityAttributes>.activities {
+                await activity.end(nil, dismissalPolicy: policy)
+                self.cancelTokenObserver(activityId: activity.id)
+            }
+        }
+
+        AsyncFunction("listActive") { () -> [[String: String]] in
+            guard #available(iOS 16.1, *) else { return [] }
+            return Activity<EventActivityAttributes>.activities.map { activity in
+                [
+                    "activityId": activity.id,
+                    "eventId": activity.attributes.eventId,
+                    "orgSlug": activity.attributes.orgSlug,
+                ]
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    @available(iOS 17.0, *)
+    private func observePushToken(for activity: Activity<EventActivityAttributes>) {
+        let activityId = activity.id
+        let task = Task { [weak self] in
+            for await tokenData in activity.pushTokenUpdates {
+                let hex = tokenData.map { String(format: "%02x", $0) }.joined()
+                self?.sendEvent("onPushTokenUpdate", [
+                    "activityId": activityId,
+                    "pushToken": hex,
+                ])
+            }
+        }
+        pushTokenObservers[activityId] = task
+    }
+
+    private func cancelTokenObserver(activityId: String) {
+        pushTokenObservers[activityId]?.cancel()
+        pushTokenObservers.removeValue(forKey: activityId)
+    }
+
+    @available(iOS 17.0, *)
+    private static func firstToken(_ activity: Activity<EventActivityAttributes>, timeoutSeconds: UInt64) async -> String? {
+        let stream = activity.pushTokenUpdates
+        return await withTaskGroup(of: String?.self) { group in
+            group.addTask {
+                for await data in stream {
+                    return data.map { String(format: "%02x", $0) }.joined()
+                }
+                return nil
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: timeoutSeconds * 1_000_000_000)
+                return nil
+            }
+            for await result in group {
+                if result != nil {
+                    group.cancelAll()
+                    return result
+                }
+            }
+            return nil
+        }
+    }
+
+    private static func parseContentState(_ raw: [String: Any]) throws -> EventActivityAttributes.ContentState {
+        guard
+            let checkedInCount = raw["checkedInCount"] as? Int,
+            let totalAttending = raw["totalAttending"] as? Int,
+            let isCheckedIn = raw["isCheckedIn"] as? Bool,
+            let status = raw["status"] as? String,
+            let startsAtRaw = raw["startsAt"] as? Double,
+            let endsAtRaw = raw["endsAt"] as? Double
+        else {
+            throw LiveActivityError.invalidArguments
+        }
+        return EventActivityAttributes.ContentState(
+            checkedInCount: checkedInCount,
+            totalAttending: totalAttending,
+            isCheckedIn: isCheckedIn,
+            status: status,
+            startsAt: Date(timeIntervalSince1970: startsAtRaw),
+            endsAt: Date(timeIntervalSince1970: endsAtRaw)
+        )
+    }
+}
+
+enum LiveActivityError: Error, CustomStringConvertible {
+    case unsupportedOSVersion
+    case notAuthorized
+    case invalidArguments
+
+    var description: String {
+        switch self {
+        case .unsupportedOSVersion: return "Live Activities require iOS 17+"
+        case .notAuthorized: return "Live Activities are disabled in iOS Settings"
+        case .invalidArguments: return "Invalid arguments passed to LiveActivityModule"
+        }
+    }
+}

--- a/apps/mobile/modules/live-activity/src/index.ts
+++ b/apps/mobile/modules/live-activity/src/index.ts
@@ -16,6 +16,8 @@ export interface LiveActivityContentState {
   isCheckedIn: boolean;
   /** 'live' | 'starting' | 'ended' | 'cancelled' */
   status: string;
+  /** Event start timestamp (Unix seconds). Drives the on-device countdown. */
+  startsAt: number;
   /** Activity end timestamp (Unix seconds). */
   endsAt: number;
 }

--- a/apps/mobile/src/components/directory/DirectoryCard.tsx
+++ b/apps/mobile/src/components/directory/DirectoryCard.tsx
@@ -19,6 +19,8 @@ interface DirectoryCardProps {
   chips?: Chip[];
   onPress?: () => void;
   colors: ThemeColors;
+  /** Renders a green dot over the avatar when true. */
+  online?: boolean;
 }
 
 export const DirectoryCard = React.memo(function DirectoryCard({
@@ -31,6 +33,7 @@ export const DirectoryCard = React.memo(function DirectoryCard({
   chips = [],
   onPress,
   colors,
+  online,
 }: DirectoryCardProps) {
   return (
     <Pressable
@@ -41,13 +44,18 @@ export const DirectoryCard = React.memo(function DirectoryCard({
         pressed && styles.cardPressed,
       ]}
     >
-      {avatarUrl ? (
-        <Image source={avatarUrl} style={styles.avatar} contentFit="cover" transition={200} />
-      ) : (
-        <View style={[styles.avatarPlaceholder, { backgroundColor: colors.primaryLight }]}>
-          <Text style={[styles.avatarText, { color: colors.primaryDark }]}>{initials}</Text>
-        </View>
-      )}
+      <View style={styles.avatarWrap}>
+        {avatarUrl ? (
+          <Image source={avatarUrl} style={styles.avatar} contentFit="cover" transition={200} />
+        ) : (
+          <View style={[styles.avatarPlaceholder, { backgroundColor: colors.primaryLight }]}>
+            <Text style={[styles.avatarText, { color: colors.primaryDark }]}>{initials}</Text>
+          </View>
+        )}
+        {online ? (
+          <View style={[styles.onlineDot, { borderColor: colors.card }]} />
+        ) : null}
+      </View>
       <View style={styles.cardContent}>
         <Text style={[styles.name, { color: colors.foreground }]} numberOfLines={1}>
           {name}
@@ -98,11 +106,14 @@ const styles = StyleSheet.create({
     opacity: 0.7,
     transform: [{ scale: 0.995 }],
   },
+  avatarWrap: {
+    position: "relative",
+    marginRight: spacing.md,
+  },
   avatar: {
     width: 40,
     height: 40,
     borderRadius: 20,
-    marginRight: spacing.md,
   },
   avatarPlaceholder: {
     width: 40,
@@ -110,7 +121,16 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     justifyContent: "center",
     alignItems: "center",
-    marginRight: spacing.md,
+  },
+  onlineDot: {
+    position: "absolute",
+    right: 0,
+    bottom: 0,
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: "#22c55e",
+    borderWidth: 2,
   },
   avatarText: {
     fontSize: fontSize.sm,

--- a/apps/mobile/src/components/profile/StreakChip.tsx
+++ b/apps/mobile/src/components/profile/StreakChip.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { Flame } from "lucide-react-native";
+import { useThemedStyles } from "@/hooks/useThemedStyles";
+import { TYPOGRAPHY } from "@/lib/typography";
+import { SPACING, RADIUS } from "@/lib/design-tokens";
+import { useMemberStreak } from "@/hooks/useMemberStreak";
+
+interface StreakChipProps {
+  userId: string | null;
+  organizationId: string | null;
+}
+
+/**
+ * Compact pill showing the current attendance streak (consecutive weeks with
+ * ≥1 checked-in event). Renders nothing when the user hasn't started a
+ * streak yet — chip should celebrate, not nag.
+ */
+export function StreakChip({ userId, organizationId }: StreakChipProps) {
+  const { streak } = useMemberStreak(userId, organizationId);
+  const styles = useThemedStyles((n) => ({
+    chip: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      gap: 6,
+      backgroundColor: n.surface,
+      borderColor: n.border,
+      borderWidth: 1,
+      borderCurve: "continuous" as const,
+      borderRadius: RADIUS.full,
+      paddingHorizontal: SPACING.sm,
+      paddingVertical: 6,
+      alignSelf: "flex-start" as const,
+    },
+    label: {
+      ...TYPOGRAPHY.labelMedium,
+      color: n.foreground,
+    },
+    longest: {
+      ...TYPOGRAPHY.caption,
+      color: n.muted,
+    },
+  }));
+
+  if (!streak || streak.currentWeeks === 0) return null;
+
+  return (
+    <View style={styles.chip}>
+      <Flame size={14} color="#f97316" />
+      <Text style={styles.label}>
+        {streak.currentWeeks}-week streak
+      </Text>
+      {streak.longestWeeks > streak.currentWeeks ? (
+        <Text style={styles.longest}>(best: {streak.longestWeeks})</Text>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/reactions/ReactionRow.tsx
+++ b/apps/mobile/src/components/reactions/ReactionRow.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { SmilePlus } from "lucide-react-native";
+import { useThemedStyles } from "@/hooks/useThemedStyles";
+import { TYPOGRAPHY } from "@/lib/typography";
+import { SPACING, RADIUS } from "@/lib/design-tokens";
+import { useReactions, type ReactionTargetKind } from "@/hooks/useReactions";
+
+const QUICK_REACTIONS = ["👍", "❤️", "🎉", "🔥", "👀", "😂"] as const;
+
+interface Props {
+  targetKind: ReactionTargetKind;
+  targetId: string | null;
+  currentUserId: string | null;
+}
+
+/**
+ * Inline reaction strip for any commentable surface. Existing reactions
+ * render as pills; the trailing + opens a quick-picker popover.
+ */
+export function ReactionRow({ targetKind, targetId, currentUserId }: Props) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const { reactions, toggle } = useReactions(targetKind, targetId, currentUserId);
+
+  const styles = useThemedStyles((n) => ({
+    row: {
+      flexDirection: "row" as const,
+      flexWrap: "wrap" as const,
+      gap: 6,
+      paddingTop: SPACING.xs,
+    },
+    pill: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      gap: 4,
+      paddingHorizontal: 8,
+      paddingVertical: 4,
+      borderRadius: RADIUS.full,
+      borderWidth: 1,
+      borderColor: n.border,
+      backgroundColor: n.surface,
+    },
+    pillActive: {
+      backgroundColor: n.background,
+      borderColor: n.foreground,
+    },
+    emoji: { fontSize: 14 },
+    count: {
+      ...TYPOGRAPHY.labelSmall,
+      color: n.foreground,
+    },
+    addButton: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
+      width: 28,
+      height: 28,
+      borderRadius: RADIUS.full,
+      borderWidth: 1,
+      borderColor: n.border,
+      backgroundColor: n.surface,
+    },
+    picker: {
+      flexDirection: "row" as const,
+      gap: 6,
+      padding: 6,
+      borderRadius: RADIUS.full,
+      borderWidth: 1,
+      borderColor: n.border,
+      backgroundColor: n.surface,
+    },
+    pickerEmoji: { fontSize: 22 },
+  }));
+
+  if (!targetId) return null;
+
+  return (
+    <View style={styles.row}>
+      {reactions.map((r) => (
+        <Pressable
+          key={r.emoji}
+          style={[styles.pill, r.userReacted && styles.pillActive]}
+          onPress={() => void toggle(r.emoji)}
+        >
+          <Text style={styles.emoji}>{r.emoji}</Text>
+          <Text style={styles.count}>{r.count}</Text>
+        </Pressable>
+      ))}
+      {pickerOpen ? (
+        <View style={styles.picker}>
+          {QUICK_REACTIONS.map((emoji) => (
+            <Pressable
+              key={emoji}
+              onPress={() => {
+                void toggle(emoji);
+                setPickerOpen(false);
+              }}
+            >
+              <Text style={styles.pickerEmoji}>{emoji}</Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : (
+        <Pressable
+          style={styles.addButton}
+          onPress={() => setPickerOpen(true)}
+          accessibilityLabel="Add reaction"
+        >
+          <SmilePlus size={14} />
+        </Pressable>
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/settings/SettingsNotificationsSection.tsx
+++ b/apps/mobile/src/components/settings/SettingsNotificationsSection.tsx
@@ -43,6 +43,11 @@ export function SettingsNotificationsSection({ orgId }: Props) {
   const [discussionPush, setDiscussionPush] = useState(false);
   const [mentorshipPush, setMentorshipPush] = useState(false);
   const [donationPush, setDonationPush] = useState(false);
+  const [digestPush, setDigestPush] = useState(true);
+  const [reengagementPush, setReengagementPush] = useState(true);
+  const [quietHoursTimezone, setQuietHoursTimezone] = useState("UTC");
+  const [quietHoursStart, setQuietHoursStart] = useState("21:00");
+  const [quietHoursEnd, setQuietHoursEnd] = useState("07:00");
 
   useEffect(() => {
     if (prefs) {
@@ -58,8 +63,27 @@ export function SettingsNotificationsSection({ orgId }: Props) {
       setDiscussionPush(prefs.discussion_push_enabled);
       setMentorshipPush(prefs.mentorship_push_enabled);
       setDonationPush(prefs.donation_push_enabled);
+      setDigestPush(prefs.digest_push_enabled);
+      setReengagementPush(prefs.reengagement_push_enabled);
+      setQuietHoursStart(prefs.quiet_hours_start.slice(0, 5));
+      setQuietHoursEnd(prefs.quiet_hours_end.slice(0, 5));
+      setQuietHoursTimezone(prefs.quiet_hours_timezone);
+
+      // First-launch timezone capture: when the saved timezone is the UTC
+      // default but the device knows better, persist the device tz so quiet
+      // hours apply to the user's actual local time.
+      if (prefs.quiet_hours_timezone === "UTC") {
+        try {
+          const deviceTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+          if (deviceTz && deviceTz !== "UTC") {
+            void updatePrefs({ quiet_hours_timezone: deviceTz });
+          }
+        } catch {
+          // Older RN runtimes may not expose Intl — skip silently.
+        }
+      }
     }
-  }, [prefs]);
+  }, [prefs, updatePrefs]);
 
   const handleSaveNotifications = async () => {
     await updatePrefs({
@@ -75,6 +99,11 @@ export function SettingsNotificationsSection({ orgId }: Props) {
       discussion_push_enabled: discussionPush,
       mentorship_push_enabled: mentorshipPush,
       donation_push_enabled: donationPush,
+      digest_push_enabled: digestPush,
+      reengagement_push_enabled: reengagementPush,
+      quiet_hours_start: quietHoursStart,
+      quiet_hours_end: quietHoursEnd,
+      quiet_hours_timezone: quietHoursTimezone,
     });
   };
 
@@ -407,6 +436,43 @@ export function SettingsNotificationsSection({ orgId }: Props) {
                   trackColor={{ false: colors.border, true: colors.primaryLight }}
                   thumbColor={donationPush ? colors.primary : colors.card}
                 />
+              </View>
+
+              <View style={[styles.switchRow, !pushEnabled && { opacity: 0.5 }]}>
+                <View style={styles.switchInfo}>
+                  <Text style={styles.switchLabel}>Weekly digest</Text>
+                  <Text style={styles.switchHint}>Sunday recap of the week's activity</Text>
+                </View>
+                <Switch
+                  value={digestPush}
+                  onValueChange={setDigestPush}
+                  disabled={!pushEnabled}
+                  trackColor={{ false: colors.border, true: colors.primaryLight }}
+                  thumbColor={digestPush ? colors.primary : colors.card}
+                />
+              </View>
+
+              <View style={[styles.switchRow, !pushEnabled && { opacity: 0.5 }]}>
+                <View style={styles.switchInfo}>
+                  <Text style={styles.switchLabel}>Re-engagement</Text>
+                  <Text style={styles.switchHint}>Occasional nudge if you've been away</Text>
+                </View>
+                <Switch
+                  value={reengagementPush}
+                  onValueChange={setReengagementPush}
+                  disabled={!pushEnabled}
+                  trackColor={{ false: colors.border, true: colors.primaryLight }}
+                  thumbColor={reengagementPush ? colors.primary : colors.card}
+                />
+              </View>
+
+              <View style={[styles.switchRow, !pushEnabled && { opacity: 0.5 }]}>
+                <View style={styles.switchInfo}>
+                  <Text style={styles.switchLabel}>Quiet hours</Text>
+                  <Text style={styles.switchHint}>
+                    Digest + re-engagement pushes deferred {quietHoursStart}–{quietHoursEnd} ({quietHoursTimezone})
+                  </Text>
+                </View>
               </View>
 
               <Pressable

--- a/apps/mobile/src/components/settings/SettingsNotificationsSection.tsx
+++ b/apps/mobile/src/components/settings/SettingsNotificationsSection.tsx
@@ -43,6 +43,7 @@ export function SettingsNotificationsSection({ orgId }: Props) {
   const [discussionPush, setDiscussionPush] = useState(false);
   const [mentorshipPush, setMentorshipPush] = useState(false);
   const [donationPush, setDonationPush] = useState(false);
+  const [mentionPush, setMentionPush] = useState(true);
 
   useEffect(() => {
     if (prefs) {
@@ -58,6 +59,7 @@ export function SettingsNotificationsSection({ orgId }: Props) {
       setDiscussionPush(prefs.discussion_push_enabled);
       setMentorshipPush(prefs.mentorship_push_enabled);
       setDonationPush(prefs.donation_push_enabled);
+      setMentionPush(prefs.mention_push_enabled);
     }
   }, [prefs]);
 
@@ -75,6 +77,7 @@ export function SettingsNotificationsSection({ orgId }: Props) {
       discussion_push_enabled: discussionPush,
       mentorship_push_enabled: mentorshipPush,
       donation_push_enabled: donationPush,
+      mention_push_enabled: mentionPush,
     });
   };
 
@@ -392,6 +395,20 @@ export function SettingsNotificationsSection({ orgId }: Props) {
                   disabled={!pushEnabled}
                   trackColor={{ false: colors.border, true: colors.primaryLight }}
                   thumbColor={mentorshipPush ? colors.primary : colors.card}
+                />
+              </View>
+
+              <View style={[styles.switchRow, !pushEnabled && { opacity: 0.5 }]}>
+                <View style={styles.switchInfo}>
+                  <Text style={styles.switchLabel}>@Mentions</Text>
+                  <Text style={styles.switchHint}>Priority push when someone @-mentions you</Text>
+                </View>
+                <Switch
+                  value={mentionPush}
+                  onValueChange={setMentionPush}
+                  disabled={!pushEnabled}
+                  trackColor={{ false: colors.border, true: colors.primaryLight }}
+                  thumbColor={mentionPush ? colors.primary : colors.card}
                 />
               </View>
 

--- a/apps/mobile/src/contexts/BiometricLockContext.tsx
+++ b/apps/mobile/src/contexts/BiometricLockContext.tsx
@@ -58,7 +58,14 @@ export function BiometricLockProvider({ children }: PropsWithChildren) {
   const [enabled, setEnabled] = useState(false);
   const [isResolving, setIsResolving] = useState(true);
   const [isLocked, setIsLocked] = useState(false);
-  const [appState, setAppState] = useState<AppStateStatus>(AppState.currentState);
+  // Backgrounded state drives the privacy overlay. We only setState when the
+  // boolean actually flips (active <-> not-active), so the Face ID system
+  // dialog's rapid inactive↔active churn doesn't re-render the entire
+  // children tree mid-prompt — that re-render was the source of the lock
+  // screen flicker on notification tap.
+  const [isBackgrounded, setIsBackgrounded] = useState(
+    AppState.currentState !== "active",
+  );
   const lastBackgroundedAtRef = useRef<number | null>(null);
   // Read inside the AppState handler so the listener can stay stable across
   // enable/disable toggles. Avoids a race where re-subscribing drops the
@@ -87,10 +94,18 @@ export function BiometricLockProvider({ children }: PropsWithChildren) {
   // deps; reads `enabled` via a ref to stay stable across toggles.
   useEffect(() => {
     const handler = (next: AppStateStatus) => {
-      setAppState(next);
+      const nextBackgrounded = next !== "active";
+      // Only setState on a transition, not on every event. iOS fires
+      // inactive→inactive duplicates around system prompts.
+      setIsBackgrounded((prev) => (prev === nextBackgrounded ? prev : nextBackgrounded));
       if (!enabledRef.current) return;
       if (next === "background" || next === "inactive") {
-        lastBackgroundedAtRef.current = Date.now();
+        // Don't overwrite an existing timestamp — the system biometric
+        // prompt cycles inactive→active→inactive and we want the original
+        // background time, not the prompt's transient inactive.
+        if (lastBackgroundedAtRef.current == null) {
+          lastBackgroundedAtRef.current = Date.now();
+        }
         return;
       }
       if (next === "active") {
@@ -105,7 +120,7 @@ export function BiometricLockProvider({ children }: PropsWithChildren) {
     return () => sub.remove();
   }, []);
 
-  const showPrivacyOverlay = enabled && appState !== "active";
+  const showPrivacyOverlay = enabled && isBackgrounded;
 
   const lock = useCallback(() => setIsLocked(true), []);
 

--- a/apps/mobile/src/contexts/LiveActivityContext.tsx
+++ b/apps/mobile/src/contexts/LiveActivityContext.tsx
@@ -308,6 +308,7 @@ function buildContentState(
     totalAttending: event.totalAttending,
     isCheckedIn: event.isCheckedIn,
     status: deriveStatus(event),
+    startsAt: Math.floor(new Date(event.startDate).getTime() / 1000),
     endsAt: Math.floor(
       new Date(
         event.endDate ?? new Date(Date.now() + 60 * 60 * 1000).toISOString(),

--- a/apps/mobile/src/contexts/PresenceContext.tsx
+++ b/apps/mobile/src/contexts/PresenceContext.tsx
@@ -1,0 +1,109 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { AppState, type AppStateStatus } from "react-native";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+import { useOrg } from "@/contexts/OrgContext";
+
+/**
+ * Org-scoped Realtime presence. One channel per active org keyed
+ * `org-presence:<orgId>`; each foregrounded device tracks `{userId}` so the
+ * org's online roster is the union of presenceState across all subscribers.
+ *
+ * This is intentionally a separate context (not folded into OrgContext) so
+ * `useOrg()` consumers don't re-render on every roster change.
+ */
+
+interface PresenceContextValue {
+  /** Set of user ids currently considered online in the active org. */
+  onlineUserIds: Set<string>;
+  /** Convenience helper for components rendering many avatars. */
+  isOnline: (userId: string | null | undefined) => boolean;
+}
+
+const PresenceContext = createContext<PresenceContextValue>({
+  onlineUserIds: new Set(),
+  isOnline: () => false,
+});
+
+export function PresenceProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const { orgId } = useOrg();
+  const [onlineUserIds, setOnlineUserIds] = useState<Set<string>>(new Set());
+  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
+
+  useEffect(() => {
+    if (!orgId || !user?.id) {
+      setOnlineUserIds(new Set());
+      return;
+    }
+
+    const channel = supabase.channel(`org-presence:${orgId}`, {
+      config: { presence: { key: user.id } },
+    });
+    channelRef.current = channel;
+
+    const updateRoster = () => {
+      // presenceState() returns Record<key, Array<{ userId }>>. Each connected
+      // device for the same user shares the same key, so a user with two
+      // devices appears once.
+      const state = channel.presenceState();
+      const ids = new Set<string>();
+      for (const key of Object.keys(state)) {
+        ids.add(key);
+      }
+      setOnlineUserIds(ids);
+    };
+
+    channel
+      .on("presence", { event: "sync" }, updateRoster)
+      .on("presence", { event: "join" }, updateRoster)
+      .on("presence", { event: "leave" }, updateRoster)
+      .subscribe(async (status) => {
+        if (status === "SUBSCRIBED") {
+          await channel.track({ userId: user.id, at: Date.now() });
+        }
+      });
+
+    // Untrack on background so we don't show stale-online dots while users
+    // have the app suspended; re-track on foreground.
+    const onAppState = (state: AppStateStatus) => {
+      if (state === "active") {
+        void channel.track({ userId: user.id, at: Date.now() });
+      } else {
+        void channel.untrack();
+      }
+    };
+    const sub = AppState.addEventListener("change", onAppState);
+
+    return () => {
+      sub.remove();
+      void supabase.removeChannel(channel);
+      channelRef.current = null;
+    };
+  }, [orgId, user?.id]);
+
+  const value = useMemo<PresenceContextValue>(
+    () => ({
+      onlineUserIds,
+      isOnline: (userId: string | null | undefined) =>
+        userId ? onlineUserIds.has(userId) : false,
+    }),
+    [onlineUserIds],
+  );
+
+  return (
+    <PresenceContext.Provider value={value}>{children}</PresenceContext.Provider>
+  );
+}
+
+export function usePresence(): PresenceContextValue {
+  return useContext(PresenceContext);
+}

--- a/apps/mobile/src/hooks/useActivityHeartbeat.ts
+++ b/apps/mobile/src/hooks/useActivityHeartbeat.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { AppState, type AppStateStatus } from "react-native";
+import { supabase } from "@/lib/supabase";
+
+/**
+ * Bumps `users.last_active_at` for the signed-in user via the
+ * `record_user_activity` RPC. Server-side debounced to 60s so we can call it
+ * liberally — once on mount (sign-in) and once on every app-foreground.
+ *
+ * Powers DAU + the re-engagement-sweep cron's "inactive ≥7d" gate.
+ */
+async function fireHeartbeat(): Promise<void> {
+  try {
+    // Cast: `record_user_activity` is a new RPC not yet in the generated
+    // Database types. Regenerate via `bun run gen:types` after the migration
+    // is applied to remove the cast.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (supabase as any).rpc("record_user_activity");
+  } catch {
+    // Silent — heartbeat failure shouldn't break the app.
+  }
+}
+
+export function useActivityHeartbeat(userId: string | null): void {
+  useEffect(() => {
+    if (!userId) return;
+
+    void fireHeartbeat();
+
+    const handler = (state: AppStateStatus) => {
+      if (state !== "active") return;
+      void fireHeartbeat();
+    };
+    const sub = AppState.addEventListener("change", handler);
+    return () => sub.remove();
+  }, [userId]);
+}

--- a/apps/mobile/src/hooks/useMemberDirectory.ts
+++ b/apps/mobile/src/hooks/useMemberDirectory.ts
@@ -7,6 +7,7 @@ const DEFAULT_PAGE_SIZE = 50;
 
 export interface DirectoryMember {
   id: string;
+  user_id: string | null;
   first_name: string;
   last_name: string;
   email: string | null;
@@ -91,6 +92,7 @@ export function useMemberDirectory(
           .select(
             `
             id,
+            user_id,
             first_name,
             last_name,
             email,

--- a/apps/mobile/src/hooks/useMemberStreak.ts
+++ b/apps/mobile/src/hooks/useMemberStreak.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState, useRef } from "react";
+import { supabase } from "@/lib/supabase";
+import * as sentry from "@/lib/analytics/sentry";
+
+export interface MemberStreak {
+  currentWeeks: number;
+  longestWeeks: number;
+}
+
+/**
+ * Reads the calling user's per-org streak from `member_streaks`. Updated by
+ * the daily streaks-recompute cron, so this hook just reads — no realtime
+ * needed.
+ */
+export function useMemberStreak(
+  userId: string | null,
+  organizationId: string | null,
+): { streak: MemberStreak | null; loading: boolean } {
+  const [streak, setStreak] = useState<MemberStreak | null>(null);
+  const [loading, setLoading] = useState(true);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!userId || !organizationId) {
+      setStreak(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    void (async () => {
+      try {
+        // Cast: member_streaks isn't in the generated Database types yet.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data, error } = await (supabase as any)
+          .from("member_streaks")
+          .select("current_weeks, longest_weeks")
+          .eq("user_id", userId)
+          .eq("organization_id", organizationId)
+          .maybeSingle();
+        if (error) throw error;
+        if (!isMountedRef.current) return;
+        setStreak(
+          data
+            ? {
+                currentWeeks: data.current_weeks,
+                longestWeeks: data.longest_weeks,
+              }
+            : { currentWeeks: 0, longestWeeks: 0 },
+        );
+      } catch (err) {
+        sentry.captureException(err as Error, { context: "useMemberStreak" });
+      } finally {
+        if (isMountedRef.current) setLoading(false);
+      }
+    })();
+  }, [userId, organizationId]);
+
+  return { streak, loading };
+}

--- a/apps/mobile/src/hooks/useNotificationPreferences.ts
+++ b/apps/mobile/src/hooks/useNotificationPreferences.ts
@@ -21,6 +21,13 @@ export interface NotificationPreferences {
   discussion_push_enabled: boolean;
   mentorship_push_enabled: boolean;
   donation_push_enabled: boolean;
+  // Phase B: digest + re-engagement controls. Quiet hours window is
+  // local-time per the user's selected timezone.
+  digest_push_enabled: boolean;
+  reengagement_push_enabled: boolean;
+  quiet_hours_start: string; // 'HH:MM' or 'HH:MM:SS'
+  quiet_hours_end: string;
+  quiet_hours_timezone: string;
 }
 
 const DEFAULT_PUSH_CATEGORIES = {
@@ -33,6 +40,11 @@ const DEFAULT_PUSH_CATEGORIES = {
   discussion_push_enabled: false,
   mentorship_push_enabled: false,
   donation_push_enabled: false,
+  digest_push_enabled: true,
+  reengagement_push_enabled: true,
+  quiet_hours_start: "21:00",
+  quiet_hours_end: "07:00",
+  quiet_hours_timezone: "UTC",
 } as const;
 
 interface UseNotificationPreferencesReturn {
@@ -61,6 +73,11 @@ const SELECT_COLUMNS = [
   "discussion_push_enabled",
   "mentorship_push_enabled",
   "donation_push_enabled",
+  "digest_push_enabled",
+  "reengagement_push_enabled",
+  "quiet_hours_start",
+  "quiet_hours_end",
+  "quiet_hours_timezone",
 ].join(",");
 
 type PrefRow = {
@@ -77,6 +94,11 @@ type PrefRow = {
   discussion_push_enabled: boolean | null;
   mentorship_push_enabled: boolean | null;
   donation_push_enabled: boolean | null;
+  digest_push_enabled: boolean | null;
+  reengagement_push_enabled: boolean | null;
+  quiet_hours_start: string | null;
+  quiet_hours_end: string | null;
+  quiet_hours_timezone: string | null;
 };
 
 function rowToPrefs(row: PrefRow): NotificationPreferences {
@@ -100,6 +122,15 @@ function rowToPrefs(row: PrefRow): NotificationPreferences {
       row.mentorship_push_enabled ?? DEFAULT_PUSH_CATEGORIES.mentorship_push_enabled,
     donation_push_enabled:
       row.donation_push_enabled ?? DEFAULT_PUSH_CATEGORIES.donation_push_enabled,
+    digest_push_enabled:
+      row.digest_push_enabled ?? DEFAULT_PUSH_CATEGORIES.digest_push_enabled,
+    reengagement_push_enabled:
+      row.reengagement_push_enabled ?? DEFAULT_PUSH_CATEGORIES.reengagement_push_enabled,
+    quiet_hours_start:
+      row.quiet_hours_start ?? DEFAULT_PUSH_CATEGORIES.quiet_hours_start,
+    quiet_hours_end: row.quiet_hours_end ?? DEFAULT_PUSH_CATEGORIES.quiet_hours_end,
+    quiet_hours_timezone:
+      row.quiet_hours_timezone ?? DEFAULT_PUSH_CATEGORIES.quiet_hours_timezone,
   };
 }
 
@@ -251,8 +282,20 @@ export function useNotificationPreferences(
         "discussion_push_enabled",
         "mentorship_push_enabled",
         "donation_push_enabled",
+        "digest_push_enabled",
+        "reengagement_push_enabled",
       ] as const;
       for (const key of pushCategoryKeys) {
+        if (key in updates) {
+          writePayload[key] = updates[key] ?? prefs?.[key] ?? DEFAULT_PUSH_CATEGORIES[key];
+        }
+      }
+      const quietHoursKeys = [
+        "quiet_hours_start",
+        "quiet_hours_end",
+        "quiet_hours_timezone",
+      ] as const;
+      for (const key of quietHoursKeys) {
         if (key in updates) {
           writePayload[key] = updates[key] ?? prefs?.[key] ?? DEFAULT_PUSH_CATEGORIES[key];
         }

--- a/apps/mobile/src/hooks/useNotificationPreferences.ts
+++ b/apps/mobile/src/hooks/useNotificationPreferences.ts
@@ -21,6 +21,7 @@ export interface NotificationPreferences {
   discussion_push_enabled: boolean;
   mentorship_push_enabled: boolean;
   donation_push_enabled: boolean;
+  mention_push_enabled: boolean;
 }
 
 const DEFAULT_PUSH_CATEGORIES = {
@@ -33,6 +34,7 @@ const DEFAULT_PUSH_CATEGORIES = {
   discussion_push_enabled: false,
   mentorship_push_enabled: false,
   donation_push_enabled: false,
+  mention_push_enabled: true,
 } as const;
 
 interface UseNotificationPreferencesReturn {
@@ -61,6 +63,7 @@ const SELECT_COLUMNS = [
   "discussion_push_enabled",
   "mentorship_push_enabled",
   "donation_push_enabled",
+  "mention_push_enabled",
 ].join(",");
 
 type PrefRow = {
@@ -77,6 +80,7 @@ type PrefRow = {
   discussion_push_enabled: boolean | null;
   mentorship_push_enabled: boolean | null;
   donation_push_enabled: boolean | null;
+  mention_push_enabled: boolean | null;
 };
 
 function rowToPrefs(row: PrefRow): NotificationPreferences {
@@ -100,6 +104,8 @@ function rowToPrefs(row: PrefRow): NotificationPreferences {
       row.mentorship_push_enabled ?? DEFAULT_PUSH_CATEGORIES.mentorship_push_enabled,
     donation_push_enabled:
       row.donation_push_enabled ?? DEFAULT_PUSH_CATEGORIES.donation_push_enabled,
+    mention_push_enabled:
+      row.mention_push_enabled ?? DEFAULT_PUSH_CATEGORIES.mention_push_enabled,
   };
 }
 
@@ -251,6 +257,7 @@ export function useNotificationPreferences(
         "discussion_push_enabled",
         "mentorship_push_enabled",
         "donation_push_enabled",
+        "mention_push_enabled",
       ] as const;
       for (const key of pushCategoryKeys) {
         if (key in updates) {

--- a/apps/mobile/src/hooks/usePushNotifications.ts
+++ b/apps/mobile/src/hooks/usePushNotifications.ts
@@ -12,6 +12,7 @@ import {
   type NotificationData,
 } from "@/lib/notifications";
 import { captureException } from "@/lib/analytics";
+import { useBiometricLock } from "@/contexts/BiometricLockContext";
 
 interface UsePushNotificationsOptions {
   userId: string | null;
@@ -33,31 +34,49 @@ export function usePushNotifications({
   const lastTokenRef = useRef<string | null>(null);
   const hasHandledColdLaunchRef = useRef(false);
   const lastHandledNotificationIdRef = useRef<string | null>(null);
+  const pendingRouteRef = useRef<string | null>(null);
 
-  // Handle notification response (user tapped on notification). De-duped by
-  // request identifier so the cold-launch path and the live response listener
-  // can't both fire for the same tap, and so effect re-runs that surface the
-  // persisted cold-launch response don't navigate twice.
-  const handleNotificationResponse = useCallback(
-    (response: Notifications.NotificationResponse) => {
-      try {
-        const id = response.notification.request.identifier;
-        if (id && lastHandledNotificationIdRef.current === id) return;
-        lastHandledNotificationIdRef.current = id ?? null;
+  const { isLocked } = useBiometricLock();
+  const isLockedRef = useRef(isLocked);
+  isLockedRef.current = isLocked;
 
-        const data = response.notification.request.content.data as unknown as NotificationData;
-        const route = getNotificationRoute(data);
+  // Stable handler: subscribed once, reads `isLocked` via ref so router
+  // identity changes don't tear down + re-subscribe the listener (which on
+  // rapid auth/nav re-renders caused duplicate response handling).
+  const handlerRef = useRef<(response: Notifications.NotificationResponse) => void>(() => {});
+  handlerRef.current = (response: Notifications.NotificationResponse) => {
+    try {
+      const id = response.notification.request.identifier;
+      if (id && lastHandledNotificationIdRef.current === id) return;
+      lastHandledNotificationIdRef.current = id ?? null;
 
-        if (route) {
-          router.push(route as any);
-        }
-      } catch (error) {
-        console.error("Error handling notification response:", error);
-        captureException(error as Error, { context: "handleNotificationResponse" });
+      const data = response.notification.request.content.data as unknown as NotificationData;
+      const route = getNotificationRoute(data);
+      if (!route) return;
+
+      // Defer routing while the biometric lock screen is up. Navigating
+      // behind the LockScreen overlay caused the underlying screen to mount
+      // mid-Face-ID prompt, producing the visible flicker. We replay the
+      // route once the lock clears.
+      if (isLockedRef.current) {
+        pendingRouteRef.current = route;
+        return;
       }
-    },
-    [router]
-  );
+      router.push(route as any);
+    } catch (error) {
+      console.error("Error handling notification response:", error);
+      captureException(error as Error, { context: "handleNotificationResponse" });
+    }
+  };
+
+  // Flush any pending notification route once the lock clears.
+  useEffect(() => {
+    if (isLocked) return;
+    const pending = pendingRouteRef.current;
+    if (!pending) return;
+    pendingRouteRef.current = null;
+    router.push(pending as any);
+  }, [isLocked, router]);
 
   // Register for push notifications
   const register = useCallback(async () => {
@@ -136,9 +155,12 @@ export function usePushNotifications({
       });
     });
 
-    // Listen for user interaction with notifications
+    // Listen for user interaction with notifications. Subscribe with a stable
+    // wrapper that reads the latest handler via ref — otherwise router
+    // identity changes would re-subscribe per render and cause duplicate
+    // response handling on rapid nav.
     responseListener.current = Notifications.addNotificationResponseReceivedListener(
-      handleNotificationResponse
+      (response) => handlerRef.current(response)
     );
 
     // Handle notification tap when app launches from a quit state. Expo
@@ -148,7 +170,7 @@ export function usePushNotifications({
       hasHandledColdLaunchRef.current = true;
       Notifications.getLastNotificationResponseAsync().then((response) => {
         if (response) {
-          handleNotificationResponse(response);
+          handlerRef.current(response);
         }
       });
     }
@@ -169,7 +191,7 @@ export function usePushNotifications({
       pushTokenListener.current?.remove();
       appStateSubscription.remove();
     };
-  }, [userId, enabled, register, handleNotificationResponse]);
+  }, [userId, enabled, register]);
 
   // Handle logout - unregister token
   useEffect(() => {

--- a/apps/mobile/src/hooks/useReactions.ts
+++ b/apps/mobile/src/hooks/useReactions.ts
@@ -1,0 +1,156 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import { supabase, createPostgresChangesChannel } from "@/lib/supabase";
+import { fetchWithAuth } from "@/lib/web-api";
+import * as sentry from "@/lib/analytics/sentry";
+
+export type ReactionTargetKind =
+  | "chat_message"
+  | "discussion_reply"
+  | "announcement";
+
+export interface ReactionAggregate {
+  emoji: string;
+  count: number;
+  userReacted: boolean;
+}
+
+interface ReactionRow {
+  emoji: string;
+  user_id: string;
+}
+
+/**
+ * Reads + mutates emoji reactions for a single target. Subscribes to realtime
+ * INSERT/DELETE on `reactions` filtered by (target_kind, target_id) so the
+ * counts stay live across devices in the same channel.
+ */
+export function useReactions(
+  targetKind: ReactionTargetKind,
+  targetId: string | null,
+  currentUserId: string | null,
+): {
+  reactions: ReactionAggregate[];
+  toggle: (emoji: string) => Promise<void>;
+  loading: boolean;
+} {
+  const [rows, setRows] = useState<ReactionRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const refetch = useCallback(async () => {
+    if (!targetId) {
+      setRows([]);
+      setLoading(false);
+      return;
+    }
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase as any)
+        .from("reactions")
+        .select("emoji, user_id")
+        .eq("target_kind", targetKind)
+        .eq("target_id", targetId);
+      if (error) throw error;
+      if (isMountedRef.current) {
+        setRows((data ?? []) as ReactionRow[]);
+      }
+    } catch (err) {
+      sentry.captureException(err as Error, { context: "useReactions.fetch" });
+    } finally {
+      if (isMountedRef.current) setLoading(false);
+    }
+  }, [targetKind, targetId]);
+
+  useEffect(() => {
+    setLoading(true);
+    void refetch();
+  }, [refetch]);
+
+  // Realtime: any reaction mutation on this target triggers a refetch. The
+  // payload doesn't carry the row's emoji/user reliably across all event
+  // types, so we just refetch on any change. Fan-out is small (one query
+  // per local thread).
+  useEffect(() => {
+    if (!targetId) return;
+    const channel = createPostgresChangesChannel(`reactions:${targetKind}:${targetId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "reactions",
+          filter: `target_id=eq.${targetId}`,
+        },
+        () => {
+          void refetch();
+        },
+      )
+      .subscribe();
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [targetKind, targetId, refetch]);
+
+  const aggregates: ReactionAggregate[] = (() => {
+    const map = new Map<string, ReactionAggregate>();
+    for (const r of rows) {
+      const existing = map.get(r.emoji) ?? {
+        emoji: r.emoji,
+        count: 0,
+        userReacted: false,
+      };
+      existing.count += 1;
+      if (r.user_id === currentUserId) existing.userReacted = true;
+      map.set(r.emoji, existing);
+    }
+    return Array.from(map.values()).sort((a, b) => b.count - a.count);
+  })();
+
+  const toggle = useCallback(
+    async (emoji: string): Promise<void> => {
+      if (!targetId || !currentUserId) return;
+      const existing = aggregates.find((a) => a.emoji === emoji);
+      const isAdding = !existing?.userReacted;
+
+      // Optimistic update.
+      if (isAdding) {
+        setRows((prev) => [...prev, { emoji, user_id: currentUserId }]);
+      } else {
+        setRows((prev) =>
+          prev.filter(
+            (r) => !(r.user_id === currentUserId && r.emoji === emoji),
+          ),
+        );
+      }
+
+      try {
+        const res = await fetchWithAuth("/api/reactions", {
+          method: isAdding ? "POST" : "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            target_kind: targetKind,
+            target_id: targetId,
+            emoji,
+          }),
+        });
+        if (!res.ok) throw new Error(`reactions ${res.status}`);
+      } catch (err) {
+        // Revert on failure.
+        sentry.captureException(err as Error, {
+          context: "useReactions.toggle",
+        });
+        await refetch();
+      }
+    },
+    [aggregates, currentUserId, refetch, targetId, targetKind],
+  );
+
+  return { reactions: aggregates, toggle, loading };
+}

--- a/apps/mobile/src/lib/mentions.ts
+++ b/apps/mobile/src/lib/mentions.ts
@@ -1,0 +1,49 @@
+/**
+ * Mention helpers for chat / discussions / announcements.
+ *
+ * Strategy: client serializes mentions as `[@uuid|Display Name]` markers in
+ * the body string AND populates the row's `mentioned_user_ids uuid[]`
+ * column. The DB trigger fans out push notifications from the array; the
+ * markers are for client-side rendering (turn into clickable chips).
+ *
+ * Markers chosen for unambiguity: a stray `@` in prose won't false-match.
+ */
+
+const MARKER_RE = /\[@([0-9a-f-]{36})\|([^\]]+)\]/gi;
+
+export interface MentionMarker {
+  userId: string;
+  displayName: string;
+}
+
+/** Returns the user ids referenced in body via [@uuid|Name] markers. */
+export function extractMentionedUserIds(body: string): string[] {
+  const ids = new Set<string>();
+  for (const match of body.matchAll(MARKER_RE)) {
+    ids.add(match[1].toLowerCase());
+  }
+  return Array.from(ids);
+}
+
+/** Parses every marker in body in order. */
+export function parseMentionMarkers(body: string): MentionMarker[] {
+  const out: MentionMarker[] = [];
+  for (const match of body.matchAll(MARKER_RE)) {
+    out.push({ userId: match[1].toLowerCase(), displayName: match[2] });
+  }
+  return out;
+}
+
+/** Replaces each marker with `@DisplayName` for plain-text rendering. */
+export function renderMentionPlainText(body: string): string {
+  return body.replace(MARKER_RE, (_full, _id, name) => `@${name}`);
+}
+
+/**
+ * Builds a marker for an autocomplete pick. Display names with `]` are
+ * sanitized so the regex stays unambiguous.
+ */
+export function buildMentionMarker(userId: string, displayName: string): string {
+  const safeName = displayName.replace(/[\[\]]/g, "");
+  return `[@${userId}|${safeName}]`;
+}

--- a/apps/mobile/targets/widget/EventActivityAttributes.swift
+++ b/apps/mobile/targets/widget/EventActivityAttributes.swift
@@ -35,8 +35,13 @@ public struct EventActivityAttributes: ActivityAttributes {
         /// this so cancellations look distinct from a live event ending.
         public var status: String
 
-        /// Activity end timestamp (Unix seconds). The widget uses this for
-        /// the on-card progress bar; APNs uses `apns-expiration` separately.
+        /// Event start timestamp. Drives the lock-screen countdown via
+        /// SwiftUI's `Text(timerInterval:)`, which ticks per-second on the
+        /// device with no APNs traffic.
+        public var startsAt: Date
+
+        /// Activity end timestamp. Used for the on-card progress bar and as
+        /// the upper bound of the countdown timer interval.
         public var endsAt: Date
 
         public init(
@@ -44,12 +49,14 @@ public struct EventActivityAttributes: ActivityAttributes {
             totalAttending: Int,
             isCheckedIn: Bool,
             status: String,
+            startsAt: Date,
             endsAt: Date
         ) {
             self.checkedInCount = checkedInCount
             self.totalAttending = totalAttending
             self.isCheckedIn = isCheckedIn
             self.status = status
+            self.startsAt = startsAt
             self.endsAt = endsAt
         }
     }

--- a/apps/mobile/targets/widget/EventLiveActivityWidget.swift
+++ b/apps/mobile/targets/widget/EventLiveActivityWidget.swift
@@ -52,16 +52,28 @@ struct EventLiveActivityWidget: Widget {
                     )
                 }
             } compactLeading: {
-                Image(systemName: "person.2.fill")
+                Image(systemName: context.state.status == "starting" ? "clock.fill" : "person.2.fill")
                     .foregroundStyle(.tint)
             } compactTrailing: {
-                Text("\(context.state.checkedInCount)/\(context.state.totalAttending)")
-                    .monospacedDigit()
-                    .font(.caption)
-                    .fontWeight(.semibold)
+                if context.state.status == "starting" {
+                    Text(timerInterval: Date()...context.state.startsAt, countsDown: true)
+                        .monospacedDigit()
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: 50)
+                } else {
+                    Text("\(context.state.checkedInCount)/\(context.state.totalAttending)")
+                        .monospacedDigit()
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                }
             } minimal: {
-                Image(systemName: context.state.isCheckedIn ? "checkmark.seal.fill" : "person.2.fill")
-                    .foregroundStyle(.tint)
+                Image(
+                    systemName: context.state.status == "starting"
+                        ? "clock.fill"
+                        : (context.state.isCheckedIn ? "checkmark.seal.fill" : "person.2.fill")
+                )
+                .foregroundStyle(.tint)
             }
             .widgetURL(URL(string: "teammeet://events/\(context.attributes.eventId)"))
             .keylineTint(Color(red: 0.145, green: 0.388, blue: 0.922))
@@ -93,22 +105,28 @@ private struct EventLockScreenView: View {
                 StatusBadge(status: context.state.status, isCheckedIn: context.state.isCheckedIn)
             }
 
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
-                Text("\(context.state.checkedInCount)")
-                    .font(.system(size: 32, weight: .bold, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundStyle(.white)
-                Text("/ \(context.state.totalAttending) checked in")
-                    .font(.subheadline)
-                    .foregroundStyle(.white.opacity(0.7))
-            }
+            // Pre-event: countdown drives the card. Once the event is live or
+            // ended, swap to the check-in tally that already shipped.
+            if context.state.status == "starting" {
+                CountdownHero(startsAt: context.state.startsAt)
+            } else {
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text("\(context.state.checkedInCount)")
+                        .font(.system(size: 32, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundStyle(.white)
+                    Text("/ \(context.state.totalAttending) checked in")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.7))
+                }
 
-            ProgressView(
-                value: Double(context.state.checkedInCount),
-                total: Double(max(context.state.totalAttending, 1))
-            )
-            .progressViewStyle(.linear)
-            .tint(Color(red: 0.145, green: 0.388, blue: 0.922))
+                ProgressView(
+                    value: Double(context.state.checkedInCount),
+                    total: Double(max(context.state.totalAttending, 1))
+                )
+                .progressViewStyle(.linear)
+                .tint(Color(red: 0.145, green: 0.388, blue: 0.922))
+            }
 
             OpenInAppButton(
                 eventId: context.attributes.eventId,
@@ -117,6 +135,25 @@ private struct EventLockScreenView: View {
         }
         .padding(.vertical, 14)
         .padding(.horizontal, 16)
+    }
+}
+
+@available(iOS 17.0, *)
+private struct CountdownHero: View {
+    let startsAt: Date
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            // Text(timerInterval:) ticks per-second locally — no APNs traffic
+            // needed for the countdown itself.
+            Text(timerInterval: Date()...startsAt, countsDown: true)
+                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(.white)
+            Text("until start")
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.7))
+        }
     }
 }
 

--- a/apps/web/src/app/api/cron/live-activity-end-stale/route.ts
+++ b/apps/web/src/app/api/cron/live-activity-end-stale/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { validateCronAuth } from "@/lib/security/cron-auth";
+
+/**
+ * Hourly sweep: end every Live Activity whose nominal `ends_at` has passed by
+ * more than the grace window. Without this, an LA whose owning device went
+ * offline between event-end and the natural APNs timeout (~12h) keeps showing
+ * stale info on the lock screen. We enqueue `live_activity_end` jobs so the
+ * existing dispatcher tears them down via APNs.
+ */
+export const dynamic = "force-dynamic";
+
+const GRACE_MINUTES = 30;
+
+export async function GET(request: Request) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const service = createServiceClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const svc = service as any;
+
+  const cutoff = new Date(
+    Date.now() - GRACE_MINUTES * 60 * 1000,
+  ).toISOString();
+
+  const { data: stale, error: queryError } = await svc
+    .from("live_activity_tokens")
+    .select("activity_id, event_id, organization_id")
+    .lt("ends_at", cutoff)
+    .is("ended_at", null)
+    .limit(500);
+
+  if (queryError) {
+    return NextResponse.json(
+      { success: false, error: queryError.message },
+      { status: 500 },
+    );
+  }
+
+  const rows = (stale ?? []) as Array<{
+    activity_id: string;
+    event_id: string;
+    organization_id: string;
+  }>;
+
+  if (rows.length === 0) {
+    return NextResponse.json({ success: true, enqueued: 0 });
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const jobs = rows.map((r) => ({
+    organization_id: r.organization_id,
+    kind: "live_activity_end",
+    priority: 5,
+    data: {
+      event_id: r.event_id,
+      activity_id: r.activity_id,
+      reason: "stale_grace_passed",
+      dismissal_date: now,
+      content_state: {},
+    },
+    status: "pending",
+    scheduled_for: new Date().toISOString(),
+  }));
+
+  const { error: insertError } = await svc.from("notification_jobs").insert(jobs);
+  if (insertError) {
+    return NextResponse.json(
+      { success: false, error: insertError.message },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ success: true, enqueued: rows.length });
+}

--- a/apps/web/src/app/api/cron/notification-dispatch/route.ts
+++ b/apps/web/src/app/api/cron/notification-dispatch/route.ts
@@ -4,6 +4,7 @@ import { validateCronAuth } from "@/lib/security/cron-auth";
 import { sendPush, type PushType } from "@/lib/notifications/push";
 import type { NotificationCategory } from "@/lib/notifications";
 import type { NotificationAudience } from "@/types/database";
+import { maybeDeferForQuietHours } from "@/lib/notifications/quiet-hours";
 
 /**
  * Notification dispatch cron worker — drains the `notification_jobs` queue
@@ -98,6 +99,27 @@ export async function GET(request: Request) {
         // Live Activity / APNs not handled in this port. Mark failed so the
         // row doesn't keep re-leasing.
         throw new Error(`unsupported kind=${job.kind} (Live Activity not yet ported to main)`);
+      }
+
+      // Quiet-hours gate for digest/reengagement single-target pushes.
+      const deferTo = await maybeDeferForQuietHours({
+        supabase: service,
+        category: job.category,
+        organizationId: job.organization_id,
+        targetUserIds: job.target_user_ids,
+      });
+      if (deferTo) {
+        await svc
+          .from("notification_jobs")
+          .update({
+            status: "pending",
+            scheduled_for: deferTo,
+            leased_at: null,
+            last_error: "deferred for quiet hours",
+          })
+          .eq("id", job.id);
+        results.push({ id: job.id, status: "deferred" });
+        continue;
       }
 
       // Resolve orgSlug for deep-link routing.

--- a/apps/web/src/app/api/cron/notification-dispatch/route.ts
+++ b/apps/web/src/app/api/cron/notification-dispatch/route.ts
@@ -4,18 +4,19 @@ import { validateCronAuth } from "@/lib/security/cron-auth";
 import { sendPush, type PushType } from "@/lib/notifications/push";
 import type { NotificationCategory } from "@/lib/notifications";
 import type { NotificationAudience } from "@/types/database";
+import {
+  dispatchLiveActivityJob,
+  isLiveActivityKind,
+} from "@/lib/notifications/live-activity-dispatch";
 
 /**
  * Notification dispatch cron worker — drains the `notification_jobs` queue
  * every minute. For each pending row:
  *   1. Lease (set status='processing' + leased_at=now()).
- *   2. Dispatch `kind="standard"` via sendPush with forceInline=true so the
- *      worker doesn't re-enqueue the same job (the bug commit 0f38c9bb fixed).
+ *   2. Dispatch `kind="standard"` via sendPush, or
+ *      `kind="live_activity_*"` via the APNs LA dispatcher.
  *   3. Mark succeeded or increment attempts + set last_error. After
  *      MAX_ATTEMPTS we mark `failed` so the row stops re-leasing.
- *
- * Live Activity / APNs kinds are not handled here on main — those land in a
- * later port if/when the LA pipeline is brought across.
  */
 export const dynamic = "force-dynamic";
 
@@ -94,10 +95,35 @@ export async function GET(request: Request) {
 
   for (const job of (leased ?? []) as JobRow[]) {
     try {
+      if (isLiveActivityKind(job.kind)) {
+        const laResult = await dispatchLiveActivityJob({
+          supabase: service,
+          kind: job.kind,
+          data: (job.data ?? {}) as Parameters<
+            typeof dispatchLiveActivityJob
+          >[0]["data"],
+        });
+        if (laResult.errors.length > 0 && laResult.sent === 0) {
+          throw new Error(laResult.errors.join("; "));
+        }
+        await svc
+          .from("notification_jobs")
+          .update({
+            status: "succeeded",
+            sent_at: new Date().toISOString(),
+            last_error:
+              laResult.errors.length > 0
+                ? laResult.errors.join("; ").slice(0, 2000)
+                : null,
+          })
+          .eq("id", job.id);
+        dispatched += 1;
+        results.push({ id: job.id, status: "succeeded", sent: laResult.sent });
+        continue;
+      }
+
       if (job.kind !== "standard") {
-        // Live Activity / APNs not handled in this port. Mark failed so the
-        // row doesn't keep re-leasing.
-        throw new Error(`unsupported kind=${job.kind} (Live Activity not yet ported to main)`);
+        throw new Error(`unsupported kind=${job.kind}`);
       }
 
       // Resolve orgSlug for deep-link routing.

--- a/apps/web/src/app/api/cron/reengagement-sweep/route.ts
+++ b/apps/web/src/app/api/cron/reengagement-sweep/route.ts
@@ -1,0 +1,185 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { validateCronAuth } from "@/lib/security/cron-auth";
+
+/**
+ * Daily re-engagement sweep.
+ *
+ * For each user who:
+ *   - has not been active in the past 7 days (users.last_active_at), AND
+ *   - belongs to ≥1 org with reengagement_push_enabled=true (the per-(user,org)
+ *     pref), AND
+ *   - has pending activity in that org (≥1 upcoming event in the next 14d
+ *     OR ≥1 announcement created in the past 14d)
+ *
+ * Enqueue ONE notification_jobs row, throttled to once per 14 days per user
+ * via the `data.last_reengagement_at` lookup against past notifications.
+ *
+ * The actual delivery time defers to quiet hours via the dispatcher's
+ * quiet-hours gate; we just enqueue with scheduled_for=now().
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+const DORMANT_DAYS = 7;
+const THROTTLE_DAYS = 14;
+const ACTIVITY_HORIZON_DAYS = 14;
+
+export async function GET(request: Request) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const service = createServiceClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const svc = service as any;
+
+  const dormantSince = new Date(
+    Date.now() - DORMANT_DAYS * 24 * 3600 * 1000,
+  ).toISOString();
+  const throttleSince = new Date(
+    Date.now() - THROTTLE_DAYS * 24 * 3600 * 1000,
+  ).toISOString();
+  const upcomingHorizon = new Date(
+    Date.now() + ACTIVITY_HORIZON_DAYS * 24 * 3600 * 1000,
+  ).toISOString();
+
+  // 1. Candidates: dormant users.
+  const { data: dormantUsers, error: dormantErr } = await svc
+    .from("users")
+    .select("id, name, last_active_at")
+    .or(`last_active_at.is.null,last_active_at.lt.${dormantSince}`)
+    .limit(5000);
+
+  if (dormantErr) {
+    return NextResponse.json(
+      { success: false, error: dormantErr.message },
+      { status: 500 },
+    );
+  }
+
+  const userIds = ((dormantUsers ?? []) as Array<{ id: string }>).map((u) => u.id);
+  if (userIds.length === 0) {
+    return NextResponse.json({ success: true, enqueued: 0 });
+  }
+
+  // 2. Throttle: skip users who already got a re-engagement push within
+  // THROTTLE_DAYS. notifications.category='reengagement'.
+  const { data: recent } = await svc
+    .from("notifications")
+    .select("user_id")
+    .eq("category", "reengagement")
+    .gte("created_at", throttleSince)
+    .in("user_id", userIds);
+  const recentlyNotified = new Set(
+    ((recent ?? []) as Array<{ user_id: string }>).map((r) => r.user_id),
+  );
+  const eligibleUserIds = userIds.filter((id) => !recentlyNotified.has(id));
+
+  if (eligibleUserIds.length === 0) {
+    return NextResponse.json({ success: true, enqueued: 0 });
+  }
+
+  // 3. For each eligible user, find an org they belong to with
+  // reengagement_push_enabled=true and pending activity. Pick the first such
+  // org to send for (don't spam multiple pushes to one user even if they're
+  // in several orgs).
+  const { data: prefs } = await svc
+    .from("notification_preferences")
+    .select("user_id, organization_id")
+    .eq("reengagement_push_enabled", true)
+    .in("user_id", eligibleUserIds);
+
+  const userOrgs = new Map<string, string[]>();
+  for (const p of (prefs ?? []) as Array<{
+    user_id: string;
+    organization_id: string;
+  }>) {
+    const list = userOrgs.get(p.user_id) ?? [];
+    list.push(p.organization_id);
+    userOrgs.set(p.user_id, list);
+  }
+
+  // Aggregate org-side pending activity once.
+  const allOrgIds = Array.from(
+    new Set(Array.from(userOrgs.values()).flat()),
+  );
+  const orgsWithActivity = new Set<string>();
+
+  if (allOrgIds.length > 0) {
+    const [{ data: upcomingEvents }, { data: recentAnns }] = await Promise.all([
+      svc
+        .from("events")
+        .select("organization_id")
+        .in("organization_id", allOrgIds)
+        .is("deleted_at", null)
+        .gte("start_date", new Date().toISOString())
+        .lte("start_date", upcomingHorizon),
+      svc
+        .from("announcements")
+        .select("organization_id")
+        .in("organization_id", allOrgIds)
+        .is("deleted_at", null)
+        .gte(
+          "created_at",
+          new Date(
+            Date.now() - ACTIVITY_HORIZON_DAYS * 24 * 3600 * 1000,
+          ).toISOString(),
+        ),
+    ]);
+    for (const r of (upcomingEvents ?? []) as Array<{ organization_id: string }>) {
+      orgsWithActivity.add(r.organization_id);
+    }
+    for (const r of (recentAnns ?? []) as Array<{ organization_id: string }>) {
+      orgsWithActivity.add(r.organization_id);
+    }
+  }
+
+  // 4. Build jobs.
+  const orgNames = new Map<string, string>();
+  if (allOrgIds.length > 0) {
+    const { data: orgs } = await svc
+      .from("organizations")
+      .select("id, name")
+      .in("id", allOrgIds);
+    for (const o of (orgs ?? []) as Array<{ id: string; name: string }>) {
+      orgNames.set(o.id, o.name);
+    }
+  }
+
+  const jobs: Array<Record<string, unknown>> = [];
+  for (const userId of eligibleUserIds) {
+    const userOrgList = userOrgs.get(userId) ?? [];
+    const target = userOrgList.find((o) => orgsWithActivity.has(o));
+    if (!target) continue;
+    const orgName = orgNames.get(target) ?? "your team";
+    jobs.push({
+      organization_id: target,
+      kind: "standard",
+      priority: 7,
+      audience: null,
+      target_user_ids: [userId],
+      category: "reengagement",
+      push_type: "reengagement",
+      push_resource_id: null,
+      title: `${orgName} has updates for you`,
+      body: "There's new activity since you last checked in. Tap to catch up.",
+      data: { reengagement: true },
+      status: "pending",
+      scheduled_for: new Date().toISOString(),
+    });
+  }
+
+  if (jobs.length === 0) {
+    return NextResponse.json({ success: true, enqueued: 0 });
+  }
+
+  const { error: insertErr } = await svc.from("notification_jobs").insert(jobs);
+  if (insertErr) {
+    return NextResponse.json(
+      { success: false, error: insertErr.message },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ success: true, enqueued: jobs.length });
+}

--- a/apps/web/src/app/api/cron/streaks-recompute/route.ts
+++ b/apps/web/src/app/api/cron/streaks-recompute/route.ts
@@ -1,0 +1,267 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { validateCronAuth } from "@/lib/security/cron-auth";
+
+/**
+ * Daily streak recompute + badge evaluation.
+ *
+ * For every (user, org) with at least one event_rsvps row checked-in within
+ * the past 365 days, derive:
+ *   - current_weeks: count of consecutive ISO weeks ending in the most recent
+ *     calendar week (Mon UTC) where the user had ≥1 checked-in attendance.
+ *   - longest_weeks: the all-time max (never decreases).
+ *
+ * Then evaluate seeded badges: streak milestones, events_attended, workouts.
+ * Inserts into member_badges; ON CONFLICT DO NOTHING means re-runs are
+ * idempotent.
+ *
+ * Designed for orgs with up to ~5k members. For larger scale, the SELECT
+ * should move to a SQL CTE; this version processes per (org, user) in JS for
+ * readability. Acceptable while we're in the ten-of-thousands rows range.
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // streak recompute is bounded but can be slow.
+
+interface BadgeRow {
+  id: string;
+  slug: string;
+  criteria: { kind: string; threshold?: number };
+}
+
+interface RsvpRow {
+  user_id: string;
+  organization_id: string;
+  checked_in_at: string;
+}
+
+interface WorkoutRow {
+  user_id: string;
+  organization_id: string;
+}
+
+function isoWeekStart(d: Date): Date {
+  // Monday 00:00:00 UTC of the week containing d.
+  const utc = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+  const day = utc.getUTCDay() || 7; // Sun=7
+  utc.setUTCDate(utc.getUTCDate() - (day - 1));
+  return utc;
+}
+
+function weekKey(d: Date): string {
+  return isoWeekStart(d).toISOString().slice(0, 10);
+}
+
+export async function GET(request: Request) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const service = createServiceClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const svc = service as any;
+
+  // 1. Pull all checked-in RSVPs over the last 365 days. The qualifying
+  // signal is `status='attending' AND checked_in_at IS NOT NULL`.
+  const since = new Date(Date.now() - 365 * 24 * 3600 * 1000).toISOString();
+  const { data: rsvps, error: rsvpErr } = await svc
+    .from("event_rsvps")
+    .select("user_id, organization_id, checked_in_at")
+    .eq("status", "attending")
+    .not("checked_in_at", "is", null)
+    .gte("checked_in_at", since)
+    .limit(100_000);
+
+  if (rsvpErr) {
+    return NextResponse.json(
+      { success: false, error: rsvpErr.message },
+      { status: 500 },
+    );
+  }
+
+  // 2. Bucket weeks per (user, org).
+  const weeksByPair = new Map<string, Set<string>>();
+  for (const r of (rsvps ?? []) as RsvpRow[]) {
+    const key = `${r.user_id}::${r.organization_id}`;
+    const wk = weekKey(new Date(r.checked_in_at));
+    let set = weeksByPair.get(key);
+    if (!set) {
+      set = new Set();
+      weeksByPair.set(key, set);
+    }
+    set.add(wk);
+  }
+
+  // 3. Compute streaks. current_weeks = consecutive weeks ending in current
+  // week. If current week missing, the streak ends last week (so a Sunday
+  // run still counts on Monday).
+  const thisWeek = weekKey(new Date());
+  const lastWeek = weekKey(new Date(Date.now() - 7 * 24 * 3600 * 1000));
+
+  const upserts: Array<{
+    user_id: string;
+    organization_id: string;
+    current_weeks: number;
+    longest_weeks: number;
+    last_qualifying_week_start: string | null;
+    last_recomputed_at: string;
+  }> = [];
+
+  for (const [key, weeks] of weeksByPair) {
+    const [user_id, organization_id] = key.split("::");
+    const sortedDesc = Array.from(weeks).sort().reverse();
+
+    let current = 0;
+    let cursor = weeks.has(thisWeek)
+      ? thisWeek
+      : weeks.has(lastWeek)
+        ? lastWeek
+        : null;
+    while (cursor && weeks.has(cursor)) {
+      current += 1;
+      const prev = new Date(cursor + "T00:00:00Z");
+      prev.setUTCDate(prev.getUTCDate() - 7);
+      cursor = weekKey(prev);
+    }
+
+    // Longest: scan sorted weeks for max run.
+    let longest = 0;
+    let run = 0;
+    let prevWk: string | null = null;
+    for (const wk of sortedDesc.slice().reverse()) {
+      if (prevWk === null) {
+        run = 1;
+      } else {
+        const expected = new Date(prevWk + "T00:00:00Z");
+        expected.setUTCDate(expected.getUTCDate() + 7);
+        run = weekKey(expected) === wk ? run + 1 : 1;
+      }
+      longest = Math.max(longest, run);
+      prevWk = wk;
+    }
+
+    upserts.push({
+      user_id,
+      organization_id,
+      current_weeks: current,
+      longest_weeks: longest,
+      last_qualifying_week_start: sortedDesc[0] ?? null,
+      last_recomputed_at: new Date().toISOString(),
+    });
+  }
+
+  // 4. Upsert. We don't decrease longest_weeks here — Postgres-side guard via
+  // the on-conflict update preserving the larger value.
+  if (upserts.length > 0) {
+    // Read existing longest values to honor the "never decreases" invariant.
+    const userIds = Array.from(new Set(upserts.map((u) => u.user_id)));
+    const orgIds = Array.from(new Set(upserts.map((u) => u.organization_id)));
+    const { data: existing } = await svc
+      .from("member_streaks")
+      .select("user_id, organization_id, longest_weeks")
+      .in("user_id", userIds)
+      .in("organization_id", orgIds);
+    const existingMap = new Map<string, number>();
+    for (const e of (existing ?? []) as Array<{
+      user_id: string;
+      organization_id: string;
+      longest_weeks: number;
+    }>) {
+      existingMap.set(`${e.user_id}::${e.organization_id}`, e.longest_weeks);
+    }
+    for (const u of upserts) {
+      const key = `${u.user_id}::${u.organization_id}`;
+      const prior = existingMap.get(key) ?? 0;
+      if (prior > u.longest_weeks) u.longest_weeks = prior;
+    }
+
+    const { error: upsertErr } = await svc
+      .from("member_streaks")
+      .upsert(upserts, { onConflict: "user_id,organization_id" });
+    if (upsertErr) {
+      return NextResponse.json(
+        { success: false, error: upsertErr.message },
+        { status: 500 },
+      );
+    }
+  }
+
+  // 5. Badge evaluation. Pull catalog + (per pair) total attended events +
+  // workouts logged. Insert any newly-earned rows; ON CONFLICT DO NOTHING.
+  const { data: badges } = await svc
+    .from("badges")
+    .select("id, slug, criteria");
+  const badgeRows = (badges ?? []) as BadgeRow[];
+
+  const eventsAttended = new Map<string, number>();
+  for (const r of (rsvps ?? []) as RsvpRow[]) {
+    const k = `${r.user_id}::${r.organization_id}`;
+    eventsAttended.set(k, (eventsAttended.get(k) ?? 0) + 1);
+  }
+
+  // Workouts logged: any row in workout_logs counts.
+  const { data: wRows } = await svc
+    .from("workout_logs")
+    .select("user_id, organization_id");
+  const workoutsLogged = new Map<string, number>();
+  for (const w of (wRows ?? []) as WorkoutRow[]) {
+    const k = `${w.user_id}::${w.organization_id}`;
+    workoutsLogged.set(k, (workoutsLogged.get(k) ?? 0) + 1);
+  }
+
+  const awards: Array<{
+    user_id: string;
+    organization_id: string;
+    badge_id: string;
+  }> = [];
+  for (const upsert of upserts) {
+    const k = `${upsert.user_id}::${upsert.organization_id}`;
+    const ea = eventsAttended.get(k) ?? 0;
+    const wl = workoutsLogged.get(k) ?? 0;
+    for (const b of badgeRows) {
+      const c = b.criteria;
+      let earned = false;
+      if (c.kind === "streak_weeks" && (c.threshold ?? 0) > 0) {
+        earned = upsert.longest_weeks >= (c.threshold ?? 0);
+      } else if (c.kind === "events_attended" && (c.threshold ?? 0) > 0) {
+        earned = ea >= (c.threshold ?? 0);
+      } else if (c.kind === "workouts_logged" && (c.threshold ?? 0) > 0) {
+        earned = wl >= (c.threshold ?? 0);
+      }
+      if (earned) {
+        awards.push({
+          user_id: upsert.user_id,
+          organization_id: upsert.organization_id,
+          badge_id: b.id,
+        });
+      }
+    }
+  }
+
+  if (awards.length > 0) {
+    // Use upsert with onConflict: ignore — Supabase doesn't expose ON CONFLICT
+    // DO NOTHING directly, but ignoreDuplicates on the unique key works.
+    const { error: awardErr } = await svc
+      .from("member_badges")
+      .upsert(awards, {
+        onConflict: "user_id,organization_id,badge_id",
+        ignoreDuplicates: true,
+      });
+    if (awardErr) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `streaks ok, badges failed: ${awardErr.message}`,
+          streaks: upserts.length,
+        },
+        { status: 500 },
+      );
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    streaksUpserted: upserts.length,
+    badgeAwards: awards.length,
+  });
+}

--- a/apps/web/src/app/api/cron/weekly-digest/route.ts
+++ b/apps/web/src/app/api/cron/weekly-digest/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { validateCronAuth } from "@/lib/security/cron-auth";
+
+/**
+ * Weekly digest fan-out.
+ *
+ * Schedule: every hour. For each (user, org) where digest_push_enabled=true
+ * AND the user's current local time is Sunday 18:00 in their quiet-hours
+ * timezone, build a one-line summary of the past week's activity and enqueue
+ * a notification_jobs row delivered immediately.
+ *
+ * The "current local time === Sun 18:00" gate runs in SQL so we don't have to
+ * read every preference row per hour and convert in JS.
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+interface PrefRow {
+  user_id: string;
+  organization_id: string;
+}
+
+export async function GET(request: Request) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const service = createServiceClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const svc = service as any;
+
+  // 1. Find recipients: enabled + currently Sun 18:00 local.
+  // Wrap the timezone math in an RPC-style query via raw SQL? Supabase JS
+  // doesn't expose ad-hoc SQL on the public client. We approximate with a
+  // narrower SELECT then filter in JS — small enough at MVP scale.
+  const { data: prefs, error: prefErr } = await svc
+    .from("notification_preferences")
+    .select("user_id, organization_id, quiet_hours_timezone")
+    .eq("digest_push_enabled", true);
+
+  if (prefErr) {
+    return NextResponse.json(
+      { success: false, error: prefErr.message },
+      { status: 500 },
+    );
+  }
+
+  const now = new Date();
+  const recipients: PrefRow[] = [];
+  for (const p of (prefs ?? []) as Array<{
+    user_id: string;
+    organization_id: string;
+    quiet_hours_timezone: string;
+  }>) {
+    try {
+      const fmt = new Intl.DateTimeFormat("en-US", {
+        timeZone: p.quiet_hours_timezone,
+        weekday: "short",
+        hour: "2-digit",
+        hour12: false,
+      });
+      const parts = fmt.formatToParts(now);
+      const wk = parts.find((x) => x.type === "weekday")?.value ?? "";
+      const hr = parseInt(
+        parts.find((x) => x.type === "hour")?.value ?? "-1",
+        10,
+      );
+      if (wk === "Sun" && hr === 18) {
+        recipients.push({
+          user_id: p.user_id,
+          organization_id: p.organization_id,
+        });
+      }
+    } catch {
+      // Invalid timezone string — skip rather than crash the cron.
+    }
+  }
+
+  if (recipients.length === 0) {
+    return NextResponse.json({ success: true, enqueued: 0 });
+  }
+
+  // 2. For each org, fetch this-past-week aggregates once and reuse for all
+  // recipients in that org.
+  const sinceIso = new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString();
+  const orgIds = Array.from(new Set(recipients.map((r) => r.organization_id)));
+
+  const orgStats = new Map<
+    string,
+    { events: number; announcements: number; discussions: number }
+  >();
+
+  for (const orgId of orgIds) {
+    const [{ count: events }, { count: announcements }, { count: discussions }] =
+      await Promise.all([
+        svc
+          .from("events")
+          .select("id", { count: "exact", head: true })
+          .eq("organization_id", orgId)
+          .is("deleted_at", null)
+          .gte("created_at", sinceIso),
+        svc
+          .from("announcements")
+          .select("id", { count: "exact", head: true })
+          .eq("organization_id", orgId)
+          .is("deleted_at", null)
+          .gte("created_at", sinceIso),
+        svc
+          .from("discussion_threads")
+          .select("id", { count: "exact", head: true })
+          .eq("organization_id", orgId)
+          .gte("created_at", sinceIso),
+      ]);
+    orgStats.set(orgId, {
+      events: events ?? 0,
+      announcements: announcements ?? 0,
+      discussions: discussions ?? 0,
+    });
+  }
+
+  // 3. Build + insert notification_jobs rows.
+  const orgNames = new Map<string, string>();
+  const { data: orgs } = await svc
+    .from("organizations")
+    .select("id, name")
+    .in("id", orgIds);
+  for (const o of (orgs ?? []) as Array<{ id: string; name: string }>) {
+    orgNames.set(o.id, o.name);
+  }
+
+  const jobs = recipients
+    .map((r) => {
+      const stats = orgStats.get(r.organization_id);
+      const orgName = orgNames.get(r.organization_id) ?? "your team";
+      if (!stats) return null;
+      const total = stats.events + stats.announcements + stats.discussions;
+      if (total === 0) return null; // nothing to digest
+      const parts: string[] = [];
+      if (stats.events) parts.push(`${stats.events} event${stats.events === 1 ? "" : "s"}`);
+      if (stats.announcements)
+        parts.push(`${stats.announcements} update${stats.announcements === 1 ? "" : "s"}`);
+      if (stats.discussions)
+        parts.push(`${stats.discussions} discussion${stats.discussions === 1 ? "" : "s"}`);
+      return {
+        organization_id: r.organization_id,
+        kind: "standard",
+        priority: 5,
+        audience: null,
+        target_user_ids: [r.user_id],
+        category: "digest",
+        push_type: "digest",
+        push_resource_id: null,
+        title: `This week in ${orgName}`,
+        body: parts.join(", ") + ".",
+        data: { digest: true },
+        status: "pending",
+        scheduled_for: new Date().toISOString(),
+      };
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null);
+
+  if (jobs.length === 0) {
+    return NextResponse.json({ success: true, enqueued: 0, recipients: recipients.length });
+  }
+
+  const { error: insertErr } = await svc.from("notification_jobs").insert(jobs);
+  if (insertErr) {
+    return NextResponse.json(
+      { success: false, error: insertErr.message, recipients: recipients.length },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    enqueued: jobs.length,
+    recipients: recipients.length,
+  });
+}

--- a/apps/web/src/app/api/reactions/route.ts
+++ b/apps/web/src/app/api/reactions/route.ts
@@ -8,6 +8,7 @@ import {
   ValidationError,
   validationErrorResponse,
 } from "@/lib/security/validation";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 
 /**
  * POST /api/reactions — add an emoji reaction.
@@ -60,6 +61,14 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    const rateLimit = checkRateLimit(request, {
+      userId: user.id,
+      feature: "reactions",
+      limitPerIp: 60,
+      limitPerUser: 30,
+    });
+    if (!rateLimit.ok) return buildRateLimitResponse(rateLimit);
+
     const body = await validateJson(request, schema, { maxBodyBytes: 4_000 });
     const orgId = await resolveOrgId(supabase, body.target_kind, body.target_id);
     if (!orgId) {
@@ -97,6 +106,14 @@ export async function DELETE(request: Request) {
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    const rateLimit = checkRateLimit(request, {
+      userId: user.id,
+      feature: "reactions",
+      limitPerIp: 60,
+      limitPerUser: 30,
+    });
+    if (!rateLimit.ok) return buildRateLimitResponse(rateLimit);
 
     const body = await validateJson(request, schema, { maxBodyBytes: 4_000 });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/web/src/app/api/reactions/route.ts
+++ b/apps/web/src/app/api/reactions/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import {
+  baseSchemas,
+  safeString,
+  validateJson,
+  ValidationError,
+  validationErrorResponse,
+} from "@/lib/security/validation";
+
+/**
+ * POST /api/reactions — add an emoji reaction.
+ * DELETE /api/reactions — remove an emoji reaction (same body shape).
+ *
+ * RLS handles authorization: a user can only insert/delete reactions on
+ * targets in orgs they belong to (see migration 20260508140000). We still
+ * resolve the target's organization_id server-side so the client can't lie
+ * about it.
+ */
+export const dynamic = "force-dynamic";
+
+const TARGET_KIND = z.enum(["chat_message", "discussion_reply", "announcement"]);
+
+const schema = z
+  .object({
+    target_kind: TARGET_KIND,
+    target_id: baseSchemas.uuid,
+    emoji: safeString(16, 1),
+  })
+  .strict();
+
+const TARGET_TABLES: Record<z.infer<typeof TARGET_KIND>, string> = {
+  chat_message: "chat_messages",
+  discussion_reply: "discussion_replies",
+  announcement: "announcements",
+};
+
+async function resolveOrgId(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  client: any,
+  kind: z.infer<typeof TARGET_KIND>,
+  targetId: string,
+): Promise<string | null> {
+  const { data } = await client
+    .from(TARGET_TABLES[kind])
+    .select("organization_id")
+    .eq("id", targetId)
+    .maybeSingle();
+  return (data as { organization_id?: string } | null)?.organization_id ?? null;
+}
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await validateJson(request, schema, { maxBodyBytes: 4_000 });
+    const orgId = await resolveOrgId(supabase, body.target_kind, body.target_id);
+    if (!orgId) {
+      return NextResponse.json({ error: "Target not found" }, { status: 404 });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const svc = supabase as any;
+    const { error } = await svc.from("reactions").upsert(
+      {
+        target_kind: body.target_kind,
+        target_id: body.target_id,
+        user_id: user.id,
+        organization_id: orgId,
+        emoji: body.emoji,
+      },
+      { onConflict: "target_kind,target_id,user_id,emoji", ignoreDuplicates: true },
+    );
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    if (err instanceof ValidationError) return validationErrorResponse(err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await validateJson(request, schema, { maxBodyBytes: 4_000 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const svc = supabase as any;
+    const { error } = await svc
+      .from("reactions")
+      .delete()
+      .eq("target_kind", body.target_kind)
+      .eq("target_id", body.target_id)
+      .eq("user_id", user.id)
+      .eq("emoji", body.emoji);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    if (err instanceof ValidationError) return validationErrorResponse(err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/apps/web/src/lib/notifications/live-activity-dispatch.ts
+++ b/apps/web/src/lib/notifications/live-activity-dispatch.ts
@@ -1,0 +1,198 @@
+/**
+ * Live Activity dispatcher — handles `notification_jobs.kind` rows of
+ * `live_activity_start | live_activity_update | live_activity_end` by sending
+ * APNs `liveactivity` pushes to every active token registered for the event.
+ *
+ * Job payload contract (`notification_jobs.data`):
+ *   - `event_id` (uuid, required)
+ *   - `activity_id` (text, optional — if set, target only that activity row)
+ *   - `content_state` (jsonb, required for start/update; optional for end)
+ *   - `alert` ({ title, body }, optional — surfaces a banner on the lock screen)
+ *   - `dismissal_date` (epoch seconds, optional — `aps.dismissal-date` for end)
+ *   - `stale_date` (epoch seconds, optional — `aps.stale-date`)
+ *
+ * Env: APNS_KEY_ID, APNS_TEAM_ID, APNS_AUTH_KEY (.p8 PEM, may be base64-
+ * encoded), APNS_BUNDLE_ID (defaults to `com.myteamnetwork.teammeet`),
+ * APNS_USE_SANDBOX (truthy → sandbox host).
+ */
+
+import { createApnsClient, ApnsError, type ApnsClient } from "@teammeet/core/apns";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+type LiveActivityKind =
+  | "live_activity_start"
+  | "live_activity_update"
+  | "live_activity_end";
+
+interface JobData {
+  event_id?: string;
+  activity_id?: string;
+  content_state?: Record<string, unknown>;
+  alert?: { title?: string; body?: string };
+  dismissal_date?: number;
+  stale_date?: number;
+}
+
+interface TokenRow {
+  activity_id: string;
+  push_token: string;
+  user_id: string;
+  event_id: string;
+}
+
+interface DispatchResult {
+  sent: number;
+  failed: number;
+  errors: string[];
+}
+
+let cachedClient: ApnsClient | null = null;
+
+function getApnsClient(): ApnsClient {
+  if (cachedClient) return cachedClient;
+  const keyId = process.env.APNS_KEY_ID;
+  const teamId = process.env.APNS_TEAM_ID;
+  const rawKey = process.env.APNS_AUTH_KEY;
+  if (!keyId || !teamId || !rawKey) {
+    throw new Error(
+      "APNs not configured: APNS_KEY_ID, APNS_TEAM_ID, APNS_AUTH_KEY required",
+    );
+  }
+  const privateKeyPem = rawKey.includes("BEGIN PRIVATE KEY")
+    ? rawKey.replace(/\\n/g, "\n")
+    : Buffer.from(rawKey, "base64").toString("utf8");
+  cachedClient = createApnsClient({
+    keyId,
+    teamId,
+    privateKeyPem,
+    sandbox: process.env.APNS_USE_SANDBOX === "true",
+  });
+  return cachedClient;
+}
+
+function bundleId(): string {
+  return process.env.APNS_BUNDLE_ID ?? "com.myteamnetwork.teammeet";
+}
+
+function apnsEvent(kind: LiveActivityKind): "start" | "update" | "end" {
+  if (kind === "live_activity_start") return "start";
+  if (kind === "live_activity_end") return "end";
+  return "update";
+}
+
+export async function dispatchLiveActivityJob(args: {
+  supabase: SupabaseClient;
+  kind: LiveActivityKind;
+  data: JobData;
+}): Promise<DispatchResult> {
+  const { supabase, kind, data } = args;
+  const result: DispatchResult = { sent: 0, failed: 0, errors: [] };
+
+  if (!data.event_id) {
+    throw new Error("live_activity job missing data.event_id");
+  }
+  if (kind !== "live_activity_end" && !data.content_state) {
+    throw new Error(`live_activity ${kind} requires data.content_state`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const svc = supabase as any;
+  let query = svc
+    .from("live_activity_tokens")
+    .select("activity_id, push_token, user_id, event_id")
+    .eq("event_id", data.event_id)
+    .is("ended_at", null);
+  if (data.activity_id) {
+    query = query.eq("activity_id", data.activity_id);
+  }
+  const { data: rows, error: tokensErr } = await query;
+  if (tokensErr) throw new Error(`token lookup: ${tokensErr.message}`);
+
+  const tokens = (rows ?? []) as TokenRow[];
+  if (tokens.length === 0) return result;
+
+  const client = getApnsClient();
+  const topic = `${bundleId()}.push-type.liveactivity`;
+  const event = apnsEvent(kind);
+  const timestamp = Math.floor(Date.now() / 1000);
+
+  // aps.event="end" must always carry a content-state (Apple requirement
+  // even though the activity is ending), so synthesize an empty object if
+  // the caller didn't pass one.
+  const contentState = data.content_state ?? {};
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const apsBody: Record<string, any> = {
+    event,
+    timestamp,
+    "content-state": contentState,
+  };
+  if (data.alert?.title || data.alert?.body) {
+    apsBody.alert = {
+      title: data.alert.title ?? "",
+      body: data.alert.body ?? "",
+    };
+  }
+  if (event === "end" && typeof data.dismissal_date === "number") {
+    apsBody["dismissal-date"] = data.dismissal_date;
+  }
+  if (typeof data.stale_date === "number") {
+    apsBody["stale-date"] = data.stale_date;
+  }
+
+  const payload = { aps: apsBody };
+
+  await Promise.all(
+    tokens.map(async (token) => {
+      try {
+        await client.send({
+          token: token.push_token,
+          topic,
+          pushType: "liveactivity",
+          payload,
+          priority: 10,
+          // 24h expiry — never let an LA push outlive the activity itself.
+          expiration: timestamp + 24 * 3600,
+        });
+        result.sent += 1;
+      } catch (err) {
+        result.failed += 1;
+        const msg =
+          err instanceof ApnsError
+            ? `${err.status} ${err.responseBody || err.message}`
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        result.errors.push(`${token.activity_id}: ${msg}`);
+
+        // Apple says 410 = "device token is no longer valid" — mark ended
+        // so we stop trying.
+        if (err instanceof ApnsError && err.status === 410) {
+          await svc
+            .from("live_activity_tokens")
+            .update({ ended_at: new Date().toISOString() })
+            .eq("activity_id", token.activity_id);
+        }
+      }
+    }),
+  );
+
+  // For a successful `end`, mark the rows ended so future fan-outs skip them.
+  if (event === "end" && result.failed === 0) {
+    const ids = tokens.map((t) => t.activity_id);
+    await svc
+      .from("live_activity_tokens")
+      .update({ ended_at: new Date().toISOString() })
+      .in("activity_id", ids);
+  }
+
+  return result;
+}
+
+export function isLiveActivityKind(kind: string): kind is LiveActivityKind {
+  return (
+    kind === "live_activity_start" ||
+    kind === "live_activity_update" ||
+    kind === "live_activity_end"
+  );
+}

--- a/apps/web/src/lib/notifications/quiet-hours.ts
+++ b/apps/web/src/lib/notifications/quiet-hours.ts
@@ -1,0 +1,107 @@
+/**
+ * Quiet-hours gate for the notification dispatcher.
+ *
+ * Categories that respect quiet hours: digest, reengagement. Transactional
+ * categories (chat, event_reminder, announcement, mention) bypass — if you
+ * @-mention me at 11pm I'd rather be pinged than wait until morning.
+ *
+ * Logic:
+ *   1. For single-target pushes in a respecting category, look up the
+ *      user's quiet_hours_{start,end,timezone} on notification_preferences
+ *      scoped to the job's organization.
+ *   2. If `now` falls inside the local-time window, compute the next
+ *      quiet_hours_end as a UTC ISO string and return it as the deferred
+ *      scheduled_for.
+ *   3. Otherwise return null — caller proceeds with normal dispatch.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const RESPECTING_CATEGORIES = new Set(["digest", "reengagement"]);
+
+interface QuietHoursPref {
+  quiet_hours_start: string; // 'HH:MM:SS' or 'HH:MM'
+  quiet_hours_end: string;
+  quiet_hours_timezone: string;
+}
+
+function parseHM(value: string): { h: number; m: number } {
+  const [h, m] = value.split(":");
+  return { h: parseInt(h, 10) || 0, m: parseInt(m ?? "0", 10) || 0 };
+}
+
+/** Returns local hour:minute in given IANA timezone for `now`. */
+function localHM(now: Date, tz: string): { h: number; m: number } {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(now);
+  const h = parseInt(parts.find((x) => x.type === "hour")?.value ?? "0", 10);
+  const m = parseInt(parts.find((x) => x.type === "minute")?.value ?? "0", 10);
+  return { h, m };
+}
+
+function isInsideWindow(
+  now: Date,
+  pref: QuietHoursPref,
+): { inside: boolean; minutesUntilEnd: number } {
+  const start = parseHM(pref.quiet_hours_start);
+  const end = parseHM(pref.quiet_hours_end);
+  const cur = localHM(now, pref.quiet_hours_timezone);
+
+  const startMin = start.h * 60 + start.m;
+  const endMin = end.h * 60 + end.m;
+  const curMin = cur.h * 60 + cur.m;
+
+  // Window may wrap midnight (start > end). Default 21:00–07:00 wraps.
+  const wraps = startMin > endMin;
+  const inside = wraps
+    ? curMin >= startMin || curMin < endMin
+    : curMin >= startMin && curMin < endMin;
+  if (!inside) return { inside: false, minutesUntilEnd: 0 };
+
+  const minutesUntilEnd = wraps
+    ? curMin >= startMin
+      ? 24 * 60 - curMin + endMin
+      : endMin - curMin
+    : endMin - curMin;
+  return { inside: true, minutesUntilEnd };
+}
+
+/**
+ * Returns an ISO string for `scheduled_for` if the job should be deferred,
+ * or null if it should proceed now.
+ */
+export async function maybeDeferForQuietHours(args: {
+  supabase: SupabaseClient;
+  category: string | null | undefined;
+  organizationId: string;
+  targetUserIds: string[] | null;
+  now?: Date;
+}): Promise<string | null> {
+  const { supabase, category, organizationId, targetUserIds } = args;
+  if (!category || !RESPECTING_CATEGORIES.has(category)) return null;
+  if (!targetUserIds || targetUserIds.length !== 1) return null;
+
+  const userId = targetUserIds[0];
+  const now = args.now ?? new Date();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const svc = supabase as any;
+  const { data: pref } = await svc
+    .from("notification_preferences")
+    .select("quiet_hours_start, quiet_hours_end, quiet_hours_timezone")
+    .eq("user_id", userId)
+    .eq("organization_id", organizationId)
+    .maybeSingle();
+
+  if (!pref) return null;
+  const result = isInsideWindow(now, pref as QuietHoursPref);
+  if (!result.inside) return null;
+
+  const deferTo = new Date(now.getTime() + result.minutesUntilEnd * 60 * 1000);
+  return deferTo.toISOString();
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -64,6 +64,10 @@
     {
       "path": "/api/cron/notification-dispatch",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/live-activity-end-stale",
+      "schedule": "0 * * * *"
     }
   ]
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -64,6 +64,18 @@
     {
       "path": "/api/cron/notification-dispatch",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/streaks-recompute",
+      "schedule": "0 9 * * *"
+    },
+    {
+      "path": "/api/cron/weekly-digest",
+      "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/reengagement-sweep",
+      "schedule": "0 10 * * *"
     }
   ]
 }

--- a/packages/core/src/apns/index.ts
+++ b/packages/core/src/apns/index.ts
@@ -11,6 +11,7 @@
 
 export {
   ApnsClient,
+  ApnsError,
   createApnsClient,
   type ApnsClientConfig,
   type ApnsPushType,

--- a/supabase/migrations/20260508120000_event_change_la_update_enqueue.sql
+++ b/supabase/migrations/20260508120000_event_change_la_update_enqueue.sql
@@ -1,0 +1,127 @@
+-- Extend the event-change push trigger to also enqueue Live Activity update/end
+-- jobs alongside the existing standard push. Without this, an admin who
+-- reschedules or cancels an event sends a banner push but the lock-screen
+-- Live Activity card stays on the wrong info until the OS times it out.
+--
+-- Cancellation → live_activity_end (with dismissal-date = now() so the card
+-- disappears immediately). Reschedule / relocation → live_activity_update so
+-- the on-card countdown re-anchors to the new start time.
+--
+-- We replace the function body but keep the trigger; this preserves any other
+-- columns/conditions in the original (20260508000002) without forcing a drop.
+
+create or replace function public.enqueue_event_change_push()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_kind text;
+  v_title text;
+  v_body text;
+  v_audience text;
+  v_has_active_la boolean;
+begin
+  if NEW.deleted_at is not null and OLD.deleted_at is null then
+    v_kind := 'cancelled';
+  elsif NEW.start_date is distinct from OLD.start_date
+     or NEW.end_date is distinct from OLD.end_date then
+    v_kind := 'rescheduled';
+  elsif NEW.location is distinct from OLD.location then
+    v_kind := 'relocated';
+  else
+    return NEW;
+  end if;
+
+  if v_kind <> 'cancelled' and NEW.deleted_at is not null then
+    return NEW;
+  end if;
+
+  v_title := case v_kind
+    when 'cancelled' then 'Event cancelled: ' || coalesce(NEW.title, 'Untitled')
+    when 'rescheduled' then 'Event rescheduled: ' || coalesce(NEW.title, 'Untitled')
+    when 'relocated' then 'New location: ' || coalesce(NEW.title, 'Untitled')
+  end;
+
+  v_body := case v_kind
+    when 'cancelled' then 'This event has been cancelled.'
+    when 'rescheduled' then 'New time: ' || to_char(NEW.start_date at time zone 'UTC', 'Mon DD, HH24:MI') || ' UTC'
+    when 'relocated' then 'Now at ' || coalesce(NEW.location, 'a new location')
+  end;
+
+  v_audience := case coalesce(NEW.audience, 'both')
+    when 'members' then 'members'
+    when 'alumni' then 'alumni'
+    else 'all'
+  end;
+
+  insert into public.notification_jobs (
+    organization_id,
+    kind,
+    audience,
+    target_user_ids,
+    category,
+    push_type,
+    push_resource_id,
+    title,
+    body,
+    data
+  ) values (
+    NEW.organization_id,
+    'standard',
+    v_audience,
+    NEW.target_user_ids,
+    'event_reminder',
+    'event_reminder',
+    NEW.id,
+    v_title,
+    v_body,
+    jsonb_build_object('eventId', NEW.id, 'changeKind', v_kind)
+  );
+
+  -- Skip the LA fan-out entirely if no devices have a Live Activity running
+  -- for this event — saves a notification_jobs insert and the dispatcher's
+  -- subsequent token query.
+  select exists (
+    select 1 from public.live_activity_tokens
+    where event_id = NEW.id and ended_at is null
+  ) into v_has_active_la;
+
+  if v_has_active_la then
+    insert into public.notification_jobs (
+      organization_id,
+      kind,
+      priority,
+      title,
+      body,
+      data
+    ) values (
+      NEW.organization_id,
+      case v_kind when 'cancelled' then 'live_activity_end' else 'live_activity_update' end,
+      1,
+      v_title,
+      v_body,
+      jsonb_build_object(
+        'event_id', NEW.id,
+        'change_kind', v_kind,
+        'content_state', jsonb_build_object(
+          'checkedInCount', 0,
+          'totalAttending', 0,
+          'isCheckedIn', false,
+          'status', case v_kind when 'cancelled' then 'cancelled' else 'starting' end,
+          'startsAt', extract(epoch from NEW.start_date)::int,
+          'endsAt', extract(epoch from coalesce(NEW.end_date, NEW.start_date + interval '1 hour'))::int
+        ),
+        'alert', jsonb_build_object('title', v_title, 'body', v_body),
+        'dismissal_date', case v_kind when 'cancelled' then extract(epoch from now())::int end
+      )
+    );
+  end if;
+
+  return NEW;
+end;
+$$;
+
+comment on function public.enqueue_event_change_push() is
+  'Enqueues a standard push and (when active LA tokens exist) a Live Activity update/end job for cancelled/rescheduled/relocated events.';

--- a/supabase/migrations/20260508130000_engagement_phase_b_schema.sql
+++ b/supabase/migrations/20260508130000_engagement_phase_b_schema.sql
@@ -1,0 +1,70 @@
+-- =============================================================================
+-- Engagement Phase B: schema for streaks, badges, digest, and quiet hours.
+-- =============================================================================
+-- Adds:
+--   - users.last_active_at — bumped on auth-bound activity. Drives DAU + the
+--     re-engagement-sweep cron's "inactive ≥7d" gate.
+--   - notification_preferences.quiet_hours_{start,end,timezone} — local-time
+--     window the dispatcher must defer to. Default 21:00–07:00 in UTC; mobile
+--     overrides the timezone on first launch.
+--   - notification_preferences.digest_push_enabled — gates the weekly digest.
+--   - notification_preferences.reengagement_push_enabled — gates the
+--     re-engagement sweep so dormant users can opt out without losing other
+--     transactional pushes.
+--   - public.record_user_activity() RPC — debounced server-side write so any
+--     authenticated client can heartbeat without RLS-policy churn.
+-- =============================================================================
+
+-- 1. users.last_active_at
+alter table public.users
+  add column if not exists last_active_at timestamptz;
+
+create index if not exists users_last_active_at_idx
+  on public.users (last_active_at);
+
+comment on column public.users.last_active_at is
+  'Updated by record_user_activity() on auth-bound activity. Drives DAU + reengagement cron.';
+
+-- 2. quiet hours + new push toggles on notification_preferences
+alter table public.notification_preferences
+  add column if not exists quiet_hours_start time not null default '21:00',
+  add column if not exists quiet_hours_end time not null default '07:00',
+  add column if not exists quiet_hours_timezone text not null default 'UTC',
+  add column if not exists digest_push_enabled boolean not null default true,
+  add column if not exists reengagement_push_enabled boolean not null default true;
+
+comment on column public.notification_preferences.quiet_hours_start is
+  'Local-time start of the user''s do-not-disturb window. Dispatcher defers digests/re-engagement pushes during this window.';
+comment on column public.notification_preferences.quiet_hours_end is
+  'Local-time end of the user''s do-not-disturb window.';
+comment on column public.notification_preferences.quiet_hours_timezone is
+  'IANA timezone (e.g. America/New_York). Mobile sets this on first launch.';
+
+-- 3. record_user_activity() RPC — debounced heartbeat.
+-- Only writes if the existing last_active_at is NULL or older than 60s, so a
+-- chatty client can call this freely without thrashing the row.
+create or replace function public.record_user_activity()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+begin
+  if v_uid is null then
+    return;
+  end if;
+
+  update public.users
+     set last_active_at = now()
+   where id = v_uid
+     and (last_active_at is null or last_active_at < now() - interval '60 seconds');
+end;
+$$;
+
+revoke all on function public.record_user_activity() from public;
+grant execute on function public.record_user_activity() to authenticated;
+
+comment on function public.record_user_activity() is
+  'Debounced heartbeat (60s) bumping users.last_active_at for the calling user. Safe to call on every authenticated request.';

--- a/supabase/migrations/20260508130001_member_streaks.sql
+++ b/supabase/migrations/20260508130001_member_streaks.sql
@@ -1,0 +1,68 @@
+-- =============================================================================
+-- member_streaks — per-(user, org) attendance streaks.
+-- =============================================================================
+-- "Attendance" is qualifying weekly activity:
+--   - any event_rsvps row where status='attending' AND checked_in_at IS NOT NULL
+--     in a given ISO week counts that week as qualifying.
+-- A streak is the count of consecutive qualifying weeks ending in the most
+-- recent calendar week (Mon-Sun, UTC). Missing a week resets `current_weeks`
+-- to 0; longest_weeks never decreases.
+--
+-- Recompute is performed by /api/cron/streaks-recompute daily.
+-- =============================================================================
+
+create table if not exists public.member_streaks (
+  user_id uuid not null references public.users(id) on delete cascade,
+  organization_id uuid not null references public.organizations(id) on delete cascade,
+  current_weeks integer not null default 0,
+  longest_weeks integer not null default 0,
+  last_qualifying_week_start date,
+  last_recomputed_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, organization_id)
+);
+
+create index if not exists member_streaks_org_current_idx
+  on public.member_streaks (organization_id, current_weeks desc);
+
+create index if not exists member_streaks_org_longest_idx
+  on public.member_streaks (organization_id, longest_weeks desc);
+
+alter table public.member_streaks enable row level security;
+
+-- Members of the org can see streaks for that org. The leaderboard surface
+-- queries by organization_id; RLS gates by org membership rather than per-row.
+drop policy if exists member_streaks_select_same_org on public.member_streaks;
+create policy member_streaks_select_same_org
+  on public.member_streaks
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.members m
+      where m.organization_id = public.member_streaks.organization_id
+        and m.user_id = auth.uid()
+        and m.deleted_at is null
+    )
+  );
+
+-- Writes are service-role only (the cron). Clients never directly write streak
+-- rows — they're always derived from RSVPs.
+
+create or replace function public.tg_member_streaks_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists member_streaks_updated_at on public.member_streaks;
+create trigger member_streaks_updated_at
+  before update on public.member_streaks
+  for each row execute function public.tg_member_streaks_updated_at();
+
+comment on table public.member_streaks is
+  'Per-(user,org) attendance streak. Recomputed daily by /api/cron/streaks-recompute. longest_weeks never decreases.';

--- a/supabase/migrations/20260508130002_badges.sql
+++ b/supabase/migrations/20260508130002_badges.sql
@@ -1,0 +1,77 @@
+-- =============================================================================
+-- badges + member_badges — earnable achievements per (user, org).
+-- =============================================================================
+-- The `badges` table is a small, mostly-read seed table; rows are added
+-- intentionally by migrations rather than admin UI. Eligibility is evaluated
+-- by /api/cron/streaks-recompute and ad-hoc evaluators (so a brand-new badge
+-- can be backfilled by editing the cron's evaluator list).
+-- =============================================================================
+
+create table if not exists public.badges (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  title text not null,
+  description text not null,
+  icon text not null, -- lucide-react-native / lucide-react icon name
+  -- Free-form criteria for the cron's evaluator: e.g.
+  --   { "kind": "streak_weeks", "threshold": 4 }
+  --   { "kind": "events_attended", "threshold": 10 }
+  --   { "kind": "first_workout" }
+  criteria jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.member_badges (
+  user_id uuid not null references public.users(id) on delete cascade,
+  organization_id uuid not null references public.organizations(id) on delete cascade,
+  badge_id uuid not null references public.badges(id) on delete cascade,
+  earned_at timestamptz not null default now(),
+  primary key (user_id, organization_id, badge_id)
+);
+
+create index if not exists member_badges_org_user_idx
+  on public.member_badges (organization_id, user_id);
+
+create index if not exists member_badges_user_recent_idx
+  on public.member_badges (user_id, earned_at desc);
+
+alter table public.badges enable row level security;
+alter table public.member_badges enable row level security;
+
+-- Anyone authenticated can read the badge catalog.
+drop policy if exists badges_select_all on public.badges;
+create policy badges_select_all
+  on public.badges for select to authenticated using (true);
+
+-- Members of the org can see who-earned-what for that org (powers profile
+-- pages + leaderboards).
+drop policy if exists member_badges_select_same_org on public.member_badges;
+create policy member_badges_select_same_org
+  on public.member_badges
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.members m
+      where m.organization_id = public.member_badges.organization_id
+        and m.user_id = auth.uid()
+        and m.deleted_at is null
+    )
+  );
+
+-- Inserts/updates/deletes are service-role only (the cron evaluator).
+
+-- =============================================================================
+-- Seed initial badge catalog.
+-- =============================================================================
+-- Five starter badges that the cron can evaluate today. More can be added by
+-- adding rows + extending the evaluator list in /api/cron/streaks-recompute.
+
+insert into public.badges (slug, title, description, icon, criteria) values
+  ('first-event',   'First Event',     'Attended your first event.',                 'calendar-check', '{"kind":"events_attended","threshold":1}'::jsonb),
+  ('event-regular', 'Event Regular',   'Attended 10 events.',                         'calendar-heart', '{"kind":"events_attended","threshold":10}'::jsonb),
+  ('streak-month',  'On a Roll',       '4-week attendance streak.',                   'flame',          '{"kind":"streak_weeks","threshold":4}'::jsonb),
+  ('streak-season', 'Stayed the Course','12-week attendance streak.',                 'medal',          '{"kind":"streak_weeks","threshold":12}'::jsonb),
+  ('first-workout', 'First Workout',   'Logged your first workout.',                  'dumbbell',       '{"kind":"workouts_logged","threshold":1}'::jsonb)
+on conflict (slug) do nothing;

--- a/supabase/migrations/20260508140000_reactions.sql
+++ b/supabase/migrations/20260508140000_reactions.sql
@@ -1,0 +1,81 @@
+-- =============================================================================
+-- reactions — polymorphic emoji reactions across chat / discussions / announcements.
+-- =============================================================================
+-- One row per (target, user, emoji). The (target_kind, target_id) pair points
+-- at chat_messages / discussion_replies / announcements respectively.
+-- Polymorphism keeps the table count down and lets one query power "give me
+-- reactions on this object" regardless of source. RLS is enforced by joining
+-- back to the parent table's org so a user can only see/write reactions on
+-- objects in orgs they belong to.
+-- =============================================================================
+
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'reaction_target_kind') then
+    create type public.reaction_target_kind as enum (
+      'chat_message',
+      'discussion_reply',
+      'announcement'
+    );
+  end if;
+end $$;
+
+create table if not exists public.reactions (
+  id uuid primary key default gen_random_uuid(),
+  target_kind public.reaction_target_kind not null,
+  target_id uuid not null,
+  user_id uuid not null references public.users(id) on delete cascade,
+  organization_id uuid not null references public.organizations(id) on delete cascade,
+  emoji text not null check (length(emoji) between 1 and 16),
+  created_at timestamptz not null default now()
+);
+
+-- One reaction per (target, user, emoji). User can react with multiple emoji
+-- to the same message but not the same emoji twice.
+create unique index if not exists reactions_unique_per_user_emoji
+  on public.reactions (target_kind, target_id, user_id, emoji);
+
+-- Aggregate query: "all reactions on this target" sorted by created_at.
+create index if not exists reactions_target_idx
+  on public.reactions (target_kind, target_id, created_at);
+
+create index if not exists reactions_user_idx
+  on public.reactions (user_id);
+
+alter table public.reactions enable row level security;
+
+-- SELECT: org members can read reactions on objects belonging to their org.
+drop policy if exists reactions_select_same_org on public.reactions;
+create policy reactions_select_same_org
+  on public.reactions for select to authenticated
+  using (
+    exists (
+      select 1 from public.members m
+      where m.organization_id = reactions.organization_id
+        and m.user_id = auth.uid()
+        and m.deleted_at is null
+    )
+  );
+
+-- INSERT: user is the actor and they belong to the target's org.
+drop policy if exists reactions_insert_self on public.reactions;
+create policy reactions_insert_self
+  on public.reactions for insert to authenticated
+  with check (
+    user_id = auth.uid()
+    and exists (
+      select 1 from public.members m
+      where m.organization_id = reactions.organization_id
+        and m.user_id = auth.uid()
+        and m.deleted_at is null
+    )
+  );
+
+-- DELETE: only the user who reacted can remove their own reaction.
+drop policy if exists reactions_delete_self on public.reactions;
+create policy reactions_delete_self
+  on public.reactions for delete to authenticated
+  using (user_id = auth.uid());
+
+comment on table public.reactions is
+  'Polymorphic emoji reactions across chat_messages, discussion_replies, announcements. Unique per (target, user, emoji).';

--- a/supabase/migrations/20260508140001_mentions.sql
+++ b/supabase/migrations/20260508140001_mentions.sql
@@ -1,0 +1,147 @@
+-- =============================================================================
+-- @mentions — column-based mention lists + push fan-out trigger.
+-- =============================================================================
+-- Approach: clients responsible for resolving @-strings to user UUIDs at send
+-- time and writing them as `mentioned_user_ids uuid[]` on the parent row.
+-- This avoids fragile server-side string parsing where two members share a
+-- display name.
+--
+-- A trigger on each surface (chat_messages, discussion_replies, announcements)
+-- enqueues a notification_jobs row with category='mention', priority=2 (jumps
+-- ahead of standard=5). The dispatcher's quiet-hours gate (Phase B) extends
+-- to this category so a 3am ping waits until morning.
+-- =============================================================================
+
+-- 1. Columns. All three surfaces get the same shape.
+alter table public.chat_messages
+  add column if not exists mentioned_user_ids uuid[] not null default '{}';
+create index if not exists chat_messages_mentions_gin
+  on public.chat_messages using gin (mentioned_user_ids);
+
+alter table public.discussion_replies
+  add column if not exists mentioned_user_ids uuid[] not null default '{}';
+create index if not exists discussion_replies_mentions_gin
+  on public.discussion_replies using gin (mentioned_user_ids);
+
+alter table public.announcements
+  add column if not exists mentioned_user_ids uuid[] not null default '{}';
+create index if not exists announcements_mentions_gin
+  on public.announcements using gin (mentioned_user_ids);
+
+-- 2. Per-user category gate. Defaults true — @mentions are a high-signal
+-- transactional notification.
+alter table public.notification_preferences
+  add column if not exists mention_push_enabled boolean not null default true;
+
+-- 3. Trigger function: extract mentions, exclude the author + any user_ids
+-- not in the org's members table, enqueue a single notification_jobs row
+-- targeting them.
+create or replace function public.enqueue_mention_push()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_kind text := TG_ARGV[0];
+  v_targets uuid[];
+  v_org uuid := NEW.organization_id;
+  v_author uuid;
+  v_title text;
+  v_body text;
+  v_resource_id uuid;
+  v_route text;
+begin
+  if NEW.mentioned_user_ids is null
+     or array_length(NEW.mentioned_user_ids, 1) is null then
+    return NEW;
+  end if;
+
+  -- Author varies by table. The trigger is invoked separately on each
+  -- surface so we resolve the author column here.
+  if v_kind = 'chat_message' then
+    v_author := NEW.author_id;
+    v_resource_id := NEW.chat_group_id;
+    v_title := 'Mentioned you in chat';
+    v_body := left(NEW.body, 140);
+  elsif v_kind = 'discussion_reply' then
+    v_author := NEW.author_id;
+    v_resource_id := NEW.thread_id;
+    v_title := 'Mentioned you in a discussion';
+    v_body := left(NEW.body, 140);
+  elsif v_kind = 'announcement' then
+    v_author := NEW.created_by_user_id;
+    v_resource_id := NEW.id;
+    v_title := 'Mentioned you in an announcement';
+    v_body := left(coalesce(NEW.title, ''), 140);
+  else
+    return NEW;
+  end if;
+
+  -- Filter: exclude author from their own mention; require recipients to be
+  -- active members of the org.
+  select array_agg(distinct uid) into v_targets
+  from unnest(NEW.mentioned_user_ids) as uid
+  where uid <> v_author
+    and exists (
+      select 1 from public.members m
+      where m.user_id = uid
+        and m.organization_id = v_org
+        and m.deleted_at is null
+    );
+
+  if v_targets is null or array_length(v_targets, 1) is null then
+    return NEW;
+  end if;
+
+  insert into public.notification_jobs (
+    organization_id,
+    kind,
+    priority,
+    audience,
+    target_user_ids,
+    category,
+    push_type,
+    push_resource_id,
+    title,
+    body,
+    data,
+    status,
+    scheduled_for
+  ) values (
+    v_org,
+    'standard',
+    2, -- ahead of standard=5 but behind LA=1
+    null,
+    v_targets,
+    'mention',
+    'mention',
+    v_resource_id,
+    v_title,
+    v_body,
+    jsonb_build_object('mention_kind', v_kind, 'author_id', v_author),
+    'pending',
+    now()
+  );
+
+  return NEW;
+end;
+$$;
+
+drop trigger if exists chat_messages_mention_push on public.chat_messages;
+create trigger chat_messages_mention_push
+  after insert on public.chat_messages
+  for each row execute function public.enqueue_mention_push('chat_message');
+
+drop trigger if exists discussion_replies_mention_push on public.discussion_replies;
+create trigger discussion_replies_mention_push
+  after insert on public.discussion_replies
+  for each row execute function public.enqueue_mention_push('discussion_reply');
+
+drop trigger if exists announcements_mention_push on public.announcements;
+create trigger announcements_mention_push
+  after insert on public.announcements
+  for each row execute function public.enqueue_mention_push('announcement');
+
+comment on function public.enqueue_mention_push() is
+  'Trigger fn: enqueues a single notification_jobs row when a row with mentioned_user_ids is inserted. Filters out author + non-members.';


### PR DESCRIPTION
## Summary

Single-PR roll-up of the three-phase retention initiative (supersedes #203, #204, #205). Targets daily-active retention via three durable engagement levers:

1. **Live Activities** — Event Countdown on lock screen + Dynamic Island, end-to-end with APNs dispatcher
2. **Engagement loops** — Streaks, badges, weekly digest, re-engagement sweep, with quiet-hours respect
3. **Real-time / social** — Emoji reactions (polymorphic), @mentions (column-based + priority push), org presence (online dots)

Bonus from merging A+B+C together: the `mention` category now respects quiet hours (was deferred when these were separate PRs).

## Phase A — Live Activities

**Mobile:** `EventActivityAttributes.ContentState` extended with `startsAt` across both Swift copies + TS bridge. Widget renders a per-second countdown via `Text(timerInterval:)`; lock-screen + Dynamic Island compact/minimal regions swap to a clock icon + countdown when `status='starting'`.

**Server:** `apps/web/src/lib/notifications/live-activity-dispatch.ts` posts to APNs topic `<bundle>.push-type.liveactivity` via `@teammeet/core/apns`. 410 responses mark tokens ended. Cron-dispatch route handles `live_activity_{start,update,end}` kinds.

**Triggers / cleanup:** `enqueue_event_change_push()` enqueues `live_activity_end` on cancel and `live_activity_update` on reschedule/relocate (only if active LA tokens exist). Hourly `/api/cron/live-activity-end-stale` enqueues end jobs for tokens past `ends_at + 30m`.

**Repo fix:** `apps/mobile/.gitignore` had an unanchored `ios/` rule that was hiding `apps/mobile/modules/live-activity/ios/*.swift` from git. Anchored to `/ios/`; three previously-untracked files now committed.

## Phase B — Engagement loops

**Schema:**
- `users.last_active_at` + `record_user_activity()` RPC (60s server-side debounce).
- `notification_preferences`: `quiet_hours_{start,end,timezone}` (defaults 21:00–07:00 UTC; mobile auto-overrides timezone on first launch), `digest_push_enabled`, `reengagement_push_enabled`.
- `member_streaks` — per-(user, org) consecutive-week attendance, `longest_weeks` invariant never decreases.
- `badges` + `member_badges` + 5 seed badges (first-event, event-regular, streak-month, streak-season, first-workout).

**Crons:**
- `/api/cron/streaks-recompute` (daily 09:00 UTC) — derives streaks from `event_rsvps.checked_in_at`; awards badges per `criteria`.
- `/api/cron/weekly-digest` (hourly) — for each user currently at Sun 18:00 in their local timezone, builds a 1-line week recap.
- `/api/cron/reengagement-sweep` (daily 10:00 UTC) — finds users dormant ≥7d with pending org activity; throttled to 1/14d.

**Dispatcher quiet-hours gate:** defers `digest`, `reengagement`, **and `mention`** single-target jobs falling inside the user's local DND window. Transactional categories (chat, event_reminder, announcement) bypass.

**Mobile:** `useActivityHeartbeat` fires the RPC on sign-in + foreground. `StreakChip` on the menu tab. Settings expose digest/reengagement toggles + quiet-hours window display with auto-captured device timezone.

## Phase C — Reactions, mentions, presence

**Reactions:** polymorphic `reactions` table (`target_kind` enum: chat_message | discussion_reply | announcement, plus target_id, user_id, emoji). Org-scoped RLS. `POST /api/reactions` add / `DELETE /api/reactions` remove (server resolves target's organization_id). `useReactions` hook with realtime subscription + optimistic toggle. `<ReactionRow />` component (pills + quick picker 👍 ❤️ 🎉 🔥 👀 😂).

**@Mentions:** `mentioned_user_ids uuid[]` columns + GIN indexes on chat_messages, discussion_replies, announcements. `mention_push_enabled` (default true) on notification_preferences. DB trigger `enqueue_mention_push()` on each surface fans out a single priority-2 notification_jobs row, filtering out author + non-members. Client-side mention markers `[@uuid|Display Name]` (helpers in `apps/mobile/src/lib/mentions.ts`) — no fragile string parsing.

**Presence:** `PresenceContext` wraps `OrgProvider`. Realtime presence channel keyed `org-presence:<orgId>`, tracks `{userId}` while foregrounded; untracks on background, re-tracks on foreground via AppState. `<DirectoryCard online />` renders a green dot on avatars in the members directory via `usePresence().isOnline()`.

## Required env

- `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_AUTH_KEY` (.p8 PEM, raw or base64). Optional: `APNS_BUNDLE_ID` (defaults to `com.myteamnetwork.teammeet`), `APNS_USE_SANDBOX=true`.
- No new env for Phase B/C.

If APNs env is missing, LA jobs fail gracefully — standard pushes are unaffected.

## Test plan

- [ ] `bun run typecheck && bun run lint` (passing — verified)
- [ ] Apply 8 migrations to staging DB
- [ ] Provision APNs env in Vercel preview
- [ ] EAS preview build; install on iOS 17+
- [ ] **A1:** RSVP "going" to event ≤24h out → LA appears with countdown
- [ ] **A2:** Reschedule from web → LA updates within 60s; cancel → LA dismisses immediately
- [ ] **B1:** Sign in → `users.last_active_at` updates within 60s
- [ ] **B2:** Manually trigger `streaks-recompute` → `member_streaks` populated
- [ ] **B3:** Set test user's quiet hours to current hour → enqueue digest → dispatcher defers (`last_error="deferred for quiet hours"`)
- [ ] **C1:** Two devices, same org → online dots in members directory
- [ ] **C2:** `POST /api/reactions` on a chat message → second device sees pill within ~1s
- [ ] **C3:** Insert chat_messages with `mentioned_user_ids` → priority-2 notification_jobs row enqueued; toggle `mention_push_enabled=false` for recipient → push skipped
- [ ] **C4 (bonus):** Set quiet hours active → @mention recipient → push deferred (the gate tweak that landed because B+C ship together)

## Post-Deploy Monitoring & Validation

- **Logs**: `[notification-dispatch]` — watch for `live_activity_*` kinds, `deferred for quiet hours` entries (digest/reengagement/mention only)
- **Metrics**:
  - DAU: `SELECT count(*) FROM users WHERE last_active_at > now() - interval '24 hours';`
  - LA health: `SELECT kind, status, count(*) FROM notification_jobs WHERE kind LIKE 'live_activity_%' GROUP BY 1,2;`
  - Engagement: `SELECT count(*) FROM reactions WHERE created_at > now() - interval '24h';` and `SELECT count(*) FROM member_streaks WHERE current_weeks > 0;`
  - Mentions: `SELECT count(*) FROM notification_jobs WHERE category='mention' AND created_at > now() - interval '24h';`
- **Healthy signals**: LA jobs >95% succeeded; digest cron returns `enqueued: N>0` on Sundays; reengagement count low; reactions and mention jobs accumulating
- **Failure signals / rollback**:
  - APNs 4xx → revert; check key rotation
  - Cron jobs piling `pending`/`failed` → check env + dispatcher logs
  - Mention triggers failing → DB logs (column has `DEFAULT '{}'`, so backfill is safe)
- **Rollback**: revert PR; all migrations are additive (no destructive drops)
- **Owner / window**: @cicconel11, 14-day post-deploy

Closes #203, #204, #205.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.46.0