### PR TITLE
fix(mobile/live-activity): enable feature flag + show during 30-min countdown

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -18,6 +18,11 @@ EXPO_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 # Error Tracking - Sentry
 EXPO_PUBLIC_SENTRY_DSN=https://xxxxx@sentry.io/xxxxx
 
+# iOS Live Activities (lock-screen / Dynamic Island event widgets).
+# Build-time gate. Must be "true" for the LiveActivityProvider to start
+# activities — otherwise the whole feature is a no-op.
+EXPO_PUBLIC_MOBILE_LIVE_ACTIVITIES_ENABLED=true
+
 # Cloudflare Turnstile (auth + donations)
 # Use 1x00000000000000000000AA in dev for an always-pass test key.
 EXPO_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -19,12 +19,18 @@
     },
     "preview": {
       "distribution": "internal",
-      "environment": "preview"
+      "environment": "preview",
+      "env": {
+        "EXPO_PUBLIC_MOBILE_LIVE_ACTIVITIES_ENABLED": "true"
+      }
     },
     "production": {
       "autoIncrement": true,
       "distribution": "store",
-      "environment": "production"
+      "environment": "production",
+      "env": {
+        "EXPO_PUBLIC_MOBILE_LIVE_ACTIVITIES_ENABLED": "true"
+      }
     }
   },
   "submit": {

--- a/apps/mobile/src/hooks/useActiveEventsForLiveActivity.ts
+++ b/apps/mobile/src/hooks/useActiveEventsForLiveActivity.ts
@@ -12,6 +12,9 @@ const STALE_TIME_MS = 30_000;
  */
 const DEFAULT_POST_EVENT_GRACE_MINUTES = 30;
 const MAX_GRACE_MINUTES = 240;
+// Mirror /api/cron/event-reminders: the lock-screen activity should appear
+// at the same moment the 30-min reminder push fires, not only after kickoff.
+const PRE_EVENT_MINUTES = 30;
 
 function resolveGraceMinutes(eventSettings: unknown): number {
   if (eventSettings && typeof eventSettings === "object") {
@@ -84,7 +87,9 @@ export function useActiveEventsForLiveActivity(
       const lower = new Date(
         now.getTime() - MAX_GRACE_MINUTES * 60 * 1000,
       ).toISOString();
-      const upper = now.toISOString();
+      const upper = new Date(
+        now.getTime() + PRE_EVENT_MINUTES * 60 * 1000,
+      ).toISOString();
 
       // 1. Find every event_rsvps row for this user where status='attending'
       // and the event window overlaps `now`. We do the join in JS so we can


### PR DESCRIPTION
## Summary
- Set `EXPO_PUBLIC_MOBILE_LIVE_ACTIVITIES_ENABLED=true` on the `preview` and `production` EAS profiles. Previously unset, so the build-time gate in `LiveActivityContext` silently no-op'd the whole Live Activities feature on TestFlight build 25.
- Widen `useActiveEventsForLiveActivity` `start_date` upper bound to `now + 30min` so the lock-screen activity appears alongside the existing 30-min reminder push, not only after the event has started.
- Document the flag in `.env.example`.

## Why
User on TestFlight build 25 reported no Live Activity appearing on the lock screen for manually-created upcoming events. Two independent causes: (1) the build flag was off, so the provider never called `Activity.request()`; (2) even with the flag on, the query only matched events with `start_date <= now`, so future events never qualified.

## Test plan
- [ ] EAS production build picks up `EXPO_PUBLIC_MOBILE_LIVE_ACTIVITIES_ENABLED=true` (visible in build banner env-var list)
- [ ] Create event starting in ~15 min, RSVP attending → Live Activity appears on lock screen within ~30s
- [ ] Live Activity ends after `end_date + 30min` grace