### PR TITLE
feat(moderation): report content + block user (App Store 1.2)

### DIFF
--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/index.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/index.tsx
@@ -354,10 +354,6 @@ export default function HomeScreen() {
     contentSheet: {
       flex: 1,
       backgroundColor: n.surface,
-      borderTopLeftRadius: RADIUS.xxl,
-      borderTopRightRadius: RADIUS.xxl,
-      overflow: "hidden" as const,
-      marginTop: -SPACING.sm,
     },
     centered: {
       flex: 1,

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/alumni/[alumniId].tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/alumni/[alumniId].tsx
@@ -1,5 +1,6 @@
 import { useMemo, useCallback, useState } from "react";
 import {
+  Alert,
   View,
   Text,
   StyleSheet,
@@ -22,13 +23,23 @@ import {
   Linkedin,
   RefreshCw,
   Pencil,
+  Flag,
+  ShieldOff,
 } from "lucide-react-native";
 import { useAlumniDetail } from "@/hooks/useAlumniDetail";
 import { useOrgRole } from "@/hooks/useOrgRole";
+import { useOrg } from "@/contexts/OrgContext";
+import { useAuth } from "@/hooks/useAuth";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
 import { APP_CHROME } from "@/lib/chrome";
 import { SPACING, RADIUS } from "@/lib/design-tokens";
 import { TYPOGRAPHY } from "@/lib/typography";
 import { openEmailAddress, openHttpsUrl } from "@/lib/url-safety";
+import { OverflowMenu, type OverflowMenuItem } from "@/components/OverflowMenu";
+import { ReportBlockSheet } from "@/components/moderation/ReportBlockSheet";
+import { showToast } from "@/components/ui/Toast";
+import { toggleBlock } from "@/lib/moderation";
+import * as sentry from "@/lib/analytics/sentry";
 
 const DETAIL_COLORS = {
   background: "#ffffff",
@@ -48,9 +59,80 @@ export default function AlumniDetailScreen() {
   const { alumniId, orgSlug } = useLocalSearchParams<{ alumniId: string; orgSlug: string }>();
   const { alumni, loading, error, refetch } = useAlumniDetail(orgSlug || "", alumniId || "");
   const { isAdmin } = useOrgRole();
+  const { orgId } = useOrg();
+  const { user } = useAuth();
+  const { blockedUserIds } = useBlockedUsers();
   const router = useRouter();
   const styles = useMemo(() => createStyles(), []);
   const [refreshing, setRefreshing] = useState(false);
+  const [reportSheetOpen, setReportSheetOpen] = useState(false);
+  const [unblockLoading, setUnblockLoading] = useState(false);
+
+  const alumniUserId = alumni?.user_id ?? null;
+  const isSelf = !!alumniUserId && alumniUserId === user?.id;
+  const isBlocked = !!alumniUserId && blockedUserIds.has(alumniUserId);
+  const canReport = !!alumni && !isSelf;
+  const canBlock = !!alumniUserId && !isSelf;
+
+  const handleUnblock = useCallback(async () => {
+    if (!alumniUserId) return;
+    Alert.alert(
+      "Unblock this user?",
+      "Their content will be visible again.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Unblock",
+          onPress: async () => {
+            try {
+              setUnblockLoading(true);
+              await toggleBlock(alumniUserId);
+              showToast("Unblocked", "success");
+            } catch (e) {
+              const message = (e as Error).message || "Failed to unblock";
+              showToast(message, "error");
+              sentry.captureException(e as Error, {
+                context: "AlumniProfile.unblock",
+              });
+            } finally {
+              setUnblockLoading(false);
+            }
+          },
+        },
+      ],
+    );
+  }, [alumniUserId]);
+
+  const headerMenuItems = useMemo<OverflowMenuItem[]>(() => {
+    if (!canReport) return [];
+    const items: OverflowMenuItem[] = [
+      {
+        id: "report",
+        label: "Report",
+        icon: <Flag size={20} color={DETAIL_COLORS.primaryText} />,
+        onPress: () => setReportSheetOpen(true),
+      },
+    ];
+    if (canBlock) {
+      items.push(
+        isBlocked
+          ? {
+              id: "unblock",
+              label: "Unblock",
+              icon: <ShieldOff size={20} color={DETAIL_COLORS.primaryText} />,
+              onPress: handleUnblock,
+            }
+          : {
+              id: "block",
+              label: "Block",
+              icon: <ShieldOff size={20} color={DETAIL_COLORS.error} />,
+              destructive: true,
+              onPress: () => setReportSheetOpen(true),
+            },
+      );
+    }
+    return items;
+  }, [canReport, canBlock, isBlocked, handleUnblock]);
 
   const handleEditPress = useCallback(() => {
     if (alumniId && orgSlug) {
@@ -161,6 +243,13 @@ export default function AlumniDetailScreen() {
                 <Pencil size={18} color={APP_CHROME.headerTitle} />
               </Pressable>
             )}
+            {headerMenuItems.length > 0 && (
+              <OverflowMenu
+                items={headerMenuItems}
+                iconColor={APP_CHROME.headerTitle}
+                accessibilityLabel="Profile options"
+              />
+            )}
           </View>
         </SafeAreaView>
       </LinearGradient>
@@ -174,7 +263,7 @@ export default function AlumniDetailScreen() {
         }
       >
         {/* Header Card */}
-        <View style={styles.profileHeader}>
+        <View style={[styles.profileHeader, isBlocked && styles.dimmed]}>
           {alumni.photo_url ? (
             <Image source={alumni.photo_url} style={styles.avatar} contentFit="cover" transition={200} />
           ) : (
@@ -191,9 +280,68 @@ export default function AlumniDetailScreen() {
           )}
         </View>
 
+        {canReport && (
+          <View style={styles.moderationActions}>
+            <Pressable
+              style={({ pressed }) => [
+                styles.moderationButton,
+                styles.moderationButtonSecondary,
+                pressed && { opacity: 0.7 },
+              ]}
+              onPress={() => setReportSheetOpen(true)}
+              accessibilityRole="button"
+              accessibilityLabel="Report this user"
+            >
+              <Flag size={18} color={DETAIL_COLORS.primaryText} />
+              <Text style={styles.moderationButtonSecondaryText}>Report</Text>
+            </Pressable>
+            {canBlock && (
+              isBlocked ? (
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.moderationButton,
+                    styles.moderationButtonSecondary,
+                    pressed && { opacity: 0.7 },
+                    unblockLoading && { opacity: 0.5 },
+                  ]}
+                  onPress={handleUnblock}
+                  disabled={unblockLoading}
+                  accessibilityRole="button"
+                  accessibilityLabel="Unblock this user"
+                >
+                  <ShieldOff size={18} color={DETAIL_COLORS.primaryText} />
+                  <Text style={styles.moderationButtonSecondaryText}>Unblock</Text>
+                </Pressable>
+              ) : (
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.moderationButton,
+                    styles.moderationButtonDestructive,
+                    pressed && { opacity: 0.7 },
+                  ]}
+                  onPress={() => setReportSheetOpen(true)}
+                  accessibilityRole="button"
+                  accessibilityLabel="Block this user"
+                >
+                  <ShieldOff size={18} color="#ffffff" />
+                  <Text style={styles.moderationButtonDestructiveText}>Block</Text>
+                </Pressable>
+              )
+            )}
+          </View>
+        )}
+
+        {isBlocked && (
+          <View style={styles.blockedNotice}>
+            <Text style={styles.blockedNoticeText}>
+              You blocked this user. Their content is hidden from you.
+            </Text>
+          </View>
+        )}
+
         {/* Quick Actions */}
         {(alumni.email || alumni.linkedin_url) && (
-          <View style={styles.actionsRow}>
+          <View style={[styles.actionsRow, isBlocked && styles.dimmed]}>
             {alumni.email && (
               <Pressable
                 style={({ pressed }) => [styles.actionButton, pressed && { opacity: 0.7 }]}
@@ -216,7 +364,7 @@ export default function AlumniDetailScreen() {
         )}
 
         {/* Details Section */}
-        <View style={styles.section}>
+        <View style={[styles.section, isBlocked && styles.dimmed]}>
           {alumni.graduation_year && (
             <View style={styles.detailRow}>
               <View style={styles.detailIcon}>
@@ -266,6 +414,16 @@ export default function AlumniDetailScreen() {
           )}
         </View>
       </ScrollView>
+
+      <ReportBlockSheet
+        visible={reportSheetOpen}
+        onClose={() => setReportSheetOpen(false)}
+        orgId={orgId}
+        targetType="user_profile"
+        targetId={alumni.user_id ?? alumni.id}
+        reportedUserId={alumni.user_id ?? null}
+        hideBlock={!alumni.user_id}
+      />
     </View>
   );
 }
@@ -452,5 +610,55 @@ const createStyles = () =>
       ...TYPOGRAPHY.bodyMedium,
       color: DETAIL_COLORS.primaryText,
       marginTop: 2,
+    },
+    moderationActions: {
+      flexDirection: "row",
+      gap: SPACING.sm,
+      paddingHorizontal: SPACING.lg,
+      marginBottom: SPACING.md,
+    },
+    moderationButton: {
+      flex: 1,
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: SPACING.xs,
+      paddingVertical: SPACING.sm + 2,
+      borderRadius: RADIUS.md,
+    },
+    moderationButtonSecondary: {
+      backgroundColor: DETAIL_COLORS.card,
+      borderWidth: 1,
+      borderColor: DETAIL_COLORS.border,
+    },
+    moderationButtonSecondaryText: {
+      ...TYPOGRAPHY.labelLarge,
+      color: DETAIL_COLORS.primaryText,
+      fontWeight: "600",
+    },
+    moderationButtonDestructive: {
+      backgroundColor: DETAIL_COLORS.error,
+    },
+    moderationButtonDestructiveText: {
+      ...TYPOGRAPHY.labelLarge,
+      color: "#ffffff",
+      fontWeight: "600",
+    },
+    blockedNotice: {
+      marginHorizontal: SPACING.lg,
+      marginBottom: SPACING.md,
+      padding: SPACING.md,
+      backgroundColor: DETAIL_COLORS.card,
+      borderRadius: RADIUS.md,
+      borderWidth: 1,
+      borderColor: DETAIL_COLORS.border,
+    },
+    blockedNoticeText: {
+      ...TYPOGRAPHY.bodySmall,
+      color: DETAIL_COLORS.secondaryText,
+      textAlign: "center",
+    },
+    dimmed: {
+      opacity: 0.4,
     },
   });

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/chat/[groupId].tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/chat/[groupId].tsx
@@ -19,6 +19,8 @@ import { supabase, createPostgresChangesChannel} from "@/lib/supabase";
 import { useOrg } from "@/contexts/OrgContext";
 import { useAuth } from "@/hooks/useAuth";
 import { useOrgRole } from "@/hooks/useOrgRole";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
+import { ReportBlockSheet } from "@/components/moderation/ReportBlockSheet";
 import { Avatar } from "@/components/ui/Avatar";
 import { ReactionRow } from "@/components/reactions/ReactionRow";
 import {
@@ -86,6 +88,9 @@ export default function ChatRoomScreen() {
   const { orgId, orgSlug } = useOrg();
   const { user } = useAuth();
   const { isAdmin } = useOrgRole();
+  const { blockedUserIds } = useBlockedUsers();
+  const blockedRef = useRef<Set<string>>(blockedUserIds);
+  blockedRef.current = blockedUserIds;
   const router = useRouter();
   const styles = useMemo(() => createStyles(), []);
   const listRef = useRef<FlatList<MessageWithAuthor>>(null);
@@ -113,6 +118,11 @@ export default function ChatRoomScreen() {
   const [canManageMembers, setCanManageMembers] = useState(false);
   const [requiresApproval, setRequiresApproval] = useState(false);
   const [userCache, setUserCache] = useState<Map<string, User>>(new Map());
+
+  // Report/block sheet target
+  const [reportTarget, setReportTarget] = useState<
+    { messageId: string; authorId: string } | null
+  >(null);
 
   // Members sheet state
   const [addMembersMode, setAddMembersMode] = useState(false);
@@ -252,9 +262,11 @@ export default function ChatRoomScreen() {
     if (error) { setError(error.message); return; }
 
     if (data) {
-      const authorIds = [...new Set(data.map((msg) => msg.author_id))];
+      const blocked = blockedRef.current;
+      const filtered = data.filter((msg) => !blocked.has(msg.author_id));
+      const authorIds = [...new Set(filtered.map((msg) => msg.author_id))];
       await fetchUnknownUsers(authorIds);
-      setMessages(data.map((msg) => ({ ...msg, author: userMap.get(msg.author_id) })));
+      setMessages(filtered.map((msg) => ({ ...msg, author: userMap.get(msg.author_id) })));
       setTimeout(scrollToBottom, 100);
     }
   }, [resolvedGroupId, fetchUnknownUsers, scrollToBottom, userMap]);
@@ -279,6 +291,7 @@ export default function ChatRoomScreen() {
         async (payload: RealtimePostgresChangesPayload<ChatMessage>) => {
           if (payload.eventType === "INSERT") {
             const newMsg = payload.new as ChatMessage;
+            if (blockedRef.current.has(newMsg.author_id)) return;
             if (!userMap.has(newMsg.author_id)) await fetchUnknownUsers([newMsg.author_id]);
             if (newMsg.status === "approved" || newMsg.author_id === currentUserId || canModerate) {
               setMessages((prev) => {
@@ -311,6 +324,10 @@ export default function ChatRoomScreen() {
       .subscribe();
     return () => { supabase.removeChannel(channel); };
   }, [resolvedGroupId, currentUserId, canModerate, fetchUnknownUsers, userMap, scrollToBottom]);
+
+  useEffect(() => {
+    setMessages((prev) => prev.filter((m) => !blockedUserIds.has(m.author_id)));
+  }, [blockedUserIds]);
 
   const pendingCount = useMemo(
     () => messages.filter((m) => m.status === "pending").length,
@@ -646,9 +663,29 @@ export default function ChatRoomScreen() {
             {isFirstInRun && isOwn && (
               <Text style={styles.messageTime}>{formatTimestamp(item.created_at)}</Text>
             )}
-            <View style={[styles.messageBubble, bubbleRadius, isOwn ? styles.messageBubbleOwn : styles.messageBubbleOther, isPending && styles.messageBubblePending]}>
+            <Pressable
+              onLongPress={
+                isOwn
+                  ? undefined
+                  : () =>
+                      setReportTarget({
+                        messageId: item.id,
+                        authorId: item.author_id,
+                      })
+              }
+              delayLongPress={350}
+              style={({ pressed }) => [
+                styles.messageBubble,
+                bubbleRadius,
+                isOwn ? styles.messageBubbleOwn : styles.messageBubbleOther,
+                isPending && styles.messageBubblePending,
+                pressed && !isOwn && { opacity: 0.8 },
+              ]}
+              accessibilityRole={isOwn ? undefined : "button"}
+              accessibilityHint={isOwn ? undefined : "Long-press to report or block"}
+            >
               <Text style={[styles.messageText, isOwn && styles.messageTextOwn]}>{item.body}</Text>
-            </View>
+            </Pressable>
             {!isPending && !isRejected && (
               <ReactionRow
                 targetKind="chat_message"
@@ -978,6 +1015,15 @@ export default function ChatRoomScreen() {
           )}
         </BottomSheet>
       )}
+
+      <ReportBlockSheet
+        visible={!!reportTarget}
+        onClose={() => setReportTarget(null)}
+        orgId={orgId}
+        targetType="chat_message"
+        targetId={reportTarget?.messageId ?? ""}
+        reportedUserId={reportTarget?.authorId ?? null}
+      />
     </View>
   );
 }

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/chat/threads/[threadId].tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/chat/threads/[threadId].tsx
@@ -18,6 +18,8 @@ import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
 import { supabase, createPostgresChangesChannel} from "@/lib/supabase";
 import { useOrg } from "@/contexts/OrgContext";
 import { useAuth } from "@/hooks/useAuth";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
+import { ReportBlockSheet } from "@/components/moderation/ReportBlockSheet";
 import { Avatar } from "@/components/ui/Avatar";
 import { spacing, borderRadius, fontSize, fontWeight } from "@/lib/theme";
 import { APP_CHROME } from "@/lib/chrome";
@@ -54,6 +56,9 @@ export default function ThreadDetailScreen() {
   const resolvedThreadId = Array.isArray(threadId) ? threadId[0] : threadId;
   const { orgId, orgSlug } = useOrg();
   const { user } = useAuth();
+  const { blockedUserIds } = useBlockedUsers();
+  const blockedRef = useRef<Set<string>>(blockedUserIds);
+  blockedRef.current = blockedUserIds;
   const router = useRouter();
   const styles = useMemo(() => createStyles(), []);
   const listRef = useRef<FlatList<ReplyWithAuthor>>(null);
@@ -65,6 +70,11 @@ export default function ThreadDetailScreen() {
   const [error, setError] = useState<string | null>(null);
   const [replyBody, setReplyBody] = useState("");
   const [sending, setSending] = useState(false);
+  const [reportTarget, setReportTarget] = useState<
+    | { kind: "thread"; id: string; authorId: string }
+    | { kind: "reply"; id: string; authorId: string }
+    | null
+  >(null);
 
   const currentUserId = user?.id ?? null;
 
@@ -97,8 +107,20 @@ export default function ThreadDetailScreen() {
       if (repliesRes.error) throw repliesRes.error;
 
       if (isMountedRef.current) {
-        setThread(threadRes.data as ThreadWithAuthor);
-        setReplies((repliesRes.data || []) as ReplyWithAuthor[]);
+        const threadData = threadRes.data as ThreadWithAuthor;
+        const blocked = blockedRef.current;
+        if (threadData && blocked.has(threadData.author_id)) {
+          setThread(null);
+          setReplies([]);
+          setError("Thread not found.");
+          return;
+        }
+        setThread(threadData);
+        setReplies(
+          ((repliesRes.data || []) as ReplyWithAuthor[]).filter(
+            (r) => !blocked.has(r.author_id),
+          ),
+        );
         setError(null);
       }
     } catch (e) {
@@ -180,6 +202,7 @@ export default function ThreadDetailScreen() {
         },
         async (payload: RealtimePostgresChangesPayload<DiscussionReply>) => {
           const newReply = payload.new as DiscussionReply;
+          if (blockedRef.current.has(newReply.author_id)) return;
           const { data: replyWithAuthor } = await supabase
             .from("discussion_replies")
             .select("*, author:users!discussion_replies_author_id_fkey(id, name, avatar_url)")
@@ -221,6 +244,13 @@ export default function ThreadDetailScreen() {
       supabase.removeChannel(channel);
     };
   }, [resolvedThreadId, scrollToBottom]);
+
+  useEffect(() => {
+    setReplies((prev) => prev.filter((r) => !blockedUserIds.has(r.author_id)));
+    setThread((prev) =>
+      prev && blockedUserIds.has(prev.author_id) ? null : prev,
+    );
+  }, [blockedUserIds]);
 
   const groupedReplies = useMemo(() => {
     return replies.map((reply, index) => {
@@ -334,12 +364,26 @@ export default function ThreadDetailScreen() {
               <Text style={styles.messageTime}>{formatTimestamp(item.created_at)}</Text>
             )}
 
-            <View
-              style={[
+            <Pressable
+              onLongPress={
+                isOwn
+                  ? undefined
+                  : () =>
+                      setReportTarget({
+                        kind: "reply",
+                        id: item.id,
+                        authorId: item.author_id,
+                      })
+              }
+              delayLongPress={350}
+              style={({ pressed }) => [
                 styles.messageBubble,
                 bubbleRadius,
                 isOwn ? styles.messageBubbleOwn : styles.messageBubbleOther,
+                pressed && !isOwn && { opacity: 0.8 },
               ]}
+              accessibilityRole={isOwn ? undefined : "button"}
+              accessibilityHint={isOwn ? undefined : "Long-press to report or block"}
             >
               <Text
                 style={[
@@ -349,7 +393,7 @@ export default function ThreadDetailScreen() {
               >
                 {item.body}
               </Text>
-            </View>
+            </Pressable>
           </View>
         </View>
       );
@@ -361,9 +405,28 @@ export default function ThreadDetailScreen() {
     if (!thread) return null;
 
     const authorName = thread.author?.name || "Unknown";
+    const isOwn = thread.author_id === currentUserId;
 
     return (
-      <View style={styles.opCard}>
+      <Pressable
+        onLongPress={
+          isOwn
+            ? undefined
+            : () =>
+                setReportTarget({
+                  kind: "thread",
+                  id: thread.id,
+                  authorId: thread.author_id,
+                })
+        }
+        delayLongPress={350}
+        style={({ pressed }) => [
+          styles.opCard,
+          pressed && !isOwn && { opacity: 0.85 },
+        ]}
+        accessibilityRole={isOwn ? undefined : "button"}
+        accessibilityHint={isOwn ? undefined : "Long-press to report or block"}
+      >
         <View style={styles.opMeta}>
           <Avatar size="sm" name={authorName} />
           <Text style={styles.opAuthor}>{authorName}</Text>
@@ -372,9 +435,9 @@ export default function ThreadDetailScreen() {
         </View>
         <Text style={styles.opTitle}>{thread.title}</Text>
         <Text style={styles.opBody}>{thread.body}</Text>
-      </View>
+      </Pressable>
     );
-  }, [thread, styles]);
+  }, [thread, currentUserId, styles]);
 
   if (loading && !thread) {
     return (
@@ -489,6 +552,15 @@ export default function ThreadDetailScreen() {
           </View>
         )}
       </KeyboardAvoidingView>
+
+      <ReportBlockSheet
+        visible={!!reportTarget}
+        onClose={() => setReportTarget(null)}
+        orgId={orgId}
+        targetType="chat_message"
+        targetId={reportTarget?.id ?? ""}
+        reportedUserId={reportTarget?.authorId ?? null}
+      />
     </View>
   );
 }

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/feed/[postId]/index.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/feed/[postId]/index.tsx
@@ -14,7 +14,7 @@ import { Image } from "expo-image";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
 import { useRouter, useLocalSearchParams } from "expo-router";
-import { ArrowLeft, Send, Edit2, Trash2, ExternalLink, Share2 } from "lucide-react-native";
+import { ArrowLeft, Send, Edit2, Trash2, ExternalLink, Share2, Flag } from "lucide-react-native";
 import { sharePost } from "@/lib/share";
 import * as Linking from "expo-linking";
 import { supabase } from "@/lib/supabase";
@@ -29,6 +29,7 @@ import { LikeButton } from "@/components/feed/LikeButton";
 import { FeedPoll } from "@/components/feed/FeedPoll";
 import { CommentItem } from "@/components/feed/CommentItem";
 import { OverflowMenu, type OverflowMenuItem } from "@/components/OverflowMenu";
+import { ReportBlockSheet } from "@/components/moderation/ReportBlockSheet";
 import { showToast } from "@/components/ui/Toast";
 import * as sentry from "@/lib/analytics/sentry";
 import { formatRelativeTime } from "@/lib/date-format";
@@ -69,6 +70,7 @@ export default function PostDetailScreen() {
   const textRef = useRef("");
   const inputRef = useRef<TextInput>(null);
   const [sending, setSending] = useState(false);
+  const [reportSheetOpen, setReportSheetOpen] = useState(false);
 
   const { neutral, semantic } = useAppColorScheme();
   const styles = useThemedStyles((n, s) => ({
@@ -372,8 +374,18 @@ export default function PostDetailScreen() {
       },
     });
 
+    if (post && userId && post.author_id !== userId) {
+      items.push({
+        id: "report",
+        label: "Report Post",
+        icon: <Flag size={20} color={semantic.error} />,
+        destructive: true,
+        onPress: () => setReportSheetOpen(true),
+      });
+    }
+
     return items;
-  }, [canEdit, post?.author_id, userId, orgSlug, postId, handleDeletePost, router, neutral, semantic]);
+  }, [canEdit, post, userId, orgSlug, postId, handleDeletePost, router, neutral, semantic]);
 
   const renderComment = useCallback(
     ({ item }: { item: FeedComment }) => (
@@ -552,6 +564,15 @@ export default function PostDetailScreen() {
           </Pressable>
         </View>
       </KeyboardAvoidingView>
+
+      <ReportBlockSheet
+        visible={reportSheetOpen}
+        onClose={() => setReportSheetOpen(false)}
+        orgId={orgId}
+        targetType="feed_post"
+        targetId={postId ?? ""}
+        reportedUserId={post?.author_id ?? null}
+      />
     </View>
   );
 }

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/members/[memberId].tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/members/[memberId].tsx
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
-import { View, Text, ScrollView, ActivityIndicator, StyleSheet, Pressable, Share } from "react-native";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Alert, View, Text, ScrollView, ActivityIndicator, StyleSheet, Pressable, Share } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
 import { Image } from "expo-image";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { ChevronLeft, Mail, MessageCircle, Share as ShareIcon, Linkedin } from "lucide-react-native";
+import { ChevronLeft, Mail, MessageCircle, Share as ShareIcon, Linkedin, Flag, ShieldOff } from "lucide-react-native";
 import { supabase } from "@/lib/supabase";
 import { useOrg } from "@/contexts/OrgContext";
 import { useAuth } from "@/hooks/useAuth";
@@ -14,6 +14,11 @@ import { TYPOGRAPHY } from "@/lib/typography";
 import { openEmailAddress, openHttpsUrl } from "@/lib/url-safety";
 import { ensureMobileDirectChatGroup } from "@/lib/chat-helpers";
 import { showToast } from "@/components/ui/Toast";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
+import { OverflowMenu, type OverflowMenuItem } from "@/components/OverflowMenu";
+import { ReportBlockSheet } from "@/components/moderation/ReportBlockSheet";
+import { toggleBlock } from "@/lib/moderation";
+import * as sentry from "@/lib/analytics/sentry";
 
 const DETAIL_COLORS = {
   background: "#ffffff",
@@ -50,6 +55,73 @@ export default function MemberProfileScreen() {
   const [loading, setLoading] = useState(true);
   const [openingChat, setOpeningChat] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [reportSheetOpen, setReportSheetOpen] = useState(false);
+  const [unblockLoading, setUnblockLoading] = useState(false);
+  const { blockedUserIds } = useBlockedUsers();
+  const isSelf = !!member?.user_id && member.user_id === user?.id;
+  const isBlocked = !!member?.user_id && blockedUserIds.has(member.user_id);
+  const canReport = !!member && !isSelf;
+  const canBlock = !!member?.user_id && !isSelf;
+
+  const handleUnblock = useCallback(async () => {
+    if (!member?.user_id) return;
+    Alert.alert(
+      "Unblock this user?",
+      "Their content will be visible again.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Unblock",
+          onPress: async () => {
+            try {
+              setUnblockLoading(true);
+              await toggleBlock(member.user_id!);
+              showToast("Unblocked", "success");
+            } catch (e) {
+              const message = (e as Error).message || "Failed to unblock";
+              showToast(message, "error");
+              sentry.captureException(e as Error, {
+                context: "MemberProfile.unblock",
+              });
+            } finally {
+              setUnblockLoading(false);
+            }
+          },
+        },
+      ],
+    );
+  }, [member?.user_id]);
+
+  const headerMenuItems = useMemo<OverflowMenuItem[]>(() => {
+    if (!canReport) return [];
+    const items: OverflowMenuItem[] = [
+      {
+        id: "report",
+        label: "Report",
+        icon: <Flag size={20} color={DETAIL_COLORS.primaryText} />,
+        onPress: () => setReportSheetOpen(true),
+      },
+    ];
+    if (canBlock) {
+      items.push(
+        isBlocked
+          ? {
+              id: "unblock",
+              label: "Unblock",
+              icon: <ShieldOff size={20} color={DETAIL_COLORS.primaryText} />,
+              onPress: handleUnblock,
+            }
+          : {
+              id: "block",
+              label: "Block",
+              icon: <ShieldOff size={20} color={DETAIL_COLORS.error} />,
+              destructive: true,
+              onPress: () => setReportSheetOpen(true),
+            },
+      );
+    }
+    return items;
+  }, [canReport, canBlock, isBlocked, handleUnblock]);
 
   useEffect(() => {
     async function fetchMember() {
@@ -182,13 +254,20 @@ export default function MemberProfileScreen() {
                 Member Profile
               </Text>
             </View>
+            {headerMenuItems.length > 0 && (
+              <OverflowMenu
+                items={headerMenuItems}
+                iconColor={APP_CHROME.headerTitle}
+                accessibilityLabel="Profile options"
+              />
+            )}
           </View>
         </SafeAreaView>
       </LinearGradient>
 
       {/* Content */}
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
-        <View style={styles.profileHeader}>
+        <View style={[styles.profileHeader, isBlocked && styles.dimmed]}>
           {member.photo_url ? (
             <Image source={member.photo_url} style={styles.avatarImage} contentFit="cover" transition={200} />
           ) : (
@@ -225,7 +304,67 @@ export default function MemberProfileScreen() {
           )}
         </View>
 
-        <View style={styles.contactSection}>
+        {canReport && (
+          <View style={styles.moderationActions}>
+            <Pressable
+              style={({ pressed }) => [
+                styles.moderationButton,
+                styles.moderationButtonSecondary,
+                pressed && { opacity: 0.7 },
+              ]}
+              onPress={() => setReportSheetOpen(true)}
+              accessibilityRole="button"
+              accessibilityLabel="Report user"
+            >
+              <Flag size={18} color={DETAIL_COLORS.primaryText} />
+              <Text style={styles.moderationButtonSecondaryText}>Report</Text>
+            </Pressable>
+            {canBlock && (
+              isBlocked ? (
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.moderationButton,
+                    styles.moderationButtonSecondary,
+                    (pressed || unblockLoading) && { opacity: 0.7 },
+                  ]}
+                  onPress={handleUnblock}
+                  disabled={unblockLoading}
+                  accessibilityRole="button"
+                  accessibilityLabel="Unblock user"
+                >
+                  <ShieldOff size={18} color={DETAIL_COLORS.primaryText} />
+                  <Text style={styles.moderationButtonSecondaryText}>
+                    {unblockLoading ? "Unblocking…" : "Unblock"}
+                  </Text>
+                </Pressable>
+              ) : (
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.moderationButton,
+                    styles.moderationButtonDestructive,
+                    pressed && { opacity: 0.85 },
+                  ]}
+                  onPress={() => setReportSheetOpen(true)}
+                  accessibilityRole="button"
+                  accessibilityLabel="Block user"
+                >
+                  <ShieldOff size={18} color="#ffffff" />
+                  <Text style={styles.moderationButtonDestructiveText}>Block</Text>
+                </Pressable>
+              )
+            )}
+          </View>
+        )}
+
+        {isBlocked && (
+          <View style={styles.blockedNotice}>
+            <Text style={styles.blockedNoticeText}>
+              You blocked this user. Their content is hidden everywhere.
+            </Text>
+          </View>
+        )}
+
+        <View style={[styles.contactSection, isBlocked && styles.dimmed]}>
           <Text style={styles.sectionTitle}>Contact</Text>
 
           {member.email && (
@@ -259,6 +398,16 @@ export default function MemberProfileScreen() {
           )}
         </View>
       </ScrollView>
+
+      <ReportBlockSheet
+        visible={reportSheetOpen}
+        onClose={() => setReportSheetOpen(false)}
+        orgId={orgId}
+        targetType="user_profile"
+        targetId={member.user_id ?? member.id}
+        reportedUserId={member.user_id ?? null}
+        hideBlock={!member.user_id}
+      />
     </View>
   );
 }
@@ -363,6 +512,53 @@ const createStyles = () =>
       backgroundColor: DETAIL_COLORS.card,
       borderRadius: RADIUS.lg,
       padding: SPACING.md,
+    },
+    moderationActions: {
+      flexDirection: "row" as const,
+      gap: SPACING.sm,
+      marginBottom: SPACING.md,
+    },
+    moderationButton: {
+      flex: 1,
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
+      gap: SPACING.xs,
+      paddingVertical: SPACING.sm,
+      paddingHorizontal: SPACING.md,
+      borderRadius: RADIUS.md,
+    },
+    moderationButtonSecondary: {
+      backgroundColor: DETAIL_COLORS.card,
+      borderWidth: 1,
+      borderColor: DETAIL_COLORS.border,
+    },
+    moderationButtonSecondaryText: {
+      ...TYPOGRAPHY.labelMedium,
+      color: DETAIL_COLORS.primaryText,
+      fontWeight: "600" as const,
+    },
+    moderationButtonDestructive: {
+      backgroundColor: DETAIL_COLORS.error,
+    },
+    moderationButtonDestructiveText: {
+      ...TYPOGRAPHY.labelMedium,
+      color: "#ffffff",
+      fontWeight: "600" as const,
+    },
+    blockedNotice: {
+      backgroundColor: "#fef2f2",
+      borderRadius: RADIUS.md,
+      padding: SPACING.md,
+      marginBottom: SPACING.md,
+    },
+    blockedNoticeText: {
+      ...TYPOGRAPHY.bodySmall,
+      color: DETAIL_COLORS.error,
+      textAlign: "center" as const,
+    },
+    dimmed: {
+      opacity: 0.4,
     },
     sectionTitle: {
       ...TYPOGRAPHY.titleMedium,

--- a/apps/mobile/app/(app)/(drawer)/_layout.tsx
+++ b/apps/mobile/app/(app)/(drawer)/_layout.tsx
@@ -67,6 +67,13 @@ export default function DrawerStackLayout() {
             title: "Delete Account",
           }}
         />
+        <Stack.Screen
+          name="blocked-users"
+          options={{
+            headerShown: false,
+            title: "Blocked Users",
+          }}
+        />
       </Stack>
     </View>
   );

--- a/apps/mobile/app/(app)/(drawer)/blocked-users.tsx
+++ b/apps/mobile/app/(app)/(drawer)/blocked-users.tsx
@@ -1,0 +1,268 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { LinearGradient } from "expo-linear-gradient";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { ChevronLeft, ShieldOff } from "lucide-react-native";
+import { APP_CHROME } from "@/lib/chrome";
+import { SPACING, RADIUS } from "@/lib/design-tokens";
+import { TYPOGRAPHY } from "@/lib/typography";
+import { useThemedStyles } from "@/hooks/useThemedStyles";
+import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
+import {
+  BlockedListItem,
+  type BlockedListItemUser,
+} from "@/components/moderation/BlockedListItem";
+import { supabase } from "@/lib/supabase";
+import { showToast } from "@/components/ui/Toast";
+import * as sentry from "@/lib/analytics/sentry";
+
+interface BlockedUserRow {
+  id: string;
+  name: string | null;
+  avatar_url: string | null;
+}
+
+export default function BlockedUsersScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ currentSlug?: string }>();
+  const { neutral } = useAppColorScheme();
+  const { blockedUserIds, toggleBlock, refresh } = useBlockedUsers();
+  const isMountedRef = useRef(true);
+
+  const [profiles, setProfiles] = useState<Record<string, BlockedUserRow>>({});
+  const [loadingProfiles, setLoadingProfiles] = useState(true);
+  const [pendingUserId, setPendingUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const idsKey = useMemo(
+    () => Array.from(blockedUserIds).sort().join(","),
+    [blockedUserIds],
+  );
+
+  useEffect(() => {
+    const ids = Array.from(blockedUserIds);
+    if (ids.length === 0) {
+      setProfiles({});
+      setLoadingProfiles(false);
+      return;
+    }
+
+    setLoadingProfiles(true);
+    void (async () => {
+      try {
+        const { data, error } = await supabase
+          .from("users")
+          .select("id, name, avatar_url")
+          .in("id", ids);
+
+        if (error) throw error;
+        if (!isMountedRef.current) return;
+
+        const map: Record<string, BlockedUserRow> = {};
+        for (const row of (data ?? []) as BlockedUserRow[]) {
+          map[row.id] = row;
+        }
+        setProfiles(map);
+      } catch (err) {
+        sentry.captureException(err as Error, {
+          context: "BlockedUsersScreen.fetchProfiles",
+        });
+        if (isMountedRef.current) {
+          showToast("Couldn't load blocked users", "error");
+        }
+      } finally {
+        if (isMountedRef.current) setLoadingProfiles(false);
+      }
+    })();
+  }, [idsKey, blockedUserIds]);
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
+    if (params.currentSlug) {
+      router.replace(`/(app)/${params.currentSlug}/(tabs)`);
+      return;
+    }
+    router.replace("/(app)");
+  }, [params.currentSlug, router]);
+
+  const handleUnblock = useCallback(
+    async (userId: string) => {
+      setPendingUserId(userId);
+      try {
+        await toggleBlock(userId);
+        showToast("Unblocked", "success");
+        void refresh();
+      } catch (err) {
+        const message = (err as Error).message || "Failed to unblock";
+        showToast(message, "error");
+        sentry.captureException(err as Error, {
+          context: "BlockedUsersScreen.unblock",
+          userId,
+        });
+      } finally {
+        if (isMountedRef.current) setPendingUserId(null);
+      }
+    },
+    [toggleBlock, refresh],
+  );
+
+  const styles = useThemedStyles((n) => ({
+    container: {
+      flex: 1,
+      backgroundColor: n.background,
+    },
+    headerContent: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      paddingHorizontal: SPACING.md,
+      paddingVertical: SPACING.sm,
+      minHeight: 44,
+    },
+    backButton: {
+      width: 36,
+      height: 36,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
+    },
+    headerTitle: {
+      ...TYPOGRAPHY.titleLarge,
+      color: APP_CHROME.headerTitle,
+      flex: 1,
+      textAlign: "center" as const,
+    },
+    headerSpacer: {
+      width: 36,
+    },
+    contentSheet: {
+      flex: 1,
+      backgroundColor: n.surface,
+    },
+    scrollContent: {
+      padding: SPACING.md,
+      paddingBottom: SPACING.xxl,
+    },
+    emptyWrap: {
+      flex: 1,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
+      paddingVertical: SPACING.xxl,
+      gap: SPACING.sm,
+    },
+    emptyIcon: {
+      width: 56,
+      height: 56,
+      borderRadius: 28,
+      backgroundColor: n.background,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
+      borderWidth: 1,
+      borderColor: n.border,
+      marginBottom: SPACING.sm,
+    },
+    emptyTitle: {
+      ...TYPOGRAPHY.titleMedium,
+      color: n.foreground,
+    },
+    emptySubtitle: {
+      ...TYPOGRAPHY.bodyMedium,
+      color: n.secondary,
+      textAlign: "center" as const,
+      paddingHorizontal: SPACING.lg,
+    },
+    intro: {
+      ...TYPOGRAPHY.bodySmall,
+      color: n.secondary,
+      marginBottom: SPACING.md,
+      paddingHorizontal: SPACING.xs,
+    },
+    loadingWrap: {
+      paddingVertical: SPACING.xl,
+      alignItems: "center" as const,
+    },
+  }));
+
+  const ids = Array.from(blockedUserIds);
+  const items: BlockedListItemUser[] = ids.map((id) => {
+    const profile = profiles[id];
+    return {
+      id,
+      full_name: profile?.name ?? null,
+      avatar_url: profile?.avatar_url ?? null,
+    };
+  });
+
+  return (
+    <View style={styles.container}>
+      <LinearGradient
+        colors={[APP_CHROME.gradientStart, APP_CHROME.gradientEnd]}
+      >
+        <SafeAreaView edges={["top"]}>
+          <View style={styles.headerContent}>
+            <Pressable
+              onPress={handleBack}
+              style={styles.backButton}
+              accessibilityRole="button"
+              accessibilityLabel="Back"
+            >
+              <ChevronLeft size={24} color={APP_CHROME.headerTitle} />
+            </Pressable>
+            <Text style={styles.headerTitle}>Blocked Users</Text>
+            <View style={styles.headerSpacer} />
+          </View>
+        </SafeAreaView>
+      </LinearGradient>
+
+      <View style={styles.contentSheet}>
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          {ids.length > 0 && (
+            <Text style={styles.intro}>
+              You won&apos;t see content from blocked users, and they won&apos;t see yours. Tap Unblock to restore visibility.
+            </Text>
+          )}
+
+          {loadingProfiles && ids.length > 0 ? (
+            <View style={styles.loadingWrap}>
+              <ActivityIndicator color={neutral.foreground} />
+            </View>
+          ) : items.length === 0 ? (
+            <View style={styles.emptyWrap}>
+              <View style={styles.emptyIcon}>
+                <ShieldOff size={24} color={neutral.secondary} />
+              </View>
+              <Text style={styles.emptyTitle}>No blocked users</Text>
+              <Text style={styles.emptySubtitle}>
+                When you block someone, they&apos;ll show up here so you can unblock them later.
+              </Text>
+            </View>
+          ) : (
+            items.map((u) => (
+              <BlockedListItem
+                key={u.id}
+                user={u}
+                loading={pendingUserId === u.id}
+                onUnblock={handleUnblock}
+              />
+            ))
+          )}
+        </ScrollView>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/(app)/(drawer)/terms.tsx
+++ b/apps/mobile/app/(app)/(drawer)/terms.tsx
@@ -57,8 +57,19 @@ const termsSections: TermsSection[] = [
     ],
   },
   {
-    id: "ip",
+    id: "ugc",
     number: "5",
+    title: "User-Generated Content, Reporting, and Blocking",
+    paragraphs: [
+      "TeamNetwork lets members share user-generated content such as chat messages, feed posts, comments, and profile information. You are solely responsible for content you submit and must not post anything that is abusive, harassing, hateful, sexually explicit, violent, illegal, or otherwise objectionable.",
+      "We provide in-app tools to report objectionable content and to block other users. Reports can be filed on any chat message, feed post, comment, or member profile. Reported content is reviewed and actioned within 24 hours where appropriate; we may remove content, restrict accounts, or terminate access for violations.",
+      "Blocking is symmetric: when you block another user, neither of you will see the other's messages, posts, comments, or profile activity. You can manage your blocked users from the in-app Blocked Users settings at any time.",
+      "We have no tolerance for objectionable content or abusive behavior. Continued violations will result in account termination.",
+    ],
+  },
+  {
+    id: "ip",
+    number: "6",
     title: "Intellectual Property & License",
     paragraphs: [
       "TeamNetwork and its licensors retain all rights, title, and interest in the Service, including software, content, designs, trademarks, and logos.",
@@ -69,7 +80,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "payments",
-    number: "6",
+    number: "7",
     title: "Payments and Subscriptions",
     paragraphs: [
       "Certain features may require payment; all fees are non-refundable unless required by law.",
@@ -79,7 +90,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "donations",
-    number: "7",
+    number: "8",
     title: "Donations and Mentorship",
     paragraphs: [
       "The Service may include options to donate to teams or programs, or participate in mentorship opportunities. Users understand that all donations are voluntary and may be subject to separate terms and conditions.",
@@ -88,7 +99,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "termination",
-    number: "8",
+    number: "9",
     title: "Termination",
     paragraphs: [
       "TeamNetwork may suspend or terminate accounts at any time for violations of these Terms.",
@@ -97,7 +108,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "disclaimers",
-    number: "9",
+    number: "10",
     title: "Disclaimers",
     paragraphs: [
       "The Service is provided \"as is\" and \"as available\" without warranties of any kind.",
@@ -107,7 +118,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "liability",
-    number: "10",
+    number: "11",
     title: "Limitation of Liability",
     paragraphs: [
       "To the fullest extent permitted by law, TeamNetwork shall not be liable for:",
@@ -120,7 +131,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "indemnification",
-    number: "11",
+    number: "12",
     title: "Indemnification",
     paragraphs: [
       "You agree to indemnify, defend, and hold harmless TeamNetwork, MAC Connect LLC, and their affiliates from any claims, damages, or expenses arising from:",
@@ -133,7 +144,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "arbitration",
-    number: "12",
+    number: "13",
     title: "Dispute Resolution and Arbitration",
     paragraphs: [],
     bullets: [
@@ -146,7 +157,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "changes",
-    number: "13",
+    number: "14",
     title: "Changes to Terms",
     paragraphs: [
       "TeamNetwork may modify these Terms at any time. Changes will be effective when posted. Continued use of the Service constitutes acceptance of the updated Terms.",
@@ -154,7 +165,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "governing-law",
-    number: "14",
+    number: "15",
     title: "Governing Law",
     paragraphs: [
       "These Terms are governed by the laws of the State of New York, without regard to conflict of law principles.",
@@ -162,7 +173,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "contact",
-    number: "15",
+    number: "16",
     title: "Contact Information",
     paragraphs: [
       "Email: support@myteamnetwork.com",
@@ -184,7 +195,7 @@ export default function TermsScreen() {
         {/* Header */}
         <View style={styles.header}>
           <Text style={styles.title}>Terms of Service</Text>
-          <Text style={styles.lastUpdated}>Last Updated: December 8, 2025</Text>
+          <Text style={styles.lastUpdated}>Last Updated: May 16, 2026</Text>
         </View>
 
         {/* Sections */}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -15,6 +15,7 @@ import {
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { ColorSchemeProvider } from "@/contexts/ColorSchemeContext";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
+import { BlockedUsersProvider } from "@/contexts/BlockedUsersContext";
 import { NetworkProvider } from "@/contexts/NetworkContext";
 import { BiometricLockProvider } from "@/contexts/BiometricLockContext";
 import { LiveActivityProvider } from "@/contexts/LiveActivityContext";
@@ -107,13 +108,15 @@ export default function RootLayout() {
   return (
     <ColorSchemeProvider>
       <AuthProvider>
-        <NetworkProvider>
-          <BiometricLockProvider>
-            <LiveActivityProvider>
-              <RootLayoutInner />
-            </LiveActivityProvider>
-          </BiometricLockProvider>
-        </NetworkProvider>
+        <BlockedUsersProvider>
+          <NetworkProvider>
+            <BiometricLockProvider>
+              <LiveActivityProvider>
+                <RootLayoutInner />
+              </LiveActivityProvider>
+            </BiometricLockProvider>
+          </NetworkProvider>
+        </BlockedUsersProvider>
       </AuthProvider>
     </ColorSchemeProvider>
   );

--- a/apps/mobile/src/components/feed/CommentItem.tsx
+++ b/apps/mobile/src/components/feed/CommentItem.tsx
@@ -1,13 +1,16 @@
-import React, { useCallback } from "react";
-import { View, Text, Pressable } from "react-native";
+import React, { useCallback, useMemo, useState } from "react";
+import { View, Text } from "react-native";
 import { Image } from "expo-image";
-import { Trash2 } from "lucide-react-native";
+import { Flag, Trash2 } from "lucide-react-native";
 import { SPACING, RADIUS } from "@/lib/design-tokens";
 import { TYPOGRAPHY } from "@/lib/typography";
 import { formatRelativeTime } from "@/lib/date-format";
 import type { FeedComment } from "@/types/feed";
 import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
 import { useThemedStyles } from "@/hooks/useThemedStyles";
+import { useOrg } from "@/contexts/OrgContext";
+import { OverflowMenu, type OverflowMenuItem } from "@/components/OverflowMenu";
+import { ReportBlockSheet } from "@/components/moderation/ReportBlockSheet";
 
 interface CommentItemProps {
   comment: FeedComment;
@@ -17,7 +20,9 @@ interface CommentItemProps {
 }
 
 export function CommentItem({ comment, isOwn, isAdmin, onDelete }: CommentItemProps) {
-  const { neutral } = useAppColorScheme();
+  const { neutral, semantic } = useAppColorScheme();
+  const { orgId } = useOrg();
+  const [sheetOpen, setSheetOpen] = useState(false);
   const styles = useThemedStyles((n) => ({
     container: {
       flexDirection: "row" as const,
@@ -67,10 +72,31 @@ export function CommentItem({ comment, isOwn, isAdmin, onDelete }: CommentItemPr
     },
   }));
 
-  const canDelete = (isOwn || isAdmin) && !!onDelete;
   const handleDelete = useCallback(() => {
     onDelete?.(comment.id);
   }, [onDelete, comment.id]);
+
+  const menuItems = useMemo<OverflowMenuItem[]>(() => {
+    const items: OverflowMenuItem[] = [];
+    if ((isOwn || isAdmin) && onDelete) {
+      items.push({
+        id: "delete",
+        label: "Delete comment",
+        icon: <Trash2 size={18} color={semantic.error} />,
+        destructive: true,
+        onPress: handleDelete,
+      });
+    }
+    if (!isOwn) {
+      items.push({
+        id: "report",
+        label: "Report comment",
+        icon: <Flag size={18} color={neutral.foreground} />,
+        onPress: () => setSheetOpen(true),
+      });
+    }
+    return items;
+  }, [isOwn, isAdmin, onDelete, handleDelete, neutral.foreground, semantic.error]);
 
   return (
     <View style={styles.container}>
@@ -96,19 +122,25 @@ export function CommentItem({ comment, isOwn, isAdmin, onDelete }: CommentItemPr
           <Text style={styles.timestamp}>
             {formatRelativeTime(comment.created_at)}
           </Text>
-          {canDelete && (
-            <Pressable
-              onPress={handleDelete}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              accessibilityLabel="Delete comment"
-              accessibilityRole="button"
-            >
-              <Trash2 size={14} color={neutral.placeholder} />
-            </Pressable>
+          {menuItems.length > 0 && (
+            <OverflowMenu
+              items={menuItems}
+              iconSize={16}
+              accessibilityLabel="Comment options"
+            />
           )}
         </View>
         <Text style={styles.body}>{comment.body}</Text>
       </View>
+
+      <ReportBlockSheet
+        visible={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        orgId={orgId}
+        targetType="feed_comment"
+        targetId={comment.id}
+        reportedUserId={comment.author_id}
+      />
     </View>
   );
 }

--- a/apps/mobile/src/components/feed/PostCard.tsx
+++ b/apps/mobile/src/components/feed/PostCard.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { View, Text, Pressable, Platform } from "react-native";
 import { Image } from "expo-image";
 import * as Haptics from "expo-haptics";
-import { MessageCircle } from "lucide-react-native";
+import { Flag, MessageCircle, ShieldOff } from "lucide-react-native";
 import { SPACING, RADIUS, SHADOWS } from "@/lib/design-tokens";
 import { TYPOGRAPHY } from "@/lib/typography";
 import { formatRelativeTime } from "@/lib/date-format";
@@ -12,6 +12,10 @@ import { FeedPoll } from "./FeedPoll";
 import type { FeedPost } from "@/types/feed";
 import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
 import { useThemedStyles } from "@/hooks/useThemedStyles";
+import { useAuth } from "@/hooks/useAuth";
+import { useOrg } from "@/contexts/OrgContext";
+import { OverflowMenu, type OverflowMenuItem } from "@/components/OverflowMenu";
+import { ReportBlockSheet } from "@/components/moderation/ReportBlockSheet";
 
 interface PostCardProps {
   post: FeedPost;
@@ -30,7 +34,11 @@ function PostCardInner({
   likeDisabled = false,
   pollDisabled = false,
 }: PostCardProps) {
-  const { neutral } = useAppColorScheme();
+  const { neutral, semantic } = useAppColorScheme();
+  const { user } = useAuth();
+  const { orgId } = useOrg();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const isOwnPost = !!user?.id && post.author_id === user.id;
   const styles = useThemedStyles((n) => ({
     card: {
       backgroundColor: n.surface,
@@ -107,6 +115,12 @@ function PostCardInner({
       ...TYPOGRAPHY.labelMedium,
       color: n.muted,
     },
+    menuAnchor: {
+      position: "absolute" as const,
+      top: SPACING.xs,
+      right: SPACING.xs,
+      zIndex: 2,
+    },
   }));
 
   const handlePress = useCallback(() => {
@@ -124,11 +138,35 @@ function PostCardInner({
     onPress(post.id);
   }, [onPress, post.id]);
 
+  const menuItems = useMemo<OverflowMenuItem[]>(() => {
+    if (isOwnPost) return [];
+    return [
+      {
+        id: "report",
+        label: "Report post",
+        icon: <Flag size={18} color={neutral.foreground} />,
+        onPress: () => setSheetOpen(true),
+      },
+      {
+        id: "block",
+        label: "Block user",
+        icon: <ShieldOff size={18} color={semantic.error} />,
+        destructive: true,
+        onPress: () => setSheetOpen(true),
+      },
+    ];
+  }, [isOwnPost, neutral.foreground, semantic.error]);
+
   // Only the header + body navigate to the detail screen. Poll, media,
   // and the actions row are siblings — interactive children inside a
   // navigating Pressable can race with the parent and swallow taps.
   return (
     <View style={styles.card}>
+      {menuItems.length > 0 && (
+        <View style={styles.menuAnchor}>
+          <OverflowMenu items={menuItems} accessibilityLabel="Post options" />
+        </View>
+      )}
       <Pressable
         onPress={handlePress}
         style={({ pressed }) => [styles.headerPress, pressed && styles.cardPressed]}
@@ -200,6 +238,15 @@ function PostCardInner({
           <Text style={styles.commentCount}>{post.comment_count}</Text>
         </Pressable>
       </View>
+
+      <ReportBlockSheet
+        visible={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        orgId={orgId}
+        targetType="feed_post"
+        targetId={post.id}
+        reportedUserId={post.author_id}
+      />
     </View>
   );
 }

--- a/apps/mobile/src/components/moderation/BlockedListItem.tsx
+++ b/apps/mobile/src/components/moderation/BlockedListItem.tsx
@@ -1,0 +1,138 @@
+import React, { useCallback } from "react";
+import { View, Text, Pressable, ActivityIndicator, Alert } from "react-native";
+import { Image } from "expo-image";
+import { ShieldOff } from "lucide-react-native";
+import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
+import { useThemedStyles } from "@/hooks/useThemedStyles";
+import { SPACING, RADIUS } from "@/lib/design-tokens";
+import { TYPOGRAPHY } from "@/lib/typography";
+
+export interface BlockedListItemUser {
+  id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+}
+
+interface BlockedListItemProps {
+  user: BlockedListItemUser;
+  loading: boolean;
+  onUnblock: (userId: string) => Promise<void> | void;
+}
+
+export function BlockedListItem({ user, loading, onUnblock }: BlockedListItemProps) {
+  const { neutral, semantic } = useAppColorScheme();
+  const styles = useThemedStyles((n) => ({
+    row: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      paddingVertical: SPACING.md,
+      paddingHorizontal: SPACING.md,
+      gap: SPACING.md,
+      backgroundColor: n.surface,
+      borderRadius: RADIUS.md,
+      borderWidth: 1,
+      borderColor: n.border,
+      marginBottom: SPACING.sm,
+    },
+    avatar: {
+      width: 44,
+      height: 44,
+      borderRadius: 22,
+    },
+    avatarFallback: {
+      width: 44,
+      height: 44,
+      borderRadius: 22,
+      backgroundColor: n.border,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
+    },
+    avatarFallbackText: {
+      ...TYPOGRAPHY.labelLarge,
+      color: n.secondary,
+      fontWeight: "600" as const,
+    },
+    meta: {
+      flex: 1,
+    },
+    name: {
+      ...TYPOGRAPHY.labelLarge,
+      color: n.foreground,
+      fontWeight: "600" as const,
+    },
+    unblockButton: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      gap: SPACING.xs,
+      paddingHorizontal: SPACING.md,
+      paddingVertical: SPACING.sm,
+      borderRadius: RADIUS.sm,
+      backgroundColor: n.background,
+      borderWidth: 1,
+      borderColor: n.border,
+    },
+    unblockText: {
+      ...TYPOGRAPHY.labelMedium,
+      color: n.foreground,
+      fontWeight: "600" as const,
+    },
+  }));
+
+  const displayName = user.full_name?.trim() || "Unknown user";
+  const initial = (displayName[0] || "?").toUpperCase();
+
+  const handlePress = useCallback(() => {
+    Alert.alert(
+      "Unblock this user?",
+      "Their content will be visible again.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Unblock",
+          onPress: () => {
+            void onUnblock(user.id);
+          },
+        },
+      ],
+    );
+  }, [onUnblock, user.id]);
+
+  return (
+    <View style={styles.row}>
+      {user.avatar_url ? (
+        <Image
+          source={user.avatar_url}
+          style={styles.avatar}
+          contentFit="cover"
+          transition={200}
+        />
+      ) : (
+        <View style={styles.avatarFallback}>
+          <Text style={styles.avatarFallbackText}>{initial}</Text>
+        </View>
+      )}
+      <View style={styles.meta}>
+        <Text style={styles.name} numberOfLines={1}>
+          {displayName}
+        </Text>
+      </View>
+      <Pressable
+        onPress={handlePress}
+        disabled={loading}
+        style={({ pressed }) => [
+          styles.unblockButton,
+          (pressed || loading) && { opacity: 0.6 },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={`Unblock ${displayName}`}
+      >
+        {loading ? (
+          <ActivityIndicator size="small" color={neutral.foreground} />
+        ) : (
+          <ShieldOff size={16} color={neutral.foreground} />
+        )}
+        <Text style={styles.unblockText}>Unblock</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/moderation/ReportBlockSheet.tsx
+++ b/apps/mobile/src/components/moderation/ReportBlockSheet.tsx
@@ -1,0 +1,456 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  Alert,
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { Flag, ShieldOff } from "lucide-react-native";
+import { SPACING, RADIUS } from "@/lib/design-tokens";
+import { TYPOGRAPHY } from "@/lib/typography";
+import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
+import { useThemedStyles } from "@/hooks/useThemedStyles";
+import { showToast } from "@/components/ui/Toast";
+import { reportContent, toggleBlock } from "@/lib/moderation";
+import type { ReportReason, ReportTargetType } from "@/lib/moderation";
+import * as sentry from "@/lib/analytics/sentry";
+
+const REASONS: { id: ReportReason; label: string; description: string }[] = [
+  { id: "spam", label: "Spam", description: "Unwanted commercial or repetitive content" },
+  { id: "harassment", label: "Harassment or bullying", description: "Targeted attacks or insults" },
+  { id: "hate", label: "Hate speech", description: "Attacks based on identity" },
+  { id: "sexual", label: "Sexual content", description: "Explicit or inappropriate sexual material" },
+  { id: "violence", label: "Violence or threats", description: "Threats of harm" },
+  { id: "self_harm", label: "Self-harm", description: "Encourages or depicts self-injury" },
+  { id: "illegal", label: "Illegal activity", description: "Promotes unlawful behavior" },
+  { id: "impersonation", label: "Impersonation", description: "Pretending to be someone else" },
+  { id: "other", label: "Other", description: "Something else not listed" },
+];
+
+export interface ReportBlockSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  orgId: string | null;
+  targetType: ReportTargetType;
+  targetId: string;
+  /** User id of the content author / profile subject. Required for Block. */
+  reportedUserId: string | null;
+  /** Hide block option (e.g. when blocking is not applicable). */
+  hideBlock?: boolean;
+  /** Hide report option (rare, e.g. block-only flow). */
+  hideReport?: boolean;
+  /** Called after a successful block toggle so parent can update UI. */
+  onBlocked?: () => void;
+}
+
+type Stage = "picker" | "reason";
+
+export function ReportBlockSheet({
+  visible,
+  onClose,
+  orgId,
+  targetType,
+  targetId,
+  reportedUserId,
+  hideBlock,
+  hideReport,
+  onBlocked,
+}: ReportBlockSheetProps) {
+  const { neutral, semantic } = useAppColorScheme();
+  const [stage, setStage] = useState<Stage>("picker");
+  const [selectedReason, setSelectedReason] = useState<ReportReason | null>(null);
+  const [details, setDetails] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const styles = useThemedStyles((n, s) => ({
+    overlay: {
+      flex: 1,
+      backgroundColor: "rgba(0,0,0,0.5)",
+      justifyContent: "flex-end" as const,
+    },
+    sheet: {
+      backgroundColor: n.surface,
+      borderTopLeftRadius: RADIUS.xl,
+      borderTopRightRadius: RADIUS.xl,
+      paddingHorizontal: SPACING.lg,
+      paddingTop: SPACING.lg,
+      paddingBottom: SPACING.xl,
+      maxHeight: "85%" as const,
+    },
+    handle: {
+      alignSelf: "center" as const,
+      width: 36,
+      height: 4,
+      borderRadius: 2,
+      backgroundColor: n.border,
+      marginBottom: SPACING.md,
+    },
+    title: {
+      ...TYPOGRAPHY.titleMedium,
+      color: n.foreground,
+      marginBottom: SPACING.xs,
+    },
+    subtitle: {
+      ...TYPOGRAPHY.bodySmall,
+      color: n.muted,
+      marginBottom: SPACING.lg,
+    },
+    actionRow: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      paddingVertical: SPACING.md,
+      paddingHorizontal: SPACING.sm,
+      borderRadius: RADIUS.md,
+      gap: SPACING.sm,
+    },
+    actionRowBorder: {
+      borderBottomWidth: 1,
+      borderBottomColor: n.border,
+    },
+    actionLabel: {
+      ...TYPOGRAPHY.bodyMedium,
+      color: n.foreground,
+      fontWeight: "500" as const,
+      flex: 1,
+    },
+    actionLabelDestructive: {
+      color: s.error,
+    },
+    reasonRow: {
+      paddingVertical: SPACING.md,
+      paddingHorizontal: SPACING.sm,
+      borderRadius: RADIUS.md,
+      flexDirection: "row" as const,
+      alignItems: "flex-start" as const,
+      gap: SPACING.sm,
+    },
+    reasonRowSelected: {
+      backgroundColor: n.muted + "1a",
+    },
+    radio: {
+      width: 20,
+      height: 20,
+      borderRadius: 10,
+      borderWidth: 2,
+      borderColor: n.border,
+      marginTop: 2,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
+    },
+    radioSelected: {
+      borderColor: s.success,
+    },
+    radioInner: {
+      width: 10,
+      height: 10,
+      borderRadius: 5,
+      backgroundColor: s.success,
+    },
+    reasonText: {
+      flex: 1,
+    },
+    reasonLabel: {
+      ...TYPOGRAPHY.bodyMedium,
+      color: n.foreground,
+      fontWeight: "500" as const,
+    },
+    reasonDesc: {
+      ...TYPOGRAPHY.bodySmall,
+      color: n.muted,
+      marginTop: 2,
+    },
+    detailsInput: {
+      marginTop: SPACING.md,
+      backgroundColor: n.background,
+      borderWidth: 1,
+      borderColor: n.border,
+      borderRadius: RADIUS.md,
+      padding: SPACING.md,
+      ...TYPOGRAPHY.bodyMedium,
+      color: n.foreground,
+      minHeight: 80,
+      textAlignVertical: "top" as const,
+    },
+    detailsCount: {
+      ...TYPOGRAPHY.caption,
+      color: n.muted,
+      textAlign: "right" as const,
+      marginTop: 4,
+    },
+    buttonRow: {
+      flexDirection: "row" as const,
+      gap: SPACING.sm,
+      marginTop: SPACING.lg,
+    },
+    button: {
+      flex: 1,
+      paddingVertical: SPACING.md,
+      borderRadius: RADIUS.md,
+      alignItems: "center" as const,
+    },
+    buttonSecondary: {
+      backgroundColor: n.background,
+      borderWidth: 1,
+      borderColor: n.border,
+    },
+    buttonPrimary: {
+      backgroundColor: s.success,
+    },
+    buttonPrimaryDisabled: {
+      opacity: 0.5,
+    },
+    buttonLabelSecondary: {
+      ...TYPOGRAPHY.labelLarge,
+      color: n.foreground,
+    },
+    buttonLabelPrimary: {
+      ...TYPOGRAPHY.labelLarge,
+      color: "#ffffff",
+    },
+    cancelButton: {
+      marginTop: SPACING.sm,
+      paddingVertical: SPACING.md,
+      borderRadius: RADIUS.md,
+      alignItems: "center" as const,
+      backgroundColor: n.background,
+    },
+  }));
+
+  const reset = useCallback(() => {
+    setStage("picker");
+    setSelectedReason(null);
+    setDetails("");
+    setSubmitting(false);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    reset();
+    onClose();
+  }, [onClose, reset]);
+
+  const handleReportPress = useCallback(() => {
+    setStage("reason");
+  }, []);
+
+  const handleBlockPress = useCallback(() => {
+    if (!reportedUserId) {
+      showToast("Cannot block this account", "error");
+      return;
+    }
+    Alert.alert(
+      "Block this user?",
+      "You won't see their messages, posts, or comments. They won't see yours either.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Block",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              setSubmitting(true);
+              await toggleBlock(reportedUserId);
+              showToast("Blocked", "success");
+              onBlocked?.();
+              handleClose();
+            } catch (e) {
+              const message = (e as Error).message || "Failed to block";
+              showToast(message, "error");
+              sentry.captureException(e as Error, {
+                context: "ReportBlockSheet.block",
+                reportedUserId,
+              });
+              setSubmitting(false);
+            }
+          },
+        },
+      ],
+    );
+  }, [reportedUserId, onBlocked, handleClose]);
+
+  const handleSubmitReport = useCallback(async () => {
+    if (!selectedReason || !orgId) return;
+    try {
+      setSubmitting(true);
+      await reportContent({
+        orgId,
+        targetType,
+        targetId,
+        reportedUserId,
+        reason: selectedReason,
+        details: details.trim() || undefined,
+      });
+      showToast("Reported. Thanks for letting us know.", "success");
+      handleClose();
+    } catch (e) {
+      const message = (e as Error).message || "Failed to report";
+      showToast(message, "error");
+      sentry.captureException(e as Error, {
+        context: "ReportBlockSheet.report",
+        targetType,
+        targetId,
+      });
+      setSubmitting(false);
+    }
+  }, [selectedReason, orgId, targetType, targetId, reportedUserId, details, handleClose]);
+
+  const showBlock = !hideBlock && !!reportedUserId;
+  const showReport = !hideReport;
+
+  const detailsRemaining = useMemo(() => 1000 - details.length, [details]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={handleClose}
+    >
+      <Pressable style={styles.overlay} onPress={handleClose}>
+        <Pressable style={styles.sheet} onPress={(e) => e.stopPropagation()}>
+          <View style={styles.handle} />
+
+          {stage === "picker" && (
+            <>
+              <Text style={styles.title}>What would you like to do?</Text>
+              <Text style={styles.subtitle}>
+                Reports are reviewed within 24 hours.
+              </Text>
+
+              {showReport && (
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.actionRow,
+                    showBlock && styles.actionRowBorder,
+                    pressed && { opacity: 0.7 },
+                  ]}
+                  onPress={handleReportPress}
+                  accessibilityRole="button"
+                  accessibilityLabel="Report"
+                >
+                  <Flag size={20} color={neutral.foreground} />
+                  <Text style={styles.actionLabel}>Report</Text>
+                </Pressable>
+              )}
+
+              {showBlock && (
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.actionRow,
+                    pressed && { opacity: 0.7 },
+                  ]}
+                  onPress={handleBlockPress}
+                  accessibilityRole="button"
+                  accessibilityLabel="Block user"
+                  disabled={submitting}
+                >
+                  <ShieldOff size={20} color={semantic.error} />
+                  <Text
+                    style={[
+                      styles.actionLabel,
+                      styles.actionLabelDestructive,
+                    ]}
+                  >
+                    Block user
+                  </Text>
+                </Pressable>
+              )}
+
+              <Pressable
+                style={({ pressed }) => [styles.cancelButton, pressed && { opacity: 0.7 }]}
+                onPress={handleClose}
+              >
+                <Text style={styles.buttonLabelSecondary}>Cancel</Text>
+              </Pressable>
+            </>
+          )}
+
+          {stage === "reason" && (
+            <ScrollView keyboardShouldPersistTaps="handled">
+              <Text style={styles.title}>Why are you reporting this?</Text>
+              <Text style={styles.subtitle}>
+                Pick the reason that fits best.
+              </Text>
+
+              {REASONS.map((r) => {
+                const selected = selectedReason === r.id;
+                return (
+                  <Pressable
+                    key={r.id}
+                    style={({ pressed }) => [
+                      styles.reasonRow,
+                      selected && styles.reasonRowSelected,
+                      pressed && { opacity: 0.7 },
+                    ]}
+                    onPress={() => setSelectedReason(r.id)}
+                    accessibilityRole="radio"
+                    accessibilityState={{ selected }}
+                  >
+                    <View
+                      style={[
+                        styles.radio,
+                        selected && styles.radioSelected,
+                      ]}
+                    >
+                      {selected && <View style={styles.radioInner} />}
+                    </View>
+                    <View style={styles.reasonText}>
+                      <Text style={styles.reasonLabel}>{r.label}</Text>
+                      <Text style={styles.reasonDesc}>{r.description}</Text>
+                    </View>
+                  </Pressable>
+                );
+              })}
+
+              <TextInput
+                style={styles.detailsInput}
+                placeholder="Add details (optional)"
+                placeholderTextColor={neutral.muted}
+                value={details}
+                onChangeText={(t) => setDetails(t.slice(0, 1000))}
+                multiline
+                maxLength={1000}
+                editable={!submitting}
+              />
+              <Text style={styles.detailsCount}>
+                {detailsRemaining} characters left
+              </Text>
+
+              <View style={styles.buttonRow}>
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.button,
+                    styles.buttonSecondary,
+                    pressed && { opacity: 0.7 },
+                  ]}
+                  onPress={handleClose}
+                  disabled={submitting}
+                >
+                  <Text style={styles.buttonLabelSecondary}>Cancel</Text>
+                </Pressable>
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.button,
+                    styles.buttonPrimary,
+                    (!selectedReason || submitting) && styles.buttonPrimaryDisabled,
+                    pressed && { opacity: 0.8 },
+                  ]}
+                  onPress={handleSubmitReport}
+                  disabled={!selectedReason || submitting}
+                >
+                  <Text style={styles.buttonLabelPrimary}>
+                    {submitting ? "Submitting…" : "Submit report"}
+                  </Text>
+                </Pressable>
+              </View>
+            </ScrollView>
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+export default ReportBlockSheet;

--- a/apps/mobile/src/contexts/BlockedUsersContext.tsx
+++ b/apps/mobile/src/contexts/BlockedUsersContext.tsx
@@ -1,0 +1,178 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { supabase, createPostgresChangesChannel } from "@/lib/supabase";
+import { useAuthOptional } from "@/contexts/AuthContext";
+import { getBlockedUsers, toggleBlock as apiToggleBlock } from "@/lib/moderation";
+
+interface BlockedUsersContextValue {
+  blockedUserIds: Set<string>;
+  isBlocked: (userId: string | null | undefined) => boolean;
+  toggleBlock: (userId: string) => Promise<boolean>;
+  refresh: () => Promise<void>;
+}
+
+const EMPTY_SET: ReadonlySet<string> = new Set();
+
+const BlockedUsersContext = createContext<BlockedUsersContextValue | null>(null);
+
+interface UserBlockRow {
+  blocker_id: string;
+  blocked_id: string;
+  deleted_at: string | null;
+}
+
+export function BlockedUsersProvider({ children }: { children: ReactNode }) {
+  const auth = useAuthOptional();
+  const userId = auth?.user?.id ?? null;
+  const [blockedUserIds, setBlockedUserIds] = useState<Set<string>>(new Set());
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const fetchAll = useCallback(async () => {
+    if (!userId) {
+      if (isMountedRef.current) setBlockedUserIds(new Set());
+      return;
+    }
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase as any)
+        .from("user_blocks")
+        .select("blocker_id, blocked_id")
+        .is("deleted_at", null)
+        .or(`blocker_id.eq.${userId},blocked_id.eq.${userId}`) as {
+          data: Pick<UserBlockRow, "blocker_id" | "blocked_id">[] | null;
+          error: { message: string } | null;
+        };
+
+      if (error) throw error;
+
+      const next = new Set<string>();
+      for (const row of data ?? []) {
+        if (row.blocker_id === userId) next.add(row.blocked_id);
+        if (row.blocked_id === userId) next.add(row.blocker_id);
+      }
+      if (isMountedRef.current) setBlockedUserIds(next);
+    } catch (err) {
+      console.warn("[BlockedUsers] direct fetch failed, falling back to web API", err);
+      try {
+        const ids = await getBlockedUsers();
+        if (isMountedRef.current) setBlockedUserIds(new Set(ids));
+      } catch (fallbackErr) {
+        console.error("[BlockedUsers] fallback fetch failed", fallbackErr);
+      }
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void fetchAll();
+  }, [fetchAll]);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const channel = createPostgresChangesChannel(`user_blocks:${userId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "user_blocks",
+          filter: `blocker_id=eq.${userId}`,
+        },
+        () => {
+          void fetchAll();
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "user_blocks",
+          filter: `blocked_id=eq.${userId}`,
+        },
+        () => {
+          void fetchAll();
+        },
+      )
+      .subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [userId, fetchAll]);
+
+  const toggleBlock = useCallback(
+    async (otherUserId: string): Promise<boolean> => {
+      const { blocked } = await apiToggleBlock(otherUserId);
+      if (isMountedRef.current) {
+        setBlockedUserIds((prev) => {
+          const next = new Set(prev);
+          if (blocked) next.add(otherUserId);
+          else next.delete(otherUserId);
+          return next;
+        });
+      }
+      return blocked;
+    },
+    [],
+  );
+
+  const isBlocked = useCallback(
+    (otherUserId: string | null | undefined) =>
+      !!otherUserId && blockedUserIds.has(otherUserId),
+    [blockedUserIds],
+  );
+
+  const value = useMemo<BlockedUsersContextValue>(
+    () => ({
+      blockedUserIds,
+      isBlocked,
+      toggleBlock,
+      refresh: fetchAll,
+    }),
+    [blockedUserIds, isBlocked, toggleBlock, fetchAll],
+  );
+
+  return (
+    <BlockedUsersContext.Provider value={value}>
+      {children}
+    </BlockedUsersContext.Provider>
+  );
+}
+
+export function useBlockedUsers(): BlockedUsersContextValue {
+  const ctx = useContext(BlockedUsersContext);
+  if (!ctx) {
+    // Soft fallback so components rendered above the provider don't crash.
+    return {
+      blockedUserIds: EMPTY_SET as Set<string>,
+      isBlocked: () => false,
+      toggleBlock: async () => false,
+      refresh: async () => {},
+    };
+  }
+  return ctx;
+}
+
+export function useBlockedUserIds(): Set<string> {
+  return useBlockedUsers().blockedUserIds;
+}
+
+export function useIsBlocked(userId: string | null | undefined): boolean {
+  return useBlockedUsers().isBlocked(userId);
+}

--- a/apps/mobile/src/hooks/useAlumni.ts
+++ b/apps/mobile/src/hooks/useAlumni.ts
@@ -2,12 +2,14 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { supabase, createPostgresChangesChannel} from "@/lib/supabase";
 import { showToast } from "@/components/ui/Toast";
 import * as sentry from "@/lib/analytics/sentry";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
 
 const STALE_TIME_MS = 30_000; // 30 seconds
 const DEFAULT_PAGE_SIZE = 50;
 
 export interface Alumni {
   id: string;
+  user_id: string | null;
   first_name: string | null;
   last_name: string | null;
   photo_url: string | null;
@@ -63,6 +65,9 @@ export function useAlumni(
   const [hasMore, setHasMore] = useState(false);
   const [totalCount, setTotalCount] = useState<number | null>(null);
   const [offset, setOffset] = useState(0);
+  const { blockedUserIds } = useBlockedUsers();
+  const blockedRef = useRef<Set<string>>(blockedUserIds);
+  blockedRef.current = blockedUserIds;
 
   useEffect(() => {
     lastFetchTimeRef.current = 0;
@@ -97,6 +102,7 @@ export function useAlumni(
           .select(
             `
             id,
+            user_id,
             first_name,
             last_name,
             photo_url,
@@ -125,7 +131,10 @@ export function useAlumni(
         if (alumniError) throw alumniError;
 
         if (isMountedRef.current) {
-          const newData = (data as Alumni[]) || [];
+          const blocked = blockedRef.current;
+          const newData = ((data as Alumni[]) || []).filter(
+            (a) => !a.user_id || !blocked.has(a.user_id),
+          );
 
           if (append) {
             setAlumni((prev) => [...prev, ...newData]);
@@ -186,6 +195,10 @@ export function useAlumni(
       isMountedRef.current = false;
     };
   }, [fetchAlumni]);
+
+  useEffect(() => {
+    setAlumni((prev) => prev.filter((a) => !a.user_id || !blockedUserIds.has(a.user_id)));
+  }, [blockedUserIds]);
 
   // Real-time subscription for alumni changes
   useEffect(() => {

--- a/apps/mobile/src/hooks/useAlumniDetail.ts
+++ b/apps/mobile/src/hooks/useAlumniDetail.ts
@@ -4,6 +4,7 @@ import * as sentry from "@/lib/analytics/sentry";
 
 interface Alumni {
   id: string;
+  user_id: string | null;
   first_name: string | null;
   last_name: string | null;
   photo_url: string | null;
@@ -58,6 +59,7 @@ export function useAlumniDetail(orgSlug: string, alumniId: string): UseAlumniDet
         .select(
           `
           id,
+          user_id,
           first_name,
           last_name,
           photo_url,

--- a/apps/mobile/src/hooks/useComments.ts
+++ b/apps/mobile/src/hooks/useComments.ts
@@ -2,11 +2,15 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { supabase, createPostgresChangesChannel} from "@/lib/supabase";
 import { showToast } from "@/components/ui/Toast";
 import * as sentry from "@/lib/analytics/sentry";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
 import type { FeedComment, PostAuthor, UseCommentsReturn } from "@/types/feed";
 
 export function useComments(postId: string | undefined, orgId: string | null): UseCommentsReturn {
   const isMountedRef = useRef(true);
   const [comments, setComments] = useState<FeedComment[]>([]);
+  const { blockedUserIds } = useBlockedUsers();
+  const blockedRef = useRef<Set<string>>(blockedUserIds);
+  blockedRef.current = blockedUserIds;
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -32,10 +36,13 @@ export function useComments(postId: string | undefined, orgId: string | null): U
 
       if (fetchError) throw fetchError;
 
-      const enriched: FeedComment[] = (data || []).map((c) => ({
-        ...c,
-        author: (Array.isArray(c.author) ? c.author[0] : c.author) as PostAuthor | null,
-      }));
+      const blocked = blockedRef.current;
+      const enriched: FeedComment[] = (data || [])
+        .filter((c) => !blocked.has(c.author_id))
+        .map((c) => ({
+          ...c,
+          author: (Array.isArray(c.author) ? c.author[0] : c.author) as PostAuthor | null,
+        }));
 
       if (isMountedRef.current) {
         setComments(enriched);
@@ -146,6 +153,10 @@ export function useComments(postId: string | undefined, orgId: string | null): U
       isMountedRef.current = false;
     };
   }, [fetchComments]);
+
+  useEffect(() => {
+    setComments((prev) => prev.filter((c) => !blockedUserIds.has(c.author_id)));
+  }, [blockedUserIds]);
 
   useEffect(() => {
     if (!postId) return;

--- a/apps/mobile/src/hooks/useFeed.ts
+++ b/apps/mobile/src/hooks/useFeed.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { supabase, createPostgresChangesChannel} from "@/lib/supabase";
 import { useAuth } from "@/hooks/useAuth";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
 import { fetchWithAuth } from "@/lib/web-api";
 import { showToast } from "@/components/ui/Toast";
 import * as sentry from "@/lib/analytics/sentry";
@@ -17,6 +18,9 @@ export function useFeed(orgId: string | null): UseFeedReturn {
   const pendingPostsRef = useRef<FeedPost[]>([]);
   const { user } = useAuth();
   const userId = user?.id ?? null;
+  const { blockedUserIds } = useBlockedUsers();
+  const blockedRef = useRef<Set<string>>(blockedUserIds);
+  blockedRef.current = blockedUserIds;
   const [posts, setPosts] = useState<FeedPost[]>([]);
   const [pendingPosts, setPendingPosts] = useState<FeedPost[]>([]);
   const [loading, setLoading] = useState(true);
@@ -43,6 +47,12 @@ export function useFeed(orgId: string | null): UseFeedReturn {
   useEffect(() => {
     pendingPostsRef.current = pendingPosts;
   }, [pendingPosts]);
+
+  // Prune locally-cached posts whenever the block set changes.
+  useEffect(() => {
+    setPosts((prev) => prev.filter((p) => !blockedUserIds.has(p.author_id)));
+    setPendingPosts((prev) => prev.filter((p) => !blockedUserIds.has(p.author_id)));
+  }, [blockedUserIds]);
 
   const fetchPosts = useCallback(
     async (fetchOffset: number = 0, append: boolean = false) => {
@@ -84,7 +94,8 @@ export function useFeed(orgId: string | null): UseFeedReturn {
         if (postsError) throw postsError;
         if (currentGeneration !== generationRef.current) return;
 
-        const rawPosts = postsData || [];
+        const blocked = blockedRef.current;
+        const rawPosts = (postsData || []).filter((p) => !blocked.has(p.author_id));
         const postIds = rawPosts.map((p) => p.id);
 
         // Identify poll posts so we can hydrate their voting state alongside likes/media.
@@ -522,6 +533,9 @@ export function useFeed(orgId: string | null): UseFeedReturn {
         },
         async (payload) => {
           const newPost = payload.new as FeedPost;
+          if (blockedRef.current.has(newPost.author_id)) {
+            return;
+          }
           if (newPost.author_id === userId) {
             void refetch();
             return;

--- a/apps/mobile/src/hooks/useMemberDirectory.ts
+++ b/apps/mobile/src/hooks/useMemberDirectory.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { supabase, createPostgresChangesChannel} from "@/lib/supabase";
 import * as sentry from "@/lib/analytics/sentry";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
 
 const STALE_TIME_MS = 30_000;
 const DEFAULT_PAGE_SIZE = 50;
@@ -59,6 +60,9 @@ export function useMemberDirectory(
   const [hasMore, setHasMore] = useState(false);
   const [totalCount, setTotalCount] = useState<number | null>(null);
   const [offset, setOffset] = useState(0);
+  const { blockedUserIds } = useBlockedUsers();
+  const blockedRef = useRef<Set<string>>(blockedUserIds);
+  blockedRef.current = blockedUserIds;
 
   useEffect(() => {
     lastFetchTimeRef.current = 0;
@@ -118,7 +122,10 @@ export function useMemberDirectory(
         if (membersError) throw membersError;
 
         if (isMountedRef.current) {
-          const newData = (data as DirectoryMember[]) || [];
+          const blocked = blockedRef.current;
+          const newData = ((data as DirectoryMember[]) || []).filter(
+            (m) => !m.user_id || !blocked.has(m.user_id),
+          );
 
           if (append) {
             setMembers((prev) => [...prev, ...newData]);
@@ -174,6 +181,10 @@ export function useMemberDirectory(
       isMountedRef.current = false;
     };
   }, [fetchMembers]);
+
+  useEffect(() => {
+    setMembers((prev) => prev.filter((m) => !m.user_id || !blockedUserIds.has(m.user_id)));
+  }, [blockedUserIds]);
 
   // Real-time subscription for member changes
   useEffect(() => {

--- a/apps/mobile/src/hooks/useMembers.ts
+++ b/apps/mobile/src/hooks/useMembers.ts
@@ -3,6 +3,7 @@ import { supabase, createPostgresChangesChannel} from "@/lib/supabase";
 import { useRequestTracker } from "@/hooks/useRequestTracker";
 import { showToast } from "@/components/ui/Toast";
 import * as sentry from "@/lib/analytics/sentry";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
 
 const STALE_TIME_MS = 30_000; // 30 seconds
 
@@ -38,6 +39,9 @@ export function useMembers(orgId: string | null): UseMembersReturn {
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { blockedUserIds } = useBlockedUsers();
+  const blockedRef = useRef<Set<string>>(blockedUserIds);
+  blockedRef.current = blockedUserIds;
 
   useEffect(() => {
     lastFetchTimeRef.current = 0;
@@ -80,7 +84,11 @@ export function useMembers(orgId: string | null): UseMembersReturn {
       if (membersError) throw membersError;
 
       if (isMountedRef.current && isCurrentRequest(requestId)) {
-        setMembers((data as unknown as Member[]) || []);
+        const blocked = blockedRef.current;
+        const rows = ((data as unknown as Member[]) || []).filter(
+          (m) => !blocked.has(m.user_id),
+        );
+        setMembers(rows);
         setError(null);
         lastFetchTimeRef.current = Date.now();
       }
@@ -109,6 +117,10 @@ export function useMembers(orgId: string | null): UseMembersReturn {
       isMountedRef.current = false;
     };
   }, [fetchMembers]);
+
+  useEffect(() => {
+    setMembers((prev) => prev.filter((m) => !blockedUserIds.has(m.user_id)));
+  }, [blockedUserIds]);
 
   // Real-time subscription for member changes
   useEffect(() => {

--- a/apps/mobile/src/hooks/usePost.ts
+++ b/apps/mobile/src/hooks/usePost.ts
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { supabase, createPostgresChangesChannel} from "@/lib/supabase";
 import * as sentry from "@/lib/analytics/sentry";
 import { showToast } from "@/components/ui/Toast";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
 import type {
   FeedPost,
   PostAuthor,
@@ -16,6 +17,7 @@ export function usePost(postId: string | undefined): UsePostReturn {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const postRef = useRef<FeedPost | null>(null);
+  const { blockedUserIds } = useBlockedUsers();
 
   useEffect(() => {
     postRef.current = post;
@@ -52,6 +54,14 @@ export function usePost(postId: string | undefined): UsePostReturn {
       if (!postData) {
         if (isMountedRef.current) {
           setPost(null);
+          setLoading(false);
+        }
+        return;
+      }
+      if (blockedUserIds.has(postData.author_id)) {
+        if (isMountedRef.current) {
+          setPost(null);
+          setError(null);
           setLoading(false);
         }
         return;

--- a/apps/mobile/src/lib/moderation.ts
+++ b/apps/mobile/src/lib/moderation.ts
@@ -1,0 +1,71 @@
+import { fetchWithAuth } from "@/lib/web-api";
+
+export type ReportTargetType =
+  | "chat_message"
+  | "feed_post"
+  | "feed_comment"
+  | "user_profile";
+
+export type ReportReason =
+  | "spam"
+  | "harassment"
+  | "hate"
+  | "sexual"
+  | "violence"
+  | "self_harm"
+  | "illegal"
+  | "impersonation"
+  | "other";
+
+export interface ReportContentInput {
+  orgId: string;
+  targetType: ReportTargetType;
+  targetId: string;
+  reportedUserId?: string | null;
+  reason: ReportReason;
+  details?: string | null;
+}
+
+export async function reportContent(input: ReportContentInput): Promise<{ id: string }> {
+  const res = await fetchWithAuth("/api/moderation/report", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      organization_id: input.orgId,
+      target_type: input.targetType,
+      target_id: input.targetId,
+      reported_user_id: input.reportedUserId ?? null,
+      reason: input.reason,
+      details: input.details ?? null,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Failed to file report (${res.status}): ${text}`);
+  }
+  return (await res.json()) as { id: string };
+}
+
+export async function toggleBlock(blockedUserId: string): Promise<{ blocked: boolean }> {
+  const res = await fetchWithAuth("/api/moderation/block", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ blocked_user_id: blockedUserId }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Failed to toggle block (${res.status}): ${text}`);
+  }
+  return (await res.json()) as { blocked: boolean };
+}
+
+export async function getBlockedUsers(): Promise<string[]> {
+  const res = await fetchWithAuth("/api/moderation/block", { method: "GET" });
+  if (!res.ok) {
+    throw new Error(`Failed to load blocks (${res.status})`);
+  }
+  const json = (await res.json()) as { blocked_user_ids?: string[] };
+  return json.blocked_user_ids ?? [];
+}

--- a/apps/mobile/src/navigation/DrawerContent.tsx
+++ b/apps/mobile/src/navigation/DrawerContent.tsx
@@ -23,6 +23,7 @@ import {
   MessageCircle,
   Receipt,
   Settings,
+  ShieldOff,
   SlidersHorizontal,
   Trophy,
   Users,
@@ -53,7 +54,7 @@ interface NavItem {
 
 // Pinned footer items (Settings, Navigation, Organizations, Sign Out)
 const PINNED_ITEM_HEIGHT = 48;
-const PINNED_FOOTER_COUNT = 2;
+const PINNED_FOOTER_COUNT = 3;
 const BRAND_STRIP_HEIGHT = 88;
 const FOOTER_PADDING = 32;
 const FOOTER_TOP_INSET = 8;
@@ -216,6 +217,7 @@ export function DrawerContent(props: DrawerContentComponentProps) {
   const pinnedItems = useMemo<NavItem[]>(() => {
     if (!slug) return [];
     return [
+      { label: "Blocked Users", href: "/(app)/(drawer)/blocked-users", icon: ShieldOff },
       { label: "Organizations", href: "/(app)", icon: Building2 },
     ];
   }, [slug]);
@@ -232,7 +234,10 @@ export function DrawerContent(props: DrawerContentComponentProps) {
     // Use replace for secondary screens to avoid stacking
     if (item.href === `/(app)/${slug}`) {
       router.push(item.href);
-    } else if (item.href === "/(app)/(drawer)/delete-account") {
+    } else if (
+      item.href === "/(app)/(drawer)/delete-account" ||
+      item.href === "/(app)/(drawer)/blocked-users"
+    ) {
       router.push({
         pathname: item.href as any,
         params: slug ? { currentSlug: slug } : undefined,

--- a/apps/web/src/app/api/moderation/block/route.ts
+++ b/apps/web/src/app/api/moderation/block/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import {
+  checkRateLimit,
+  buildRateLimitResponse,
+} from "@/lib/security/rate-limit";
+import {
+  validateJson,
+  ValidationError,
+  validationErrorResponse,
+} from "@/lib/security/validation";
+import { toggleBlockSchema } from "@/lib/schemas/moderation";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+export async function POST(request: Request) {
+  let respond:
+    | ((payload: unknown, status?: number) => ReturnType<typeof NextResponse.json>)
+    | null = null;
+
+  try {
+    const { createAuthenticatedApiClient } = await import("@/lib/supabase/api");
+    const { supabase, user } = await createAuthenticatedApiClient(request);
+
+    const rateLimit = checkRateLimit(request, {
+      userId: user?.id ?? null,
+      feature: "toggle block",
+      limitPerIp: 90,
+      limitPerUser: 60,
+      windowMs: HOUR_MS,
+    });
+
+    if (!rateLimit.ok) {
+      return buildRateLimitResponse(rateLimit);
+    }
+
+    respond = (payload: unknown, status = 200) =>
+      NextResponse.json(payload, { status, headers: rateLimit.headers });
+
+    if (!user) {
+      return respond({ error: "Unauthorized" }, 401);
+    }
+
+    const body = await validateJson(request, toggleBlockSchema, {
+      maxBodyBytes: 1_000,
+    });
+
+    if (body.blocked_user_id === user.id) {
+      return respond({ error: "Cannot block yourself" }, 400);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (supabase as any).rpc("toggle_block", {
+      p_blocked_id: body.blocked_user_id,
+    }) as { data: { blocked: boolean } | null; error: { message: string } | null };
+
+    if (error) {
+      console.error("[moderation/block] rpc failed", error);
+      return respond({ error: "Failed to toggle block" }, 500);
+    }
+
+    return respond({ blocked: data?.blocked ?? false });
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      if (respond) {
+        return respond({ error: err.message, details: err.details }, 400);
+      }
+      return validationErrorResponse(err);
+    }
+    console.error("[moderation/block] unexpected error", err);
+    return NextResponse.json({ error: "Failed to toggle block" }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const { createAuthenticatedApiClient } = await import("@/lib/supabase/api");
+    const { supabase, user } = await createAuthenticatedApiClient(request);
+
+    const rateLimit = checkRateLimit(request, {
+      userId: user?.id ?? null,
+      feature: "list blocks",
+      limitPerIp: 120,
+      limitPerUser: 90,
+      windowMs: 60_000,
+    });
+
+    if (!rateLimit.ok) {
+      return buildRateLimitResponse(rateLimit);
+    }
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401, headers: rateLimit.headers },
+      );
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (supabase as any)
+      .from("user_blocks")
+      .select("blocker_id, blocked_id")
+      .is("deleted_at", null)
+      .or(`blocker_id.eq.${user.id},blocked_id.eq.${user.id}`) as {
+        data: Array<{ blocker_id: string; blocked_id: string }> | null;
+        error: { message: string } | null;
+      };
+
+    if (error) {
+      console.error("[moderation/block GET] query failed", error);
+      return NextResponse.json(
+        { error: "Failed to load blocks" },
+        { status: 500, headers: rateLimit.headers },
+      );
+    }
+
+    const ids = new Set<string>();
+    for (const row of data ?? []) {
+      if (row.blocker_id === user.id) ids.add(row.blocked_id);
+      if (row.blocked_id === user.id) ids.add(row.blocker_id);
+    }
+
+    return NextResponse.json(
+      { blocked_user_ids: Array.from(ids) },
+      { headers: rateLimit.headers },
+    );
+  } catch (err) {
+    console.error("[moderation/block GET] unexpected error", err);
+    return NextResponse.json({ error: "Failed to load blocks" }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/moderation/report/route.ts
+++ b/apps/web/src/app/api/moderation/report/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse } from "next/server";
+import {
+  checkRateLimit,
+  buildRateLimitResponse,
+} from "@/lib/security/rate-limit";
+import {
+  validateJson,
+  ValidationError,
+  validationErrorResponse,
+} from "@/lib/security/validation";
+import { reportContentSchema } from "@/lib/schemas/moderation";
+import { sendNewReportEmail } from "@/lib/notifications";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+export async function POST(request: Request) {
+  let respond:
+    | ((payload: unknown, status?: number) => ReturnType<typeof NextResponse.json>)
+    | null = null;
+
+  try {
+    const { createAuthenticatedApiClient } = await import("@/lib/supabase/api");
+    const { createServiceClient } = await import("@/lib/supabase/service");
+    const { supabase, user } = await createAuthenticatedApiClient(request);
+    const serviceSupabase = createServiceClient();
+
+    const rateLimit = checkRateLimit(request, {
+      userId: user?.id ?? null,
+      feature: "content report",
+      limitPerIp: 20,
+      limitPerUser: 10,
+      windowMs: HOUR_MS,
+    });
+
+    if (!rateLimit.ok) {
+      return buildRateLimitResponse(rateLimit);
+    }
+
+    respond = (payload: unknown, status = 200) =>
+      NextResponse.json(payload, { status, headers: rateLimit.headers });
+
+    if (!user) {
+      return respond({ error: "Unauthorized" }, 401);
+    }
+
+    const body = await validateJson(request, reportContentSchema, {
+      maxBodyBytes: 4_000,
+    });
+
+    // Verify reporter is active member of the org.
+    const { data: membership, error: membershipError } = await supabase
+      .from("user_organization_roles")
+      .select("role, status")
+      .eq("user_id", user.id)
+      .eq("organization_id", body.organization_id)
+      .eq("status", "active")
+      .maybeSingle();
+
+    if (membershipError) {
+      console.error("[moderation/report] membership lookup failed", membershipError);
+      return respond({ error: "Unable to verify membership" }, 500);
+    }
+    if (!membership) {
+      return respond({ error: "Not a member of this organization" }, 403);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const reportsTable = (serviceSupabase as any).from("content_reports");
+    const { data: insertedRows, error: insertError } = await reportsTable
+      .insert({
+        organization_id: body.organization_id,
+        reporter_id: user.id,
+        target_type: body.target_type,
+        target_id: body.target_id,
+        reported_user_id: body.reported_user_id ?? null,
+        reason: body.reason,
+        details: body.details ?? null,
+      })
+      .select("id, target_type, reason, details")
+      .single() as {
+        data: {
+          id: string;
+          target_type: typeof body.target_type;
+          reason: typeof body.reason;
+          details: string | null;
+        } | null;
+        error: { message: string; code?: string } | null;
+      };
+
+    if (insertError || !insertedRows) {
+      console.error("[moderation/report] insert failed", insertError);
+      return respond({ error: "Failed to file report" }, 500);
+    }
+
+    // Best-effort admin email — never blocks the user response.
+    const { data: reporterProfile } = await supabase
+      .from("users")
+      .select("name")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const reporterFirstName =
+      reporterProfile?.name?.trim().split(/\s+/)[0] ?? null;
+
+    void sendNewReportEmail({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      supabase: serviceSupabase as any,
+      organizationId: body.organization_id,
+      report: insertedRows,
+      reporterFirstName,
+    });
+
+    return respond({ id: insertedRows.id }, 201);
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      if (respond) {
+        return respond({ error: err.message, details: err.details }, 400);
+      }
+      return validationErrorResponse(err);
+    }
+    console.error("[moderation/report] unexpected error", err);
+    return NextResponse.json({ error: "Failed to file report" }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -59,8 +59,19 @@ const termsSections: TermsSection[] = [
     ],
   },
   {
-    id: "ip",
+    id: "ugc",
     number: "5",
+    title: "User-Generated Content, Reporting, and Blocking",
+    paragraphs: [
+      "TeamNetwork lets members share user-generated content such as chat messages, feed posts, comments, and profile information. You are solely responsible for content you submit and must not post anything that is abusive, harassing, hateful, sexually explicit, violent, illegal, or otherwise objectionable.",
+      "We provide in-app tools to report objectionable content and to block other users. Reports can be filed on any chat message, feed post, comment, or member profile. Reported content is reviewed and actioned within 24 hours where appropriate; we may remove content, restrict accounts, or terminate access for violations.",
+      "Blocking is symmetric: when you block another user, neither of you will see the other's messages, posts, comments, or profile activity. You can manage your blocked users from the in-app Blocked Users settings at any time.",
+      "We have no tolerance for objectionable content or abusive behavior. Continued violations will result in account termination.",
+    ],
+  },
+  {
+    id: "ip",
+    number: "6",
     title: "Intellectual Property & License",
     paragraphs: [
       "TeamNetwork and its licensors retain all rights, title, and interest in the Service, including software, content, designs, trademarks, and logos.",
@@ -71,7 +82,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "payments",
-    number: "6",
+    number: "7",
     title: "Payments and Subscriptions",
     paragraphs: [
       "Certain features may require payment; all fees are non-refundable unless required by law.",
@@ -81,7 +92,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "donations",
-    number: "7",
+    number: "8",
     title: "Donations and Mentorship",
     paragraphs: [
       "The Service may include options to donate to teams or programs, or participate in mentorship opportunities. Users understand that all donations are voluntary and may be subject to separate terms and conditions.",
@@ -90,7 +101,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "termination",
-    number: "8",
+    number: "9",
     title: "Termination",
     paragraphs: [
       "TeamNetwork may suspend or terminate accounts at any time for violations of these Terms.",
@@ -99,7 +110,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "disclaimers",
-    number: "9",
+    number: "10",
     title: "Disclaimers",
     paragraphs: [
       "The Service is provided \"as is\" and \"as available\" without warranties of any kind.",
@@ -109,7 +120,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "liability",
-    number: "10",
+    number: "11",
     title: "Limitation of Liability",
     paragraphs: [
       "To the fullest extent permitted by law, TeamNetwork shall not be liable for:",
@@ -122,7 +133,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "indemnification",
-    number: "11",
+    number: "12",
     title: "Indemnification",
     paragraphs: [
       "You agree to indemnify, defend, and hold harmless TeamNetwork, MAC Connect LLC, and their affiliates from any claims, damages, or expenses arising from:",
@@ -135,7 +146,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "arbitration",
-    number: "12",
+    number: "13",
     title: "Dispute Resolution and Arbitration",
     paragraphs: [],
     bullets: [
@@ -148,7 +159,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "changes",
-    number: "13",
+    number: "14",
     title: "Changes to Terms",
     paragraphs: [
       "TeamNetwork may modify these Terms at any time. Changes will be effective when posted. Continued use of the Service constitutes acceptance of the updated Terms.",
@@ -156,7 +167,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "governing-law",
-    number: "14",
+    number: "15",
     title: "Governing Law",
     paragraphs: [
       "These Terms are governed by the laws of the State of New York, without regard to conflict of law principles.",
@@ -164,7 +175,7 @@ const termsSections: TermsSection[] = [
   },
   {
     id: "contact",
-    number: "15",
+    number: "16",
     title: "Contact Information",
     paragraphs: [
       "Email: mleonard@myteamnetwork.com",
@@ -216,7 +227,7 @@ export default function TermsPage() {
             Legal
           </div>
           <h1 className="font-display text-4xl sm:text-5xl font-bold mb-4">Terms of Service</h1>
-          <p className="text-landing-cream/50">Last Updated: December 8, 2025</p>
+          <p className="text-landing-cream/50">Last Updated: May 16, 2026</p>
         </div>
 
         <div className="grid lg:grid-cols-[280px_1fr] gap-12">

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { Resend } from "resend";
 import type { Database, NotificationAudience, NotificationChannel, UserRole } from "@/types/database";
+import { buildNewReportEmail, type NewReportEmailContext } from "./notifications/templates/moderation/new-report";
 
 const resend = process.env.RESEND_API_KEY
   ? new Resend(process.env.RESEND_API_KEY)
@@ -391,4 +392,73 @@ export async function sendNotificationBlast(input: NotificationBlastInput): Prom
     skippedMissingContact: stats.skippedMissingContact,
     errors,
   };
+}
+
+export interface SendNewReportEmailInput {
+  supabase: SupabaseClient<Database>;
+  organizationId: string;
+  report: {
+    id: string;
+    target_type: NewReportEmailContext["targetType"];
+    reason: NewReportEmailContext["reason"];
+    details: string | null;
+  };
+  reporterFirstName: string | null;
+}
+
+/**
+ * Best-effort admin alert for a new content_reports row. Never throws — caller
+ * always returns success to the user even if email plumbing fails.
+ */
+export async function sendNewReportEmail(input: SendNewReportEmailInput): Promise<void> {
+  try {
+    const { supabase, organizationId, report, reporterFirstName } = input;
+
+    const { data: org } = await supabase
+      .from("organizations")
+      .select("name")
+      .eq("id", organizationId)
+      .maybeSingle();
+
+    const orgName = org?.name ?? "your organization";
+
+    const { data: adminRoles } = await supabase
+      .from("user_organization_roles")
+      .select("user_id")
+      .eq("organization_id", organizationId)
+      .eq("role", "admin")
+      .eq("status", "active");
+
+    const adminIds = (adminRoles ?? []).map((r) => r.user_id).filter(Boolean) as string[];
+    if (adminIds.length === 0) return;
+
+    const { data: admins } = await supabase
+      .from("users")
+      .select("id, email")
+      .in("id", adminIds);
+
+    const recipients = (admins ?? [])
+      .map((u) => u.email)
+      .filter((e): e is string => typeof e === "string" && e.length > 0);
+
+    if (recipients.length === 0) return;
+
+    const reviewUrl = process.env.MODERATION_REVIEW_URL || null;
+
+    const { subject, body } = buildNewReportEmail({
+      orgName,
+      targetType: report.target_type,
+      reason: report.reason,
+      reporterFirstName,
+      details: report.details,
+      reportId: report.id,
+      reviewUrl,
+    });
+
+    await Promise.allSettled(
+      recipients.map((to) => sendEmail({ to, subject, body })),
+    );
+  } catch (err) {
+    console.error("[sendNewReportEmail] best-effort failure", err);
+  }
 }

--- a/apps/web/src/lib/notifications/templates/moderation/new-report.ts
+++ b/apps/web/src/lib/notifications/templates/moderation/new-report.ts
@@ -1,0 +1,67 @@
+import type { ReportReason, ReportTargetType } from "@/lib/schemas/moderation";
+
+export interface NewReportEmailContext {
+  orgName: string;
+  targetType: ReportTargetType;
+  reason: ReportReason;
+  reporterFirstName: string | null;
+  details: string | null;
+  reportId: string;
+  reviewUrl: string | null;
+}
+
+const TARGET_LABEL: Record<ReportTargetType, string> = {
+  chat_message: "chat message",
+  feed_post: "feed post",
+  feed_comment: "feed comment",
+  user_profile: "member profile",
+};
+
+const REASON_LABEL: Record<ReportReason, string> = {
+  spam: "Spam",
+  harassment: "Harassment or bullying",
+  hate: "Hate speech",
+  sexual: "Sexual content",
+  violence: "Violence or threats",
+  self_harm: "Self-harm",
+  illegal: "Illegal activity",
+  impersonation: "Impersonation",
+  other: "Other",
+};
+
+export function buildNewReportEmail(ctx: NewReportEmailContext): { subject: string; body: string } {
+  const reporter = ctx.reporterFirstName ? ctx.reporterFirstName : "A member";
+  const target = TARGET_LABEL[ctx.targetType];
+  const reason = REASON_LABEL[ctx.reason];
+
+  const lines = [
+    `${reporter} reported a ${target} in ${ctx.orgName}.`,
+    "",
+    `Reason: ${reason}`,
+  ];
+
+  if (ctx.details && ctx.details.trim().length > 0) {
+    lines.push("", "Details from reporter:", ctx.details.trim());
+  }
+
+  lines.push(
+    "",
+    `Report ID: ${ctx.reportId}`,
+    "",
+    "App Store policy requires action on reports within 24 hours. Please triage as soon as possible.",
+  );
+
+  if (ctx.reviewUrl) {
+    lines.push("", `Review: ${ctx.reviewUrl}`);
+  } else {
+    lines.push(
+      "",
+      "Open Supabase Studio and query content_reports filtered by this report ID, or contact your TeamNetwork admin.",
+    );
+  }
+
+  return {
+    subject: `[TeamNetwork] New content report in ${ctx.orgName}`,
+    body: lines.join("\n"),
+  };
+}

--- a/apps/web/src/lib/schemas/index.ts
+++ b/apps/web/src/lib/schemas/index.ts
@@ -84,3 +84,6 @@ export * from "./global-search";
 
 // AI feedback schemas
 export * from "./ai-feedback";
+
+// Moderation schemas (content reports, blocks)
+export * from "./moderation";

--- a/apps/web/src/lib/schemas/moderation.ts
+++ b/apps/web/src/lib/schemas/moderation.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { baseSchemas } from "@/lib/security/validation";
+
+export const reportTargetTypeSchema = z.enum([
+  "chat_message",
+  "feed_post",
+  "feed_comment",
+  "user_profile",
+]);
+export type ReportTargetType = z.infer<typeof reportTargetTypeSchema>;
+
+export const reportReasonSchema = z.enum([
+  "spam",
+  "harassment",
+  "hate",
+  "sexual",
+  "violence",
+  "self_harm",
+  "illegal",
+  "impersonation",
+  "other",
+]);
+export type ReportReason = z.infer<typeof reportReasonSchema>;
+
+export const reportContentSchema = z.object({
+  organization_id: baseSchemas.uuid,
+  target_type: reportTargetTypeSchema,
+  target_id: baseSchemas.uuid,
+  reported_user_id: baseSchemas.uuid.nullable().optional(),
+  reason: reportReasonSchema,
+  details: z.string().trim().max(1000).optional().nullable(),
+});
+export type ReportContentInput = z.infer<typeof reportContentSchema>;
+
+export const toggleBlockSchema = z.object({
+  blocked_user_id: baseSchemas.uuid,
+});
+export type ToggleBlockInput = z.infer<typeof toggleBlockSchema>;

--- a/supabase/migrations/20260515191027_create_user_blocks_and_content_reports.sql
+++ b/supabase/migrations/20260515191027_create_user_blocks_and_content_reports.sql
@@ -1,0 +1,199 @@
+-- =============================================================================
+-- App Store UGC compliance (Guideline 1.2): user_blocks + content_reports
+-- =============================================================================
+
+-- 1. user_blocks ---------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.user_blocks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  blocker_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  blocked_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  CHECK (blocker_id <> blocked_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_blocks_unique_active
+  ON public.user_blocks (blocker_id, blocked_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS user_blocks_blocker_active_idx
+  ON public.user_blocks (blocker_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS user_blocks_blocked_active_idx
+  ON public.user_blocks (blocked_id)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE public.user_blocks ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "user_blocks_select_own" ON public.user_blocks;
+CREATE POLICY "user_blocks_select_own"
+  ON public.user_blocks
+  FOR SELECT
+  TO authenticated
+  USING (
+    blocker_id = (select auth.uid())
+    OR blocked_id = (select auth.uid())
+  );
+
+DROP POLICY IF EXISTS "user_blocks_insert_own" ON public.user_blocks;
+CREATE POLICY "user_blocks_insert_own"
+  ON public.user_blocks
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (blocker_id = (select auth.uid()));
+
+DROP POLICY IF EXISTS "user_blocks_update_own" ON public.user_blocks;
+CREATE POLICY "user_blocks_update_own"
+  ON public.user_blocks
+  FOR UPDATE
+  TO authenticated
+  USING (blocker_id = (select auth.uid()))
+  WITH CHECK (blocker_id = (select auth.uid()));
+
+DROP POLICY IF EXISTS "user_blocks_service" ON public.user_blocks;
+CREATE POLICY "user_blocks_service"
+  ON public.user_blocks
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE public.user_blocks IS
+  'Symmetric block relationships. toggle_block() creates one row per direction so both sides see the block.';
+
+-- 2. content_reports -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.content_reports (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  reporter_id uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  target_type text NOT NULL CHECK (target_type IN ('chat_message','feed_post','feed_comment','user_profile')),
+  target_id uuid NOT NULL,
+  reported_user_id uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  reason text NOT NULL CHECK (reason IN ('spam','harassment','hate','sexual','violence','self_harm','illegal','impersonation','other')),
+  details text CHECK (details IS NULL OR char_length(details) <= 1000),
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','reviewing','actioned','dismissed')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  reviewed_at timestamptz,
+  reviewed_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  deleted_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS content_reports_org_recent_idx
+  ON public.content_reports (organization_id, created_at DESC)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS content_reports_reporter_idx
+  ON public.content_reports (reporter_id);
+
+CREATE INDEX IF NOT EXISTS content_reports_reported_user_idx
+  ON public.content_reports (reported_user_id);
+
+CREATE INDEX IF NOT EXISTS content_reports_target_idx
+  ON public.content_reports (target_type, target_id)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE public.content_reports ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "content_reports_select_reporter" ON public.content_reports;
+CREATE POLICY "content_reports_select_reporter"
+  ON public.content_reports
+  FOR SELECT
+  TO authenticated
+  USING (reporter_id = (select auth.uid()));
+
+DROP POLICY IF EXISTS "content_reports_select_admin" ON public.content_reports;
+CREATE POLICY "content_reports_select_admin"
+  ON public.content_reports
+  FOR SELECT
+  TO authenticated
+  USING (public.has_active_role(organization_id, array['admin']));
+
+DROP POLICY IF EXISTS "content_reports_insert_member" ON public.content_reports;
+CREATE POLICY "content_reports_insert_member"
+  ON public.content_reports
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    reporter_id = (select auth.uid())
+    AND public.has_active_role(
+      organization_id,
+      array['admin','active_member','alumni','parent']
+    )
+  );
+
+DROP POLICY IF EXISTS "content_reports_service" ON public.content_reports;
+CREATE POLICY "content_reports_service"
+  ON public.content_reports
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE public.content_reports IS
+  'Polymorphic UGC reports (chat_message, feed_post, feed_comment, user_profile). App Store Guideline 1.2.';
+
+-- 3. toggle_block RPC ----------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.toggle_block(p_blocked_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_me uuid;
+  v_existing_id uuid;
+  v_now timestamptz := now();
+BEGIN
+  v_me := auth.uid();
+  IF v_me IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  IF p_blocked_id IS NULL OR p_blocked_id = v_me THEN
+    RAISE EXCEPTION 'invalid blocked user';
+  END IF;
+
+  -- Forward direction: me -> them
+  SELECT id INTO v_existing_id
+  FROM public.user_blocks
+  WHERE blocker_id = v_me AND blocked_id = p_blocked_id AND deleted_at IS NULL
+  LIMIT 1;
+
+  IF v_existing_id IS NOT NULL THEN
+    -- Currently blocked: unblock both directions
+    UPDATE public.user_blocks
+    SET deleted_at = v_now
+    WHERE deleted_at IS NULL
+      AND (
+        (blocker_id = v_me AND blocked_id = p_blocked_id)
+        OR (blocker_id = p_blocked_id AND blocked_id = v_me)
+      );
+
+    RETURN jsonb_build_object('blocked', false);
+  END IF;
+
+  -- Not blocked: insert both directions (revive soft-deleted rows if any)
+  INSERT INTO public.user_blocks (blocker_id, blocked_id)
+  VALUES (v_me, p_blocked_id)
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.user_blocks (blocker_id, blocked_id)
+  VALUES (p_blocked_id, v_me)
+  ON CONFLICT DO NOTHING;
+
+  -- In case the unique-active index allowed (soft-deleted) duplicates, revive them too
+  UPDATE public.user_blocks
+  SET deleted_at = NULL, created_at = v_now
+  WHERE deleted_at IS NOT NULL
+    AND (
+      (blocker_id = v_me AND blocked_id = p_blocked_id)
+      OR (blocker_id = p_blocked_id AND blocked_id = v_me)
+    );
+
+  RETURN jsonb_build_object('blocked', true);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.toggle_block(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.toggle_block(uuid) TO authenticated;


### PR DESCRIPTION
## Summary
- Adds report content + block user across all UGC surfaces (App Store Guideline 1.2)
- DB: \`user_blocks\` (symmetric), \`content_reports\` (polymorphic 4 target types, 9 reasons), \`toggle_block\` RPC, RLS
- Web API: \`/api/moderation/report\` + \`/api/moderation/block\` (POST/GET), Resend admin email on each new report, **Bearer-or-cookie auth via \`createAuthenticatedApiClient\`** so mobile bearer tokens work
- Mobile: \`ReportBlockSheet\`, \`BlockedUsersContext\` (initial fetch + realtime), Blocked Users settings screen + drawer entry, filters across feed/post/comments/chat/thread/members/alumni, visible Report+Block buttons on member/alumni profiles, OverflowMenu w/ Report on feed/comments, long-press Report on chat
- Terms: UGC clause on web Terms page

## Notes
- Migration already applied to production via Supabase MCP (\`20260515191027_create_user_blocks_and_content_reports.sql\`).
- Orphan members (no \`user_id\`) show Report only; Block hidden.
- Reviewer 1-tap demo path: visible Report button on profiles.

## Test plan
- [ ] Report chat message → toast → row in \`content_reports\`
- [ ] Report feed post + comment + profile → all 4 \`target_type\` values exercised
- [ ] Block from profile (visible button) → button toggles to Unblock, profile dimmed, B's posts/messages disappear from A's feed/chat, symmetric on B's side
- [ ] Blocked Users settings → Unblock → row removed
- [ ] Self-protection: no Report/Block on own profile or own messages
- [ ] Rate limits: 11th rapid report returns 429
- [ ] Admin email lands at org admin mailbox