### PR TITLE
mobile: App Store 1.2 — visible Terms + signup consent + Terms screen polish

### DIFF
--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/members.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/(tabs)/members.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState, useCallback, useRef, useEffect } from "react";
+import { useMemo, useState, useCallback, useRef, useEffect, useDeferredValue } from "react";
 import {
   View,
   Text,
   FlatList,
   RefreshControl,
   Pressable,
+  StyleSheet,
 } from "react-native";
 import { Image } from "expo-image";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -134,6 +135,7 @@ export default function MembersScreen() {
       backgroundColor: n.surface,
       paddingTop: SPACING.md,
       paddingBottom: SPACING.sm,
+      paddingHorizontal: SPACING.md,
       gap: SPACING.md,
     },
     sortButton: {
@@ -153,9 +155,13 @@ export default function MembersScreen() {
       color: n.muted,
     },
     listContent: {
-      paddingHorizontal: SPACING.md,
       paddingBottom: SPACING.xl,
       flexGrow: 1,
+    },
+    rowSeparator: {
+      height: StyleSheet.hairlineWidth,
+      backgroundColor: n.border,
+      marginLeft: SPACING.md + 44 + SPACING.md,
     },
   }));
 
@@ -210,8 +216,9 @@ export default function MembersScreen() {
     return Array.from(yearSet).sort((a, b) => b - a);
   }, [members]);
 
+  const deferredSearchQuery = useDeferredValue(searchQuery);
   const filteredMembers = useMemo(() => {
-    const q = searchQuery.toLowerCase().trim();
+    const q = deferredSearchQuery.toLowerCase().trim();
     let result = members.filter((m) => {
       if (selectedRole === "admin" && m.role !== "admin") return false;
       if (selectedRole === "member" && m.role === "admin") return false;
@@ -236,7 +243,7 @@ export default function MembersScreen() {
     });
 
     return result;
-  }, [members, searchQuery, selectedRole, selectedYear, sortBy]);
+  }, [members, deferredSearchQuery, selectedRole, selectedYear, sortBy]);
 
   const getInitials = (member: DirectoryMember) => {
     if (member.first_name && member.last_name) {
@@ -282,6 +289,21 @@ export default function MembersScreen() {
       );
     },
     [handleMemberPress, directoryColors, isOnline]
+  );
+
+  const renderRowSeparator = useCallback(
+    () => <View style={styles.rowSeparator} />,
+    [styles.rowSeparator],
+  );
+
+  const ROW_HEIGHT = 64;
+  const getItemLayout = useCallback(
+    (_: unknown, index: number) => ({
+      length: ROW_HEIGHT,
+      offset: ROW_HEIGHT * index,
+      index,
+    }),
+    [],
   );
 
   const roleOptions: { value: RoleFilter; label: string }[] = [
@@ -473,6 +495,8 @@ export default function MembersScreen() {
           data={filteredMembers}
           keyExtractor={(item) => item.id}
           renderItem={renderMemberCard}
+          ItemSeparatorComponent={renderRowSeparator}
+          getItemLayout={getItemLayout}
           contentContainerStyle={styles.listContent}
           stickyHeaderIndices={[0]}
           ListHeaderComponent={renderListHeader}
@@ -481,9 +505,9 @@ export default function MembersScreen() {
             <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={semantic.success} />
           }
           keyboardShouldPersistTaps="handled"
-          initialNumToRender={10}
-          maxToRenderPerBatch={10}
-          windowSize={5}
+          initialNumToRender={12}
+          maxToRenderPerBatch={12}
+          windowSize={7}
           removeClippedSubviews={true}
           updateCellsBatchingPeriod={50}
         />

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/alumni/[alumniId].tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/alumni/[alumniId].tsx
@@ -38,7 +38,6 @@ import { openEmailAddress, openHttpsUrl } from "@/lib/url-safety";
 import { OverflowMenu, type OverflowMenuItem } from "@/components/OverflowMenu";
 import { ReportBlockSheet } from "@/components/moderation/ReportBlockSheet";
 import { showToast } from "@/components/ui/Toast";
-import { toggleBlock } from "@/lib/moderation";
 import * as sentry from "@/lib/analytics/sentry";
 
 const DETAIL_COLORS = {
@@ -61,7 +60,7 @@ export default function AlumniDetailScreen() {
   const { isAdmin } = useOrgRole();
   const { orgId } = useOrg();
   const { user } = useAuth();
-  const { blockedUserIds } = useBlockedUsers();
+  const { blockedUserIds, toggleBlock } = useBlockedUsers();
   const router = useRouter();
   const styles = useMemo(() => createStyles(), []);
   const [refreshing, setRefreshing] = useState(false);

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/members/[memberId].tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/members/[memberId].tsx
@@ -17,7 +17,6 @@ import { showToast } from "@/components/ui/Toast";
 import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
 import { OverflowMenu, type OverflowMenuItem } from "@/components/OverflowMenu";
 import { ReportBlockSheet } from "@/components/moderation/ReportBlockSheet";
-import { toggleBlock } from "@/lib/moderation";
 import * as sentry from "@/lib/analytics/sentry";
 
 const DETAIL_COLORS = {
@@ -57,7 +56,7 @@ export default function MemberProfileScreen() {
   const [error, setError] = useState<string | null>(null);
   const [reportSheetOpen, setReportSheetOpen] = useState(false);
   const [unblockLoading, setUnblockLoading] = useState(false);
-  const { blockedUserIds } = useBlockedUsers();
+  const { blockedUserIds, toggleBlock } = useBlockedUsers();
   const isSelf = !!member?.user_id && member.user_id === user?.id;
   const isBlocked = !!member?.user_id && blockedUserIds.has(member.user_id);
   const canReport = !!member && !isSelf;

--- a/apps/mobile/app/(app)/(drawer)/blocked-users.tsx
+++ b/apps/mobile/app/(app)/(drawer)/blocked-users.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { ChevronLeft, ShieldOff } from "lucide-react-native";
 import { APP_CHROME } from "@/lib/chrome";
 import { SPACING, RADIUS } from "@/lib/design-tokens";
@@ -47,6 +47,12 @@ export default function BlockedUsersScreen() {
       isMountedRef.current = false;
     };
   }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      void refresh();
+    }, [refresh]),
+  );
 
   const idsKey = useMemo(
     () => Array.from(blockedUserIds).sort().join(","),

--- a/apps/mobile/app/(app)/(drawer)/profile.tsx
+++ b/apps/mobile/app/(app)/(drawer)/profile.tsx
@@ -20,6 +20,7 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronDown,
+  FileText,
   ShieldOff,
   Trash2,
 } from "lucide-react-native";
@@ -1083,6 +1084,25 @@ export default function ProfileScreen() {
               <View style={styles.groupedListWrap}>
                 <Text style={styles.groupedListHeader}>Account</Text>
                 <View style={styles.groupedList}>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Terms of Service"
+                    onPress={() => {
+                      router.push({
+                        pathname: "/(app)/(drawer)/terms",
+                        params: routeSlug ? { currentSlug: routeSlug } : undefined,
+                      } as any);
+                    }}
+                    style={({ pressed }) => [
+                      styles.groupedRow,
+                      pressed && styles.groupedRowPressed,
+                    ]}
+                  >
+                    <FileText size={20} color={neutral.foreground} />
+                    <Text style={styles.groupedRowLabel}>Terms of Service</Text>
+                    <ChevronRight size={18} color={neutral.placeholder} />
+                  </Pressable>
+                  <View style={styles.groupedDivider} />
                   <Pressable
                     accessibilityRole="button"
                     accessibilityLabel="Blocked Users"

--- a/apps/mobile/app/(app)/(drawer)/profile.tsx
+++ b/apps/mobile/app/(app)/(drawer)/profile.tsx
@@ -1,6 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import {
+  ActionSheetIOS,
   ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
   Platform,
   Pressable,
   ScrollView,
@@ -12,7 +15,14 @@ import { Image } from "expo-image";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { ChevronLeft, Camera, Trash2 } from "lucide-react-native";
+import {
+  Camera,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  ShieldOff,
+  Trash2,
+} from "lucide-react-native";
 import * as Haptics from "expo-haptics";
 import Animated, { FadeInDown } from "react-native-reanimated";
 import type { Database, Organization } from "@teammeet/types";
@@ -55,6 +65,61 @@ function getRowPhotoUrl(row: EditableProfileRow): string | null {
   return row.photo_url ?? null;
 }
 
+interface FormFieldProps {
+  label: string;
+  value: string;
+  onChangeText: (text: string) => void;
+  placeholder?: string;
+  placeholderTextColor: string;
+  helperText?: string;
+  multiline?: boolean;
+  keyboardType?: "default" | "number-pad" | "email-address";
+  autoCapitalize?: "none" | "sentences" | "words";
+  maxLength?: number;
+  inputStyle: any;
+  textAreaStyle: any;
+  labelStyle: any;
+  hintStyle: any;
+  groupStyle: any;
+}
+
+const FormField = memo(function FormField({
+  label,
+  value,
+  onChangeText,
+  placeholder,
+  placeholderTextColor,
+  helperText,
+  multiline,
+  keyboardType,
+  autoCapitalize,
+  maxLength,
+  inputStyle,
+  textAreaStyle,
+  labelStyle,
+  hintStyle,
+  groupStyle,
+}: FormFieldProps) {
+  return (
+    <View style={groupStyle}>
+      <Text style={labelStyle}>{label}</Text>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={placeholderTextColor}
+        style={[inputStyle, multiline ? textAreaStyle : null]}
+        multiline={multiline}
+        keyboardType={keyboardType}
+        autoCapitalize={autoCapitalize ?? "words"}
+        autoCorrect={false}
+        maxLength={maxLength}
+      />
+      {helperText ? <Text style={hintStyle}>{helperText}</Text> : null}
+    </View>
+  );
+});
+
 export default function ProfileScreen() {
   const router = useRouter();
   const { currentSlug } = useLocalSearchParams<{ currentSlug?: string | string[] }>();
@@ -67,10 +132,18 @@ export default function ProfileScreen() {
   const [profileRecordId, setProfileRecordId] = useState<string | null>(null);
   const [profileAvatarUrl, setProfileAvatarUrl] = useState<string | null>(null);
   const [formValues, setFormValues] = useState<ProfileFormValues>(INITIAL_PROFILE_FORM_VALUES);
+  const [initialFormValues, setInitialFormValues] = useState<ProfileFormValues>(INITIAL_PROFILE_FORM_VALUES);
   const [localAvatarUrl, setLocalAvatarUrl] = useState<string | null>(null);
   const [loadingProfile, setLoadingProfile] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const isDirty = useMemo(() => {
+    if (localAvatarUrl) return true;
+    return (Object.keys(formValues) as Array<keyof ProfileFormValues>).some(
+      (key) => formValues[key] !== initialFormValues[key]
+    );
+  }, [formValues, initialFormValues, localAvatarUrl]);
 
   const styles = useThemedStyles((n, s) => ({
     container: {
@@ -100,6 +173,20 @@ export default function ProfileScreen() {
     },
     headerSpacer: {
       width: 36,
+    },
+    headerSaveButton: {
+      minWidth: 56,
+      height: 36,
+      alignItems: "flex-end" as const,
+      justifyContent: "center" as const,
+    },
+    headerSaveText: {
+      ...TYPOGRAPHY.labelLarge,
+      color: APP_CHROME.headerTitle,
+      fontWeight: "600" as const,
+    },
+    headerSaveTextDisabled: {
+      opacity: 0.4,
     },
     contentSheet: {
       flex: 1,
@@ -138,9 +225,6 @@ export default function ProfileScreen() {
       ...TYPOGRAPHY.bodySmall,
       color: n.muted,
     },
-    orgSelectorList: {
-      gap: SPACING.sm,
-    },
     orgOption: {
       borderWidth: 1,
       borderColor: n.border,
@@ -150,43 +234,9 @@ export default function ProfileScreen() {
       paddingVertical: SPACING.sm,
       backgroundColor: n.background,
     },
-    orgOptionSelected: {
-      borderColor: s.success,
-      backgroundColor: s.successLight,
-    },
     orgOptionText: {
       ...TYPOGRAPHY.bodyMedium,
       color: n.foreground,
-    },
-    orgOptionTextSelected: {
-      color: s.successDark,
-    },
-    contextCard: {
-      backgroundColor: n.background,
-      borderRadius: RADIUS.lg,
-      padding: SPACING.md,
-      gap: SPACING.xs,
-    },
-    contextLabel: {
-      ...TYPOGRAPHY.labelMedium,
-      color: n.secondary,
-      textTransform: "uppercase" as const,
-      letterSpacing: 0.4,
-    },
-    contextValue: {
-      ...TYPOGRAPHY.bodyLarge,
-      color: n.foreground,
-    },
-    rolePill: {
-      alignSelf: "flex-start" as const,
-      backgroundColor: s.successLight,
-      borderRadius: 999,
-      paddingHorizontal: SPACING.sm,
-      paddingVertical: 6,
-    },
-    rolePillText: {
-      ...TYPOGRAPHY.labelMedium,
-      color: s.successDark,
     },
     avatarSection: {
       alignItems: "center" as const,
@@ -287,33 +337,67 @@ export default function ProfileScreen() {
       ...TYPOGRAPHY.bodySmall,
       color: s.error,
     },
-    primaryButton: {
-      backgroundColor: s.success,
-      borderRadius: RADIUS.md,
-      paddingVertical: SPACING.md,
-      alignItems: "center" as const,
-    },
-    primaryButtonPressed: {
-      opacity: 0.9,
-    },
-    primaryButtonText: {
-      ...TYPOGRAPHY.labelLarge,
-      color: "#ffffff",
-    },
-    buttonDisabled: {
-      opacity: 0.6,
-    },
-    deleteAccountRow: {
+    orgChip: {
       flexDirection: "row" as const,
       alignItems: "center" as const,
-      justifyContent: "center" as const,
-      gap: SPACING.sm,
-      paddingVertical: SPACING.md,
-      marginTop: SPACING.sm,
+      alignSelf: "center" as const,
+      gap: 6,
+      marginTop: SPACING.md,
+      paddingHorizontal: SPACING.md,
+      paddingVertical: 8,
+      borderRadius: 999,
+      backgroundColor: n.background,
+      borderWidth: 1,
+      borderColor: n.border,
+      maxWidth: "90%" as const,
     },
-    deleteAccountLabel: {
-      ...TYPOGRAPHY.labelLarge,
-      color: s.error,
+    orgChipLabel: {
+      ...TYPOGRAPHY.labelMedium,
+      color: n.foreground,
+      flexShrink: 1,
+    },
+    orgChipRole: {
+      ...TYPOGRAPHY.labelMedium,
+      color: n.secondary,
+    },
+    groupedListWrap: {
+      gap: SPACING.xs,
+    },
+    groupedListHeader: {
+      ...TYPOGRAPHY.labelMedium,
+      color: n.secondary,
+      textTransform: "uppercase" as const,
+      letterSpacing: 0.4,
+      paddingHorizontal: SPACING.md,
+    },
+    groupedList: {
+      backgroundColor: n.surface,
+      borderRadius: RADIUS.lg,
+      borderCurve: "continuous" as const,
+      borderWidth: 1,
+      borderColor: n.border,
+      overflow: "hidden" as const,
+    },
+    groupedRow: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      gap: SPACING.md,
+      paddingVertical: SPACING.md,
+      paddingHorizontal: SPACING.md,
+      minHeight: 48,
+    },
+    groupedRowPressed: {
+      backgroundColor: n.background,
+    },
+    groupedRowLabel: {
+      ...TYPOGRAPHY.bodyLarge,
+      color: n.foreground,
+      flex: 1,
+    },
+    groupedDivider: {
+      height: 1,
+      marginLeft: SPACING.md + 20 + SPACING.md,
+      backgroundColor: n.border,
     },
   }));
 
@@ -359,6 +443,7 @@ export default function ProfileScreen() {
       setProfileRecordId(null);
       setProfileAvatarUrl(null);
       setFormValues(INITIAL_PROFILE_FORM_VALUES);
+      setInitialFormValues(INITIAL_PROFILE_FORM_VALUES);
       setLoadingProfile(false);
       return;
     }
@@ -435,13 +520,17 @@ export default function ProfileScreen() {
         setProfileRole(nextRole);
         setProfileRecordId(row.id);
         setProfileAvatarUrl(getRowPhotoUrl(row));
-        setFormValues(buildProfileFormValues(nextRole, row, currentUser));
+        const nextValues = buildProfileFormValues(nextRole, row, currentUser);
+        setFormValues(nextValues);
+        setInitialFormValues(nextValues);
+        setLocalAvatarUrl(null);
       } catch (loadError) {
         if (!isMounted) return;
         setProfileRole(null);
         setProfileRecordId(null);
         setProfileAvatarUrl(null);
         setFormValues(INITIAL_PROFILE_FORM_VALUES);
+        setInitialFormValues(INITIAL_PROFILE_FORM_VALUES);
         setError((loadError as Error).message || "Failed to load profile");
       } finally {
         if (isMounted) {
@@ -458,8 +547,66 @@ export default function ProfileScreen() {
   }, [resolvedOrganization, user]);
 
   const handleBack = useCallback(() => {
+    if (isDirty) {
+      Alert.alert(
+        "Discard changes?",
+        "You have unsaved changes. Are you sure you want to leave?",
+        [
+          { text: "Keep editing", style: "cancel" },
+          {
+            text: "Discard",
+            style: "destructive",
+            onPress: () => router.back(),
+          },
+        ],
+      );
+      return;
+    }
     router.back();
-  }, [router]);
+  }, [isDirty, router]);
+
+  const handleOrgPress = useCallback(() => {
+    if (organizations.length <= 1) return;
+    const orgList = organizations as Organization[];
+    const labels = orgList.map((o) => o.name || o.slug);
+    const activeIndex = orgList.findIndex(
+      (o) => o.slug === resolvedOrganization?.slug,
+    );
+    const onPick = (idx: number) => {
+      const next = orgList[idx];
+      if (!next || next.slug === resolvedOrganization?.slug) return;
+      setSelectedOrgSlug(next.slug);
+      if (Platform.OS === "ios") {
+        void Haptics.selectionAsync();
+      }
+    };
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          options: [...labels, "Cancel"],
+          cancelButtonIndex: labels.length,
+          title: "Switch organization",
+          userInterfaceStyle: "light",
+        },
+        (idx) => {
+          if (idx === labels.length) return;
+          onPick(idx);
+        },
+      );
+      return;
+    }
+    Alert.alert(
+      "Switch organization",
+      undefined,
+      [
+        ...orgList.map((o, idx) => ({
+          text: `${o.name || o.slug}${idx === activeIndex ? "  ✓" : ""}`,
+          onPress: () => onPick(idx),
+        })),
+        { text: "Cancel", style: "cancel" as const },
+      ],
+    );
+  }, [organizations, resolvedOrganization]);
 
   const handleFieldChange = useCallback(
     <K extends keyof ProfileFormValues>(field: K, value: ProfileFormValues[K]) => {
@@ -470,6 +617,16 @@ export default function ProfileScreen() {
     },
     []
   );
+
+  const fieldHandlers = useMemo(() => {
+    const handlers = {} as Record<keyof ProfileFormValues, (text: string) => void>;
+    (Object.keys(INITIAL_PROFILE_FORM_VALUES) as Array<keyof ProfileFormValues>).forEach(
+      (key) => {
+        handlers[key] = (text: string) => handleFieldChange(key, text);
+      },
+    );
+    return handlers;
+  }, [handleFieldChange]);
 
   const handleAvatarPress = useCallback(async () => {
     const newUrl = await pickAndUpload();
@@ -566,25 +723,23 @@ export default function ProfileScreen() {
       maxLength?: number;
     }
   ) => (
-    <View style={styles.fieldGroup}>
-      <Text style={styles.fieldLabel}>{label}</Text>
-      <TextInput
-        value={formValues[field]}
-        onChangeText={(text) => handleFieldChange(field, text)}
-        placeholder={options?.placeholder}
-        placeholderTextColor={neutral.placeholder}
-        style={[
-          styles.input,
-          options?.multiline ? styles.textArea : null,
-        ] as any}
-        multiline={options?.multiline}
-        keyboardType={options?.keyboardType}
-        autoCapitalize={options?.autoCapitalize ?? "words"}
-        autoCorrect={false}
-        maxLength={options?.maxLength}
-      />
-      {options?.helperText ? <Text style={styles.fieldHint}>{options.helperText}</Text> : null}
-    </View>
+    <FormField
+      label={label}
+      value={formValues[field]}
+      onChangeText={fieldHandlers[field]}
+      placeholder={options?.placeholder}
+      placeholderTextColor={neutral.placeholder}
+      helperText={options?.helperText}
+      multiline={options?.multiline}
+      keyboardType={options?.keyboardType}
+      autoCapitalize={options?.autoCapitalize}
+      maxLength={options?.maxLength}
+      inputStyle={styles.input}
+      textAreaStyle={styles.textArea}
+      labelStyle={styles.fieldLabel}
+      hintStyle={styles.fieldHint}
+      groupStyle={styles.fieldGroup}
+    />
   );
 
   const renderRoleFields = () => {
@@ -749,60 +904,65 @@ export default function ProfileScreen() {
     );
   }
 
+  const saveDisabled = isSaving || isUploading || !isDirty;
+  const activeOrgLabel = resolvedOrganization
+    ? resolvedOrganization.name || resolvedOrganization.slug
+    : null;
+
   return (
     <View style={styles.container}>
       <LinearGradient colors={[APP_CHROME.gradientStart, APP_CHROME.gradientEnd]} style={styles.headerGradient}>
         <SafeAreaView edges={["top"]} style={styles.headerSafeArea}>
           <View style={styles.headerContent}>
-            <Pressable onPress={handleBack} style={styles.backButton}>
+            <Pressable
+              onPress={handleBack}
+              style={styles.backButton}
+              hitSlop={12}
+              accessibilityRole="button"
+              accessibilityLabel="Back"
+            >
               <ChevronLeft size={28} color={APP_CHROME.headerTitle} />
             </Pressable>
             <Text style={styles.headerTitle}>Edit Profile</Text>
-            <View style={styles.headerSpacer} />
+            <Pressable
+              onPress={handleSave}
+              disabled={saveDisabled}
+              hitSlop={12}
+              accessibilityRole="button"
+              accessibilityLabel="Save"
+              style={({ pressed }) => [
+                styles.headerSaveButton,
+                pressed && !saveDisabled && { opacity: 0.6 },
+              ]}
+            >
+              {isSaving ? (
+                <ActivityIndicator color={APP_CHROME.headerTitle} size="small" />
+              ) : (
+                <Text
+                  style={[
+                    styles.headerSaveText,
+                    saveDisabled && styles.headerSaveTextDisabled,
+                  ]}
+                >
+                  Save
+                </Text>
+              )}
+            </Pressable>
           </View>
         </SafeAreaView>
       </LinearGradient>
 
-      <View style={styles.contentSheet}>
+      <KeyboardAvoidingView
+        style={styles.contentSheet}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
         <ScrollView
           contentContainerStyle={styles.scrollContent}
           keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="interactive"
           showsVerticalScrollIndicator={false}
           contentInsetAdjustmentBehavior="automatic"
         >
-          {hasMultipleOrganizations ? (
-            <View style={styles.sectionCard}>
-              <Text style={styles.sectionTitle}>Organization</Text>
-              <Text style={styles.sectionBody}>
-                Your profile edits apply to one organization at a time.
-              </Text>
-              <View style={styles.orgSelectorList}>
-                {organizations.map((organization) => {
-                  const isSelected = organization.slug === resolvedOrganization?.slug;
-                  return (
-                    <Pressable
-                      key={organization.id}
-                      onPress={() => setSelectedOrgSlug(organization.slug)}
-                      style={[
-                        styles.orgOption,
-                        isSelected ? styles.orgOptionSelected : null,
-                      ]}
-                    >
-                      <Text
-                        style={[
-                          styles.orgOptionText,
-                          isSelected ? styles.orgOptionTextSelected : null,
-                        ]}
-                      >
-                        {organization.name || organization.slug}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
-            </View>
-          ) : null}
-
           {!user ? (
             <View style={styles.errorCard}>
               <Text style={styles.errorText}>You must be signed in to edit your profile.</Text>
@@ -815,20 +975,20 @@ export default function ProfileScreen() {
               <Text style={styles.sectionBody}>
                 Select which organization profile you want to edit.
               </Text>
-            </View>
-          ) : null}
-
-          {resolvedOrganization ? (
-            <View style={styles.contextCard}>
-              <Text style={styles.contextLabel}>Active organization</Text>
-              <Text style={styles.contextValue}>
-                {resolvedOrganization.name || resolvedOrganization.slug}
-              </Text>
-              {profileRole ? (
-                <View style={styles.rolePill}>
-                  <Text style={styles.rolePillText}>{getEditableProfileRoleLabel(profileRole)}</Text>
-                </View>
-              ) : null}
+              {organizations.map((organization) => (
+                <Pressable
+                  key={organization.id}
+                  onPress={() => setSelectedOrgSlug(organization.slug)}
+                  style={({ pressed }) => [
+                    styles.orgOption,
+                    pressed && { opacity: 0.7 },
+                  ]}
+                >
+                  <Text style={styles.orgOptionText}>
+                    {organization.name || organization.slug}
+                  </Text>
+                </Pressable>
+              ))}
             </View>
           ) : null}
 
@@ -844,6 +1004,8 @@ export default function ProfileScreen() {
                 <Pressable
                   onPress={handleAvatarPress}
                   disabled={isUploading}
+                  accessibilityRole="button"
+                  accessibilityLabel="Change photo"
                   style={styles.avatarWrapper as any}
                 >
                   {avatarUrl ? (
@@ -861,6 +1023,33 @@ export default function ProfileScreen() {
                     )}
                   </View>
                 </Pressable>
+                {activeOrgLabel ? (
+                  <Pressable
+                    onPress={handleOrgPress}
+                    disabled={organizations.length <= 1}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Active organization: ${activeOrgLabel}. ${
+                      organizations.length > 1 ? "Tap to switch." : ""
+                    }`}
+                    hitSlop={8}
+                    style={({ pressed }) => [
+                      styles.orgChip,
+                      pressed && organizations.length > 1 && { opacity: 0.7 },
+                    ]}
+                  >
+                    <Text style={styles.orgChipLabel} numberOfLines={1}>
+                      {activeOrgLabel}
+                    </Text>
+                    {profileRole ? (
+                      <Text style={styles.orgChipRole}>
+                        · {getEditableProfileRoleLabel(profileRole)}
+                      </Text>
+                    ) : null}
+                    {organizations.length > 1 ? (
+                      <ChevronDown size={14} color={neutral.secondary} />
+                    ) : null}
+                  </Pressable>
+                ) : null}
               </View>
 
               <Animated.View entering={FadeInDown.duration(250)} style={styles.sectionCard}>
@@ -891,43 +1080,54 @@ export default function ProfileScreen() {
 
               {renderRoleFields()}
 
-              <Pressable
-                onPress={handleSave}
-                disabled={isSaving || isUploading}
-                style={({ pressed }) => [
-                  styles.primaryButton,
-                  pressed && styles.primaryButtonPressed,
-                  (isSaving || isUploading) && styles.buttonDisabled,
-                ]}
-              >
-                {isSaving ? (
-                  <ActivityIndicator color="#ffffff" />
-                ) : (
-                  <Text style={styles.primaryButtonText}>Save Changes</Text>
-                )}
-              </Pressable>
-
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Delete My Account"
-                onPress={() => {
-                  router.push({
-                    pathname: "/(app)/(drawer)/delete-account",
-                    params: routeSlug ? { currentSlug: routeSlug } : undefined,
-                  } as any);
-                }}
-                style={({ pressed }) => [
-                  styles.deleteAccountRow,
-                  pressed && { opacity: 0.85 },
-                ]}
-              >
-                <Trash2 size={18} color={semantic.error} />
-                <Text style={styles.deleteAccountLabel}>Delete My Account</Text>
-              </Pressable>
+              <View style={styles.groupedListWrap}>
+                <Text style={styles.groupedListHeader}>Account</Text>
+                <View style={styles.groupedList}>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Blocked Users"
+                    onPress={() => {
+                      router.push({
+                        pathname: "/(app)/(drawer)/blocked-users",
+                        params: routeSlug ? { currentSlug: routeSlug } : undefined,
+                      } as any);
+                    }}
+                    style={({ pressed }) => [
+                      styles.groupedRow,
+                      pressed && styles.groupedRowPressed,
+                    ]}
+                  >
+                    <ShieldOff size={20} color={neutral.foreground} />
+                    <Text style={styles.groupedRowLabel}>Blocked Users</Text>
+                    <ChevronRight size={18} color={neutral.placeholder} />
+                  </Pressable>
+                  <View style={styles.groupedDivider} />
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Delete My Account"
+                    onPress={() => {
+                      router.push({
+                        pathname: "/(app)/(drawer)/delete-account",
+                        params: routeSlug ? { currentSlug: routeSlug } : undefined,
+                      } as any);
+                    }}
+                    style={({ pressed }) => [
+                      styles.groupedRow,
+                      pressed && styles.groupedRowPressed,
+                    ]}
+                  >
+                    <Trash2 size={20} color={semantic.error} />
+                    <Text style={[styles.groupedRowLabel, { color: semantic.error }]}>
+                      Delete My Account
+                    </Text>
+                    <ChevronRight size={18} color={neutral.placeholder} />
+                  </Pressable>
+                </View>
+              </View>
             </>
           ) : null}
         </ScrollView>
-      </View>
+      </KeyboardAvoidingView>
     </View>
   );
 }

--- a/apps/mobile/app/(app)/(drawer)/terms.tsx
+++ b/apps/mobile/app/(app)/(drawer)/terms.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo } from "react";
-import { View, Text, ScrollView, StyleSheet } from "react-native";
+import React from "react";
+import { View, Text, ScrollView } from "react-native";
 import { Stack } from "expo-router";
-import { useOrgTheme } from "@/hooks/useOrgTheme";
-import type { ThemeColors } from "@/lib/theme";
+import { useThemedStyles } from "@/hooks/useThemedStyles";
+import { SPACING, RADIUS } from "@/lib/design-tokens";
+import { TYPOGRAPHY } from "@/lib/typography";
 
 type TermsSection = {
   id: string;
@@ -176,14 +177,95 @@ const termsSections: TermsSection[] = [
     number: "16",
     title: "Contact Information",
     paragraphs: [
-      "Email: support@myteamnetwork.com",
+      "Email: mleonard@myteamnetwork.com",
     ],
   },
 ];
 
 export default function TermsScreen() {
-  const { colors } = useOrgTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = useThemedStyles((n) => ({
+    container: {
+      flex: 1,
+      backgroundColor: n.background,
+    },
+    scrollContent: {
+      paddingHorizontal: SPACING.md,
+      paddingTop: SPACING.md,
+      paddingBottom: SPACING.xl,
+    },
+    header: {
+      marginBottom: SPACING.lg,
+    },
+    title: {
+      ...TYPOGRAPHY.displayMedium,
+      color: n.foreground,
+      marginBottom: SPACING.xs,
+    },
+    lastUpdated: {
+      ...TYPOGRAPHY.bodySmall,
+      color: n.muted,
+    },
+    sectionCard: {
+      backgroundColor: n.surface,
+      borderRadius: RADIUS.lg,
+      borderCurve: "continuous" as const,
+      borderWidth: 1,
+      borderColor: n.border,
+      paddingHorizontal: SPACING.md,
+      paddingVertical: SPACING.md,
+      marginBottom: SPACING.sm,
+    },
+    sectionHeader: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      marginBottom: SPACING.sm,
+      gap: SPACING.sm,
+    },
+    numberBadge: {
+      minWidth: 28,
+      height: 28,
+      paddingHorizontal: SPACING.xs,
+      borderRadius: RADIUS.full,
+      backgroundColor: n.divider,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
+    },
+    numberBadgeText: {
+      ...TYPOGRAPHY.labelSmall,
+      color: n.secondary,
+      fontVariant: ["tabular-nums" as const],
+    },
+    sectionTitle: {
+      flex: 1,
+      ...TYPOGRAPHY.titleMedium,
+      color: n.foreground,
+    },
+    sectionContent: {
+      gap: SPACING.sm,
+    },
+    paragraph: {
+      ...TYPOGRAPHY.bodyMedium,
+      color: n.secondary,
+    },
+    bulletList: {
+      gap: SPACING.xs,
+      marginTop: SPACING.xs / 2,
+    },
+    bulletItem: {
+      flexDirection: "row" as const,
+      gap: SPACING.sm,
+    },
+    bulletDot: {
+      ...TYPOGRAPHY.bodyMedium,
+      color: n.placeholder,
+      marginTop: 1,
+    },
+    bulletText: {
+      flex: 1,
+      ...TYPOGRAPHY.bodyMedium,
+      color: n.secondary,
+    },
+  }));
 
   return (
     <View style={styles.container}>
@@ -191,14 +273,13 @@ export default function TermsScreen() {
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
       >
-        {/* Header */}
         <View style={styles.header}>
           <Text style={styles.title}>Terms of Service</Text>
           <Text style={styles.lastUpdated}>Last Updated: May 16, 2026</Text>
         </View>
 
-        {/* Sections */}
         {termsSections.map((section) => (
           <View key={section.id} style={styles.sectionCard}>
             <View style={styles.sectionHeader}>
@@ -213,7 +294,7 @@ export default function TermsScreen() {
                   {paragraph}
                 </Text>
               ))}
-              {section.bullets && (
+              {section.bullets ? (
                 <View style={styles.bulletList}>
                   {section.bullets.map((bullet, index) => (
                     <View key={index} style={styles.bulletItem}>
@@ -222,7 +303,7 @@ export default function TermsScreen() {
                     </View>
                   ))}
                 </View>
-              )}
+              ) : null}
             </View>
           </View>
         ))}
@@ -230,90 +311,3 @@ export default function TermsScreen() {
     </View>
   );
 }
-
-const createStyles = (colors: ThemeColors) =>
-  StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: colors.background,
-    },
-    scrollContent: {
-      padding: 16,
-      paddingBottom: 40,
-    },
-    header: {
-      marginBottom: 24,
-    },
-    title: {
-      fontSize: 28,
-      fontWeight: "700",
-      color: colors.foreground,
-      marginBottom: 8,
-    },
-    lastUpdated: {
-      fontSize: 14,
-      color: colors.mutedForeground,
-    },
-    sectionCard: {
-      backgroundColor: colors.card,
-      borderRadius: 12,
-      borderCurve: "continuous",
-      padding: 16,
-      marginBottom: 12,
-      boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
-    },
-    sectionHeader: {
-      flexDirection: "row",
-      alignItems: "flex-start",
-      marginBottom: 12,
-      gap: 12,
-    },
-    numberBadge: {
-      width: 32,
-      height: 32,
-      borderRadius: 8,
-      backgroundColor: colors.primary,
-      alignItems: "center",
-      justifyContent: "center",
-    },
-    numberBadgeText: {
-      fontSize: 16,
-      fontWeight: "700",
-      color: colors.primaryForeground,
-    },
-    sectionTitle: {
-      flex: 1,
-      fontSize: 18,
-      fontWeight: "600",
-      color: colors.foreground,
-      lineHeight: 24,
-      paddingTop: 4,
-    },
-    sectionContent: {
-      gap: 12,
-    },
-    paragraph: {
-      fontSize: 15,
-      lineHeight: 22,
-      color: colors.mutedForeground,
-    },
-    bulletList: {
-      gap: 8,
-    },
-    bulletItem: {
-      flexDirection: "row",
-      gap: 8,
-    },
-    bulletDot: {
-      fontSize: 15,
-      color: colors.primary,
-      lineHeight: 22,
-      marginTop: 1,
-    },
-    bulletText: {
-      flex: 1,
-      fontSize: 15,
-      lineHeight: 22,
-      color: colors.mutedForeground,
-    },
-  });

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -5,6 +5,7 @@ import {
   TextInput,
   Pressable,
   KeyboardAvoidingView,
+  Linking,
   Platform,
   ActivityIndicator,
   StyleSheet,
@@ -94,6 +95,14 @@ export default function SignupScreen() {
     } else {
       router.replace("/(auth)/login");
     }
+  };
+
+  const handleTermsPress = () => {
+    Linking.openURL(`${getWebAppUrl()}/terms`).catch(() => {});
+  };
+
+  const handlePrivacyPress = () => {
+    Linking.openURL(`${getWebAppUrl()}/privacy`).catch(() => {});
   };
 
   // Form state
@@ -566,7 +575,26 @@ export default function SignupScreen() {
               </View>
             )}
 
-            {/* Primary CTA */}
+            <Text style={styles.consentText}>
+              By creating an account, you agree to our{" "}
+              <Text
+                style={styles.consentLink}
+                onPress={handleTermsPress}
+                accessibilityRole="link"
+              >
+                Terms of Service
+              </Text>{" "}
+              and{" "}
+              <Text
+                style={styles.consentLink}
+                onPress={handlePrivacyPress}
+                accessibilityRole="link"
+              >
+                Privacy Policy
+              </Text>
+              . We have zero tolerance for objectionable content or abusive users.
+            </Text>
+
             <Pressable
               style={({ pressed }) => [
                 styles.primaryButton,
@@ -861,6 +889,18 @@ const styles = StyleSheet.create({
     fontSize: fontSize.sm,
     textAlign: "center",
     lineHeight: 20,
+  },
+  consentText: {
+    color: colors.subtitle,
+    fontSize: fontSize.sm,
+    lineHeight: 20,
+    marginTop: spacing.xs,
+    marginBottom: spacing.sm,
+    textAlign: "center",
+  },
+  consentLink: {
+    color: colors.link,
+    fontWeight: "600",
   },
 
   // Primary Button

--- a/apps/mobile/src/components/directory/DirectoryCard.tsx
+++ b/apps/mobile/src/components/directory/DirectoryCard.tsx
@@ -86,7 +86,7 @@ export const DirectoryCard = React.memo(function DirectoryCard({
             ))}
           </View>
         )}
-        <ChevronRight size={16} color={colors.border} />
+        <ChevronRight size={18} color={colors.mutedForeground} />
       </View>
     </Pressable>
   );
@@ -96,29 +96,26 @@ const styles = StyleSheet.create({
   card: {
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: spacing.sm,
-    paddingLeft: spacing.md,
-    paddingRight: spacing.sm,
-    borderRadius: borderRadius.md,
-    marginBottom: spacing.xs + 2,
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.md,
+    minHeight: 64,
   },
   cardPressed: {
-    opacity: 0.7,
-    transform: [{ scale: 0.995 }],
+    opacity: 0.6,
   },
   avatarWrap: {
     position: "relative",
     marginRight: spacing.md,
   },
   avatar: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
   },
   avatarPlaceholder: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
     justifyContent: "center",
     alignItems: "center",
   },
@@ -133,7 +130,7 @@ const styles = StyleSheet.create({
     borderWidth: 2,
   },
   avatarText: {
-    fontSize: fontSize.sm,
+    fontSize: fontSize.base,
     fontWeight: fontWeight.semibold,
   },
   cardContent: {
@@ -147,7 +144,7 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: fontSize.sm,
-    marginTop: 1,
+    marginTop: 2,
     lineHeight: 18,
   },
   locationRow: {
@@ -162,7 +159,7 @@ const styles = StyleSheet.create({
   cardRight: {
     flexDirection: "row",
     alignItems: "center",
-    gap: spacing.xs,
+    gap: spacing.sm,
     marginLeft: spacing.sm,
   },
   cardChipColumn: {

--- a/apps/mobile/src/components/directory/DirectorySearchBar.tsx
+++ b/apps/mobile/src/components/directory/DirectorySearchBar.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { View, TextInput, Pressable, StyleSheet } from "react-native";
 import { Search, X } from "lucide-react-native";
 import { spacing, fontSize, borderRadius, type ThemeColors } from "@/lib/theme";
@@ -10,7 +11,7 @@ interface DirectorySearchBarProps {
   rightSlot?: React.ReactNode;
 }
 
-export function DirectorySearchBar({
+function DirectorySearchBarBase({
   value,
   onChangeText,
   placeholder = "Search...",
@@ -19,8 +20,8 @@ export function DirectorySearchBar({
 }: DirectorySearchBarProps) {
   return (
     <View style={styles.searchRow}>
-      <View style={[styles.searchContainer, { backgroundColor: colors.card }]}>
-        <Search size={20} color={colors.muted} style={styles.searchIcon} />
+      <View style={[styles.searchContainer, { backgroundColor: colors.mutedSurface }]}>
+        <Search size={18} color={colors.mutedForeground} style={styles.searchIcon} />
         <TextInput
           style={[styles.searchInput, { color: colors.foreground }]}
           placeholder={placeholder}
@@ -29,6 +30,8 @@ export function DirectorySearchBar({
           onChangeText={onChangeText}
           autoCapitalize="none"
           autoCorrect={false}
+          returnKeyType="search"
+          clearButtonMode="never"
         />
         {value.length > 0 && (
           <Pressable onPress={() => onChangeText("")} hitSlop={12}>
@@ -41,27 +44,28 @@ export function DirectorySearchBar({
   );
 }
 
+export const DirectorySearchBar = React.memo(DirectorySearchBarBase);
+
 const styles = StyleSheet.create({
   searchRow: {
     flexDirection: "row",
     alignItems: "center",
-    paddingHorizontal: spacing.md,
     gap: spacing.sm,
   },
   searchContainer: {
     flex: 1,
     flexDirection: "row",
     alignItems: "center",
-    borderRadius: borderRadius.xl,
-    paddingHorizontal: spacing.md,
-    height: 48,
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing.sm + 2,
+    height: 40,
   },
   searchIcon: {
-    marginRight: spacing.sm,
+    marginRight: spacing.xs + 2,
   },
   searchInput: {
     flex: 1,
-    fontSize: fontSize.base,
+    fontSize: 17,
     paddingVertical: 0,
   },
 });

--- a/apps/mobile/src/components/moderation/ReportBlockSheet.tsx
+++ b/apps/mobile/src/components/moderation/ReportBlockSheet.tsx
@@ -14,8 +14,9 @@ import { TYPOGRAPHY } from "@/lib/typography";
 import { useAppColorScheme } from "@/contexts/ColorSchemeContext";
 import { useThemedStyles } from "@/hooks/useThemedStyles";
 import { showToast } from "@/components/ui/Toast";
-import { reportContent, toggleBlock } from "@/lib/moderation";
+import { reportContent } from "@/lib/moderation";
 import type { ReportReason, ReportTargetType } from "@/lib/moderation";
+import { useBlockedUsers } from "@/contexts/BlockedUsersContext";
 import * as sentry from "@/lib/analytics/sentry";
 
 const REASONS: { id: ReportReason; label: string; description: string }[] = [
@@ -60,6 +61,7 @@ export function ReportBlockSheet({
   onBlocked,
 }: ReportBlockSheetProps) {
   const { neutral, semantic } = useAppColorScheme();
+  const { toggleBlock } = useBlockedUsers();
   const [stage, setStage] = useState<Stage>("picker");
   const [selectedReason, setSelectedReason] = useState<ReportReason | null>(null);
   const [details, setDetails] = useState("");

--- a/apps/mobile/src/contexts/OrgContext.tsx
+++ b/apps/mobile/src/contexts/OrgContext.tsx
@@ -60,7 +60,14 @@ export async function waitForAuthUser(timeoutMs: number) {
 }
 
 export function OrgProvider({ children }: { children: ReactNode }) {
-  const { orgSlug } = useGlobalSearchParams<{ orgSlug: string }>();
+  const { orgSlug: rawOrgSlug, currentSlug } = useGlobalSearchParams<{
+    orgSlug?: string;
+    currentSlug?: string;
+  }>();
+  const orgSlug =
+    (typeof rawOrgSlug === "string" && rawOrgSlug) ||
+    (typeof currentSlug === "string" && currentSlug) ||
+    "";
   const [orgId, setOrgId] = useState<string | null>(null);
   const [orgName, setOrgName] = useState<string | null>(null);
   const [orgLogoUrl, setOrgLogoUrl] = useState<string | null>(null);

--- a/apps/mobile/src/lib/moderation.ts
+++ b/apps/mobile/src/lib/moderation.ts
@@ -26,37 +26,55 @@ export interface ReportContentInput {
   details?: string | null;
 }
 
+function summarizeErrorBody(text: string): string {
+  if (!text) return "";
+  try {
+    const json = JSON.parse(text) as {
+      error?: string;
+      details?: string[];
+    };
+    const detail = json.details && json.details.length > 0 ? ` (${json.details.join("; ")})` : "";
+    return json.error ? `${json.error}${detail}` : text;
+  } catch {
+    return text;
+  }
+}
+
 export async function reportContent(input: ReportContentInput): Promise<{ id: string }> {
+  const payload = {
+    organization_id: input.orgId,
+    target_type: input.targetType,
+    target_id: input.targetId,
+    reported_user_id: input.reportedUserId ?? null,
+    reason: input.reason,
+    details: input.details ?? null,
+  };
   const res = await fetchWithAuth("/api/moderation/report", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      organization_id: input.orgId,
-      target_type: input.targetType,
-      target_id: input.targetId,
-      reported_user_id: input.reportedUserId ?? null,
-      reason: input.reason,
-      details: input.details ?? null,
-    }),
+    body: JSON.stringify(payload),
   });
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`Failed to file report (${res.status}): ${text}`);
+    console.warn("[moderation.reportContent] failed", { status: res.status, payload, body: text });
+    throw new Error(summarizeErrorBody(text) || `Report failed (${res.status})`);
   }
   return (await res.json()) as { id: string };
 }
 
 export async function toggleBlock(blockedUserId: string): Promise<{ blocked: boolean }> {
+  const payload = { blocked_user_id: blockedUserId };
   const res = await fetchWithAuth("/api/moderation/block", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ blocked_user_id: blockedUserId }),
+    body: JSON.stringify(payload),
   });
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`Failed to toggle block (${res.status}): ${text}`);
+    console.warn("[moderation.toggleBlock] failed", { status: res.status, payload, body: text });
+    throw new Error(summarizeErrorBody(text) || `Block failed (${res.status})`);
   }
   return (await res.json()) as { blocked: boolean };
 }

--- a/apps/mobile/src/navigation/DrawerContent.tsx
+++ b/apps/mobile/src/navigation/DrawerContent.tsx
@@ -12,6 +12,7 @@ import {
   Award,
   Briefcase,
   Building2,
+  ChevronRight,
   ClipboardList,
   DollarSign,
   Dumbbell,
@@ -23,7 +24,6 @@ import {
   MessageCircle,
   Receipt,
   Settings,
-  ShieldOff,
   SlidersHorizontal,
   Trophy,
   Users,
@@ -54,7 +54,7 @@ interface NavItem {
 
 // Pinned footer items (Settings, Navigation, Organizations, Sign Out)
 const PINNED_ITEM_HEIGHT = 48;
-const PINNED_FOOTER_COUNT = 3;
+const PINNED_FOOTER_COUNT = 2;
 const BRAND_STRIP_HEIGHT = 88;
 const FOOTER_PADDING = 32;
 const FOOTER_TOP_INSET = 8;
@@ -68,17 +68,22 @@ export function DrawerContent(props: DrawerContentComponentProps) {
   const router = useRouter();
   const pathname = usePathname();
   const { top: topInset, bottom: bottomInset } = useSafeAreaInsets();
-  const { orgSlug } = useGlobalSearchParams<{ orgSlug?: string }>();
+  const { orgSlug, currentSlug } = useGlobalSearchParams<{
+    orgSlug?: string;
+    currentSlug?: string;
+  }>();
   const { user } = useAuth();
   const { permissions, role } = useOrgRole();
   const { orgName, orgLogoUrl, hasParentsAccess, orgId } = useOrg();
   const { navConfig } = useNavConfig(orgId);
-  const slug = typeof orgSlug === "string" ? orgSlug : "";
+  const rawSlug =
+    (typeof orgSlug === "string" && orgSlug) ||
+    (typeof currentSlug === "string" && currentSlug) ||
+    "";
+  const slug = rawSlug;
   const orgInitial = (orgName ?? slug ?? "").trim().charAt(0).toUpperCase() || "O";
   const userMeta = (user?.user_metadata ?? {}) as { name?: string; avatar_url?: string };
   const displayName = userMeta.name || user?.email || "Member";
-  const displayEmail = user?.email || "";
-  const isAppleRelayEmail = /@privaterelay\.appleid\.com$/i.test(displayEmail);
   const avatarUrl = userMeta.avatar_url || "";
   const initial = displayName.trim().charAt(0).toUpperCase() || "M";
 
@@ -217,7 +222,6 @@ export function DrawerContent(props: DrawerContentComponentProps) {
   const pinnedItems = useMemo<NavItem[]>(() => {
     if (!slug) return [];
     return [
-      { label: "Blocked Users", href: "/(app)/(drawer)/blocked-users", icon: ShieldOff },
       { label: "Organizations", href: "/(app)", icon: Building2 },
     ];
   }, [slug]);
@@ -331,8 +335,11 @@ export function DrawerContent(props: DrawerContentComponentProps) {
             </View>
           </View>
         ) : null}
-        {/* Profile Card */}
+        {/* Profile Card — taps to profile screen */}
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Profile — ${displayName}`}
+          accessibilityHint="Opens your profile"
           style={({ pressed }) => [styles.profileCard, pressed && styles.profileCardPressed]}
           onPress={() => {
             props.navigation.closeDrawer();
@@ -350,18 +357,9 @@ export function DrawerContent(props: DrawerContentComponentProps) {
             )}
           </View>
           <View style={styles.profileMeta}>
-            <Text style={styles.profileName}>{displayName}</Text>
-            {displayEmail ? (
-              <Text style={styles.profileEmail} numberOfLines={1} ellipsizeMode="tail">
-                {displayEmail}
-              </Text>
-            ) : null}
-            {isAppleRelayEmail ? (
-              <View style={styles.relayBadge}>
-                <Text style={styles.relayBadgeText}>Hidden by Apple</Text>
-              </View>
-            ) : null}
+            <Text style={styles.profileName}>Profile</Text>
           </View>
+          <ChevronRight size={20} color={NEUTRAL.placeholder} strokeWidth={1.8} />
         </Pressable>
         <View style={styles.divider} />
 
@@ -504,27 +502,6 @@ const styles = StyleSheet.create({
     fontSize: fontSize.base,
     fontWeight: fontWeight.semibold,
     color: NEUTRAL.surface,
-  },
-  profileEmail: {
-    marginTop: 2,
-    fontSize: fontSize.sm,
-    color: NEUTRAL.placeholder,
-  },
-  relayBadge: {
-    alignSelf: "flex-start",
-    marginTop: 6,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 999,
-    backgroundColor: "rgba(255, 255, 255, 0.08)",
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: "rgba(255, 255, 255, 0.16)",
-  },
-  relayBadgeText: {
-    fontSize: 10,
-    fontWeight: fontWeight.medium,
-    color: NEUTRAL.placeholder,
-    letterSpacing: 0.2,
   },
   divider: {
     height: StyleSheet.hairlineWidth,

--- a/supabase/migrations/20260517002035_user_blocks_realtime.sql
+++ b/supabase/migrations/20260517002035_user_blocks_realtime.sql
@@ -1,0 +1,13 @@
+-- Add user_blocks to supabase_realtime publication so BlockedUsersContext
+-- receives INSERT/UPDATE events after toggle_block().
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'user_blocks'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.user_blocks;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Add Terms of Service row to Profile → Account (App Store Guideline 1.2 visible-EULA surface).
- Pre-account consent line on signup with Terms + Privacy links and zero-tolerance copy.
- Restyle Terms screen: neutral palette via `useThemedStyles`, design tokens, typography scale — fixes solid-blue background drowning section cards.
- Align mobile Terms contact email to `mleonard@myteamnetwork.com` (matches web).

Includes 3 prior unpushed commits on `main` (drawer profile entry, blocked-users fix, iOS profile polish).

## Test plan
- [ ] Build dev client, open Profile → Account → tap **Terms of Service** → lands on Terms screen, white surface, slate badges, readable body.
- [ ] Terms §16 Contact reads `Email: mleonard@myteamnetwork.com`.
- [ ] Signup screen shows consent line above Create Account; tapping Terms / Privacy opens web pages.
- [ ] `bun run --cwd apps/mobile typecheck` clean.
- [ ] `bun --cwd apps/mobile test` green.

## Apple 1.2 reviewer note
Cite path **Profile → Account → Terms of Service**. Sections 4, 5, 9 cover objectionable content prohibition, abusive-user prohibition, 24-hour SLA, report + block tools, and termination.