### PR TITLE
feat(mobile): native Join Organization flow + RSVP/QR check-in mode

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,8 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
 }

--- a/apps/mobile/__tests__/contexts/OrgContext-waitForAuthUser.test.ts
+++ b/apps/mobile/__tests__/contexts/OrgContext-waitForAuthUser.test.ts
@@ -1,0 +1,73 @@
+/**
+ * waitForAuthUser — guards against the cold-launch race where AsyncStorage
+ * hasn't rehydrated the Supabase session before OrgContext queries it.
+ */
+
+const mockGetUser = jest.fn();
+const mockUnsubscribe = jest.fn();
+let mockAuthChangeCb: ((event: string, session: { user: { id: string } } | null) => void) | null = null;
+
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    from: jest.fn(),
+    auth: {
+      getUser: (...args: unknown[]) => mockGetUser(...args),
+      onAuthStateChange: (cb: typeof mockAuthChangeCb) => {
+        mockAuthChangeCb = cb;
+        return { data: { subscription: { unsubscribe: mockUnsubscribe } } };
+      },
+    },
+  },
+}));
+
+jest.mock("expo-router", () => ({ useGlobalSearchParams: jest.fn(() => ({})) }));
+jest.mock("../../src/lib/analytics", () => ({
+  setUserProperties: jest.fn(),
+  captureException: jest.fn(),
+}));
+jest.mock("@teammeet/core", () => ({ normalizeRole: (r: string) => r }));
+
+import { waitForAuthUser } from "../../src/contexts/OrgContext";
+
+describe("waitForAuthUser", () => {
+  beforeEach(() => {
+    mockAuthChangeCb = null;
+    mockUnsubscribe.mockClear();
+    mockGetUser.mockReset();
+  });
+
+  it("resolves with the user when onAuthStateChange fires before timeout", async () => {
+    const promise = waitForAuthUser(500);
+    setTimeout(() => mockAuthChangeCb?.("INITIAL_SESSION", { user: { id: "u1" } }), 10);
+    await expect(promise).resolves.toEqual({ id: "u1" });
+    expect(mockUnsubscribe).toHaveBeenCalled();
+  });
+
+  it("falls back to getUser() on timeout and resolves with the recovered user", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "late" } } });
+    const user = await waitForAuthUser(20);
+    expect(user).toEqual({ id: "late" });
+    expect(mockUnsubscribe).toHaveBeenCalled();
+  });
+
+  it("resolves null when both onAuthStateChange and getUser yield nothing", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const user = await waitForAuthUser(20);
+    expect(user).toBeNull();
+  });
+
+  it("does not resolve twice if onAuthStateChange fires after the timeout fallback", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "first" } } });
+    const user = await waitForAuthUser(10);
+    expect(user).toEqual({ id: "first" });
+    mockAuthChangeCb?.("SIGNED_IN", { user: { id: "second" } });
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores null-session events while still waiting", async () => {
+    const promise = waitForAuthUser(50);
+    mockAuthChangeCb?.("SIGNED_OUT", null);
+    setTimeout(() => mockAuthChangeCb?.("SIGNED_IN", { user: { id: "u2" } }), 10);
+    await expect(promise).resolves.toEqual({ id: "u2" });
+  });
+});

--- a/apps/mobile/__tests__/lib/deep-link.test.ts
+++ b/apps/mobile/__tests__/lib/deep-link.test.ts
@@ -253,4 +253,16 @@ describe("routeIntent", () => {
       "/(app)/acme-hs/events/evt-42/scan?mode=self"
     );
   });
+
+  it("routes join-org intents to the native join screen with the token", async () => {
+    const router = { push: jest.fn(), replace: jest.fn() };
+
+    await routeIntent(router, { kind: "join-org", token: "ABCD1234" });
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: "/(app)/(drawer)/join-organization",
+      params: { token: "ABCD1234" },
+    });
+    expect(router.replace).not.toHaveBeenCalled();
+  });
 });

--- a/apps/mobile/__tests__/lib/event-location.test.ts
+++ b/apps/mobile/__tests__/lib/event-location.test.ts
@@ -1,0 +1,72 @@
+import { captureCurrentCoords } from "../../src/lib/event-location";
+
+jest.mock("expo-location", () => ({
+  hasServicesEnabledAsync: jest.fn(),
+  requestForegroundPermissionsAsync: jest.fn(),
+  getCurrentPositionAsync: jest.fn(),
+  Accuracy: { Balanced: 3 },
+}));
+
+jest.mock("../../src/lib/analytics/sentry", () => ({
+  captureException: jest.fn(),
+}));
+
+import * as Location from "expo-location";
+
+const mocks = Location as unknown as {
+  hasServicesEnabledAsync: jest.Mock;
+  requestForegroundPermissionsAsync: jest.Mock;
+  getCurrentPositionAsync: jest.Mock;
+};
+
+describe("captureCurrentCoords", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns ok=true with coords when permission granted and services on", async () => {
+    mocks.hasServicesEnabledAsync.mockResolvedValue(true);
+    mocks.requestForegroundPermissionsAsync.mockResolvedValue({ status: "granted" });
+    mocks.getCurrentPositionAsync.mockResolvedValue({
+      coords: { latitude: 37.7749, longitude: -122.4194 },
+    });
+
+    const result = await captureCurrentCoords();
+    expect(result).toEqual({
+      ok: true,
+      coords: { latitude: 37.7749, longitude: -122.4194 },
+    });
+  });
+
+  it("returns services_off when Location Services disabled at the OS level", async () => {
+    mocks.hasServicesEnabledAsync.mockResolvedValue(false);
+
+    const result = await captureCurrentCoords();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("services_off");
+    expect(mocks.requestForegroundPermissionsAsync).not.toHaveBeenCalled();
+  });
+
+  it("returns denied when foreground permission rejected", async () => {
+    mocks.hasServicesEnabledAsync.mockResolvedValue(true);
+    mocks.requestForegroundPermissionsAsync.mockResolvedValue({ status: "denied" });
+
+    const result = await captureCurrentCoords();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("denied");
+    expect(mocks.getCurrentPositionAsync).not.toHaveBeenCalled();
+  });
+
+  it("returns error and reports to Sentry when getCurrentPositionAsync throws", async () => {
+    mocks.hasServicesEnabledAsync.mockResolvedValue(true);
+    mocks.requestForegroundPermissionsAsync.mockResolvedValue({ status: "granted" });
+    mocks.getCurrentPositionAsync.mockRejectedValue(new Error("GPS unavailable"));
+
+    const result = await captureCurrentCoords();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("error");
+      expect(result.message).toContain("GPS unavailable");
+    }
+  });
+});

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -19,7 +19,7 @@ if (process.env.EAS_BUILD_PROFILE === "production") {
 }
 
 const config: ExpoConfig = {
-  name: "TeamMeet",
+  name: "TeamNetwork",
   slug: "teammeet",
   owner: "teamnetwork",
   version: "1.0.0",
@@ -54,17 +54,19 @@ const config: ExpoConfig = {
       NSSupportsLiveActivitiesFrequentUpdates: true,
       ITSAppUsesNonExemptEncryption: false,
       NSCameraUsageDescription:
-        "Scan a TeamMeet QR code to join your organization or check members in at events.",
+        "Scan a TeamNetwork QR code to join your organization or check members in at events.",
       NSCalendarsFullAccessUsageDescription:
-        "Add TeamMeet events to your device calendar so you see them alongside your other commitments.",
+        "Add TeamNetwork events to your device calendar so you see them alongside your other commitments.",
       NSCalendarsWriteOnlyAccessUsageDescription:
-        "Add TeamMeet events to your device calendar so you see them alongside your other commitments.",
+        "Add TeamNetwork events to your device calendar so you see them alongside your other commitments.",
       NSCalendarsUsageDescription:
-        "Add TeamMeet events to your device calendar so you see them alongside your other commitments.",
+        "Add TeamNetwork events to your device calendar so you see them alongside your other commitments.",
       NSRemindersFullAccessUsageDescription:
-        "TeamMeet uses reminders to surface event-related reminders alongside your existing reminders.",
+        "TeamNetwork uses reminders to surface event-related reminders alongside your existing reminders.",
       NSRemindersUsageDescription:
-        "TeamMeet uses reminders to surface event-related reminders alongside your existing reminders.",
+        "TeamNetwork uses reminders to surface event-related reminders alongside your existing reminders.",
+      NSLocationWhenInUseUsageDescription:
+        "TeamNetwork uses your location to verify you're at the event venue when checking in, and to tag the location of events you create.",
       CFBundleURLTypes: [
         {
           CFBundleURLSchemes: ["teammeet"],
@@ -147,7 +149,7 @@ const config: ExpoConfig = {
       "expo-image-picker",
       {
         photosPermission:
-          "TeamMeet needs access to your photos to attach images to posts.",
+          "TeamNetwork needs access to your photos to attach images to posts.",
         microphonePermission: false,
       },
     ],
@@ -155,7 +157,7 @@ const config: ExpoConfig = {
       "expo-camera",
       {
         cameraPermission:
-          "Scan a TeamMeet QR code to join your organization or check members in at events.",
+          "Scan a TeamNetwork QR code to join your organization or check members in at events.",
         microphonePermission: false,
         recordAudioAndroid: false,
       },
@@ -163,16 +165,23 @@ const config: ExpoConfig = {
     [
       "expo-local-authentication",
       {
-        faceIDPermission: "Use Face ID to quickly and securely sign in to TeamMeet.",
+        faceIDPermission: "Use Face ID to quickly and securely sign in to TeamNetwork.",
       },
     ],
     [
       "expo-calendar",
       {
         calendarPermission:
-          "Add TeamMeet events to your device calendar so you see them alongside your other commitments.",
+          "Add TeamNetwork events to your device calendar so you see them alongside your other commitments.",
         remindersPermission:
-          "TeamMeet uses reminders to surface event-related reminders alongside your existing reminders.",
+          "TeamNetwork uses reminders to surface event-related reminders alongside your existing reminders.",
+      },
+    ],
+    [
+      "expo-location",
+      {
+        locationWhenInUsePermission:
+          "TeamNetwork uses your location to verify you're at the event venue when checking in, and to tag the location of events you create.",
       },
     ],
     "expo-quick-actions",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "TeamMeet",
+    "name": "TeamNetwork",
     "slug": "teammeet",
     "owner": "teamnetwork",
     "version": "1.0.0",

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/_layout.tsx
@@ -95,8 +95,8 @@ export default function TabsLayout() {
   const handleShareOrg = useCallback(async () => {
     const orgUrl = getWebPath(orgSlug);
     const shareMessage = orgName
-      ? `Check out ${orgName} on TeamMeet: ${orgUrl}`
-      : `Check out this organization on TeamMeet: ${orgUrl}`;
+      ? `Check out ${orgName} on TeamNetwork: ${orgUrl}`
+      : `Check out this organization on TeamNetwork: ${orgUrl}`;
 
     try {
       await Share.share({

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/menu.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/menu.tsx
@@ -505,8 +505,8 @@ export default function MenuScreen() {
     const version = Application.nativeApplicationVersion || "1.0.0";
     const buildNumber = Application.nativeBuildVersion || "1";
     Alert.alert(
-      "About TeamMeet",
-      `Version ${version} (${buildNumber})\n\nTeamMeet helps teams stay connected and organized.`,
+      "About TeamNetwork",
+      `Version ${version} (${buildNumber})\n\nTeamNetwork helps teams stay connected and organized.`,
       [
         { text: "OK", style: "default" },
         {
@@ -525,7 +525,7 @@ export default function MenuScreen() {
     },
     {
       icon: <Info size={20} color={neutral.muted} />,
-      label: "About TeamMeet",
+      label: "About TeamNetwork",
       onPress: handleAbout,
     },
     {

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/_layout.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/_layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { View } from "react-native";
 import { Stack, useRouter } from "expo-router";
 import type { ErrorBoundaryProps } from "expo-router";
@@ -7,9 +7,11 @@ import LoadingScreen from "@/components/LoadingScreen";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { ColorSchemeProvider } from "@/contexts/ColorSchemeContext";
 import { captureException } from "@/lib/analytics";
+import { useAuth } from "@/contexts/AuthContext";
 import { useOrg } from "@/contexts/OrgContext";
 import { useOrgRole } from "@/hooks/useOrgRole";
 import { rememberLastActiveOrg, registerQuickActions } from "@/lib/quick-actions";
+import { showToast } from "@/components/ui/Toast";
 
 export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
   captureException(error, { context: "OrgErrorBoundary" });
@@ -36,16 +38,36 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
 
 function OrgLayoutInner() {
   const router = useRouter();
+  const { session, isLoading: authLoading } = useAuth();
   const { orgSlug, status, isLoading } = useOrg();
   const { isAdmin } = useOrgRole();
+  // Track which orgSlug we have already bounced from. Per-slug rather than
+  // per-mount so navigating to a different org in the same mount can still
+  // trigger a fresh bounce when warranted.
+  const redirectedSlugRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!orgSlug || isLoading || status === "loading" || status === "ready") {
-      return;
-    }
+    // Don't redirect on transient non-ready states caused by auth still
+    // hydrating (cold launch from a notification tap) or by org data still
+    // loading. The root layout owns the auth-group redirect.
+    if (!orgSlug || authLoading || !session) return;
+    if (isLoading || status === "loading" || status === "ready") return;
+    if (redirectedSlugRef.current === orgSlug) return;
 
-    router.replace("/(app)");
-  }, [orgSlug, isLoading, status, router]);
+    // Only `not_found` and `unauthorized` should bounce to the org list.
+    // `error` is rendered in place with a retry, so a flaky network doesn't
+    // throw the user out of their deep link.
+    if (status === "not_found" || status === "unauthorized") {
+      redirectedSlugRef.current = orgSlug;
+      showToast(
+        status === "not_found"
+          ? "That organization is no longer available."
+          : "You no longer have access to this organization.",
+        "warning",
+      );
+      router.replace("/(app)");
+    }
+  }, [orgSlug, authLoading, session, isLoading, status, router]);
 
   // Keep the home-screen Quick Actions in sync with the most recently visited
   // org + role so the action set matches what the user is most likely to do.
@@ -57,8 +79,22 @@ function OrgLayoutInner() {
     }).then(() => registerQuickActions());
   }, [orgSlug, status, isAdmin]);
 
-  if (!orgSlug || isLoading || status === "loading") {
+  if (!orgSlug || authLoading || isLoading || status === "loading") {
     return <LoadingScreen />;
+  }
+
+  if (status === "error") {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: "#0f172a" }}>
+        <View style={{ flex: 1, backgroundColor: "#ffffff" }}>
+          <ErrorState
+            onRetry={() => router.replace(`/(app)/${orgSlug}` as any)}
+            title="Couldn't load this organization"
+            subtitle="Check your connection and try again."
+          />
+        </View>
+      </SafeAreaView>
+    );
   }
 
   if (status !== "ready") {

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/[eventId]/edit.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/[eventId]/edit.tsx
@@ -19,19 +19,25 @@ import { useOrgTheme } from "@/hooks/useOrgTheme";
 import { SPACING, RADIUS, SHADOWS } from "@/lib/design-tokens";
 import { TYPOGRAPHY } from "@/lib/typography";
 import { formatDatePickerLabel, formatTimePickerLabel } from "@/lib/date-format";
-import { openVenueInMaps } from "@/lib/venue-maps";
+import { captureCurrentCoords } from "@/lib/event-location";
 import type { ThemeColors } from "@/lib/theme";
 import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
 import type { NeutralColors, SemanticColors } from "@/lib/design-tokens";
 
 type Audience = "members" | "alumni" | "both";
 type EventType = "general" | "philanthropy" | "game" | "meeting" | "social" | "fundraiser";
+type CheckInMode = "qr" | "rsvp";
 type PickerTarget = "start-date" | "start-time" | "end-date" | "end-time";
 
 const AUDIENCE_OPTIONS: { value: Audience; label: string }[] = [
   { value: "both", label: "Members + Alumni" },
   { value: "members", label: "Members" },
   { value: "alumni", label: "Alumni" },
+];
+
+const CHECK_IN_MODE_OPTIONS: { value: CheckInMode; label: string }[] = [
+  { value: "rsvp", label: "Simple RSVP" },
+  { value: "qr", label: "QR check-in" },
 ];
 
 const EVENT_TYPE_OPTIONS: { value: EventType; label: string }[] = [
@@ -73,8 +79,13 @@ export default function EditEventScreen() {
   const [endTime, setEndTime] = useState<Date | null>(null);
   const [location, setLocation] = useState("");
   const [geofenceEnabled, setGeofenceEnabled] = useState(false);
+  const [latitude, setLatitude] = useState<number | null>(null);
+  const [longitude, setLongitude] = useState<number | null>(null);
+  const [radiusM, setRadiusM] = useState<number>(100);
+  const [capturingLocation, setCapturingLocation] = useState(false);
   const [eventType, setEventType] = useState<EventType>("general");
   const [audience, setAudience] = useState<Audience>("both");
+  const [checkInMode, setCheckInMode] = useState<CheckInMode>("rsvp");
   const [loading, setLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -103,8 +114,16 @@ export default function EditEventScreen() {
         setDescription(data.description || "");
         setLocation(data.location || "");
         setGeofenceEnabled(!!data.geofence_enabled);
+        setLatitude(typeof data.latitude === "number" ? data.latitude : null);
+        setLongitude(typeof data.longitude === "number" ? data.longitude : null);
+        setRadiusM(
+          typeof data.geofence_radius_m === "number" && data.geofence_radius_m > 0
+            ? data.geofence_radius_m
+            : 100,
+        );
         setEventType((data.event_type as EventType) || "general");
         setAudience((data.audience as Audience) || "both");
+        setCheckInMode(((data as { check_in_mode?: CheckInMode }).check_in_mode) || "rsvp");
 
         // Parse dates
         if (data.start_date) {
@@ -192,8 +211,8 @@ export default function EditEventScreen() {
       return;
     }
 
-    if (geofenceEnabled && !location.trim()) {
-      setError("Add a location so members can open it in Maps for check-in.");
+    if (checkInMode === "qr" && geofenceEnabled && (latitude == null || longitude == null)) {
+      setError("Tap \"Use my current location\" so members can be geofence-verified.");
       return;
     }
 
@@ -231,13 +250,14 @@ export default function EditEventScreen() {
           start_date: startDateTime,
           end_date: endDateTime,
           location: location.trim() || null,
-          geofence_enabled: geofenceEnabled,
-          geofence_radius_m: 100,
-          latitude: null,
-          longitude: null,
+          geofence_enabled: checkInMode === "qr" ? geofenceEnabled : false,
+          geofence_radius_m: radiusM,
+          latitude: checkInMode === "qr" && geofenceEnabled ? latitude : null,
+          longitude: checkInMode === "qr" && geofenceEnabled ? longitude : null,
           event_type: eventType,
           is_philanthropy: eventType === "philanthropy",
           audience,
+          check_in_mode: checkInMode,
           updated_at: new Date().toISOString(),
         })
         .eq("id", eventId)
@@ -264,8 +284,12 @@ export default function EditEventScreen() {
     endTime,
     location,
     geofenceEnabled,
+    latitude,
+    longitude,
+    radiusM,
     eventType,
     audience,
+    checkInMode,
     router,
   ]);
 
@@ -437,46 +461,79 @@ export default function EditEventScreen() {
         />
       </View>
 
-      <View style={styles.field}>
-        <View
-          style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}
-        >
-          <Text style={styles.label}>Verify check-in at venue (geofence)</Text>
-          <Switch
-            value={geofenceEnabled}
-            onValueChange={setGeofenceEnabled}
-            trackColor={{ false: neutral.border, true: semantic.success }}
-          />
-        </View>
-      </View>
-      {geofenceEnabled ? (
+      {checkInMode === "qr" && (
         <View style={styles.field}>
-          <Text
-            style={[
-              TYPOGRAPHY.bodySmall,
-              { color: neutral.secondary, marginBottom: SPACING.sm },
-            ]}
+          <View
+            style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}
           >
-            Members open this address in Apple Maps and confirm they’re at the venue before
-            self check-in.
-          </Text>
-          <Pressable
-            onPress={() => {
-              if (!location.trim()) {
-                Alert.alert("Location", "Enter a location first.");
-                return;
-              }
-              void openVenueInMaps(location.trim());
-            }}
-            style={({ pressed }) => [
-              fieldStyle,
-              { marginBottom: SPACING.sm, alignItems: "center" as const },
-              pressed && { opacity: 0.85 },
-            ]}
-          >
-            <Text style={styles.dateText}>Preview in Apple Maps</Text>
-          </Pressable>
+            <Text style={styles.label}>Verify check-in at venue (geofence)</Text>
+            <Switch
+              value={geofenceEnabled}
+              onValueChange={setGeofenceEnabled}
+              trackColor={{ false: neutral.border, true: semantic.success }}
+            />
+          </View>
         </View>
+      )}
+      {checkInMode === "qr" && geofenceEnabled ? (
+        <>
+          <View style={styles.field}>
+            <Text
+              style={[
+                TYPOGRAPHY.bodySmall,
+                { color: neutral.secondary, marginBottom: SPACING.sm },
+              ]}
+            >
+              Stamp this event with your current GPS so members can only check in when they’re nearby.
+            </Text>
+            <Pressable
+              onPress={async () => {
+                setCapturingLocation(true);
+                const result = await captureCurrentCoords();
+                setCapturingLocation(false);
+                if (result.ok) {
+                  setLatitude(result.coords.latitude);
+                  setLongitude(result.coords.longitude);
+                } else {
+                  Alert.alert("Couldn't read location", result.message);
+                }
+              }}
+              disabled={capturingLocation}
+              style={({ pressed }) => [
+                fieldStyle,
+                { marginBottom: SPACING.sm, alignItems: "center" as const },
+                (capturingLocation || pressed) && { opacity: 0.7 },
+              ]}
+            >
+              <Text style={styles.dateText}>
+                {capturingLocation
+                  ? "Reading GPS…"
+                  : latitude != null && longitude != null
+                    ? `Update location (captured ${latitude.toFixed(4)}, ${longitude.toFixed(4)})`
+                    : "Use my current location"}
+              </Text>
+            </Pressable>
+          </View>
+          <View style={styles.field}>
+            <Text style={styles.label}>Allowed distance from venue</Text>
+            <View style={styles.chipRow}>
+              {[25, 50, 100, 250, 500].map((meters) => {
+                const selected = radiusM === meters;
+                return (
+                  <Pressable
+                    key={meters}
+                    onPress={() => setRadiusM(meters)}
+                    style={[styles.chip, selected && styles.chipSelected]}
+                  >
+                    <Text style={[styles.chipText, selected && styles.chipTextSelected]}>
+                      {meters} m
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+        </>
       ) : null}
 
       {/* Event Type */}
@@ -510,6 +567,27 @@ export default function EditEventScreen() {
               <Pressable
                 key={option.value}
                 onPress={() => setAudience(option.value)}
+                style={[styles.chip, selected && styles.chipSelected]}
+              >
+                <Text style={[styles.chipText, selected && styles.chipTextSelected]}>
+                  {option.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+
+      {/* Check-in mode */}
+      <View style={styles.field}>
+        <Text style={styles.label}>Check-in mode</Text>
+        <View style={styles.chipRow}>
+          {CHECK_IN_MODE_OPTIONS.map((option) => {
+            const selected = checkInMode === option.value;
+            return (
+              <Pressable
+                key={option.value}
+                onPress={() => setCheckInMode(option.value)}
                 style={[styles.chip, selected && styles.chipSelected]}
               >
                 <Text style={[styles.chipText, selected && styles.chipTextSelected]}>

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/[eventId]/index.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/[eventId]/index.tsx
@@ -14,6 +14,7 @@ import { useOrg } from "@/contexts/OrgContext";
 import { useOrgRole } from "@/hooks/useOrgRole";
 import { useNetwork } from "@/contexts/NetworkContext";
 import { useRsvp } from "@/hooks/useRsvp";
+import type { EventRSVP } from "@/hooks/useEventRSVPs";
 import { ErrorState } from "@/components/ui";
 import type { Event } from "@/hooks/useEvents";
 import { getWebPath } from "@/lib/web-api";
@@ -26,11 +27,10 @@ import { formatShortWeekdayDate, formatTime } from "@/lib/date-format";
 import { EventCountdownBadge } from "@/components/calendar/event-countdown-badge";
 import { OverflowMenu, type OverflowMenuItem } from "@/components/OverflowMenu";
 import * as sentry from "@/lib/analytics/sentry";
-import type { RsvpStatus } from "@teammeet/core";
+import { normalizeRsvpStatus, type RsvpStatus } from "@teammeet/core";
 import { useAuth } from "@/hooks/useAuth";
+import { useNow } from "@/hooks/useNow";
 
-
-type RSVPStatus = RsvpStatus;
 
 function rsvpButtonLabel(status: RsvpStatus): string {
   switch (status) {
@@ -47,16 +47,6 @@ function sentryCaptureRsvpRefetchError(err: unknown): void {
   sentry.captureException(err as Error, {
     context: "EventDetailScreen.fetchRsvps",
   });
-}
-
-interface RSVP {
-  id: string;
-  user_id: string;
-  status: RSVPStatus;
-  users: {
-    name: string | null;
-    email: string | null;
-  } | null;
 }
 
 export default function EventDetailScreen() {
@@ -257,7 +247,11 @@ export default function EventDetailScreen() {
     },
   }));
   const [event, setEvent] = useState<Event | null>(null);
-  const [rsvps, setRsvps] = useState<RSVP[]>([]);
+  // Only the fields this screen reads. Keeps the type local to what we
+  // actually project from the query without redeclaring the full row shape.
+  const [rsvps, setRsvps] = useState<
+    Pick<EventRSVP, "id" | "user_id" | "status" | "checked_in_at">[]
+  >([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isCancelling, setIsCancelling] = useState(false);
@@ -270,11 +264,12 @@ export default function EventDetailScreen() {
   });
 
   const fetchRsvps = useCallback(async () => {
-    if (!eventId) return;
+    if (!eventId || !orgId) return;
     const { data: rsvpData, error: rsvpError } = await supabase
       .from("event_rsvps")
-      .select("id, user_id, status, users!user_id(name, email)")
+      .select("id, user_id, status, checked_in_at")
       .eq("event_id", eventId)
+      .eq("organization_id", orgId)
       .order("created_at", { ascending: false });
 
     if (rsvpError) {
@@ -282,9 +277,16 @@ export default function EventDetailScreen() {
       return;
     }
     if (rsvpData) {
-      setRsvps(rsvpData as unknown as RSVP[]);
+      setRsvps(
+        rsvpData.map((r) => ({
+          id: r.id,
+          user_id: r.user_id,
+          status: normalizeRsvpStatus(r.status) ?? "maybe",
+          checked_in_at: r.checked_in_at,
+        })),
+      );
     }
-  }, [eventId]);
+  }, [eventId, orgId]);
 
   // Whether THIS user has opted into Live Activity tracking for this event.
   // Independent fetch from fetchRsvps so the toggle state survives unrelated
@@ -319,11 +321,12 @@ export default function EventDetailScreen() {
     const next = !trackOnLockScreen;
     setSavingTrack(true);
     setTrackOnLockScreen(next);
-    // Cast: `track_on_lock_screen` was added in a recent migration; the
-    // generated Supabase types haven't been regenerated yet.
-    const { error: updateError } = await (supabase as any)
+    // `track_on_lock_screen` is missing from the generated Supabase types
+    // until the next gen:types run; cast the payload (not the client) to
+    // keep the rest of the chain type-checked.
+    const { error: updateError } = await supabase
       .from("event_rsvps")
-      .update({ track_on_lock_screen: next })
+      .update({ track_on_lock_screen: next } as never)
       .eq("event_id", eventId)
       .eq("user_id", user.id);
     setSavingTrack(false);
@@ -454,7 +457,7 @@ export default function EventDetailScreen() {
         if (calendarPermission.status === "denied" && !calendarPermission.canAskAgain) {
           Alert.alert(
             "Calendar access needed",
-            "Open Settings to allow TeamMeet to add events to your calendar.",
+            "Open Settings to allow TeamNetwork to add events to your calendar.",
             [
               { text: "Cancel", style: "cancel" },
               { text: "Open Settings", onPress: () => void calendarPermission.openSettings() },
@@ -467,7 +470,7 @@ export default function EventDetailScreen() {
     try {
       await syncEventToDevice({
         orgId,
-        orgName: orgName ?? "TeamMeet",
+        orgName: orgName ?? "TeamNetwork",
         event,
       });
       Alert.alert("Added to calendar", `${event.title} is now in your device calendar.`);
@@ -495,6 +498,8 @@ export default function EventDetailScreen() {
     };
     if (!permissions.canUseAdminActions) return [shareItem, calendarItem];
 
+    const qrEnabled = (event?.check_in_mode ?? "rsvp") === "qr";
+
     return [
       shareItem,
       calendarItem,
@@ -510,12 +515,16 @@ export default function EventDetailScreen() {
         icon: <List size={20} color={neutral.foreground} />,
         onPress: handleViewRsvps,
       },
-      {
-        id: "event-qr",
-        label: "Show Event QR",
-        icon: <QrCode size={20} color={neutral.foreground} />,
-        onPress: handleShowEventQr,
-      },
+      ...(qrEnabled
+        ? [
+            {
+              id: "event-qr",
+              label: "Show Event QR",
+              icon: <QrCode size={20} color={neutral.foreground} />,
+              onPress: handleShowEventQr,
+            } as OverflowMenuItem,
+          ]
+        : []),
       {
         id: "open-web",
         label: "Open in Web",
@@ -532,6 +541,7 @@ export default function EventDetailScreen() {
     ];
   }, [
     permissions.canUseAdminActions,
+    event?.check_in_mode,
     handleEditEvent,
     handleViewRsvps,
     handleShowEventQr,
@@ -548,14 +558,36 @@ export default function EventDetailScreen() {
     const attending = rsvps.filter((r) => r.status === "attending").length;
     const maybe = rsvps.filter((r) => r.status === "maybe").length;
     const notAttending = rsvps.filter((r) => r.status === "not_attending").length;
-    return { attending, maybe, notAttending, total: rsvps.length };
-  }, [rsvps]);
+    const checkedIn = rsvps.filter((r) => r.checked_in_at != null).length;
+    const myRow = user?.id ? rsvps.find((r) => r.user_id === user.id) : undefined;
+    return {
+      attending,
+      maybe,
+      notAttending,
+      checkedIn,
+      total: rsvps.length,
+      myCheckedInAt: myRow?.checked_in_at ?? null,
+    };
+  }, [rsvps, user?.id]);
 
   const handleCheckInPress = () => {
     router.push(`/(app)/${orgSlug}/events/check-in?eventId=${eventId}`);
   };
 
   const isAdmin = permissions.canUseAdminActions;
+  const qrCheckInEnabled = (event?.check_in_mode ?? "rsvp") === "qr";
+
+  // Live window: now is within [start_date, end_date]. Used to flip the
+  // header counter from RSVP/attending to actual check-in counts at kickoff.
+  const now = useNow(event?.start_date ?? undefined);
+  const isLive = useMemo(() => {
+    if (!event?.start_date) return false;
+    const start = Date.parse(event.start_date);
+    if (Number.isNaN(start) || now.getTime() < start) return false;
+    if (!event.end_date) return true;
+    const end = Date.parse(event.end_date);
+    return Number.isNaN(end) ? true : now.getTime() <= end;
+  }, [event?.start_date, event?.end_date, now]);
 
   if (loading) {
     return (
@@ -630,7 +662,11 @@ export default function EventDetailScreen() {
           {event.rsvp_count !== undefined && (
             <View style={styles.detailRow}>
               <Users size={18} color={neutral.muted} />
-              <Text style={styles.detailText}>{event.rsvp_count} attending</Text>
+              <Text style={styles.detailText}>
+                {isLive
+                  ? `${rsvpCounts.checkedIn} checked in of ${rsvpCounts.attending} going`
+                  : `${rsvpCounts.attending} going`}
+              </Text>
             </View>
           )}
         </View>
@@ -665,45 +701,53 @@ export default function EventDetailScreen() {
                   </Text>
                 </View>
               )}
+              {rsvpCounts.checkedIn > 0 && (
+                <View style={[styles.rsvpCountBadge, { backgroundColor: semantic.successLight ?? RSVP_COLORS.attending.background }]}>
+                  <Text style={[styles.rsvpCountText, { color: semantic.success }]}>
+                    {rsvpCounts.checkedIn} Checked In
+                  </Text>
+                </View>
+              )}
             </View>
             <Text style={styles.rsvpTapHint}>Tap to view all RSVPs</Text>
           </Pressable>
         )}
 
-        {/* Admin Check-In Button */}
-        {isAdmin && (
+        {/* Admin Check-In Button — orthogonal to RSVP. Admins can RSVP for themselves AND check others in. */}
+        {isAdmin && qrCheckInEnabled && (
           <Pressable style={styles.checkInButton} onPress={handleCheckInPress}>
             <UserCheck size={20} color="#ffffff" />
             <Text style={styles.checkInButtonText}>Check In Attendees</Text>
           </Pressable>
         )}
 
-        {!isAdmin && (
-          <Pressable
-            style={({ pressed }) => [
-              styles.rsvpButton,
-              (rsvp.saving || pressed) && { opacity: 0.7 },
-            ]}
-            onPress={rsvp.promptRsvp}
-            disabled={rsvp.saving}
-            accessibilityRole="button"
-            accessibilityLabel={
-              rsvp.status
-                ? `Update RSVP, currently ${rsvpButtonLabel(rsvp.status)}`
-                : "RSVP to event"
-            }
-          >
-            <Text style={styles.rsvpButtonText}>
-              {rsvp.saving
-                ? "Saving…"
+        {/* RSVP button is always available regardless of check-in mode. */}
+        <Pressable
+          style={({ pressed }) => [
+            styles.rsvpButton,
+            (rsvp.saving || pressed) && { opacity: 0.7 },
+          ]}
+          onPress={rsvp.promptRsvp}
+          disabled={rsvp.saving}
+          accessibilityRole="button"
+          accessibilityLabel={
+            rsvp.status
+              ? `Update RSVP, currently ${rsvpButtonLabel(rsvp.status)}`
+              : "RSVP to event"
+          }
+        >
+          <Text style={styles.rsvpButtonText}>
+            {rsvp.saving
+              ? "Saving…"
+              : rsvpCounts.myCheckedInAt
+                ? `Checked In · ${rsvpButtonLabel(rsvp.status ?? "attending")}`
                 : rsvp.status
                   ? `RSVP: ${rsvpButtonLabel(rsvp.status)}`
                   : "RSVP"}
-            </Text>
-          </Pressable>
-        )}
+          </Text>
+        </Pressable>
 
-        {user && !isAdmin && (
+        {user && qrCheckInEnabled && (
           <Pressable
             style={({ pressed }) => [styles.selfScanRow, pressed && { opacity: 0.85 }]}
             onPress={() =>

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/[eventId]/qr.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/[eventId]/qr.tsx
@@ -166,7 +166,7 @@ export default function EventQrScreen() {
     if (!qrValue || !event) return;
     try {
       await Share.share({
-        message: `${event.title}: check in with TeamMeet.\n${qrValue}`,
+        message: `${event.title}: check in with TeamNetwork.\n${qrValue}`,
       });
     } catch {
       /* user cancelled */
@@ -207,6 +207,22 @@ export default function EventQrScreen() {
           title={error ? "Unable to load event" : "Event not found"}
           isOffline={isOffline}
         />
+      </View>
+    );
+  }
+
+  if ((event.check_in_mode ?? "rsvp") !== "qr") {
+    return (
+      <View style={[styles.container, styles.centered]}>
+        <Text style={[styles.deniedTitle, { color: neutral.foreground }]}>
+          No QR for this event
+        </Text>
+        <Text style={[styles.deniedBody, { color: neutral.muted, textAlign: "center" }]}>
+          This event uses simple RSVP — attendees just confirm they&apos;re coming, no QR check-in needed.
+        </Text>
+        <Pressable onPress={() => router.back()}>
+          <Text style={[styles.linkBackText, { color: semantic.success }]}>Go back</Text>
+        </Pressable>
       </View>
     );
   }
@@ -255,7 +271,7 @@ export default function EventQrScreen() {
         </View>
 
         <Text style={styles.hint}>
-          Members scan this code in the TeamMeet app to RSVP as going and check in
+          Members scan this code in the TeamNetwork app to RSVP as going and check in
           {event.geofence_enabled ? " when they are at the venue." : "."}
         </Text>
 

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/[eventId]/scan.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/[eventId]/scan.tsx
@@ -10,7 +10,7 @@ import { useOrgRole } from "@/hooks/useOrgRole";
 import { useEventRSVPs } from "@/hooks/useEventRSVPs";
 import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
 import { parseTeammeetUrl } from "@/lib/deep-link";
-import { openVenueInMaps } from "@/lib/venue-maps";
+import { captureCurrentCoords } from "@/lib/event-location";
 import { TYPOGRAPHY } from "@/lib/typography";
 import { SPACING } from "@/lib/design-tokens";
 import { supabase } from "@/lib/supabase";
@@ -52,7 +52,7 @@ export default function ScanCheckInScreen() {
   }, [router, orgSlug, eventId]);
 
   const [geofenceEnabled, setGeofenceEnabled] = useState(false);
-  const [eventLocation, setEventLocation] = useState("");
+  const [checkInMode, setCheckInMode] = useState<"qr" | "rsvp">("qr");
   const [toast, setToast] = useState<Toast>(null);
 
   useEffect(() => {
@@ -61,12 +61,13 @@ export default function ScanCheckInScreen() {
       if (!eventId) return;
       const { data } = await supabase
         .from("events")
-        .select("geofence_enabled, location")
+        .select("geofence_enabled, check_in_mode")
         .eq("id", eventId)
         .maybeSingle();
       if (!cancelled) {
         setGeofenceEnabled(!!data?.geofence_enabled);
-        setEventLocation(typeof data?.location === "string" ? data.location : "");
+        const mode = (data as { check_in_mode?: "qr" | "rsvp" } | null)?.check_in_mode;
+        if (mode === "rsvp" || mode === "qr") setCheckInMode(mode);
       }
     }
     void loadEventMeta();
@@ -81,11 +82,17 @@ export default function ScanCheckInScreen() {
   }, []);
 
   const completeSelfCheckIn = useCallback(
-    async (venueConfirmed: boolean): Promise<boolean> => {
+    async (
+      coords: { latitude: number; longitude: number } | null,
+    ): Promise<boolean> => {
       if (!eventId) return false;
       const { data, error: rpcError } = await supabase.rpc("self_check_in_event", {
         p_event_id: eventId,
-        p_venue_confirmed: venueConfirmed,
+        p_lat: coords?.latitude ?? undefined,
+        p_lng: coords?.longitude ?? undefined,
+        // venue_confirmed retained for back-compat with the old RPC signature;
+        // ignored when p_lat/p_lng are present.
+        p_venue_confirmed: coords != null,
       });
 
       if (rpcError) {
@@ -144,43 +151,24 @@ export default function ScanCheckInScreen() {
         }
 
         if (geofenceEnabled) {
-          if (!eventLocation.trim()) {
-            await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+          showToast({ kind: "info", text: "Reading your location…" });
+          const locResult = await captureCurrentCoords();
+          if (!locResult.ok) {
+            await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
             showToast({
               kind: "error",
-              text: "This event is missing a location for venue verification.",
+              text:
+                locResult.reason === "denied"
+                  ? "Allow Location in Settings → TeamNetwork to check in."
+                  : locResult.message,
             });
             return true;
           }
-          await new Promise<void>((resolve) => {
-            Alert.alert(
-              "Confirm venue",
-              "Open the location in Apple Maps, then confirm you’re at the venue.",
-              [
-                { text: "Cancel", style: "cancel", onPress: () => resolve() },
-                {
-                  text: "Open Maps",
-                  onPress: () => {
-                    void openVenueInMaps(eventLocation);
-                    resolve();
-                  },
-                },
-                {
-                  text: "I’m at the venue",
-                  onPress: () => {
-                    void (async () => {
-                      await completeSelfCheckIn(true);
-                      resolve();
-                    })();
-                  },
-                },
-              ]
-            );
-          });
+          await completeSelfCheckIn(locResult.coords);
           return true;
         }
 
-        await completeSelfCheckIn(false);
+        await completeSelfCheckIn(null);
         return true;
       }
 
@@ -231,7 +219,6 @@ export default function ScanCheckInScreen() {
       eventId,
       orgSlug,
       geofenceEnabled,
-      eventLocation,
       findRsvpByUserId,
       checkInAttendee,
       showToast,
@@ -250,6 +237,40 @@ export default function ScanCheckInScreen() {
         <Text style={[styles.title, { color: neutral.foreground }]}>Admins only</Text>
         <Text style={[styles.body, { color: neutral.muted }]}>
           Only admins can scan member QR codes for check-in.
+        </Text>
+      </View>
+    );
+  }
+
+  if (checkInMode === "rsvp") {
+    return (
+      <View
+        style={[
+          styles.container,
+          { backgroundColor: neutral.background, paddingTop: topInset },
+        ]}
+      >
+        <Pressable
+          onPress={handleClose}
+          style={({ pressed }) => [
+            styles.backButton,
+            { alignSelf: "flex-start", margin: SPACING.md },
+            pressed && { opacity: 0.7 },
+          ]}
+        >
+          <ArrowLeft size={24} color={neutral.foreground} />
+        </Pressable>
+        <Text style={[styles.title, { color: neutral.foreground, textAlign: "center" }]}>
+          No QR for this event
+        </Text>
+        <Text
+          style={[
+            styles.body,
+            { color: neutral.muted, textAlign: "center", marginHorizontal: SPACING.lg },
+          ]}
+        >
+          This event uses simple RSVP — attendees just confirm they’re coming, no QR check-in
+          needed.
         </Text>
       </View>
     );
@@ -299,6 +320,36 @@ export default function ScanCheckInScreen() {
           <Text style={styles.toastText}>{toast.text}</Text>
         </View>
       )}
+      {__DEV__ && eventId && mode === "self" ? (
+        <Pressable
+          onPress={async () => {
+            // Always exercise the self+geofence path — that's what's actually
+            // hard to reach on the sim (no camera). Independent of `mode`.
+            if (geofenceEnabled) {
+              showToast({ kind: "info", text: "Reading your location…" });
+              const locResult = await captureCurrentCoords();
+              if (!locResult.ok) {
+                await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+                showToast({
+                  kind: "error",
+                  text:
+                    locResult.reason === "denied"
+                      ? "Allow Location in Settings → TeamNetwork to check in."
+                      : locResult.message,
+                });
+                return;
+              }
+              await completeSelfCheckIn(locResult.coords);
+            } else {
+              await completeSelfCheckIn(null);
+            }
+          }}
+          style={({ pressed }) => [styles.simulateButton, pressed && { opacity: 0.7 }]}
+          accessibilityLabel="Dev: simulate successful self check-in"
+        >
+          <Text style={styles.simulateButtonText}>Dev: simulate scan (self)</Text>
+        </Pressable>
+      ) : null}
     </View>
   );
 }
@@ -325,6 +376,16 @@ const styles = StyleSheet.create({
     alignSelf: "flex-start",
   },
   backText: { ...TYPOGRAPHY.labelMedium, color: "#fff" },
+  simulateButton: {
+    position: "absolute",
+    bottom: 32,
+    alignSelf: "center",
+    backgroundColor: "rgba(37, 99, 235, 0.95)",
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.sm + 2,
+    borderRadius: 999,
+  },
+  simulateButtonText: { ...TYPOGRAPHY.labelMedium, color: "#fff" },
   toast: {
     position: "absolute",
     left: SPACING.md,

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/check-in.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/check-in.tsx
@@ -640,8 +640,8 @@ export default function CheckInScreen() {
           )}
         </View>
 
-        {/* Scan QR action */}
-        {eventId && (
+        {/* Scan QR action — only when event uses QR check-in mode */}
+        {eventId && (event?.check_in_mode ?? "rsvp") === "qr" && (
           <Pressable
             onPress={() => router.push(`/(app)/${orgSlug}/events/${eventId}/scan` as never)}
             style={({ pressed }) => [styles.scanButton, pressed && { opacity: 0.85 }]}

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/new.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/events/new.tsx
@@ -26,11 +26,12 @@ import { TYPOGRAPHY } from "@/lib/typography";
 import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
 import { useThemedStyles } from "@/hooks/useThemedStyles";
 import { formatDatePickerLabel, formatTimePickerLabel } from "@/lib/date-format";
-import { openVenueInMaps } from "@/lib/venue-maps";
+import { captureCurrentCoords } from "@/lib/event-location";
 
 type Audience = "members" | "alumni" | "both" | "specific";
 type Channel = "email" | "sms" | "both";
 type EventType = "general" | "philanthropy" | "game" | "meeting" | "social" | "fundraiser";
+type CheckInMode = "qr" | "rsvp";
 type PickerTarget = "start-date" | "start-time" | "end-date" | "end-time";
 
 type TargetUser = {
@@ -49,6 +50,11 @@ const CHANNEL_OPTIONS: { value: Channel; label: string }[] = [
   { value: "email", label: "Email" },
   { value: "sms", label: "SMS" },
   { value: "both", label: "Email + SMS" },
+];
+
+const CHECK_IN_MODE_OPTIONS: { value: CheckInMode; label: string }[] = [
+  { value: "rsvp", label: "Simple RSVP" },
+  { value: "qr", label: "QR check-in" },
 ];
 
 const EVENT_TYPE_OPTIONS: { value: EventType; label: string }[] = [
@@ -87,8 +93,13 @@ export default function NewEventScreen() {
   const [endTime, setEndTime] = useState<Date | null>(null);
   const [location, setLocation] = useState("");
   const [geofenceEnabled, setGeofenceEnabled] = useState(false);
+  const [latitude, setLatitude] = useState<number | null>(null);
+  const [longitude, setLongitude] = useState<number | null>(null);
+  const [radiusM, setRadiusM] = useState<number>(100);
+  const [capturingLocation, setCapturingLocation] = useState(false);
   const [eventType, setEventType] = useState<EventType>("general");
   const [audience, setAudience] = useState<Audience>("both");
+  const [checkInMode, setCheckInMode] = useState<CheckInMode>("rsvp");
   const [channel, setChannel] = useState<Channel>("email");
   const [sendNotification, setSendNotification] = useState(true);
   const [targetUserIds, setTargetUserIds] = useState<string[]>([]);
@@ -455,8 +466,8 @@ export default function NewEventScreen() {
       return;
     }
 
-    if (geofenceEnabled && !location.trim()) {
-      setError("Add a location so members can open it in Maps for check-in.");
+    if (checkInMode === "qr" && geofenceEnabled && (latitude == null || longitude == null)) {
+      setError("Tap \"Use my current location\" so members can be geofence-verified.");
       return;
     }
 
@@ -501,15 +512,16 @@ export default function NewEventScreen() {
           start_date: startDateTime,
           end_date: endDateTime,
           location: location.trim() || null,
-          geofence_enabled: geofenceEnabled,
-          geofence_radius_m: 100,
-          latitude: null,
-          longitude: null,
+          geofence_enabled: checkInMode === "qr" ? geofenceEnabled : false,
+          geofence_radius_m: radiusM,
+          latitude: checkInMode === "qr" && geofenceEnabled ? latitude : null,
+          longitude: checkInMode === "qr" && geofenceEnabled ? longitude : null,
           event_type: eventType,
           is_philanthropy: eventType === "philanthropy",
           audience: audienceValue,
           target_user_ids: targetIds,
           created_by_user_id: createdByUserId,
+          check_in_mode: checkInMode,
         })
         .select()
         .single();
@@ -742,40 +754,75 @@ export default function NewEventScreen() {
             />
           </View>
 
-          <View style={styles.fieldGroup}>
-            <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
-              <Text style={styles.fieldLabel}>Verify check-in at venue (geofence)</Text>
-              <Switch
-                value={geofenceEnabled}
-                onValueChange={setGeofenceEnabled}
-                trackColor={{ false: neutral.border, true: semantic.success }}
-              />
-            </View>
-          </View>
-          {geofenceEnabled ? (
-            <View style={styles.fieldGroup}>
-              <Text style={[styles.fieldLabel, { fontWeight: "400" as const, marginBottom: SPACING.sm }]}>
-                Members open this address in Apple Maps and confirm they’re at the venue before
-                self check-in.
-              </Text>
-              <Pressable
-                onPress={() => {
-                  if (!location.trim()) {
-                    Alert.alert("Location", "Enter a location first.");
-                    return;
-                  }
-                  void openVenueInMaps(location.trim());
-                }}
-                style={({ pressed }) => [
-                  styles.chipRow,
-                  { alignSelf: "flex-start", marginBottom: SPACING.sm },
-                  pressed && { opacity: 0.85 },
-                ]}
-              >
-                <Text style={[styles.fieldLabel, { fontSize: 14 }]}>Preview in Apple Maps</Text>
-              </Pressable>
-            </View>
-          ) : null}
+          {checkInMode === "qr" && (
+            <>
+              <View style={styles.fieldGroup}>
+                <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
+                  <Text style={styles.fieldLabel}>Verify check-in at venue (geofence)</Text>
+                  <Switch
+                    value={geofenceEnabled}
+                    onValueChange={setGeofenceEnabled}
+                    trackColor={{ false: neutral.border, true: semantic.success }}
+                  />
+                </View>
+              </View>
+              {geofenceEnabled ? (
+                <>
+                  <View style={styles.fieldGroup}>
+                    <Text style={[styles.fieldLabel, { fontWeight: "400" as const, marginBottom: SPACING.sm }]}>
+                      Stamp this event with your current GPS so members can only check in when they’re nearby.
+                    </Text>
+                    <Pressable
+                      onPress={async () => {
+                        setCapturingLocation(true);
+                        const result = await captureCurrentCoords();
+                        setCapturingLocation(false);
+                        if (result.ok) {
+                          setLatitude(result.coords.latitude);
+                          setLongitude(result.coords.longitude);
+                        } else {
+                          Alert.alert("Couldn't read location", result.message);
+                        }
+                      }}
+                      disabled={capturingLocation}
+                      style={({ pressed }) => [
+                        styles.chip,
+                        styles.chipSelected,
+                        { alignSelf: "flex-start", marginBottom: SPACING.sm, opacity: capturingLocation || pressed ? 0.7 : 1 },
+                      ]}
+                    >
+                      <Text style={[styles.chipText, styles.chipTextSelected]}>
+                        {capturingLocation
+                          ? "Reading GPS…"
+                          : latitude != null && longitude != null
+                            ? `Update location (captured ${latitude.toFixed(4)}, ${longitude.toFixed(4)})`
+                            : "Use my current location"}
+                      </Text>
+                    </Pressable>
+                  </View>
+                  <View style={styles.fieldGroup}>
+                    <Text style={styles.fieldLabel}>Allowed distance from venue</Text>
+                    <View style={styles.chipRow}>
+                      {[25, 50, 100, 250, 500].map((meters) => {
+                        const selected = radiusM === meters;
+                        return (
+                          <Pressable
+                            key={meters}
+                            onPress={() => setRadiusM(meters)}
+                            style={[styles.chip, selected && styles.chipSelected]}
+                          >
+                            <Text style={[styles.chipText, selected && styles.chipTextSelected]}>
+                              {meters} m
+                            </Text>
+                          </Pressable>
+                        );
+                      })}
+                    </View>
+                  </View>
+                </>
+              ) : null}
+            </>
+          )}
 
           <View style={styles.fieldGroup}>
             <Text style={styles.fieldLabel}>Event type</Text>
@@ -853,6 +900,26 @@ export default function NewEventScreen() {
               )}
             </View>
           )}
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.fieldLabel}>Check-in mode</Text>
+            <View style={styles.chipRow}>
+              {CHECK_IN_MODE_OPTIONS.map((option) => {
+                const selected = checkInMode === option.value;
+                return (
+                  <Pressable
+                    key={option.value}
+                    onPress={() => setCheckInMode(option.value)}
+                    style={[styles.chip, selected && styles.chipSelected]}
+                  >
+                    <Text style={[styles.chipText, selected && styles.chipTextSelected]}>
+                      {option.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
 
           <View style={styles.fieldGroup}>
             <Text style={styles.fieldLabel}>Notification channel</Text>

--- a/apps/mobile/app/(app)/(drawer)/_layout.tsx
+++ b/apps/mobile/app/(app)/(drawer)/_layout.tsx
@@ -47,6 +47,13 @@ export default function DrawerStackLayout() {
           }}
         />
         <Stack.Screen
+          name="join-organization"
+          options={{
+            headerShown: false,
+            presentation: "modal",
+          }}
+        />
+        <Stack.Screen
           name="profile"
           options={{
             headerShown: false,

--- a/apps/mobile/app/(app)/(drawer)/join-organization.tsx
+++ b/apps/mobile/app/(app)/(drawer)/join-organization.tsx
@@ -1,0 +1,474 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import {
+  redeemInviteWithFallback,
+  completeEnterpriseInviteRedemption,
+  type AvailableOrg,
+  type InviteFlow,
+  type RedeemResult,
+} from "@teammeet/core/invites";
+import { supabase } from "@/lib/supabase";
+import { SPACING, RADIUS } from "@/lib/design-tokens";
+import { TYPOGRAPHY } from "@/lib/typography";
+import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
+import { useThemedStyles } from "@/hooks/useThemedStyles";
+import { useOrganizations } from "@/hooks/useOrganizations";
+import { showToast } from "@/components/ui/Toast";
+
+const normalizeCode = (raw: string): string =>
+  raw.toUpperCase().replace(/[^A-Z0-9-]/g, "");
+
+export default function JoinOrganizationScreen() {
+  const router = useRouter();
+  const { neutral } = useAppColorScheme();
+  const { refetch: refetchOrganizations } = useOrganizations();
+  const params = useLocalSearchParams<{
+    token?: string;
+    code?: string;
+    invite?: string;
+  }>();
+  const tokenParam = typeof params.token === "string" ? params.token : undefined;
+  const codeParam = typeof params.code === "string" ? params.code : undefined;
+  const inviteTypeParam =
+    typeof params.invite === "string" ? params.invite : undefined;
+
+  const [code, setCode] = useState<string>(codeParam ? normalizeCode(codeParam) : "");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingApproval, setPendingApproval] = useState<{ orgName: string } | null>(
+    null,
+  );
+  const [chooseOrgState, setChooseOrgState] = useState<{
+    organizations: AvailableOrg[];
+    role: string;
+    inviteToken: string;
+  } | null>(null);
+
+  const autoRedeemRef = useRef(false);
+
+  const handleSuccess = useCallback(
+    async (result: RedeemResult) => {
+      try {
+        await refetchOrganizations();
+      } catch {
+        // best-effort — the user can still navigate manually
+      }
+      const slug = result.slug ?? result.organization_slug;
+      if (slug) {
+        showToast(`Joined ${result.name ?? "organization"}`, "success");
+        router.replace(`/(app)/(drawer)/${slug}/(tabs)` as never);
+      } else {
+        router.replace("/(app)/(drawer)" as never);
+      }
+    },
+    [refetchOrganizations, router],
+  );
+
+  const applyResult = useCallback(
+    async (result: RedeemResult) => {
+      if (
+        result.status === "choose_org" &&
+        result.organizations &&
+        result.invite_token
+      ) {
+        setChooseOrgState({
+          organizations: result.organizations,
+          role: result.role || "active_member",
+          inviteToken: result.invite_token,
+        });
+        return;
+      }
+
+      if (result.already_member) {
+        if (result.status === "pending") {
+          setPendingApproval({ orgName: result.name || "the organization" });
+        } else {
+          showToast("You're already a member of this organization.", "info");
+          await handleSuccess(result);
+        }
+        return;
+      }
+
+      if (result.pending_approval) {
+        setPendingApproval({ orgName: result.name || "the organization" });
+        return;
+      }
+
+      await handleSuccess(result);
+    },
+    [handleSuccess],
+  );
+
+  const redeem = useCallback(
+    async (codeOrToken: string, preferredFlow: InviteFlow = "org") => {
+      setIsLoading(true);
+      setError(null);
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) {
+        setError("You must be signed in to join an organization.");
+        setIsLoading(false);
+        return;
+      }
+
+      const { result, rpcError } = await redeemInviteWithFallback(
+        supabase,
+        codeOrToken,
+        preferredFlow,
+      );
+
+      if (rpcError) {
+        setError(rpcError);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!result?.success) {
+        setError(result?.error || "Failed to join organization.");
+        setIsLoading(false);
+        return;
+      }
+
+      await applyResult(result);
+      setIsLoading(false);
+    },
+    [applyResult],
+  );
+
+  useEffect(() => {
+    if (autoRedeemRef.current) return;
+    if (!tokenParam) return;
+    autoRedeemRef.current = true;
+    const preferred: InviteFlow =
+      inviteTypeParam === "enterprise" ? "enterprise" : "org";
+    void redeem(tokenParam, preferred);
+  }, [tokenParam, inviteTypeParam, redeem]);
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = code.trim();
+    if (!trimmed) {
+      setError("Invite code is required.");
+      return;
+    }
+    void redeem(trimmed, "org");
+  }, [code, redeem]);
+
+  const handleOrgSelected = useCallback(
+    async (orgId: string) => {
+      if (!chooseOrgState) return;
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (!uuidRegex.test(orgId)) {
+        setError("Invalid organization selection.");
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      const { result, rpcError } = await completeEnterpriseInviteRedemption(
+        supabase,
+        chooseOrgState.inviteToken,
+        orgId,
+      );
+
+      if (rpcError) {
+        setError(rpcError);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!result?.success) {
+        setError(result?.error || "Failed to join organization.");
+        setIsLoading(false);
+        return;
+      }
+
+      await handleSuccess(result);
+      setIsLoading(false);
+    },
+    [chooseOrgState, handleSuccess],
+  );
+
+  const handleCancel = useCallback(() => {
+    router.back();
+  }, [router]);
+
+  const styles = useThemedStyles((n, s) => ({
+    container: { flex: 1, backgroundColor: n.background },
+    sheetHeader: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      paddingHorizontal: SPACING.md,
+      paddingTop: SPACING.md,
+      paddingBottom: SPACING.sm,
+      minHeight: 48,
+      backgroundColor: n.surface,
+      borderBottomWidth: 1,
+      borderBottomColor: n.border,
+    },
+    headerSideButton: {
+      paddingVertical: SPACING.xs,
+      paddingRight: SPACING.sm,
+      minWidth: 56,
+    },
+    headerSideButtonText: { ...TYPOGRAPHY.bodyMedium, color: n.foreground },
+    headerTitle: {
+      ...TYPOGRAPHY.titleMedium,
+      color: n.foreground,
+      flex: 1,
+      textAlign: "center" as const,
+      fontWeight: "600" as const,
+    },
+    headerSpacer: { width: 56 },
+    contentSheet: { flex: 1, backgroundColor: n.surface },
+    scrollContent: {
+      padding: SPACING.md,
+      paddingBottom: SPACING.xxl,
+      gap: SPACING.lg,
+    },
+    heading: { ...TYPOGRAPHY.titleLarge, color: n.foreground },
+    subhead: {
+      ...TYPOGRAPHY.bodyMedium,
+      color: n.muted,
+      marginTop: SPACING.xs,
+    },
+    fieldLabel: { ...TYPOGRAPHY.labelMedium, color: n.secondary },
+    input: {
+      borderWidth: 1,
+      borderColor: n.border,
+      borderRadius: RADIUS.md,
+      paddingHorizontal: SPACING.md,
+      paddingVertical: SPACING.md,
+      fontSize: 22,
+      letterSpacing: 4,
+      fontVariant: ["tabular-nums"] as const,
+      textAlign: "center" as const,
+      color: n.foreground,
+      backgroundColor: n.surface,
+    },
+    errorCard: {
+      backgroundColor: s.errorLight,
+      borderRadius: RADIUS.md,
+      padding: SPACING.md,
+      borderWidth: 1,
+      borderColor: s.error,
+    },
+    errorText: { ...TYPOGRAPHY.bodySmall, color: s.error },
+    pendingCard: {
+      backgroundColor: s.warningLight,
+      borderRadius: RADIUS.md,
+      padding: SPACING.md,
+      borderWidth: 1,
+      borderColor: s.warning,
+      gap: SPACING.xs,
+    },
+    pendingTitle: {
+      ...TYPOGRAPHY.labelLarge,
+      color: s.warningDark,
+      fontWeight: "600" as const,
+    },
+    pendingBody: { ...TYPOGRAPHY.bodySmall, color: s.warningDark },
+    orgRow: {
+      borderWidth: 1,
+      borderColor: n.border,
+      borderRadius: RADIUS.md,
+      padding: SPACING.md,
+      backgroundColor: n.surface,
+      gap: 2,
+    },
+    orgName: { ...TYPOGRAPHY.labelLarge, color: n.foreground },
+    orgDescription: { ...TYPOGRAPHY.bodySmall, color: n.muted },
+    primaryButton: {
+      backgroundColor: s.success,
+      borderRadius: RADIUS.md,
+      paddingVertical: SPACING.md,
+      alignItems: "center" as const,
+    },
+    primaryButtonPressed: { opacity: 0.9 },
+    primaryButtonText: { ...TYPOGRAPHY.labelLarge, color: "#ffffff" },
+    secondaryButton: {
+      borderRadius: RADIUS.md,
+      paddingVertical: SPACING.md,
+      alignItems: "center" as const,
+      borderWidth: 1,
+      borderColor: n.border,
+      backgroundColor: n.surface,
+    },
+    secondaryButtonText: { ...TYPOGRAPHY.labelLarge, color: n.foreground },
+    buttonDisabled: { opacity: 0.6 },
+    helperText: { ...TYPOGRAPHY.labelSmall, color: n.muted },
+  }));
+
+  const renderBody = () => {
+    if (chooseOrgState) {
+      return (
+        <>
+          <View>
+            <Text style={styles.heading}>Choose an organization</Text>
+            <Text style={styles.subhead}>
+              Your invite gives access to multiple organizations. Pick one to
+              join.
+            </Text>
+          </View>
+          {error != null && (
+            <View style={styles.errorCard}>
+              <Text style={styles.errorText}>{error}</Text>
+            </View>
+          )}
+          <View style={{ gap: SPACING.sm }}>
+            {chooseOrgState.organizations.map((org) => (
+              <Pressable
+                key={org.id}
+                onPress={() => handleOrgSelected(org.id)}
+                disabled={isLoading}
+                style={({ pressed }) => [
+                  styles.orgRow,
+                  pressed && styles.primaryButtonPressed,
+                  isLoading && styles.buttonDisabled,
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={`Join ${org.name}`}
+              >
+                <Text style={styles.orgName}>{org.name}</Text>
+                {org.description ? (
+                  <Text style={styles.orgDescription}>{org.description}</Text>
+                ) : null}
+              </Pressable>
+            ))}
+          </View>
+        </>
+      );
+    }
+
+    if (pendingApproval) {
+      return (
+        <>
+          <View>
+            <Text style={styles.heading}>Request sent</Text>
+            <Text style={styles.subhead}>
+              Your request to join {pendingApproval.orgName} has been
+              submitted.
+            </Text>
+          </View>
+          <View style={styles.pendingCard}>
+            <Text style={styles.pendingTitle}>Awaiting admin approval</Text>
+            <Text style={styles.pendingBody}>
+              An admin will review your request. You&apos;ll get access once
+              approved.
+            </Text>
+          </View>
+          <Pressable
+            onPress={handleCancel}
+            style={({ pressed }) => [
+              styles.primaryButton,
+              pressed && styles.primaryButtonPressed,
+            ]}
+            accessibilityRole="button"
+          >
+            <Text style={styles.primaryButtonText}>Back to organizations</Text>
+          </Pressable>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <View>
+          <Text style={styles.heading}>Join an organization</Text>
+          <Text style={styles.subhead}>
+            Enter the invite code you received from an organization admin.
+          </Text>
+        </View>
+
+        {error != null && (
+          <View style={styles.errorCard}>
+            <Text style={styles.errorText}>{error}</Text>
+          </View>
+        )}
+
+        {tokenParam && isLoading ? (
+          <View style={{ alignItems: "center", padding: SPACING.lg }}>
+            <ActivityIndicator color={neutral.foreground} />
+            <Text style={[styles.helperText, { marginTop: SPACING.sm }]}>
+              Processing your invite link…
+            </Text>
+          </View>
+        ) : (
+          <>
+            <View style={{ gap: SPACING.xs }}>
+              <Text style={styles.fieldLabel}>Invite code</Text>
+              <TextInput
+                value={code}
+                onChangeText={(v) => setCode(normalizeCode(v))}
+                placeholder="ABCD1234"
+                placeholderTextColor={neutral.placeholder}
+                autoCapitalize="characters"
+                autoCorrect={false}
+                editable={!isLoading}
+                style={styles.input}
+                returnKeyType="go"
+                onSubmitEditing={handleSubmit}
+                accessibilityLabel="Invite code"
+              />
+            </View>
+
+            <Pressable
+              onPress={handleSubmit}
+              disabled={isLoading || code.trim().length === 0}
+              style={({ pressed }) => [
+                styles.primaryButton,
+                pressed && styles.primaryButtonPressed,
+                (isLoading || code.trim().length === 0) && styles.buttonDisabled,
+              ]}
+              accessibilityRole="button"
+            >
+              {isLoading ? (
+                <ActivityIndicator color="#ffffff" />
+              ) : (
+                <Text style={styles.primaryButtonText}>Join organization</Text>
+              )}
+            </Pressable>
+          </>
+        )}
+      </>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.sheetHeader}>
+        <Pressable
+          onPress={handleCancel}
+          style={styles.headerSideButton}
+          accessibilityRole="button"
+          accessibilityLabel="Cancel"
+        >
+          <Text style={styles.headerSideButtonText}>Cancel</Text>
+        </Pressable>
+        <Text style={styles.headerTitle}>Join Organization</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <View style={styles.contentSheet}>
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {renderBody()}
+        </ScrollView>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -13,6 +13,9 @@
       "developmentClient": true,
       "distribution": "internal",
       "environment": "development",
+      "env": {
+        "EXPO_PUBLIC_MOBILE_LIVE_ACTIVITIES_ENABLED": "true"
+      },
       "ios": {
         "simulator": true
       }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -67,6 +67,7 @@
     "expo-linear-gradient": "^15.0.8",
     "expo-linking": "~8.0.11",
     "expo-local-authentication": "^55.0.13",
+    "expo-location": "^55.1.9",
     "expo-modules-core": "~3.0.29",
     "expo-notifications": "^0.32.16",
     "expo-quick-actions": "^6.0.1",

--- a/apps/mobile/src/components/biometric/LockScreen.tsx
+++ b/apps/mobile/src/components/biometric/LockScreen.tsx
@@ -42,7 +42,7 @@ export function LockScreen({ onUnlock }: LockScreenProps) {
         <View style={styles.iconWrap}>
           <Lock size={28} color="#fff" />
         </View>
-        <Text style={styles.title}>TeamMeet locked</Text>
+        <Text style={styles.title}>TeamNetwork locked</Text>
         <Text style={styles.body}>
           {failures === 0
             ? "Use Face ID, Touch ID, or your device passcode to unlock."

--- a/apps/mobile/src/components/home/event-starting-soon-banner.tsx
+++ b/apps/mobile/src/components/home/event-starting-soon-banner.tsx
@@ -149,16 +149,19 @@ export function EventStartingSoonBanner({
           ) : null}
 
           <View style={styles.countsRow}>
-            <View style={styles.countItem}>
-              <Users size={14} color={neutral.muted} />
-              <Text style={styles.countText}>{attendingCount}</Text>
-              <Text style={styles.countLabel}>going</Text>
-            </View>
-            <View style={styles.countItem}>
-              <CheckCircle2 size={14} color={neutral.muted} />
-              <Text style={styles.countText}>{checkedInCount}</Text>
-              <Text style={styles.countLabel}>checked in</Text>
-            </View>
+            {isLive ? (
+              <View style={styles.countItem}>
+                <CheckCircle2 size={14} color={accent} />
+                <Text style={styles.countText}>{checkedInCount}</Text>
+                <Text style={styles.countLabel}>checked in of {attendingCount}</Text>
+              </View>
+            ) : (
+              <View style={styles.countItem}>
+                <Users size={14} color={neutral.muted} />
+                <Text style={styles.countText}>{attendingCount}</Text>
+                <Text style={styles.countLabel}>going</Text>
+              </View>
+            )}
           </View>
         </View>
       </Pressable>

--- a/apps/mobile/src/components/org-switcher/OrgSwitcherActions.tsx
+++ b/apps/mobile/src/components/org-switcher/OrgSwitcherActions.tsx
@@ -1,23 +1,14 @@
 import { View, Text, Pressable, StyleSheet } from "react-native";
-import * as WebBrowser from "expo-web-browser";
-import { ExternalLink, LogOut } from "lucide-react-native";
+import { LogOut } from "lucide-react-native";
 import { useRouter } from "expo-router";
 import { signOut } from "@/lib/supabase";
-import { getWebAppUrl } from "@/lib/web-api";
 import { NEUTRAL, SEMANTIC, SHADOWS, RADIUS, SPACING } from "@/lib/design-tokens";
 
 export function OrgSwitcherActions() {
   const router = useRouter();
 
-  const openInApp = (path: string) => {
-    void WebBrowser.openBrowserAsync(`${getWebAppUrl()}${path}`, {
-      presentationStyle: WebBrowser.WebBrowserPresentationStyle.PAGE_SHEET,
-      controlsColor: NEUTRAL.foreground,
-      dismissButtonStyle: "close",
-    });
-  };
-
-  const handleJoin = () => openInApp("/app/join");
+  const handleJoin = () =>
+    router.push("/(app)/(drawer)/join-organization" as never);
   const handleCreate = () => router.push("/(app)/(drawer)/create-org" as never);
 
   const handleSignOut = async () => {
@@ -38,11 +29,10 @@ export function OrgSwitcherActions() {
               styles.rowFirst,
               pressed && styles.rowPressed,
             ]}
-            accessibilityRole="link"
-            accessibilityLabel="Join another organization (opens web)"
+            accessibilityRole="button"
+            accessibilityLabel="Join another organization"
           >
             <Text style={styles.rowText}>Join another organization</Text>
-            <ExternalLink size={16} color={NEUTRAL.muted} />
           </Pressable>
 
           <View style={styles.divider} />

--- a/apps/mobile/src/components/settings/SettingsCalendarSection.tsx
+++ b/apps/mobile/src/components/settings/SettingsCalendarSection.tsx
@@ -90,7 +90,7 @@ export function SettingsCalendarSection({ orgId, orgName }: Props) {
         if (!calendarPermission.canAskAgain) {
           Alert.alert(
             "Calendar access needed",
-            "Open Settings to allow TeamMeet to add events to your calendar.",
+            "Open Settings to allow TeamNetwork to add events to your calendar.",
             [
               { text: "Cancel", style: "cancel" },
               {
@@ -126,7 +126,7 @@ export function SettingsCalendarSection({ orgId, orgName }: Props) {
       try {
         await syncEventToDevice({
           orgId,
-          orgName: orgName ?? "TeamMeet",
+          orgName: orgName ?? "TeamNetwork",
           event,
         });
         count += 1;
@@ -190,10 +190,10 @@ export function SettingsCalendarSection({ orgId, orgName }: Props) {
             <View style={{ flex: 1, paddingRight: 12 }}>
               <Text style={styles.rowLabel}>Sync this org&apos;s events</Text>
               <Text style={styles.hint}>
-                Adds upcoming events to a &quot;TeamMeet — {orgName ?? "Org"}&quot;
+                Adds upcoming events to a &quot;TeamNetwork — {orgName ?? "Org"}&quot;
                 calendar on your device. You can hide or delete that calendar
                 from your phone&apos;s Calendar settings without affecting the rest
-                of TeamMeet.
+                of TeamNetwork.
               </Text>
             </View>
             <Switch value={enabled} onValueChange={handleToggle} disabled={busy} />

--- a/apps/mobile/src/components/settings/SettingsSecuritySection.tsx
+++ b/apps/mobile/src/components/settings/SettingsSecuritySection.tsx
@@ -119,7 +119,7 @@ export function SettingsSecuritySection() {
               <Text style={styles.rowLabel}>Unlock with biometrics</Text>
               <Text style={styles.hint}>
                 {isEnrolled
-                  ? "Use Face ID, Touch ID, or your device passcode when you open or return to TeamMeet."
+                  ? "Use Face ID, Touch ID, or your device passcode when you open or return to TeamNetwork."
                   : "Set up Face ID, Touch ID, or a fingerprint in your device settings to enable this."}
               </Text>
             </View>

--- a/apps/mobile/src/contexts/AuthContext.tsx
+++ b/apps/mobile/src/contexts/AuthContext.tsx
@@ -88,8 +88,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
         };
         const timeoutId = setTimeout(() => settle(false), 30_000);
         Alert.alert(
-          "Remove TeamMeet calendars?",
-          `You have ${syncedOrgIds.length} TeamMeet calendar${
+          "Remove TeamNetwork calendars?",
+          `You have ${syncedOrgIds.length} TeamNetwork calendar${
             syncedOrgIds.length === 1 ? "" : "s"
           } on this device. Remove them when signing out?`,
           [

--- a/apps/mobile/src/contexts/BiometricLockContext.tsx
+++ b/apps/mobile/src/contexts/BiometricLockContext.tsx
@@ -125,7 +125,7 @@ export function BiometricLockProvider({ children }: PropsWithChildren) {
   const lock = useCallback(() => setIsLocked(true), []);
 
   const unlock = useCallback(async (): Promise<{ success: boolean }> => {
-    const result = await authenticate("Unlock TeamMeet");
+    const result = await authenticate("Unlock TeamNetwork");
     if (result.success) {
       setIsLocked(false);
       return { success: true };

--- a/apps/mobile/src/contexts/LiveActivityContext.tsx
+++ b/apps/mobile/src/contexts/LiveActivityContext.tsx
@@ -92,18 +92,38 @@ export function LiveActivityProvider({ children }: LiveActivityProviderProps) {
         const supported = await LiveActivityNative.isSupported();
         if (cancelled) return;
         if (!supported) {
+          if (__DEV__) {
+            console.warn(
+              "[LiveActivity] ActivityKit reports unsupported (iOS <16.1 or Live Activities disabled in Settings). No LA will start.",
+            );
+          }
           setEligible(false);
           return;
         }
         const res = await fetchWithAuth("/api/live-activity/eligibility");
         if (!res.ok) {
+          if (__DEV__) {
+            console.warn(
+              `[LiveActivity] eligibility endpoint returned ${res.status}. No LA will start. Check that the web app is running and APNs env vars are set.`,
+            );
+          }
           setEligible(false);
           return;
         }
-        const body = (await res.json()) as { enabled?: boolean };
+        const body = (await res.json()) as { enabled?: boolean; reason?: string };
+        if (__DEV__ && body.enabled !== true) {
+          console.warn(
+            `[LiveActivity] eligibility disabled by server (reason=${body.reason ?? "unknown"}). No LA will start.`,
+          );
+        }
         if (!cancelled) setEligible(body.enabled === true);
       } catch (err) {
         if (!cancelled) setEligible(false);
+        if (__DEV__) {
+          console.warn(
+            `[LiveActivity] eligibility check threw (${(err as Error).message}). Web dev server unreachable? No LA will start.`,
+          );
+        }
         sentry.captureException(err as Error, {
           context: "LiveActivityContext.eligibility",
         });
@@ -113,6 +133,27 @@ export function LiveActivityProvider({ children }: LiveActivityProviderProps) {
       cancelled = true;
     };
   }, [userId, platformOk, buildFlagOn]);
+
+  // Sign-out / kill-switch cleanup. When `userId` becomes null (or eligibility
+  // is revoked while activities are running) ActivityKit otherwise keeps the
+  // lockscreen card alive — exposing the previous session's event to the next
+  // person to wake the device. End every known activity immediately.
+  useEffect(() => {
+    if (userId) return;
+    const running = knownActivitiesRef.current;
+    if (running.size === 0) return;
+    void (async () => {
+      try {
+        await LiveActivityNative.endAll("immediate");
+      } catch (err) {
+        sentry.captureException(err as Error, {
+          context: "LiveActivityContext.endAll.signout",
+        });
+      }
+      running.clear();
+      setActivityIds({});
+    })();
+  }, [userId]);
 
   // Hydrate `knownActivitiesRef` with anything ActivityKit already has running
   // (e.g., from a prior session). Without this we'd request a duplicate LA

--- a/apps/mobile/src/contexts/OrgContext.tsx
+++ b/apps/mobile/src/contexts/OrgContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useMemo, ReactNode } from "react";
+import { createContext, useContext, useState, useEffect, useMemo, useRef, ReactNode } from "react";
 import { useGlobalSearchParams } from "expo-router";
 import { supabase } from "@/lib/supabase";
 import { setUserProperties, captureException } from "@/lib/analytics";
@@ -36,6 +36,29 @@ interface OrgContextValue {
 
 const OrgContext = createContext<OrgContextValue | null>(null);
 
+// Cold launch from a notification tap can race the Supabase session
+// rehydration in AsyncStorage. Wait up to `timeoutMs` for the first
+// non-null user emitted by onAuthStateChange or a follow-up getUser().
+export async function waitForAuthUser(timeoutMs: number) {
+  return new Promise<Awaited<ReturnType<typeof supabase.auth.getUser>>["data"]["user"]>((resolve) => {
+    let settled = false;
+    const finish = (user: Awaited<ReturnType<typeof supabase.auth.getUser>>["data"]["user"]) => {
+      if (settled) return;
+      settled = true;
+      subscription?.unsubscribe();
+      clearTimeout(timer);
+      resolve(user);
+    };
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) finish(session.user);
+    });
+    const timer = setTimeout(() => {
+      // Last-chance retry before giving up.
+      supabase.auth.getUser().then(({ data }) => finish(data?.user ?? null)).catch(() => finish(null));
+    }, timeoutMs);
+  });
+}
+
 export function OrgProvider({ children }: { children: ReactNode }) {
   const { orgSlug } = useGlobalSearchParams<{ orgSlug: string }>();
   const [orgId, setOrgId] = useState<string | null>(null);
@@ -49,8 +72,12 @@ export function OrgProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const runIdRef = useRef(0);
+
   useEffect(() => {
     let isMounted = true;
+    const runId = ++runIdRef.current;
+    const isStale = () => !isMounted || runIdRef.current !== runId;
 
     async function fetchOrgData() {
       if (!orgSlug) {
@@ -70,7 +97,7 @@ export function OrgProvider({ children }: { children: ReactNode }) {
           supabase.auth.getUser(),
         ]);
 
-        if (!isMounted) return;
+        if (isStale()) return;
 
         if (orgResult.error) {
           const nextStatus = orgResult.error.code === "PGRST116" ? "not_found" : "error";
@@ -79,7 +106,16 @@ export function OrgProvider({ children }: { children: ReactNode }) {
           return;
         }
 
-        const currentUser = userResult.data?.user;
+        // Cold-launch from a notification can land here before AsyncStorage
+        // has finished rehydrating the Supabase session. getUser() momentarily
+        // returns null; falling straight through to `unauthorized` would
+        // bounce the user out of their deep link. Wait briefly for the
+        // session to materialize before giving up.
+        let currentUser = userResult.data?.user ?? null;
+        if (!currentUser) {
+          currentUser = await waitForAuthUser(2000);
+          if (isStale()) return;
+        }
         if (!currentUser) {
           setStatus("unauthorized");
           return;
@@ -104,14 +140,10 @@ export function OrgProvider({ children }: { children: ReactNode }) {
             .maybeSingle(),
         ]);
 
-        if (!isMounted) return;
+        if (isStale()) return;
 
         if (roleResult.error) {
           throw roleResult.error;
-        }
-
-        if (subscriptionResult.error && subscriptionResult.error.code !== "PGRST116") {
-          throw subscriptionResult.error;
         }
 
         if (!roleResult.data?.role) {
@@ -119,7 +151,19 @@ export function OrgProvider({ children }: { children: ReactNode }) {
           return;
         }
 
-        const subscriptionData = subscriptionResult.data;
+        // Subscription metadata is informational (controls parents bucket
+        // visibility). A flaky RPC must not gate org access — fall back to
+        // disabled-parents and continue.
+        const subscriptionData =
+          subscriptionResult.error && subscriptionResult.error.code !== "PGRST116"
+            ? null
+            : subscriptionResult.data;
+        if (subscriptionResult.error && subscriptionResult.error.code !== "PGRST116") {
+          captureException(
+            new Error(subscriptionResult.error.message),
+            { context: "OrgContext.get_subscription_status", orgSlug },
+          );
+        }
         const parentsEnabled =
           subscriptionData?.status === "enterprise_managed" ||
           (subscriptionData?.parents_bucket != null && subscriptionData.parents_bucket !== "none");
@@ -133,7 +177,7 @@ export function OrgProvider({ children }: { children: ReactNode }) {
         setUserRole(normalizeRole(roleResult.data.role));
         setStatus("ready");
       } catch (err) {
-        if (isMounted) {
+        if (!isStale()) {
           const message = err instanceof Error ? err.message : String(err);
           captureException(
             err instanceof Error ? err : new Error(message),
@@ -143,7 +187,7 @@ export function OrgProvider({ children }: { children: ReactNode }) {
           setError(message);
         }
       } finally {
-        if (isMounted) {
+        if (!isStale()) {
           setIsLoading(false);
         }
       }

--- a/apps/mobile/src/contexts/PresenceContext.tsx
+++ b/apps/mobile/src/contexts/PresenceContext.tsx
@@ -45,6 +45,16 @@ export function PresenceProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    // Guard against stale channels left over from HMR / unclean teardown:
+    // supabase.channel(name) returns the cached instance if one already
+    // exists, and calling .on() on an already-subscribed channel throws.
+    const existing = supabase
+      .getChannels()
+      .find((c) => c.topic === `realtime:org-presence:${orgId}`);
+    if (existing) {
+      void supabase.removeChannel(existing);
+    }
+
     const channel = supabase.channel(`org-presence:${orgId}`, {
       config: { presence: { key: user.id } },
     });

--- a/apps/mobile/src/hooks/useEvents.ts
+++ b/apps/mobile/src/hooks/useEvents.ts
@@ -22,6 +22,7 @@ export interface Event {
   longitude?: number | null;
   geofence_radius_m?: number | null;
   geofence_enabled?: boolean | null;
+  check_in_mode?: "qr" | "rsvp" | null;
 }
 
 interface UseEventsOptions {

--- a/apps/mobile/src/hooks/usePushNotifications.ts
+++ b/apps/mobile/src/hooks/usePushNotifications.ts
@@ -14,6 +14,8 @@ import {
 import { captureException } from "@/lib/analytics";
 import { useBiometricLock } from "@/contexts/BiometricLockContext";
 
+const DEDUPE_TTL_MS = 60_000;
+
 interface UsePushNotificationsOptions {
   userId: string | null;
   enabled?: boolean;
@@ -33,7 +35,11 @@ export function usePushNotifications({
   const isRegisteredRef = useRef(false);
   const lastTokenRef = useRef<string | null>(null);
   const hasHandledColdLaunchRef = useRef(false);
-  const lastHandledNotificationIdRef = useRef<string | null>(null);
+  // Short-TTL dedupe: iOS can deliver the same response twice (cold-launch +
+  // listener for the same payload, or rapid double-taps). A lifetime-scoped
+  // ref silently swallowed legitimate re-taps after the user navigated away,
+  // so we expire entries after DEDUPE_TTL_MS.
+  const handledNotificationsRef = useRef<Map<string, number>>(new Map());
   const pendingRouteRef = useRef<string | null>(null);
 
   const { isLocked } = useBiometricLock();
@@ -47,8 +53,16 @@ export function usePushNotifications({
   handlerRef.current = (response: Notifications.NotificationResponse) => {
     try {
       const id = response.notification.request.identifier;
-      if (id && lastHandledNotificationIdRef.current === id) return;
-      lastHandledNotificationIdRef.current = id ?? null;
+      if (id) {
+        const now = Date.now();
+        // Sweep expired entries so the map can't grow unbounded.
+        for (const [key, ts] of handledNotificationsRef.current) {
+          if (now - ts > DEDUPE_TTL_MS) handledNotificationsRef.current.delete(key);
+        }
+        const seen = handledNotificationsRef.current.get(id);
+        if (seen && now - seen <= DEDUPE_TTL_MS) return;
+        handledNotificationsRef.current.set(id, now);
+      }
 
       const data = response.notification.request.content.data as unknown as NotificationData;
       const route = getNotificationRoute(data);

--- a/apps/mobile/src/hooks/useRsvp.ts
+++ b/apps/mobile/src/hooks/useRsvp.ts
@@ -44,13 +44,18 @@ export async function setEventRsvp(args: {
   status: RsvpStatus;
 }): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
+    // `track_on_lock_screen` intentionally omitted. The DB column defaults
+    // to true (migration 20261203000002), so new "attending" RSVPs opt in
+    // automatically. Updates preserve whatever the user set via the per-event
+    // toggle — clobbering it here would silently undo their opt-out the next
+    // time they re-tapped RSVP=Going.
     const { error } = await supabase.from("event_rsvps").upsert(
       {
         event_id: args.eventId,
         user_id: args.userId,
         organization_id: args.organizationId,
         status: args.status,
-      },
+      } as never,
       { onConflict: "event_id,user_id" },
     );
 
@@ -136,6 +141,12 @@ export function useRsvp(
   const initial = normalizeRsvpStatus(options?.initialStatus ?? null);
   const [status, setStatus] = useState<RsvpStatus | null>(initial);
   const [saving, setSaving] = useState(false);
+  // Stable handle on the latest status so `setRsvp` doesn't have to
+  // re-create on every status change (which would defeat consumer memoization).
+  const statusRef = useRef<RsvpStatus | null>(initial);
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -161,7 +172,7 @@ export function useRsvp(
         return { ok: false, error: "Already saving" };
       }
 
-      const previous = status;
+      const previous = statusRef.current;
       inFlightRef.current = true;
       if (isMountedRef.current) {
         setStatus(next);
@@ -184,7 +195,7 @@ export function useRsvp(
       if (isMountedRef.current) setSaving(false);
       return result;
     },
-    [eventId, organizationId, userId, status],
+    [eventId, organizationId, userId],
   );
 
   const promptRsvp = useCallback(() => {

--- a/apps/mobile/src/lib/deep-link.ts
+++ b/apps/mobile/src/lib/deep-link.ts
@@ -15,12 +15,10 @@
  */
 
 import type { Router } from "expo-router";
-import * as Linking from "expo-linking";
 import { supabase } from "@/lib/supabase";
 import { parseMobileAuthCallbackUrl } from "@/lib/auth-redirects";
 import { consumeMobileAuthHandoff } from "@/lib/mobile-auth";
 import { getNativeAppLinkRoute, sanitizeUrlForTelemetry } from "@/lib/url-safety";
-import { getWebAppUrl } from "@/lib/web-api";
 import { captureException } from "@/lib/analytics";
 
 export type ShortcutAction =
@@ -321,19 +319,10 @@ export async function routeIntent(
       return;
 
     case "join-org":
-      // Defer to the web join handler — it owns invite acceptance, captcha,
-      // sign-in/sign-up routing, and parent-vs-org logic. Universal Links
-      // bring users with the app installed back into native afterwards.
-      try {
-        await Linking.openURL(
-          `${getWebAppUrl()}/app/join?token=${encodeURIComponent(intent.token)}`
-        );
-      } catch (err) {
-        captureException(err as Error, {
-          context: "routeIntent.join-org",
-          ...sanitizeUrlForTelemetry(originalUrl),
-        });
-      }
+      router.push({
+        pathname: "/(app)/(drawer)/join-organization",
+        params: { token: intent.token },
+      } as never);
       return;
 
     case "event":

--- a/apps/mobile/src/lib/device-permissions.ts
+++ b/apps/mobile/src/lib/device-permissions.ts
@@ -54,25 +54,25 @@ export interface PermissionCopy {
 const COPY: Record<PermissionKind, PermissionCopy> = {
   notifications: {
     title: "Stay in the loop",
-    body: "TeamMeet sends pushes for new announcements, chat mentions, and event reminders. You can pick which categories in Settings later.",
+    body: "TeamNetwork sends pushes for new announcements, chat mentions, and event reminders. You can pick which categories in Settings later.",
     primaryCta: "Turn on notifications",
-    deniedHint: "Open Settings to enable notifications for TeamMeet.",
+    deniedHint: "Open Settings to enable notifications for TeamNetwork.",
   },
   camera: {
     title: "Scan to join or check in",
-    body: "Use the camera to scan a TeamMeet QR code — to join your organization or to check members in at events.",
+    body: "Use the camera to scan a TeamNetwork QR code — to join your organization or to check members in at events.",
     primaryCta: "Allow camera",
     deniedHint: "Camera access is off. Open Settings to enable it.",
   },
   calendar: {
     title: "Add events to your calendar",
-    body: "TeamMeet writes practices, games, and events into your device calendar so you see them alongside your other commitments.",
+    body: "TeamNetwork writes practices, games, and events into your device calendar so you see them alongside your other commitments.",
     primaryCta: "Allow calendar",
     deniedHint: "Calendar access is off. Open Settings to enable it.",
   },
   biometric: {
     title: "Faster sign-in",
-    body: "Use Face ID or Touch ID to unlock TeamMeet without typing your password each time.",
+    body: "Use Face ID or Touch ID to unlock TeamNetwork without typing your password each time.",
     primaryCta: "Enable biometrics",
     deniedHint: "Set up Face ID, Touch ID, or a fingerprint in your device settings to use this.",
   },

--- a/apps/mobile/src/lib/event-location.ts
+++ b/apps/mobile/src/lib/event-location.ts
@@ -1,0 +1,49 @@
+import * as Location from "expo-location";
+import * as sentry from "@/lib/analytics/sentry";
+
+export type Coords = { latitude: number; longitude: number };
+
+export type CaptureResult =
+  | { ok: true; coords: Coords }
+  | { ok: false; reason: "denied" | "services_off" | "timeout" | "error"; message: string };
+
+/**
+ * Request foreground location permission and read the device's current
+ * position. Used for two flows:
+ *   1. Event creation — the organizer stamps the event with their current
+ *      lat/lng so members can geofence-verify check-ins.
+ *   2. Self check-in — the user proves they're at the venue.
+ *
+ * Returns a discriminated union so callers can show specific UI per failure.
+ * Permission denial is NOT treated as an error to surface to Sentry — it's
+ * a user choice.
+ */
+export async function captureCurrentCoords(): Promise<CaptureResult> {
+  try {
+    const servicesOn = await Location.hasServicesEnabledAsync();
+    if (!servicesOn) {
+      return { ok: false, reason: "services_off", message: "Turn on Location Services in iOS Settings." };
+    }
+    const perm = await Location.requestForegroundPermissionsAsync();
+    if (perm.status !== "granted") {
+      return { ok: false, reason: "denied", message: "Location permission was denied." };
+    }
+    const position = await Location.getCurrentPositionAsync({
+      accuracy: Location.Accuracy.Balanced,
+    });
+    return {
+      ok: true,
+      coords: {
+        latitude: position.coords.latitude,
+        longitude: position.coords.longitude,
+      },
+    };
+  } catch (err) {
+    sentry.captureException(err as Error, { context: "captureCurrentCoords" });
+    return {
+      ok: false,
+      reason: "error",
+      message: (err as Error).message ?? "Couldn't read location.",
+    };
+  }
+}

--- a/apps/mobile/src/lib/native-calendar.ts
+++ b/apps/mobile/src/lib/native-calendar.ts
@@ -18,7 +18,11 @@ import * as Calendar from "expo-calendar";
 import { Platform } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-const CALENDAR_TITLE_PREFIX = "TeamMeet";
+const CALENDAR_TITLE_PREFIX = "TeamNetwork";
+// Pre-rename prefix kept solely so existing installs reuse their old calendar
+// instead of creating a duplicate. Safe to remove once we're confident no
+// devices have a "TeamMeet — Org" calendar lying around.
+const LEGACY_CALENDAR_TITLE_PREFIX = "TeamMeet";
 const STORAGE_KEY_PREFIX = "teammeet.calendar.v1";
 
 function calendarTitleForOrg(orgName: string): string {
@@ -64,7 +68,10 @@ export async function getOrCreateAppCalendar(
   // Find existing by title (handles app reinstall / cache miss).
   const all = await Calendar.getCalendarsAsync(Calendar.EntityTypes.EVENT);
   const wanted = calendarTitleForOrg(orgName);
-  const existing = all.find((c) => c.title === wanted && c.allowsModifications);
+  const legacy = `${LEGACY_CALENDAR_TITLE_PREFIX} — ${orgName}`;
+  const existing = all.find(
+    (c) => (c.title === wanted || c.title === legacy) && c.allowsModifications,
+  );
   if (existing) {
     await AsyncStorage.setItem(calendarIdStorageKey(orgId), existing.id);
     return existing.id;
@@ -88,9 +95,9 @@ export async function getOrCreateAppCalendar(
     sourceId: source?.id,
     source: source
       ? undefined
-      : { isLocalAccount: true, name: "TeamMeet", type: Calendar.SourceType.LOCAL },
+      : { isLocalAccount: true, name: "TeamNetwork", type: Calendar.SourceType.LOCAL },
     accessLevel: Calendar.CalendarAccessLevel.OWNER,
-    ownerAccount: "TeamMeet",
+    ownerAccount: "TeamNetwork",
   });
   await AsyncStorage.setItem(calendarIdStorageKey(orgId), id);
   return id;

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -244,9 +244,11 @@ export async function unregisterPushToken(tokenOverride?: string): Promise<void>
     // Ignore table-not-found errors silently
     if (error && !isTableNotFoundError(error)) {
       console.warn("Error unregistering push token:", error.message);
+      captureException(new Error(error.message), { context: "unregisterPushToken" });
     }
   } catch (error) {
     console.warn("Error unregistering push token:", error);
+    captureException(error as Error, { context: "unregisterPushToken" });
   }
 }
 
@@ -329,7 +331,11 @@ export async function setBadgeCount(count: number): Promise<void> {
  */
 export async function dismissDeliveredNotifications(): Promise<void> {
   if (Platform.OS === "web") return;
-  await Notifications.dismissAllNotificationsAsync();
+  try {
+    await Notifications.dismissAllNotificationsAsync();
+  } catch (error) {
+    captureException(error as Error, { context: "dismissDeliveredNotifications" });
+  }
 }
 
 /**

--- a/apps/mobile/src/lib/share.ts
+++ b/apps/mobile/src/lib/share.ts
@@ -39,7 +39,7 @@ export async function shareInvite(invite: Invite): Promise<ShareResult> {
   return shareSafely(
     {
       url,
-      message: `Join my organization on TeamMeet: ${url}`,
+      message: `Join my organization on TeamNetwork: ${url}`,
     },
     "invite"
   );

--- a/apps/mobile/targets/widget/EventLiveActivityWidget.swift
+++ b/apps/mobile/targets/widget/EventLiveActivityWidget.swift
@@ -223,7 +223,7 @@ private struct OpenInAppButton: View {
         Link(destination: URL(string: "teammeet://events/\(eventId)")!) {
             HStack(spacing: 6) {
                 Image(systemName: "arrow.up.forward.app")
-                Text("Open in TeamMeet")
+                Text("Open in TeamNetwork")
                     .fontWeight(.semibold)
             }
             .font(.footnote)

--- a/apps/mobile/targets/widget/Info.plist
+++ b/apps/mobile/targets/widget/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>CFBundleDisplayName</key>
+  <string>TeamNetwork</string>
   <key>NSExtension</key>
   <dict>
     <key>NSExtensionPointIdentifier</key>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,7 +54,7 @@
     "framer-motion": "^12.38.0",
     "googleapis": "^170.0.0",
     "lucide-react": "^0.474.0",
-    "next": "15.5.15",
+    "next": "15.5.18",
     "next-intl": "^4.11.0",
     "next-themes": "^0.4.6",
     "node-ical": "^0.26.0",

--- a/apps/web/src/app/[orgSlug]/calendar/events/[eventId]/edit/page.tsx
+++ b/apps/web/src/app/[orgSlug]/calendar/events/[eventId]/edit/page.tsx
@@ -58,6 +58,7 @@ export default function EditCalendarEventPage() {
       location: "",
       event_type: "general",
       is_philanthropy: false,
+      check_in_mode: "rsvp",
     },
   });
 
@@ -117,6 +118,7 @@ export default function EditCalendarEventPage() {
         location: e.location || "",
         event_type: e.event_type || "general",
         is_philanthropy: e.is_philanthropy || false,
+        check_in_mode: e.check_in_mode ?? "rsvp",
       });
       setIsFetching(false);
     };
@@ -173,6 +175,7 @@ export default function EditCalendarEventPage() {
         location: data.location || null,
         event_type: data.event_type,
         is_philanthropy: data.is_philanthropy || data.event_type === "philanthropy",
+        check_in_mode: data.check_in_mode,
       });
 
       if (updateError) {
@@ -224,6 +227,7 @@ export default function EditCalendarEventPage() {
         location: data.location || null,
         event_type: data.event_type,
         is_philanthropy: data.is_philanthropy || data.event_type === "philanthropy",
+        check_in_mode: data.check_in_mode,
         updated_at: new Date().toISOString(),
       })
       .eq("id", eventId)
@@ -355,6 +359,16 @@ export default function EditCalendarEventPage() {
             onChange={(e) => setValue("event_type", e.target.value as EventType)}
             error={errors.event_type?.message}
             options={EVENT_TYPE_OPTIONS.map((o) => ({ value: o.value, label: tEvents(o.value) }))}
+          />
+
+          <Select
+            label="Check-in mode"
+            error={errors.check_in_mode?.message}
+            options={[
+              { label: "Simple RSVP (no check-in)", value: "rsvp" },
+              { label: "QR code check-in", value: "qr" },
+            ]}
+            {...register("check_in_mode")}
           />
 
           <div className="flex items-center gap-3">

--- a/apps/web/src/app/[orgSlug]/calendar/events/[eventId]/page.tsx
+++ b/apps/web/src/app/[orgSlug]/calendar/events/[eventId]/page.tsx
@@ -147,6 +147,9 @@ export default async function CalendarEventDetailPage({ params, searchParams }: 
                 Recurring
               </Badge>
             )}
+            {event.check_in_mode === "qr" && (
+              <Badge variant="primary">QR check-in</Badge>
+            )}
           </div>
 
           <h2 className="text-2xl font-bold text-foreground mb-4">{event.title}</h2>

--- a/apps/web/src/app/[orgSlug]/calendar/events/new/page.tsx
+++ b/apps/web/src/app/[orgSlug]/calendar/events/new/page.tsx
@@ -66,6 +66,7 @@ export default function NewCalendarEventPage() {
       event_type: "general",
       is_philanthropy: false,
       audience: "both",
+      check_in_mode: "rsvp",
       send_notification: true,
       channel: "email",
       is_recurring: false,
@@ -252,6 +253,7 @@ export default function NewCalendarEventPage() {
         created_by_user_id: user?.id || null,
         audience: audienceValue,
         target_user_ids: targetIds,
+        check_in_mode: data.check_in_mode,
       }, rule);
 
       if (result.error) {
@@ -274,6 +276,7 @@ export default function NewCalendarEventPage() {
         created_by_user_id: user?.id || null,
         audience: audienceValue,
         target_user_ids: targetIds,
+        check_in_mode: data.check_in_mode,
       }).select().single();
 
       if (insertError) {
@@ -520,6 +523,16 @@ export default function NewCalendarEventPage() {
               </div>
             </div>
           )}
+
+          <Select
+            label="Check-in mode"
+            error={errors.check_in_mode?.message}
+            options={[
+              { label: "Simple RSVP (no check-in)", value: "rsvp" },
+              { label: "QR code check-in", value: "qr" },
+            ]}
+            {...register("check_in_mode")}
+          />
 
           <div className="space-y-3 rounded-xl border border-border p-4">
             <div className="flex items-center gap-3">

--- a/apps/web/src/lib/events/recurring-operations.ts
+++ b/apps/web/src/lib/events/recurring-operations.ts
@@ -5,6 +5,7 @@ import { expandRecurrence, type RecurrenceRule } from "./recurrence";
 type EventInsert = Database["public"]["Tables"]["events"]["Insert"];
 type EventUpdate = Database["public"]["Tables"]["events"]["Update"];
 type EventType = Database["public"]["Enums"]["event_type"];
+type CheckInMode = Database["public"]["Enums"]["event_check_in_mode"];
 
 interface BaseEventData {
   organization_id: string;
@@ -18,6 +19,7 @@ interface BaseEventData {
   audience?: string | null;
   target_user_ids?: string[] | null;
   created_by_user_id?: string | null;
+  check_in_mode?: CheckInMode;
 }
 
 /**
@@ -50,6 +52,7 @@ export async function createRecurringEvents(
     audience: baseEvent.audience ?? null,
     target_user_ids: baseEvent.target_user_ids ?? null,
     created_by_user_id: baseEvent.created_by_user_id ?? null,
+    check_in_mode: baseEvent.check_in_mode ?? "rsvp",
     recurrence_group_id: groupId,
     recurrence_index: inst.recurrence_index,
     recurrence_rule: inst.recurrence_index === 0 ? (rule as unknown as Database["public"]["Tables"]["events"]["Insert"]["recurrence_rule"]) : null,
@@ -76,7 +79,7 @@ export async function updateFutureEvents(
   supabase: SupabaseClient<Database>,
   eventId: string,
   orgId: string,
-  updates: Pick<EventUpdate, "title" | "description" | "location" | "event_type" | "is_philanthropy">,
+  updates: Pick<EventUpdate, "title" | "description" | "location" | "event_type" | "is_philanthropy" | "check_in_mode">,
 ): Promise<{ updatedIds: string[]; error: string | null }> {
   // First, get the event to find its group and index
   const { data: event, error: fetchError } = await supabase

--- a/apps/web/src/lib/schemas/content.ts
+++ b/apps/web/src/lib/schemas/content.ts
@@ -106,6 +106,9 @@ export const recurrenceRuleSchema = z.discriminatedUnion("occurrence_type", [
 ]);
 export type RecurrenceRuleForm = z.infer<typeof recurrenceRuleSchema>;
 
+export const checkInModeSchema = z.enum(["qr", "rsvp"]);
+export type CheckInMode = z.infer<typeof checkInModeSchema>;
+
 export const editScopeSchema = z.enum(["this_only", "this_and_future"]);
 export type EditScope = z.infer<typeof editScopeSchema>;
 
@@ -125,6 +128,7 @@ export const newEventSchema = z
     event_type: eventTypeSchema,
     is_philanthropy: z.boolean(),
     audience: audienceSchema,
+    check_in_mode: checkInModeSchema,
     send_notification: z.boolean(),
     channel: channelSchema,
     is_recurring: z.boolean(),
@@ -170,6 +174,7 @@ export const editEventSchema = z
     location: optionalSafeString(500),
     event_type: eventTypeSchema,
     is_philanthropy: z.boolean(),
+    check_in_mode: checkInModeSchema,
   })
   .refine(
     (data) => {

--- a/apps/web/src/types/database.ts
+++ b/apps/web/src/types/database.ts
@@ -2648,6 +2648,7 @@ export type Database = {
       events: {
         Row: {
           audience: string | null
+          check_in_mode: Database["public"]["Enums"]["event_check_in_mode"]
           created_at: string | null
           created_by_user_id: string | null
           deleted_at: string | null
@@ -2672,6 +2673,7 @@ export type Database = {
         }
         Insert: {
           audience?: string | null
+          check_in_mode?: Database["public"]["Enums"]["event_check_in_mode"]
           created_at?: string | null
           created_by_user_id?: string | null
           deleted_at?: string | null
@@ -2696,6 +2698,7 @@ export type Database = {
         }
         Update: {
           audience?: string | null
+          check_in_mode?: Database["public"]["Enums"]["event_check_in_mode"]
           created_at?: string | null
           created_by_user_id?: string | null
           deleted_at?: string | null
@@ -7481,6 +7484,7 @@ export type Database = {
         | "search_action_click"
       chat_group_role: "admin" | "moderator" | "member"
       chat_message_status: "pending" | "approved" | "rejected"
+      event_check_in_mode: "qr" | "rsvp"
       event_type:
         | "general"
         | "philanthropy"
@@ -7660,6 +7664,7 @@ export const Constants = {
       ],
       chat_group_role: ["admin", "moderator", "member"],
       chat_message_status: ["pending", "approved", "rejected"],
+      event_check_in_mode: ["qr", "rsvp"],
       event_type: [
         "general",
         "philanthropy",

--- a/apps/web/tests/events/recurrence-schema.test.ts
+++ b/apps/web/tests/events/recurrence-schema.test.ts
@@ -87,6 +87,7 @@ describe("newEventSchema recurrence validation", () => {
     event_type: "general",
     is_philanthropy: false,
     audience: "both",
+    check_in_mode: "rsvp",
     send_notification: true,
     channel: "email",
     is_recurring: false,

--- a/apps/web/tests/redeem-invite.test.ts
+++ b/apps/web/tests/redeem-invite.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  redeemInviteWithFallback,
+  completeEnterpriseInviteRedemption,
+} from "@teammeet/core/invites";
+import { createSupabaseStub } from "./utils/supabaseStub";
+
+type Stub = ReturnType<typeof createSupabaseStub>;
+
+function setupAllInvalid(stub: Stub) {
+  stub.registerRpc("redeem_enterprise_invite", () => ({
+    success: false,
+    error: "Invalid invite",
+  }));
+  stub.registerRpc("redeem_parent_invite", () => ({
+    success: false,
+    error: "Invalid invite",
+  }));
+  stub.registerRpc("redeem_org_invite", () => ({
+    success: false,
+    error: "Invalid invite",
+  }));
+}
+
+describe("redeemInviteWithFallback", () => {
+  let stub: Stub;
+  beforeEach(() => {
+    stub = createSupabaseStub();
+  });
+
+  it("returns the org-flow result when the org RPC succeeds first", async () => {
+    let orgCalls = 0;
+    let parentCalls = 0;
+    let enterpriseCalls = 0;
+    stub.registerRpc("redeem_org_invite", (params) => {
+      orgCalls++;
+      assert.deepEqual(params, { p_code: "ABCD1234" });
+      return {
+        success: true,
+        organization_id: "org-1",
+        slug: "stanford-crew",
+        name: "Stanford Crew",
+        role: "active_member",
+      };
+    });
+    stub.registerRpc("redeem_parent_invite", () => {
+      parentCalls++;
+      return { success: false };
+    });
+    stub.registerRpc("redeem_enterprise_invite", () => {
+      enterpriseCalls++;
+      return { success: false };
+    });
+
+    const { result, rpcError } = await redeemInviteWithFallback(
+      stub as never,
+      "ABCD1234",
+    );
+
+    assert.equal(rpcError, null);
+    assert.equal(result?.success, true);
+    assert.equal(result?.slug, "stanford-crew");
+    assert.equal(orgCalls, 1);
+    assert.equal(parentCalls, 0, "should not fall through after success");
+    assert.equal(enterpriseCalls, 0);
+  });
+
+  it("falls through org → parent → enterprise when each returns success:false", async () => {
+    const calls: string[] = [];
+    stub.registerRpc("redeem_org_invite", () => {
+      calls.push("org");
+      return { success: false, error: "not org" };
+    });
+    stub.registerRpc("redeem_parent_invite", () => {
+      calls.push("parent");
+      return { success: false, error: "not parent" };
+    });
+    stub.registerRpc("redeem_enterprise_invite", (params) => {
+      calls.push("enterprise");
+      assert.deepEqual(params, { p_code_or_token: "TOKEN-ABC" });
+      return {
+        success: true,
+        organization_id: "ent-1",
+        organization_slug: "ent-slug",
+        organization_name: "Ent Org",
+      };
+    });
+
+    const { result, rpcError } = await redeemInviteWithFallback(
+      stub as never,
+      "TOKEN-ABC",
+    );
+
+    assert.equal(rpcError, null);
+    assert.equal(result?.success, true);
+    assert.deepEqual(calls, ["org", "parent", "enterprise"]);
+    // Normalized fields populate from organization_slug/name aliases.
+    assert.equal(result?.slug, "ent-slug");
+    assert.equal(result?.name, "Ent Org");
+  });
+
+  it("starts with enterprise when preferredFlow is enterprise", async () => {
+    const calls: string[] = [];
+    stub.registerRpc("redeem_enterprise_invite", () => {
+      calls.push("enterprise");
+      return {
+        success: true,
+        slug: "ent-org",
+        name: "Ent Org",
+      };
+    });
+    stub.registerRpc("redeem_org_invite", () => {
+      calls.push("org");
+      return { success: false };
+    });
+
+    const { result } = await redeemInviteWithFallback(
+      stub as never,
+      "TOK",
+      "enterprise",
+    );
+
+    assert.equal(result?.success, true);
+    assert.deepEqual(calls, ["enterprise"]);
+  });
+
+  it("returns choose_org status with available organizations for enterprise invites", async () => {
+    stub.registerRpc("redeem_enterprise_invite", () => ({
+      success: true,
+      status: "choose_org",
+      role: "active_member",
+      invite_token: "tok-xyz",
+      organizations: [
+        { id: "org-a", name: "Org A", slug: "org-a", description: null },
+        { id: "org-b", name: "Org B", slug: "org-b", description: "desc" },
+      ],
+    }));
+
+    const { result } = await redeemInviteWithFallback(
+      stub as never,
+      "CODE",
+      "enterprise",
+    );
+
+    assert.equal(result?.success, true);
+    assert.equal(result?.status, "choose_org");
+    assert.equal(result?.organizations?.length, 2);
+    assert.equal(result?.invite_token, "tok-xyz");
+  });
+
+  it("surfaces the last unsuccessful result when no flow returns success", async () => {
+    setupAllInvalid(stub);
+
+    const { result, rpcError } = await redeemInviteWithFallback(
+      stub as never,
+      "BAD-CODE",
+    );
+
+    // When all flows return success:false, the last non-error result is returned
+    // so the caller can show the specific error from the RPC.
+    assert.equal(rpcError, null);
+    assert.equal(result?.success, false);
+    assert.equal(result?.error, "Invalid invite");
+  });
+
+  it("returns generic rpcError when every flow throws transport errors", async () => {
+    stub.registerRpc("redeem_org_invite", () => {
+      throw new Error("transport-fail-org");
+    });
+    stub.registerRpc("redeem_parent_invite", () => {
+      throw new Error("transport-fail-parent");
+    });
+    stub.registerRpc("redeem_enterprise_invite", () => {
+      throw new Error("transport-fail-enterprise");
+    });
+
+    const { result, rpcError } = await redeemInviteWithFallback(
+      stub as never,
+      "BAD",
+    );
+
+    assert.equal(result, null);
+    // Last RPC error message is bubbled up
+    assert.equal(rpcError, "transport-fail-enterprise");
+  });
+
+  it("trims whitespace from the invite code before calling RPCs", async () => {
+    let captured: unknown;
+    stub.registerRpc("redeem_org_invite", (params) => {
+      captured = params;
+      return { success: true, slug: "x", name: "X" };
+    });
+
+    await redeemInviteWithFallback(stub as never, "  ABCD1234  ");
+
+    assert.deepEqual(captured, { p_code: "ABCD1234" });
+  });
+});
+
+describe("completeEnterpriseInviteRedemption", () => {
+  it("calls complete_enterprise_invite_redemption with token + org id", async () => {
+    const stub = createSupabaseStub();
+    let captured: unknown;
+    stub.registerRpc("complete_enterprise_invite_redemption", (params) => {
+      captured = params;
+      return {
+        success: true,
+        organization_slug: "chosen-org",
+        organization_name: "Chosen Org",
+      };
+    });
+
+    const { result, rpcError } = await completeEnterpriseInviteRedemption(
+      stub as never,
+      "tok-xyz",
+      "11111111-1111-1111-1111-111111111111",
+    );
+
+    assert.equal(rpcError, null);
+    assert.equal(result?.success, true);
+    // Slug normalizes from organization_slug alias.
+    assert.equal(result?.slug, "chosen-org");
+    assert.deepEqual(captured, {
+      p_token: "tok-xyz",
+      p_organization_id: "11111111-1111-1111-1111-111111111111",
+    });
+  });
+
+  it("returns rpcError when the RPC errors", async () => {
+    const stub = createSupabaseStub();
+    stub.registerRpc("complete_enterprise_invite_redemption", () => {
+      throw new Error("invite expired");
+    });
+
+    const { result, rpcError } = await completeEnterpriseInviteRedemption(
+      stub as never,
+      "tok",
+      "22222222-2222-2222-2222-222222222222",
+    );
+
+    assert.equal(result, null);
+    assert.equal(rpcError, "invite expired");
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "expo-linear-gradient": "^15.0.8",
         "expo-linking": "~8.0.11",
         "expo-local-authentication": "^55.0.13",
+        "expo-location": "^55.1.9",
         "expo-modules-core": "~3.0.29",
         "expo-notifications": "^0.32.16",
         "expo-quick-actions": "^6.0.1",
@@ -1661,6 +1662,8 @@
     "expo-linking": ["expo-linking@8.0.12", "", { "dependencies": { "expo-constants": "~18.0.13", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ=="],
 
     "expo-local-authentication": ["expo-local-authentication@55.0.13", "", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "expo": "*" } }, "sha512-7m1+Roub/6xxjHtVKe0vVtsC5g0MXp1Nf0dxK0YfJ1i5314hvi/Glhl5/2loAgnplw8Nx4UVbf6L0/rDjhljsQ=="],
+
+    "expo-location": ["expo-location@55.1.9", "", { "dependencies": { "@expo/image-utils": "^0.8.13" }, "peerDependencies": { "expo": "*" } }, "sha512-PIH9/qeyhtGh190FyIJNZYHXZOoi42SbVHY9IoTMBmqWLHf1BJyGhPpFlaLBSCjxObqfVZmrWsN5dtjueSwYQA=="],
 
     "expo-manifests": ["expo-manifests@1.0.11", "", { "dependencies": { "@expo/config": "~12.0.13", "expo-json-utils": "~0.15.0" }, "peerDependencies": { "expo": "*" } }, "sha512-6zItytTewN37Cjhp3glUg0ozrgW2GwB8x9wtfzUNoJIMmxO38nnGdTLMaotYhRqdf5PP2Dzdmej1HDHXVNUpRw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -119,7 +119,7 @@
         "framer-motion": "^12.38.0",
         "googleapis": "^170.0.0",
         "lucide-react": "^0.474.0",
-        "next": "15.5.15",
+        "next": "15.5.18",
         "next-intl": "^4.11.0",
         "next-themes": "^0.4.6",
         "node-ical": "^0.26.0",
@@ -669,25 +669,25 @@
 
     "@next/bundle-analyzer": ["@next/bundle-analyzer@15.5.15", "", { "dependencies": { "webpack-bundle-analyzer": "4.10.1" } }, "sha512-Y9XFxAGfk7E9Se1WYmmZWhznfWFVugsroZy+gD7qv8vZmHSIlI0izLESz3yRXJ8FPTuDSdIqP1Azw1u88gDx5g=="],
 
-    "@next/env": ["@next/env@15.5.15", "", {}, "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg=="],
+    "@next/env": ["@next/env@15.5.18", "", {}, "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@15.5.15", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-ExQoBfyKMjAUQ2nuF39ryQsG26H374ZfH13dlOZqf6TaE9ycRbIm+qUbUFCliU4BtQhiqtS7cnGA1yWfPMQ+jA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.15", "", { "os": "linux", "cpu": "x64" }, "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.18", "", { "os": "linux", "cpu": "x64" }, "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.15", "", { "os": "linux", "cpu": "x64" }, "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.18", "", { "os": "linux", "cpu": "x64" }, "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.15", "", { "os": "win32", "cpu": "x64" }, "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.18", "", { "os": "win32", "cpu": "x64" }, "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -2355,7 +2355,7 @@
 
     "nested-error-stacks": ["nested-error-stacks@2.0.1", "", {}, "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A=="],
 
-    "next": ["next@15.5.15", "", { "dependencies": { "@next/env": "15.5.15", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.15", "@next/swc-darwin-x64": "15.5.15", "@next/swc-linux-arm64-gnu": "15.5.15", "@next/swc-linux-arm64-musl": "15.5.15", "@next/swc-linux-x64-gnu": "15.5.15", "@next/swc-linux-x64-musl": "15.5.15", "@next/swc-win32-arm64-msvc": "15.5.15", "@next/swc-win32-x64-msvc": "15.5.15", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ=="],
+    "next": ["next@15.5.18", "", { "dependencies": { "@next/env": "15.5.18", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.18", "@next/swc-darwin-x64": "15.5.18", "@next/swc-linux-arm64-gnu": "15.5.18", "@next/swc-linux-arm64-musl": "15.5.18", "@next/swc-linux-x64-gnu": "15.5.18", "@next/swc-linux-x64-musl": "15.5.18", "@next/swc-win32-arm64-msvc": "15.5.18", "@next/swc-win32-x64-msvc": "15.5.18", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ=="],
 
     "next-intl": ["next-intl@4.11.0", "", { "dependencies": { "@formatjs/intl-localematcher": "^0.8.1", "@parcel/watcher": "^2.4.1", "@swc/core": "^1.15.2", "icu-minify": "^4.11.0", "negotiator": "^1.0.0", "next-intl-swc-plugin-extractor": "^4.11.0", "po-parser": "^2.1.1", "use-intl": "^4.11.0" }, "peerDependencies": { "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0" } }, "sha512-Chp8rgEVUYOX/bCtYy+PXH6lDX3X+GPT9sR9HScHroL283em/4urP9btfdHEMEHJJXdq2W/5wDaDDtWONPdNSA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,8 @@
     "./announcements": "./src/announcements/index.ts",
     "./formatters": "./src/formatters/index.ts",
     "./apns": "./src/apns/index.ts",
-    "./calendar": "./src/calendar/event-status.ts"
+    "./calendar": "./src/calendar/event-status.ts",
+    "./invites": "./src/invites/index.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/core/src/invites/index.ts
+++ b/packages/core/src/invites/index.ts
@@ -2,9 +2,9 @@ export {
   redeemInviteWithFallback,
   completeEnterpriseInviteRedemption,
   normalizeRedeemResult,
-} from "@teammeet/core/invites";
+} from "./redeemInvite";
 export type {
   AvailableOrg,
   RedeemResult,
   InviteFlow,
-} from "@teammeet/core/invites";
+} from "./redeemInvite";

--- a/packages/core/src/invites/redeemInvite.ts
+++ b/packages/core/src/invites/redeemInvite.ts
@@ -1,0 +1,139 @@
+export interface AvailableOrg {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+}
+
+export interface RedeemResult {
+  success: boolean;
+  error?: string;
+  organization_id?: string;
+  slug?: string;
+  name?: string;
+  organization_slug?: string;
+  organization_name?: string;
+  role?: string;
+  already_member?: boolean;
+  pending_approval?: boolean;
+  status?: string;
+  organizations?: AvailableOrg[];
+  invite_token?: string;
+}
+
+export type InviteFlow = "org" | "parent" | "enterprise";
+
+interface RpcCapableClient {
+  rpc(
+    fn: string,
+    args: Record<string, unknown>,
+  ): PromiseLike<{ data: unknown; error: { message: string } | null }>;
+}
+
+export function normalizeRedeemResult(data: unknown): RedeemResult {
+  const result = (data ?? {}) as RedeemResult;
+  return {
+    ...result,
+    slug: result.slug ?? result.organization_slug,
+    name: result.name ?? result.organization_name,
+  };
+}
+
+export async function redeemInviteWithFallback<T extends RpcCapableClient>(
+  supabase: T,
+  codeOrToken: string,
+  preferredFlow: InviteFlow = "org",
+): Promise<{ result: RedeemResult | null; rpcError: string | null }> {
+  const trimmedCode = codeOrToken.trim();
+  const flows: InviteFlow[] = preferredFlow === "enterprise"
+    ? ["enterprise", "org", "parent"]
+    : ["org", "parent", "enterprise"];
+
+  let lastResult: RedeemResult | null = null;
+  let lastRpcError: string | null = null;
+
+  for (const flow of flows) {
+    if (flow === "enterprise") {
+      const { data, error } = await supabase.rpc("redeem_enterprise_invite", {
+        p_code_or_token: trimmedCode,
+      });
+
+      if (error) {
+        lastRpcError = error.message;
+        continue;
+      }
+
+      const normalized = normalizeRedeemResult(data);
+      lastResult = normalized;
+      if (normalized.success) {
+        return { result: normalized, rpcError: null };
+      }
+      continue;
+    }
+
+    if (flow === "parent") {
+      const { data, error } = await supabase.rpc("redeem_parent_invite", {
+        p_code: trimmedCode,
+      });
+
+      if (error) {
+        lastRpcError = error.message;
+        continue;
+      }
+
+      const normalized = normalizeRedeemResult(data);
+      lastResult = normalized;
+      if (normalized.success) {
+        return { result: normalized, rpcError: null };
+      }
+      continue;
+    }
+
+    const { data, error } = await supabase.rpc("redeem_org_invite", {
+      p_code: trimmedCode,
+    });
+
+    if (error) {
+      lastRpcError = error.message;
+      continue;
+    }
+
+    const normalized = normalizeRedeemResult(data);
+    lastResult = normalized;
+    if (normalized.success) {
+      return { result: normalized, rpcError: null };
+    }
+  }
+
+  if (lastResult) {
+    return { result: lastResult, rpcError: null };
+  }
+
+  return {
+    result: null,
+    rpcError:
+      lastRpcError || "Invalid invite code. Please check the code and try again.",
+  };
+}
+
+export async function completeEnterpriseInviteRedemption<
+  T extends RpcCapableClient,
+>(
+  supabase: T,
+  inviteToken: string,
+  organizationId: string,
+): Promise<{ result: RedeemResult | null; rpcError: string | null }> {
+  const { data, error } = await supabase.rpc(
+    "complete_enterprise_invite_redemption",
+    {
+      p_token: inviteToken,
+      p_organization_id: organizationId,
+    },
+  );
+
+  if (error) {
+    return { result: null, rpcError: error.message };
+  }
+
+  return { result: normalizeRedeemResult(data), rpcError: null };
+}

--- a/packages/types/src/database.ts
+++ b/packages/types/src/database.ts
@@ -2648,6 +2648,7 @@ export type Database = {
       events: {
         Row: {
           audience: string | null
+          check_in_mode: Database["public"]["Enums"]["event_check_in_mode"]
           created_at: string | null
           created_by_user_id: string | null
           deleted_at: string | null
@@ -2672,6 +2673,7 @@ export type Database = {
         }
         Insert: {
           audience?: string | null
+          check_in_mode?: Database["public"]["Enums"]["event_check_in_mode"]
           created_at?: string | null
           created_by_user_id?: string | null
           deleted_at?: string | null
@@ -2696,6 +2698,7 @@ export type Database = {
         }
         Update: {
           audience?: string | null
+          check_in_mode?: Database["public"]["Enums"]["event_check_in_mode"]
           created_at?: string | null
           created_by_user_id?: string | null
           deleted_at?: string | null
@@ -7387,6 +7390,7 @@ export type Database = {
         | "search_action_click"
       chat_group_role: "admin" | "moderator" | "member"
       chat_message_status: "pending" | "approved" | "rejected"
+      event_check_in_mode: "qr" | "rsvp"
       event_type:
         | "general"
         | "philanthropy"
@@ -7566,6 +7570,7 @@ export const Constants = {
       ],
       chat_group_role: ["admin", "moderator", "member"],
       chat_message_status: ["pending", "approved", "rejected"],
+      event_check_in_mode: ["qr", "rsvp"],
       event_type: [
         "general",
         "philanthropy",

--- a/scripts/magic-link.sh
+++ b/scripts/magic-link.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+set -a; source .env.local; set +a
+curl -s -X POST "$NEXT_PUBLIC_SUPABASE_URL/auth/v1/admin/generate_link" \
+  -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+  -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"type\":\"magiclink\",\"email\":\"$E2E_ADMIN_EMAIL\"}" \
+  | python3 -c '
+import sys, json, urllib.parse
+d = json.load(sys.stdin)
+props = d.get("properties", d)
+h = props.get("hashed_token") or d.get("hashed_token")
+if not h:
+    print("NO_TOKEN:", json.dumps(d))
+    sys.exit(1)
+qs = urllib.parse.urlencode({
+    "token_hash": h,
+    "type": "magiclink",
+    "next": "/upenn-sprint-football",
+})
+print(f"http://localhost:3001/auth/confirm?{qs}")
+'

--- a/scripts/mobile-handoff.mjs
+++ b/scripts/mobile-handoff.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Mints a mobile-handoff code for the E2E admin user.
+//
+// Flow:
+//   1. admin/generate_link  -> get an email OTP for the user.
+//   2. POST /auth/v1/verify with the OTP -> exchange for access/refresh tokens
+//      (no captcha, no redirect dance).
+//   3. encryptMobileHandoffToken on each token.
+//   4. INSERT into public.mobile_auth_handoffs via service-role REST.
+//   5. Print the unhashed `code`.
+//
+// The mobile app's deep-link handler consumes the code via
+// teammeet://callback?handoff_code=<code> and lands a session.
+
+import crypto from "node:crypto";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const email = process.env.E2E_ADMIN_EMAIL;
+const handoffKey = process.env.AUTH_HANDOFF_ENCRYPTION_KEY;
+
+for (const [name, value] of Object.entries({
+  NEXT_PUBLIC_SUPABASE_URL: url,
+  SUPABASE_SERVICE_ROLE_KEY: serviceKey,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: anonKey,
+  E2E_ADMIN_EMAIL: email,
+  AUTH_HANDOFF_ENCRYPTION_KEY: handoffKey,
+})) {
+  if (!value) {
+    console.error("Missing env:", name);
+    process.exit(1);
+  }
+}
+
+// 1) admin/generate_link -> OTP
+let r = await fetch(`${url}/auth/v1/admin/generate_link`, {
+  method: "POST",
+  headers: {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({ type: "magiclink", email }),
+});
+let d = await r.json();
+if (!r.ok || !d.email_otp) {
+  console.error("generate_link failed:", JSON.stringify(d));
+  process.exit(1);
+}
+const otp = d.email_otp;
+
+// 2) Verify OTP -> tokens
+r = await fetch(`${url}/auth/v1/verify`, {
+  method: "POST",
+  headers: { apikey: anonKey, "Content-Type": "application/json" },
+  body: JSON.stringify({ type: "magiclink", email, token: otp }),
+});
+d = await r.json();
+if (!r.ok || !d.access_token || !d.refresh_token) {
+  console.error("verify failed:", JSON.stringify(d));
+  process.exit(1);
+}
+const accessToken = d.access_token;
+const refreshToken = d.refresh_token;
+
+// 3) Encrypt tokens. Format matches apps/web/src/lib/crypto/token-encryption.ts:
+//   key: 64 hex chars (32 bytes), AES-256-GCM, 12-byte IV
+//   output: "<iv-base64>:<authTag-base64>:<ciphertext-base64>"
+function encryptToken(plain, hexKey) {
+  if (!/^[0-9a-fA-F]{64}$/.test(hexKey)) {
+    throw new Error("AUTH_HANDOFF_ENCRYPTION_KEY must be 64 hex chars (32 bytes)");
+  }
+  const key = Buffer.from(hexKey, "hex");
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  let ct = cipher.update(plain, "utf8", "base64");
+  ct += cipher.final("base64");
+  const tag = cipher.getAuthTag();
+  return `${iv.toString("base64")}:${tag.toString("base64")}:${ct}`;
+}
+
+const encryptedAccess = encryptToken(accessToken, handoffKey);
+const encryptedRefresh = encryptToken(refreshToken, handoffKey);
+
+// 4) Insert handoff row
+const handoffCode = crypto.randomBytes(32).toString("base64url");
+const codeHash = crypto.createHash("sha256").update(handoffCode, "utf8").digest("hex");
+const userId = d.user?.id;
+if (!userId) {
+  console.error("No user.id in verify response");
+  process.exit(1);
+}
+
+r = await fetch(`${url}/rest/v1/mobile_auth_handoffs`, {
+  method: "POST",
+  headers: {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    "Content-Type": "application/json",
+    Prefer: "return=minimal",
+  },
+  body: JSON.stringify({
+    code_hash: codeHash,
+    user_id: userId,
+    encrypted_access_token: encryptedAccess,
+    encrypted_refresh_token: encryptedRefresh,
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+  }),
+});
+if (!r.ok) {
+  const text = await r.text();
+  console.error("insert handoff failed:", r.status, text);
+  process.exit(1);
+}
+
+// 5) Print just the deep-link URL so the launcher script can `openurl` it.
+console.log(`teammeet://callback?handoff_code=${handoffCode}`);

--- a/scripts/mobile-magic-link.sh
+++ b/scripts/mobile-magic-link.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+set -a; source .env.local; set +a
+curl -s -X POST "$NEXT_PUBLIC_SUPABASE_URL/auth/v1/admin/generate_link" \
+  -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+  -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"type\":\"magiclink\",\"email\":\"$E2E_ADMIN_EMAIL\",\"options\":{\"redirect_to\":\"teammeet://callback\"}}" \
+  | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+print(json.dumps(d, indent=2))
+'

--- a/supabase/migrations/20260512163634_self_check_in_event_haversine_geofence.sql
+++ b/supabase/migrations/20260512163634_self_check_in_event_haversine_geofence.sql
@@ -1,0 +1,112 @@
+-- Replace self_check_in_event so geofence enforcement uses real GPS distance
+-- (Haversine) instead of trusting a boolean "I'm at the venue" from the client.
+-- The mobile app captures the user's GPS via expo-location and passes p_lat/p_lng;
+-- p_venue_confirmed is kept for backward compatibility with older clients but is
+-- only honored when both coords are null (i.e. clients that pre-date GPS capture).
+
+create or replace function public.self_check_in_event(
+  p_event_id uuid,
+  p_lat double precision default null,
+  p_lng double precision default null,
+  p_venue_confirmed boolean default false
+) returns jsonb
+language plpgsql
+security definer
+set search_path = 'public'
+as $function$
+declare
+  v_uid uuid := auth.uid();
+  v_event record;
+  v_distance_m double precision;
+begin
+  if v_uid is null then
+    return jsonb_build_object('success', false, 'error', 'Not authenticated');
+  end if;
+
+  select
+    e.id, e.organization_id, e.geofence_enabled, e.geofence_radius_m,
+    e.latitude, e.longitude, e.location as ev_location, e.check_in_mode
+  into v_event
+  from public.events e
+  where e.id = p_event_id and e.deleted_at is null;
+
+  if not found then
+    return jsonb_build_object('success', false, 'error', 'Event not found');
+  end if;
+
+  if not public.has_active_role(
+    v_event.organization_id,
+    array['admin', 'active_member', 'alumni', 'parent']::text[]
+  ) then
+    return jsonb_build_object('success', false, 'error', 'Not a member of this organization');
+  end if;
+
+  if v_event.check_in_mode is not null and v_event.check_in_mode <> 'qr' then
+    return jsonb_build_object('success', false, 'error', 'This event does not use QR check-in.');
+  end if;
+
+  if coalesce(v_event.geofence_enabled, false) then
+    -- Modern client: validate against real GPS via Haversine.
+    if p_lat is not null and p_lng is not null then
+      if v_event.latitude is null or v_event.longitude is null then
+        return jsonb_build_object(
+          'success', false,
+          'error', 'This event is missing a venue location.'
+        );
+      end if;
+
+      v_distance_m := 6371000.0 * 2.0 * asin(sqrt(
+        sin(radians((p_lat - v_event.latitude) / 2.0)) ^ 2 +
+        cos(radians(v_event.latitude)) * cos(radians(p_lat)) *
+        sin(radians((p_lng - v_event.longitude) / 2.0)) ^ 2
+      ));
+
+      if v_distance_m > coalesce(v_event.geofence_radius_m, 100) then
+        return jsonb_build_object(
+          'success', false,
+          'error', format(
+            'You''re %s m from the venue. You must be within %s m.',
+            round(v_distance_m)::text,
+            coalesce(v_event.geofence_radius_m, 100)::text
+          ),
+          'distance_m', round(v_distance_m)
+        );
+      end if;
+    else
+      -- Legacy client (pre-GPS) only sends p_venue_confirmed. Require a non-empty
+      -- venue string AND the confirmation flag, exactly like the old behavior.
+      if length(trim(coalesce(v_event.ev_location, ''))) < 1 then
+        return jsonb_build_object(
+          'success', false,
+          'error', 'This event needs a location before self check-in with venue verification.'
+        );
+      end if;
+      if not coalesce(p_venue_confirmed, false) then
+        return jsonb_build_object(
+          'success', false,
+          'error', 'Open the venue in Apple Maps, then confirm you''re there before checking in.'
+        );
+      end if;
+    end if;
+  end if;
+
+  perform set_config('app.allow_self_event_check_in', '1', true);
+
+  -- Preserve the original arrival timestamp on repeat calls. We only set
+  -- checked_in_at / checked_in_by when the row hasn't been checked in yet,
+  -- so the audit trail reflects first-arrival, not the latest tap.
+  insert into public.event_rsvps (event_id, user_id, organization_id, status, checked_in_at, checked_in_by)
+  values (p_event_id, v_uid, v_event.organization_id, 'attending', now(), v_uid)
+  on conflict (event_id, user_id) do update set
+    status = 'attending',
+    checked_in_at = coalesce(public.event_rsvps.checked_in_at, excluded.checked_in_at),
+    checked_in_by = coalesce(public.event_rsvps.checked_in_by, excluded.checked_in_by),
+    updated_at = now();
+
+  perform set_config('app.allow_self_event_check_in', '0', true);
+  return jsonb_build_object('success', true);
+exception when others then
+  perform set_config('app.allow_self_event_check_in', '0', true);
+  raise;
+end;
+$function$;

--- a/supabase/migrations/20261204000000_events_check_in_mode.sql
+++ b/supabase/migrations/20261204000000_events_check_in_mode.sql
@@ -1,0 +1,13 @@
+-- Add a per-event check-in mode so creators can choose between QR-based
+-- check-in and a simple RSVP confirmation.
+--
+-- 'qr'   = scan-to-check-in flow (existing behavior)
+-- 'rsvp' = RSVP buttons only, no check-in step
+
+create type public.event_check_in_mode as enum ('qr', 'rsvp');
+
+alter table public.events
+  add column check_in_mode public.event_check_in_mode not null default 'rsvp';
+
+-- Existing events were all created under the QR-check-in flow; preserve that.
+update public.events set check_in_mode = 'qr';


### PR DESCRIPTION
## Summary

- **Native in-app Join Organization flow (mobile)** — replaces the WebBrowser handoff to a localhost link with a native screen that calls the same Supabase redeem RPCs the web `/app/join` page uses. Mirrors all states (form, choose-org picker for enterprise invites, pending-approval, already-member, success). Captcha intentionally skipped (RPCs are not server-enforced; mobile is session-authenticated).
- **Per-event check-in mode (RSVP vs QR) + geofence** — already on this branch (commit `6b604c7b`).
- **E2E tooling** — adds magic-link helper scripts and Playwright MCP server config.

## What changed in this PR

| Commit | What |
|---|---|
| `6b604c7b` | feat(events): per-event check-in mode (RSVP vs QR) + geofence + review fixes |
| `f085da38` | feat(mobile): native in-app Join Organization flow |
| `1df11aa4` | chore: add E2E auth helper scripts and Playwright MCP server |

## Shared code

The join logic moved to `@teammeet/core/invites` and is now consumed by both `apps/web` (re-export shim, no behavior change) and `apps/mobile`. Wire shape matches the existing RPCs (`redeem_org_invite`, `redeem_parent_invite`, `redeem_enterprise_invite`, `complete_enterprise_invite_redemption`).

## Test plan

- [x] Mobile Jest: 442/442 passing (incl. new join-org `routeIntent` test)
- [x] Web unit suites: `redeem-invite.test.ts` (9), `parent-invite` (12), `parents-invite` (44), `parent-invite-migrations-regressions` (2), `enterprise-invite-redemption` (11) — all green
- [x] `bun run typecheck` clean (pre-existing `.next/types/validator.ts` route-config noise unrelated)
- [x] `bun run lint` clean
- [x] Live RPC sigs verified against project `rytsziwekhtjdqzzpdso`
- [x] Manual: invalid code → inline error; valid code path → confirmed working
- [ ] Manual: deep link with bad token surfaces form for retry (after spinner-gate fix)
- [ ] Manual: deep link with valid code auto-redeems