### PR TITLE
chore(mobile): bump iOS buildNumber to 29

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -40,7 +40,7 @@ const config: ExpoConfig = {
     supportsTablet: true,
     appleTeamId: "5GWLTFG43T",
     bundleIdentifier: "com.myteamnetwork.teammeet",
-    buildNumber: "22",
+    buildNumber: "29",
     usesAppleSignIn: true,
     associatedDomains: [
       "applinks:www.myteamnetwork.com",


### PR DESCRIPTION
Bumps iOS buildNumber to 29 for the next TestFlight release (App Store 1.2 Terms + signup consent changes from #228).