### PR TITLE
fix(mobile): cap @xmldom/xmldom at 0.8.x for EAS prebuild

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -212,7 +212,7 @@
     "@tootallnate/once": ">=3.0.1",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "@xmldom/xmldom": ">=0.8.13",
+    "@xmldom/xmldom": "~0.8.13",
     "brace-expansion": ">=5.0.6",
     "glob": ">=10.4.6",
     "postcss": ">=8.5.10",
@@ -1155,7 +1155,7 @@
 
     "@webassemblyjs/wast-printer": ["@webassemblyjs/wast-printer@1.14.1", "", { "dependencies": { "@webassemblyjs/ast": "1.14.1", "@xtuc/long": "4.2.2" } }, "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw=="],
 
-    "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
 
     "@xtuc/ieee754": ["@xtuc/ieee754@1.2.0", "", {}, "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
     "ws": ">=8.20.1",
     "brace-expansion": ">=5.0.6",
     "postcss": ">=8.5.10",
-    "@xmldom/xmldom": ">=0.8.13",
+    "@xmldom/xmldom": "~0.8.13",
     "@tootallnate/once": ">=3.0.1"
+  },
+  "resolutions": {
+    "@xmldom/xmldom": "~0.8.13"
   }
 }


### PR DESCRIPTION
## Summary
- EAS iOS production prebuild was crashing with `DOMParser.parseFromString: mimeType "undefined" is not valid` because the existing `>=0.8.13` override let `@xmldom/xmldom@0.9.x` resolve on EAS cloud, which rejects the `undefined` mimeType that older `@expo/plist` passes.
- Tightens the root override to `~0.8.13` and mirrors it under `resolutions` so non-Bun resolvers EAS may use also honor it.
- Verified: production iOS build 1.0.0 (54) completed and was submitted to TestFlight on this branch (submission 75843449).

## Test plan
- [x] `bun pm ls --all | grep xmldom` shows only `@xmldom/xmldom@0.8.13`
- [x] `bun run eas:ios:production` builds successfully on EAS
- [x] `bun run eas:submit:ios` uploads the build to App Store Connect
- [ ] Build processes successfully in TestFlight