### PR TITLE
chore(engagement): advisor follow-ups + e2e smokes for PR #206

### DIFF
--- a/apps/web/tests/e2e/specs/engagement-smoke.spec.ts
+++ b/apps/web/tests/e2e/specs/engagement-smoke.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, request } from "@playwright/test";
+
+/**
+ * Smoke tests for PR #206 (engagement: live activities + streaks/badges/digest +
+ * reactions/mentions/presence).
+ *
+ * Two slices:
+ *   1. Cron route auth — every cron endpoint added by the PR rejects callers
+ *      without a Bearer CRON_SECRET. We don't try to invoke them with a real
+ *      secret here; that belongs in a job, not an e2e run.
+ *   2. /api/reactions auth + validation — the route requires an authenticated
+ *      session, validates the JSON body strictly, and returns 404 for unknown
+ *      targets. RLS does the actual authorization, so the e2e bar is "the
+ *      surface plumbs through to RLS without crashing."
+ */
+
+const CRON_PATHS = [
+  "/api/cron/streaks-recompute",
+  "/api/cron/weekly-digest",
+  "/api/cron/reengagement-sweep",
+  "/api/cron/live-activity-end-stale",
+];
+
+test.describe("engagement cron auth", () => {
+  for (const path of CRON_PATHS) {
+    test(`${path} rejects unauthenticated GET`, async ({ baseURL }) => {
+      const ctx = await request.newContext({ baseURL });
+      const noAuth = await ctx.get(path);
+      expect(noAuth.status(), `${path} no-auth`).toBe(401);
+
+      const badAuth = await ctx.get(path, {
+        headers: { authorization: "Bearer not-the-real-secret" },
+      });
+      expect(badAuth.status(), `${path} bad-auth`).toBe(401);
+      await ctx.dispose();
+    });
+  }
+});
+
+test.describe("/api/reactions", () => {
+  test("rejects unauthenticated POST", async ({ baseURL }) => {
+    const ctx = await request.newContext({ baseURL });
+    const res = await ctx.post("/api/reactions", {
+      data: {
+        target_kind: "chat_message",
+        target_id: "00000000-0000-0000-0000-000000000000",
+        emoji: "👍",
+      },
+    });
+    expect(res.status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test("rejects malformed payload when authenticated", async ({ page }) => {
+    // The e2e project pre-authenticates via storageState — `page.request`
+    // inherits those cookies, so this call is on behalf of the test user.
+    const res = await page.request.post("/api/reactions", {
+      data: { target_kind: "wrong_kind", target_id: "not-a-uuid", emoji: "" },
+    });
+    expect([400, 422]).toContain(res.status());
+  });
+
+  test("returns 404 for unknown target when authenticated", async ({ page }) => {
+    const res = await page.request.post("/api/reactions", {
+      data: {
+        target_kind: "chat_message",
+        target_id: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        emoji: "👍",
+      },
+    });
+    expect(res.status()).toBe(404);
+  });
+});

--- a/supabase/migrations/20260508150000_engagement_advisor_fixes.sql
+++ b/supabase/migrations/20260508150000_engagement_advisor_fixes.sql
@@ -1,0 +1,93 @@
+-- =============================================================================
+-- Advisor follow-ups for PR #206 (engagement: streaks/badges/reactions/mentions).
+-- =============================================================================
+-- 1. Pin search_path on tg_member_streaks_updated_at (function_search_path_mutable).
+-- 2. Wrap auth.uid() in (select auth.uid()) on the 5 new RLS policies so the
+--    planner caches the value once per query (auth_rls_initplan).
+-- 3. Add covering indexes for the unindexed foreign keys flagged on
+--    member_badges.badge_id and reactions.organization_id.
+-- =============================================================================
+
+-- 1. Lock down search_path on the streaks updated_at trigger.
+create or replace function public.tg_member_streaks_updated_at()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+-- 2. Re-create RLS policies with (select auth.uid()) so RLS init-plan caches.
+
+-- member_streaks
+drop policy if exists member_streaks_select_same_org on public.member_streaks;
+create policy member_streaks_select_same_org
+  on public.member_streaks
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.members m
+      where m.organization_id = public.member_streaks.organization_id
+        and m.user_id = (select auth.uid())
+        and m.deleted_at is null
+    )
+  );
+
+-- member_badges
+drop policy if exists member_badges_select_same_org on public.member_badges;
+create policy member_badges_select_same_org
+  on public.member_badges
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.members m
+      where m.organization_id = public.member_badges.organization_id
+        and m.user_id = (select auth.uid())
+        and m.deleted_at is null
+    )
+  );
+
+-- reactions: select / insert / delete
+drop policy if exists reactions_select_same_org on public.reactions;
+create policy reactions_select_same_org
+  on public.reactions for select to authenticated
+  using (
+    exists (
+      select 1 from public.members m
+      where m.organization_id = reactions.organization_id
+        and m.user_id = (select auth.uid())
+        and m.deleted_at is null
+    )
+  );
+
+drop policy if exists reactions_insert_self on public.reactions;
+create policy reactions_insert_self
+  on public.reactions for insert to authenticated
+  with check (
+    user_id = (select auth.uid())
+    and exists (
+      select 1 from public.members m
+      where m.organization_id = reactions.organization_id
+        and m.user_id = (select auth.uid())
+        and m.deleted_at is null
+    )
+  );
+
+drop policy if exists reactions_delete_self on public.reactions;
+create policy reactions_delete_self
+  on public.reactions for delete to authenticated
+  using (user_id = (select auth.uid()));
+
+-- 3. Cover the FKs flagged by the advisor.
+create index if not exists member_badges_badge_id_idx
+  on public.member_badges (badge_id);
+
+create index if not exists reactions_organization_id_idx
+  on public.reactions (organization_id);

--- a/supabase/migrations/20260508160000_record_user_activity_revoke_anon.sql
+++ b/supabase/migrations/20260508160000_record_user_activity_revoke_anon.sql
@@ -1,0 +1,4 @@
+-- Tighten record_user_activity() so anon cannot call it. The function is a
+-- no-op for anon (auth.uid() is null and it returns early), but explicit
+-- revokes are easier to audit than implicit no-ops.
+revoke execute on function public.record_user_activity() from anon;


### PR DESCRIPTION
## Summary
- Pin `search_path` on `tg_member_streaks_updated_at` and rewrite the new RLS policies on `member_streaks` / `member_badges` / `reactions` to use `(select auth.uid())` so the planner caches per query instead of re-evaluating per row. Add covering indexes on `member_badges.badge_id` and `reactions.organization_id`.
- Revoke `EXECUTE` on `record_user_activity()` from `anon`. The function early-returns when `auth.uid()` is null, but the explicit revoke is easier to audit than relying on the no-op.
- Add Playwright smokes for the four new cron routes (each must 401 without a Bearer secret) and for `/api/reactions` (unauth / malformed / unknown-target).

These are post-merge follow-ups for #206 surfaced by the Supabase advisors after the migrations went live.

## Test plan
- [x] `bun run typecheck` (web)
- [x] Mobile Jest suite (29 tests, includes `mentions`, `LiveActivityContext`, `notifications`)
- [x] DB smoke: mention trigger E2E, reactions unique constraint, RPC grants
- [x] `playwright test --list` discovers the new smokes (7 tests)
- [ ] CI Playwright run against the new smokes
- [ ] Manual cron invocation with real `CRON_SECRET` (cannot be done from this session)

## Notes
The two migrations in this PR have already been applied to the live Supabase project (`rytsziwekhtjdqzzpdso`) and verified via advisors and live SQL. The migration files are checked in here to keep `supabase/migrations/` in sync with prod.