### PR TITLE
chore(mobile): bump iOS buildNumber to 22 for TestFlight

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -27,7 +27,7 @@
       "supportsTablet": true,
       "appleTeamId": "5GWLTFG43T",
       "bundleIdentifier": "com.myteamnetwork.teammeet",
-      "buildNumber": "11",
+      "buildNumber": "22",
       "deploymentTarget": "17.0",
       "usesAppleSignIn": true,
       "associatedDomains": [


### PR DESCRIPTION
## Summary

- Bumps `apps/mobile/app.json` iOS `buildNumber` from `11` → `22` so the next EAS production iOS build can be submitted to TestFlight / ASC without a duplicate-build-number rejection.

## Test plan

- [ ] CI green (no code change, just metadata)
- [ ] Next `bun run eas:ios:production` consumes the new buildNumber