### PR TITLE
test(web): fix flaky mobile backdrop-click spec

### DIFF
--- a/apps/web/tests/e2e/page-objects/MobileNavPage.ts
+++ b/apps/web/tests/e2e/page-objects/MobileNavPage.ts
@@ -66,7 +66,15 @@ export class MobileNavPage extends BasePage {
   }
 
   async clickBackdrop(): Promise<void> {
-    await this.backdrop.click();
+    // The drawer (w-64 = 256px, z-50) overlays the left side of the backdrop.
+    // Click on the right side of the viewport so the drawer doesn't intercept.
+    const viewport = this.page.viewportSize();
+    const x = viewport ? viewport.width - 40 : 350;
+    const y = viewport ? Math.floor(viewport.height / 2) : 400;
+    await this.backdrop.click({ position: { x, y } }).catch(async () => {
+      // Fallback: click directly on page coords (in case position is still occluded)
+      await this.page.mouse.click(x, y);
+    });
   }
 
   async isMenuOpen(): Promise<boolean> {


### PR DESCRIPTION
## Summary
The mobile drawer (w-64 = 256px, z-50) sits on top of the left ~256px of the full-viewport backdrop. Playwright's default centered click on the `mobile-nav-backdrop` locator was landing inside the drawer subtree (`intercepts pointer events`), causing the "closes via backdrop click" spec to time out.

Click at `viewport.width - 40` so it always hits the visible right portion of the backdrop, with a `page.mouse.click` fallback. Test-only change; no product code touched.

Local: `bunx playwright test --project=e2e-mobile` → 13 passed, 2 skipped, 0 failed.

## Test plan
- [ ] `bunx playwright test --project=e2e-mobile` passes (specifically `closes via backdrop click`)
- [ ] Other mobile specs still pass (no regressions in open/close behavior assertions)