### PR TITLE
feat(mobile): philanthropy form polish + DM from member profiles

### DIFF
--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/members/[memberId].tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/members/[memberId].tsx
@@ -4,13 +4,16 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
 import { Image } from "expo-image";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { ChevronLeft, Mail, Share as ShareIcon, Linkedin } from "lucide-react-native";
+import { ChevronLeft, Mail, MessageCircle, Share as ShareIcon, Linkedin } from "lucide-react-native";
 import { supabase } from "@/lib/supabase";
 import { useOrg } from "@/contexts/OrgContext";
+import { useAuth } from "@/hooks/useAuth";
 import { APP_CHROME } from "@/lib/chrome";
 import { SPACING, RADIUS } from "@/lib/design-tokens";
 import { TYPOGRAPHY } from "@/lib/typography";
 import { openEmailAddress, openHttpsUrl } from "@/lib/url-safety";
+import { ensureMobileDirectChatGroup } from "@/lib/chat-helpers";
+import { showToast } from "@/components/ui/Toast";
 
 const DETAIL_COLORS = {
   background: "#ffffff",
@@ -34,15 +37,18 @@ interface Member {
   graduation_year: number | null;
   role: string | null;
   linkedin_url: string | null;
+  user_id: string | null;
 }
 
 export default function MemberProfileScreen() {
   const { memberId } = useLocalSearchParams<{ memberId: string }>();
-  const { orgId } = useOrg();
+  const { orgId, orgSlug } = useOrg();
+  const { user } = useAuth();
   const router = useRouter();
   const styles = useMemo(() => createStyles(), []);
   const [member, setMember] = useState<Member | null>(null);
   const [loading, setLoading] = useState(true);
+  const [openingChat, setOpeningChat] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -53,7 +59,7 @@ export default function MemberProfileScreen() {
         setLoading(true);
         const { data, error: memberError } = await supabase
           .from("members")
-          .select("id, first_name, last_name, email, photo_url, graduation_year, role, linkedin_url")
+          .select("id, first_name, last_name, email, photo_url, graduation_year, role, linkedin_url, user_id")
           .eq("id", memberId)
           .eq("organization_id", orgId)
           .is("deleted_at", null)
@@ -86,6 +92,34 @@ export default function MemberProfileScreen() {
   const handleLinkedIn = () => {
     if (member?.linkedin_url) {
       void openHttpsUrl(member.linkedin_url);
+    }
+  };
+
+  const handleMessage = async () => {
+    if (!member || !orgId || !orgSlug || !user?.id || openingChat) return;
+
+    if (!member.user_id) {
+      showToast("This member hasn't linked an app account yet.", "info");
+      return;
+    }
+
+    setOpeningChat(true);
+    try {
+      const result = await ensureMobileDirectChatGroup(supabase, {
+        organizationId: orgId,
+        currentUserId: user.id,
+        recipientUserId: member.user_id,
+        recipientDisplayName: getDisplayName(),
+      });
+
+      if (!result.ok) {
+        showToast(result.error, "error");
+        return;
+      }
+
+      router.push(`/(app)/${orgSlug}/chat/${result.chatGroupId}`);
+    } finally {
+      setOpeningChat(false);
     }
   };
 
@@ -166,6 +200,28 @@ export default function MemberProfileScreen() {
           <Text style={styles.role}>{getRoleLabel(member.role)}</Text>
           {member.graduation_year && (
             <Text style={styles.year}>Class of {member.graduation_year}</Text>
+          )}
+
+          {member.user_id && member.user_id !== user?.id && (
+            <Pressable
+              style={({ pressed }) => [
+                styles.messageButton,
+                (pressed || openingChat) && { opacity: 0.75 },
+              ]}
+              onPress={handleMessage}
+              disabled={openingChat}
+              accessibilityRole="button"
+              accessibilityLabel={`Message ${getDisplayName()}`}
+            >
+              {openingChat ? (
+                <ActivityIndicator size="small" color="#ffffff" />
+              ) : (
+                <MessageCircle size={20} color="#ffffff" />
+              )}
+              <Text style={styles.messageButtonText}>
+                {openingChat ? "Opening..." : "Message"}
+              </Text>
+            </Pressable>
           )}
         </View>
 
@@ -285,6 +341,23 @@ const createStyles = () =>
       ...TYPOGRAPHY.bodySmall,
       color: DETAIL_COLORS.secondaryText,
       marginTop: 2,
+    },
+    messageButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: SPACING.sm,
+      marginTop: SPACING.md,
+      paddingVertical: SPACING.sm,
+      paddingHorizontal: SPACING.lg,
+      borderRadius: RADIUS.lg,
+      backgroundColor: DETAIL_COLORS.success,
+      minWidth: 160,
+    },
+    messageButtonText: {
+      ...TYPOGRAPHY.labelLarge,
+      color: "#ffffff",
+      fontWeight: "600",
     },
     contactSection: {
       backgroundColor: DETAIL_COLORS.card,

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/philanthropy/new.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/philanthropy/new.tsx
@@ -4,19 +4,24 @@ import {
   Platform,
   Pressable,
   ScrollView,
-  StyleSheet,
   Text,
   TextInput,
   View,
 } from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { Stack, useRouter } from "expo-router";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { LinearGradient } from "expo-linear-gradient";
+import { ChevronLeft } from "lucide-react-native";
 import { useOrg } from "@/contexts/OrgContext";
 import { useOrgRole } from "@/hooks/useOrgRole";
-import { useOrgTheme } from "@/hooks/useOrgTheme";
 import { supabase } from "@/lib/supabase";
-import { borderRadius, fontSize, fontWeight, spacing, type ThemeColors } from "@/lib/theme";
+import { SPACING, RADIUS } from "@/lib/design-tokens";
+import { TYPOGRAPHY } from "@/lib/typography";
+import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
+import { useThemedStyles } from "@/hooks/useThemedStyles";
 import { formatDatePickerLabel, formatTimePickerLabel } from "@/lib/date-format";
+import { APP_CHROME } from "@/lib/chrome";
 
 type PickerTarget = "start-date" | "start-time" | "end-date" | "end-time";
 
@@ -38,8 +43,145 @@ export default function NewPhilanthropyEventScreen() {
   const router = useRouter();
   const { orgId, orgSlug } = useOrg();
   const { isAdmin, isActiveMember, isLoading: roleLoading } = useOrgRole();
-  const { colors } = useOrgTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const { neutral, semantic } = useAppColorScheme();
+  const styles = useThemedStyles((n, s) => ({
+    container: {
+      flex: 1,
+      backgroundColor: n.background,
+    },
+    headerGradient: {
+      paddingBottom: SPACING.xs,
+    },
+    headerSafeArea: {},
+    navHeader: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      paddingHorizontal: SPACING.md,
+      paddingTop: SPACING.xs,
+      minHeight: 40,
+      gap: SPACING.sm,
+    },
+    backButton: {
+      padding: SPACING.xs,
+      marginLeft: -SPACING.xs,
+    },
+    navTitle: {
+      ...TYPOGRAPHY.titleLarge,
+      color: APP_CHROME.headerTitle,
+      flex: 1,
+    },
+    scrollContent: {
+      padding: SPACING.md,
+      paddingBottom: SPACING.xl,
+      gap: SPACING.lg,
+    },
+    header: {
+      gap: SPACING.xs,
+    },
+    headerTitle: {
+      ...TYPOGRAPHY.headlineLarge,
+      color: n.foreground,
+    },
+    headerSubtitle: {
+      ...TYPOGRAPHY.bodyMedium,
+      color: n.secondary,
+    },
+    errorCard: {
+      backgroundColor: s.errorLight,
+      borderRadius: RADIUS.md,
+      padding: SPACING.md,
+      borderWidth: 1,
+      borderColor: s.error,
+    },
+    errorText: {
+      ...TYPOGRAPHY.bodySmall,
+      color: s.error,
+    },
+    loadingState: {
+      alignItems: "center" as const,
+      gap: SPACING.sm,
+    },
+    loadingText: {
+      ...TYPOGRAPHY.bodySmall,
+      color: n.secondary,
+    },
+    fieldGroup: {
+      gap: SPACING.xs,
+    },
+    fieldLabel: {
+      ...TYPOGRAPHY.labelMedium,
+      color: n.secondary,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: n.border,
+      borderRadius: RADIUS.md,
+      paddingHorizontal: SPACING.md,
+      paddingVertical: SPACING.sm,
+      ...TYPOGRAPHY.bodyMedium,
+      color: n.foreground,
+      backgroundColor: n.surface,
+    },
+    textArea: {
+      minHeight: 140,
+    },
+    inlineRow: {
+      flexDirection: "row" as const,
+      gap: SPACING.sm,
+    },
+    selectField: {
+      flex: 1,
+      borderWidth: 1,
+      borderColor: n.border,
+      borderRadius: RADIUS.md,
+      paddingHorizontal: SPACING.md,
+      paddingVertical: SPACING.sm,
+      backgroundColor: n.surface,
+    },
+    selectFieldPressed: {
+      opacity: 0.9,
+    },
+    selectFieldText: {
+      ...TYPOGRAPHY.bodyMedium,
+      color: n.foreground,
+    },
+    pickerContainer: {
+      borderWidth: 1,
+      borderColor: n.border,
+      borderRadius: RADIUS.md,
+      overflow: "hidden" as const,
+      backgroundColor: n.surface,
+    },
+    ghostButton: {
+      alignItems: "center" as const,
+      paddingVertical: SPACING.sm,
+      borderTopWidth: 1,
+      borderTopColor: n.border,
+    },
+    ghostButtonPressed: {
+      opacity: 0.85,
+    },
+    ghostButtonText: {
+      ...TYPOGRAPHY.labelLarge,
+      color: s.success,
+    },
+    primaryButton: {
+      backgroundColor: s.success,
+      borderRadius: RADIUS.md,
+      paddingVertical: SPACING.md,
+      alignItems: "center" as const,
+    },
+    primaryButtonPressed: {
+      opacity: 0.9,
+    },
+    primaryButtonText: {
+      ...TYPOGRAPHY.labelLarge,
+      color: "#ffffff",
+    },
+    buttonDisabled: {
+      opacity: 0.6,
+    },
+  }));
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [startDate, setStartDate] = useState<Date | null>(null);
@@ -52,6 +194,32 @@ export default function NewPhilanthropyEventScreen() {
   const [error, setError] = useState<string | null>(null);
 
   const canEdit = isAdmin || isActiveMember;
+  const handleBack = () => {
+    router.replace(`/(app)/${orgSlug}/philanthropy`);
+  };
+
+  const renderHeader = () => (
+    <LinearGradient
+      colors={[APP_CHROME.gradientStart, APP_CHROME.gradientEnd]}
+      style={styles.headerGradient}
+    >
+      <SafeAreaView edges={["top"]} style={styles.headerSafeArea}>
+        <View style={styles.navHeader}>
+          <Pressable
+            onPress={handleBack}
+            style={({ pressed }) => [styles.backButton, pressed && { opacity: 0.7 }]}
+            accessibilityRole="button"
+            accessibilityLabel="Back to philanthropy"
+          >
+            <ChevronLeft size={24} color={APP_CHROME.headerTitle} />
+          </Pressable>
+          <Text style={styles.navTitle} numberOfLines={1}>
+            New Philanthropy Event
+          </Text>
+        </View>
+      </SafeAreaView>
+    </LinearGradient>
+  );
 
   const pickerMode = useMemo(() => {
     if (!activePicker) return "date";
@@ -168,49 +336,54 @@ export default function NewPhilanthropyEventScreen() {
 
   if (roleLoading) {
     return (
-      <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        style={styles.container}
-        contentContainerStyle={styles.scrollContent}
-      >
+      <View style={styles.container}>
         <Stack.Screen options={{ title: "New Philanthropy Event" }} />
-        <View style={styles.loadingState}>
-          <ActivityIndicator color={colors.primary} />
-          <Text style={styles.loadingText}>Loading...</Text>
-        </View>
-      </ScrollView>
+        {renderHeader()}
+        <ScrollView
+          contentInsetAdjustmentBehavior="automatic"
+          contentContainerStyle={styles.scrollContent}
+        >
+          <View style={styles.loadingState}>
+            <ActivityIndicator color={semantic.success} />
+            <Text style={styles.loadingText}>Loading...</Text>
+          </View>
+        </ScrollView>
+      </View>
     );
   }
 
   if (!canEdit) {
     return (
-      <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        style={styles.container}
-        contentContainerStyle={styles.scrollContent}
-      >
+      <View style={styles.container}>
         <Stack.Screen options={{ title: "New Philanthropy Event" }} />
-        <View style={styles.errorCard}>
-          <Text selectable style={styles.errorText}>
-            You do not have access to add philanthropy events.
-          </Text>
-        </View>
-      </ScrollView>
+        {renderHeader()}
+        <ScrollView
+          contentInsetAdjustmentBehavior="automatic"
+          contentContainerStyle={styles.scrollContent}
+        >
+          <View style={styles.errorCard}>
+            <Text selectable style={styles.errorText}>
+              You do not have access to add philanthropy events.
+            </Text>
+          </View>
+        </ScrollView>
+      </View>
     );
   }
 
   return (
-    <ScrollView
-      contentInsetAdjustmentBehavior="automatic"
-      style={styles.container}
-      contentContainerStyle={styles.scrollContent}
-      keyboardShouldPersistTaps="handled"
-    >
+    <View style={styles.container}>
       <Stack.Screen options={{ title: "New Philanthropy Event" }} />
-      <View style={styles.header}>
-        <Text style={styles.headerTitle}>New Philanthropy Event</Text>
-        <Text style={styles.headerSubtitle}>Add a volunteer or community service event</Text>
-      </View>
+      {renderHeader()}
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>New Philanthropy Event</Text>
+          <Text style={styles.headerSubtitle}>Add a volunteer or community service event</Text>
+        </View>
 
       {error ? (
         <View style={styles.errorCard}>
@@ -226,7 +399,7 @@ export default function NewPhilanthropyEventScreen() {
           value={title}
           onChangeText={setTitle}
           placeholder="e.g., Charity 5K Run, Food Bank Volunteering"
-          placeholderTextColor={colors.mutedForeground}
+          placeholderTextColor={neutral.placeholder}
           style={styles.input}
         />
       </View>
@@ -237,7 +410,7 @@ export default function NewPhilanthropyEventScreen() {
           value={description}
           onChangeText={setDescription}
           placeholder="Describe the philanthropy event, what volunteers will be doing, any requirements..."
-          placeholderTextColor={colors.mutedForeground}
+          placeholderTextColor={neutral.placeholder}
           multiline
           textAlignVertical="top"
           style={[styles.input, styles.textArea]}
@@ -326,7 +499,7 @@ export default function NewPhilanthropyEventScreen() {
           value={location}
           onChangeText={setLocation}
           placeholder="e.g., Philadelphia Food Bank, Schuylkill River Trail"
-          placeholderTextColor={colors.mutedForeground}
+          placeholderTextColor={neutral.placeholder}
           style={styles.input}
         />
       </View>
@@ -341,135 +514,12 @@ export default function NewPhilanthropyEventScreen() {
         ]}
       >
         {isSaving ? (
-          <ActivityIndicator color={colors.primaryForeground} />
+          <ActivityIndicator color="#ffffff" />
         ) : (
           <Text style={styles.primaryButtonText}>Create event</Text>
         )}
       </Pressable>
-    </ScrollView>
+      </ScrollView>
+    </View>
   );
 }
-
-const createStyles = (colors: ThemeColors) =>
-  StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: colors.background,
-    },
-    scrollContent: {
-      padding: spacing.md,
-      paddingBottom: spacing.xl,
-      gap: spacing.lg,
-    },
-    header: {
-      gap: spacing.xs,
-    },
-    headerTitle: {
-      fontSize: fontSize["2xl"],
-      fontWeight: fontWeight.bold,
-      color: colors.foreground,
-    },
-    headerSubtitle: {
-      fontSize: fontSize.sm,
-      color: colors.mutedForeground,
-    },
-    errorCard: {
-      backgroundColor: `${colors.error}14`,
-      borderRadius: borderRadius.md,
-      padding: spacing.md,
-      borderWidth: 1,
-      borderColor: `${colors.error}55`,
-    },
-    errorText: {
-      fontSize: fontSize.sm,
-      color: colors.error,
-    },
-    loadingState: {
-      alignItems: "center",
-      gap: spacing.sm,
-    },
-    loadingText: {
-      fontSize: fontSize.sm,
-      color: colors.mutedForeground,
-    },
-    fieldGroup: {
-      gap: spacing.xs,
-    },
-    fieldLabel: {
-      fontSize: fontSize.sm,
-      fontWeight: fontWeight.medium,
-      color: colors.mutedForeground,
-    },
-    input: {
-      borderWidth: 1,
-      borderColor: colors.border,
-      borderRadius: borderRadius.md,
-      paddingHorizontal: spacing.md,
-      paddingVertical: spacing.sm,
-      fontSize: fontSize.base,
-      color: colors.foreground,
-      backgroundColor: colors.background,
-    },
-    textArea: {
-      minHeight: 140,
-    },
-    inlineRow: {
-      flexDirection: "row",
-      gap: spacing.sm,
-    },
-    selectField: {
-      flex: 1,
-      borderWidth: 1,
-      borderColor: colors.border,
-      borderRadius: borderRadius.md,
-      paddingHorizontal: spacing.md,
-      paddingVertical: spacing.sm,
-      backgroundColor: colors.background,
-    },
-    selectFieldPressed: {
-      opacity: 0.9,
-    },
-    selectFieldText: {
-      fontSize: fontSize.base,
-      color: colors.foreground,
-    },
-    pickerContainer: {
-      borderWidth: 1,
-      borderColor: colors.border,
-      borderRadius: borderRadius.md,
-      overflow: "hidden",
-      backgroundColor: colors.card,
-    },
-    ghostButton: {
-      alignItems: "center",
-      paddingVertical: spacing.sm,
-      borderTopWidth: 1,
-      borderTopColor: colors.border,
-    },
-    ghostButtonPressed: {
-      opacity: 0.85,
-    },
-    ghostButtonText: {
-      fontSize: fontSize.base,
-      color: colors.primary,
-      fontWeight: fontWeight.semibold,
-    },
-    primaryButton: {
-      backgroundColor: colors.primary,
-      borderRadius: borderRadius.md,
-      paddingVertical: spacing.sm,
-      alignItems: "center",
-      borderCurve: "continuous",
-    },
-    primaryButtonPressed: {
-      opacity: 0.9,
-    },
-    primaryButtonText: {
-      fontSize: fontSize.base,
-      fontWeight: fontWeight.semibold,
-      color: colors.primaryForeground,
-    },
-    buttonDisabled: {
-      opacity: 0.6,
-    },
-  });

--- a/apps/mobile/src/lib/chat-helpers.ts
+++ b/apps/mobile/src/lib/chat-helpers.ts
@@ -1,7 +1,23 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@teammeet/types";
 
 type ChatGroupMemberInsert = Database["public"]["Tables"]["chat_group_members"]["Insert"];
 type ChatGroupMemberUpdate = Database["public"]["Tables"]["chat_group_members"]["Update"];
+type ChatGroupInsert = Database["public"]["Tables"]["chat_groups"]["Insert"];
+
+type DirectChatSupabase = Pick<SupabaseClient<Database>, "from">;
+
+type ChatGroupMemberRow = {
+  id?: string;
+  chat_group_id: string;
+  user_id: string;
+  removed_at?: string | null;
+};
+
+type ChatGroupRow = {
+  id: string;
+  updated_at?: string | null;
+};
 
 export const MOBILE_DISCUSSION_THREADS_TABLE = "discussion_threads" as const;
 export const MOBILE_DISCUSSION_AUTHOR_SELECT =
@@ -60,4 +76,155 @@ export function buildChatGroupMemberReactivationPayload(
     added_by: addedBy ?? null,
     removed_at: null,
   };
+}
+
+export async function findExactMobileDirectChatGroup(
+  supabase: DirectChatSupabase,
+  input: {
+    organizationId: string;
+    senderUserId: string;
+    recipientUserId: string;
+  }
+): Promise<{ chatGroupId: string | null; error: string | null }> {
+  const { data: memberships, error: membershipError } = await supabase
+    .from("chat_group_members")
+    .select("chat_group_id, user_id, removed_at")
+    .eq("organization_id", input.organizationId)
+    .in("user_id", [input.senderUserId, input.recipientUserId]);
+
+  if (membershipError) {
+    return { chatGroupId: null, error: membershipError.message ?? "Chat lookup failed" };
+  }
+
+  const membershipMap = new Map<string, Set<string>>();
+  for (const row of ((memberships as ChatGroupMemberRow[] | null) ?? [])) {
+    if (row.removed_at != null) continue;
+    const set = membershipMap.get(row.chat_group_id) ?? new Set<string>();
+    set.add(row.user_id);
+    membershipMap.set(row.chat_group_id, set);
+  }
+
+  const candidateGroupIds = [...membershipMap.entries()]
+    .filter(([, userIds]) => userIds.has(input.senderUserId) && userIds.has(input.recipientUserId))
+    .map(([groupId]) => groupId);
+
+  if (candidateGroupIds.length === 0) {
+    return { chatGroupId: null, error: null };
+  }
+
+  const { data: groups, error: groupsError } = await supabase
+    .from("chat_groups")
+    .select("id, updated_at")
+    .eq("organization_id", input.organizationId)
+    .is("deleted_at", null)
+    .in("id", candidateGroupIds)
+    .order("updated_at", { ascending: false });
+
+  if (groupsError) {
+    return { chatGroupId: null, error: groupsError.message ?? "Chat lookup failed" };
+  }
+
+  const orderedGroups = (groups as ChatGroupRow[] | null) ?? [];
+  if (orderedGroups.length === 0) {
+    return { chatGroupId: null, error: null };
+  }
+
+  const { data: allMemberships, error: allMembershipsError } = await supabase
+    .from("chat_group_members")
+    .select("chat_group_id, user_id, removed_at")
+    .in("chat_group_id", orderedGroups.map((row) => row.id));
+
+  if (allMembershipsError) {
+    return { chatGroupId: null, error: allMembershipsError.message ?? "Chat lookup failed" };
+  }
+
+  const groupedMemberships = new Map<string, ChatGroupMemberRow[]>();
+  for (const row of ((allMemberships as ChatGroupMemberRow[] | null) ?? [])) {
+    const rows = groupedMemberships.get(row.chat_group_id) ?? [];
+    rows.push(row);
+    groupedMemberships.set(row.chat_group_id, rows);
+  }
+
+  for (const group of orderedGroups) {
+    const rows = groupedMemberships.get(group.id) ?? [];
+    if (rows.some((row) => row.removed_at != null)) continue;
+
+    const activeUserIds = [...new Set(rows.map((row) => row.user_id))];
+    if (
+      activeUserIds.length === 2 &&
+      activeUserIds.includes(input.senderUserId) &&
+      activeUserIds.includes(input.recipientUserId)
+    ) {
+      return { chatGroupId: group.id, error: null };
+    }
+  }
+
+  return { chatGroupId: null, error: null };
+}
+
+export async function ensureMobileDirectChatGroup(
+  supabase: DirectChatSupabase,
+  input: {
+    organizationId: string;
+    currentUserId: string;
+    recipientUserId: string;
+    recipientDisplayName: string;
+  }
+): Promise<{ ok: true; chatGroupId: string } | { ok: false; error: string }> {
+  if (input.currentUserId === input.recipientUserId) {
+    return { ok: false, error: "You can't message yourself from your own profile." };
+  }
+
+  const existing = await findExactMobileDirectChatGroup(supabase, {
+    organizationId: input.organizationId,
+    senderUserId: input.currentUserId,
+    recipientUserId: input.recipientUserId,
+  });
+  if (existing.error) return { ok: false, error: existing.error };
+  if (existing.chatGroupId) return { ok: true, chatGroupId: existing.chatGroupId };
+
+  const chatGroup: ChatGroupInsert = {
+    organization_id: input.organizationId,
+    name: input.recipientDisplayName,
+    description: null,
+    is_default: false,
+    require_approval: false,
+    created_by: input.currentUserId,
+  };
+  const { data: group, error: groupError } = await supabase
+    .from("chat_groups")
+    .insert(chatGroup)
+    .select("id")
+    .single();
+
+  if (groupError || !group?.id) {
+    return { ok: false, error: groupError?.message ?? "Failed to create chat." };
+  }
+
+  const memberInserts: ChatGroupMemberInsert[] = [
+    {
+      chat_group_id: group.id,
+      organization_id: input.organizationId,
+      user_id: input.currentUserId,
+      role: "admin",
+      added_by: input.currentUserId,
+    },
+    {
+      chat_group_id: group.id,
+      organization_id: input.organizationId,
+      user_id: input.recipientUserId,
+      role: "member",
+      added_by: input.currentUserId,
+    },
+  ];
+
+  const { error: membersError } = await supabase
+    .from("chat_group_members")
+    .insert(memberInserts);
+
+  if (membersError) {
+    return { ok: false, error: membersError.message ?? "Failed to add chat members." };
+  }
+
+  return { ok: true, chatGroupId: group.id };
 }


### PR DESCRIPTION
## Summary
Re-applies two mobile changes that were lost via the earlier revert + empty-squash sequence (#224 reverted, #225 merged but had a zero-diff staging branch). This branch cherry-picks the two original commits directly onto current main.

### 1. Philanthropy event form usability
- Custom gradient header with explicit back button (replaces stock Stack header)
- Migrates legacy `useOrgTheme` + `StyleSheet.create` to `useThemedStyles` + design tokens (`SPACING`, `RADIUS`, `TYPOGRAPHY`)
- Wraps body in `View` so header stays fixed while form scrolls

### 2. Start DMs from member profiles
- Adds Message button to member detail screen (only renders when target has linked user account and is not self)
- New helpers in `apps/mobile/src/lib/chat-helpers.ts`:
  - `findExactMobileDirectChatGroup` — looks up existing 1:1 chat by membership intersection
  - `ensureMobileDirectChatGroup` — finds or creates 1:1 `chat_group` + two `chat_group_members` rows
- Toast for error path; spinner while opening

## Notes
- No DB migrations.
- chat-helpers.ts on main = 63 lines, this PR restores it to 230 lines with the helpers.

## Test plan
- [ ] Philanthropy → New Event: header gradient + back button present, form scrolls under header
- [ ] Member profile (linked teammate): Message button opens chat
- [ ] Member profile (unlinked / self): button absent
- [ ] Re-tap Message reuses existing 1:1 chat (no duplicate `chat_groups` row)