### PR TITLE
refactor(ai): trim unused formatter re-exports, name structured-job thresholds

### DIFF
--- a/apps/web/src/app/api/ai/[orgId]/chat/handler/formatters/index.ts
+++ b/apps/web/src/app/api/ai/[orgId]/chat/handler/formatters/index.ts
@@ -72,49 +72,7 @@ export {
   hasPendingConnectionDisambiguation,
   looksLikeConnectionDisambiguationReply,
 } from "./connections";
-export {
-  formatSuggestMentorsResponse,
-  formatDonationAnalyticsResponse,
-  formatListAvailableMentorsResponse,
-  formatAnnouncementsResponse,
-  formatEventsResponse,
-  formatDiscussionsResponse,
-  formatJobPostingsResponse,
-  formatOrgStatsResponse,
-  formatMembersResponse,
-  formatAlumniResponse,
-  formatEnterpriseAlumniResponse,
-  formatEnterpriseStatsResponse,
-  formatEnterpriseQuotaResponse,
-  formatEnterpriseOrgCapacityResponse,
-  formatManagedOrgsResponse,
-  formatAuditEventsResponse,
-  formatDonationsResponse,
-  formatParentsResponse,
-  formatPhilanthropyEventsResponse,
-  formatChatGroupsResponse,
-  formatNavigationTargetsResponse,
-  formatSearchOrgContentResponse,
-  type DonationResponseOptions,
-  type FormatterOptions,
-} from "./reads";
-export {
-  formatPrepareJobPostingResponse,
-  formatPrepareAnnouncementResponse,
-  formatPrepareEnterpriseInviteResponse,
-  formatRevokeEnterpriseInviteResponse,
-  formatPrepareDiscussionThreadResponse,
-  formatPrepareDiscussionReplyResponse,
-  formatPrepareChatMessageResponse,
-  formatPrepareMemberRoleChangeResponse,
-  formatPrepareGroupMessageResponse,
-  formatPrepareEventResponse,
-  formatPrepareEventsBatchResponse,
-  formatPrepareUpdateAnnouncementResponse,
-  formatPrepareDeleteAnnouncementResponse,
-  formatRevisedPendingEventResponse,
-} from "./prepares";
-export { formatExtractScheduleFileResponse } from "./schedules";
+export { formatRevisedPendingEventResponse } from "./prepares";
 
 export function formatDeterministicToolErrorResponse(
   name: string,

--- a/apps/web/src/app/api/ai/[orgId]/chat/handler/pass1-tools.ts
+++ b/apps/web/src/app/api/ai/[orgId]/chat/handler/pass1-tools.ts
@@ -273,6 +273,12 @@ export function deriveForcedPass1ToolArgs(
   return undefined;
 }
 
+// Treat a prompt as a structured job draft only when it has job context and
+// enough field markers + length that it is clearly a paste-in, not a casual
+// "post a job" mention. Tuned to avoid false positives on short prompts.
+const MIN_STRUCTURED_JOB_FIELD_HITS = 2;
+const MIN_STRUCTURED_JOB_LENGTH = 80;
+
 export function looksLikeStructuredJobDraft(message: string): boolean {
   const hasJobContext =
     /\b(job|job posting|opening|role|position|hiring|apply|application)\b/i.test(message);
@@ -286,7 +292,11 @@ export function looksLikeStructuredJobDraft(message: string): boolean {
     /https?:\/\//i,
   ].filter((pattern) => pattern.test(message)).length;
 
-  return hasJobContext && structuredFieldMatches >= 2 && message.trim().length >= 80;
+  return (
+    hasJobContext &&
+    structuredFieldMatches >= MIN_STRUCTURED_JOB_FIELD_HITS &&
+    message.trim().length >= MIN_STRUCTURED_JOB_LENGTH
+  );
 }
 
 // Multi-event intent: "create 3 events", "schedule multiple events", numbered


### PR DESCRIPTION
## Summary
- Drop 43 dead re-exports from `apps/web/src/app/api/ai/[orgId]/chat/handler/formatters/index.ts` (no external consumers; tests import directly from leaf files). Kept `formatRevisedPendingEventResponse` — used by `run-pending-event-revision` stage.
- Promote magic numbers `2` / `80` in `looksLikeStructuredJobDraft` to named module constants (`MIN_STRUCTURED_JOB_FIELD_HITS`, `MIN_STRUCTURED_JOB_LENGTH`) with a rationale comment.

## Test plan
- [x] `bun run --cwd apps/web typecheck` clean
- [x] `bun run --cwd apps/web lint` clean
- [x] `bun run --cwd apps/web test` — 5613 tests, 0 failures