### PR TITLE
feat(linkedin): backfill education years via apimaestro hybrid

### DIFF
--- a/apps/web/src/lib/linkedin/apify.ts
+++ b/apps/web/src/lib/linkedin/apify.ts
@@ -493,3 +493,102 @@ export function getApifyProfileUrlKey(profile: ApifyProfileResult): string | nul
     return null;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Education-dates supplement (hybrid).
+//
+// The primary actor (dev_fusion) returns rich skills/certs/languages but leaves
+// education `period` null for every profile. apimaestro's profile-detail actor
+// returns education start/end years (as `{year, month?}`) but only top-5 skills
+// and no certs/languages. So we keep dev_fusion as primary and call apimaestro
+// solely to backfill the missing education years, merged by school name.
+// Same Apify token; best-effort (never blocks a write-back).
+// ---------------------------------------------------------------------------
+
+const DEFAULT_EDU_DATES_ACTOR_ID = "apimaestro~linkedin-profile-detail";
+
+function getEduDatesActorId(): string {
+  const id = process.env.APIFY_EDU_DATES_ACTOR_ID;
+  return id && id.trim() !== "" ? id.trim() : DEFAULT_EDU_DATES_ACTOR_ID;
+}
+
+interface EducationYears {
+  start_year: string | null;
+  end_year: string | null;
+}
+
+/** apimaestro emits dates as `{year:number, month?:string}`; we keep the year. */
+function extractYear(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const year = (value as Record<string, unknown>).year;
+  if (typeof year === "number" && Number.isFinite(year)) return String(year);
+  return str(year);
+}
+
+/** Case/space-insensitive school name key for matching across the two actors. */
+function normalizeSchoolKey(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/**
+ * Fetches education start/end years from the apimaestro detail actor for a
+ * single profile URL, keyed by normalized school name. Best-effort: returns an
+ * empty map on any failure or missing config.
+ */
+export async function fetchApimaestroEducationDates(
+  profileUrl: string | null,
+  options: ApifyFetchOptions = {},
+): Promise<Map<string, EducationYears>> {
+  const out = new Map<string, EducationYears>();
+  const token = getApifyToken();
+  const fetchFn = options.fetchFn ?? fetch;
+  if (!token || !profileUrl) return out;
+
+  try {
+    const url = `${APIFY_BASE_URL}/acts/${getEduDatesActorId()}/run-sync-get-dataset-items?token=${encodeURIComponent(token)}&format=json`;
+    const res = await fetchFn(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: profileUrl }),
+    });
+    if (!res.ok) return out;
+    const data = await res.json().catch(() => null);
+    const item = Array.isArray(data) ? data[0] : data;
+    const educations = item && typeof item === "object" ? (item as Record<string, unknown>).education : null;
+    if (!Array.isArray(educations)) return out;
+
+    for (const e of educations) {
+      if (!e || typeof e !== "object") continue;
+      const row = e as Record<string, unknown>;
+      const school = str(row.school);
+      if (!school) continue;
+      const start_year = extractYear(row.start_date);
+      const end_year = extractYear(row.end_date);
+      if (!start_year && !end_year) continue;
+      out.set(normalizeSchoolKey(school), { start_year, end_year });
+    }
+  } catch {
+    // best-effort supplement; the primary record is already written from dev_fusion.
+  }
+  return out;
+}
+
+/**
+ * Fills missing `start_year`/`end_year` on a normalized profile's education
+ * entries from an apimaestro school→years map (matched by school name). Mutates
+ * the profile in place; only fills gaps, never overwrites existing years.
+ */
+export function mergeEducationYears(
+  profile: ApifyProfileResult,
+  yearsBySchool: Map<string, EducationYears>,
+): void {
+  if (yearsBySchool.size === 0) return;
+  for (const edu of profile.education) {
+    if (edu.start_year && edu.end_year) continue;
+    if (!edu.title) continue;
+    const match = yearsBySchool.get(normalizeSchoolKey(edu.title));
+    if (!match) continue;
+    if (!edu.start_year && match.start_year) edu.start_year = match.start_year;
+    if (!edu.end_year && match.end_year) edu.end_year = match.end_year;
+  }
+}

--- a/apps/web/src/lib/linkedin/enrichment-writeback.ts
+++ b/apps/web/src/lib/linkedin/enrichment-writeback.ts
@@ -8,7 +8,14 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database";
-import { fetchApifyRunDataset, mapApifyToFields, getApifyProfileUrlKey, type ApifyProfileResult } from "@/lib/linkedin/apify";
+import {
+  fetchApifyRunDataset,
+  mapApifyToFields,
+  getApifyProfileUrlKey,
+  fetchApimaestroEducationDates,
+  mergeEducationYears,
+  type ApifyProfileResult,
+} from "@/lib/linkedin/apify";
 import { normalizeLinkedInProfileUrl } from "@/lib/alumni/linkedin-url";
 
 interface RunTargetRow {
@@ -127,6 +134,18 @@ export async function processFinishedApifyRun(
     const key = getApifyProfileUrlKey(profile);
     if (key) byUrl.set(key, profile);
   }
+
+  // Hybrid supplement: the primary actor leaves education years null, so fetch
+  // them from apimaestro (in parallel, best-effort) and merge in place before
+  // mapping. Only for profiles that actually have an education row missing years.
+  await Promise.all(
+    profiles.map(async (profile) => {
+      if (profile.education.length === 0) return;
+      if (profile.education.every((e) => e.start_year && e.end_year)) return;
+      const years = await fetchApimaestroEducationDates(profile.profile_url);
+      mergeEducationYears(profile, years);
+    }),
+  );
 
   for (const target of targets) {
     let profile = byUrl.get(safeNormalize(target.linkedin_url) ?? "");

--- a/apps/web/tests/routes/linkedin/apify-mapping.test.ts
+++ b/apps/web/tests/routes/linkedin/apify-mapping.test.ts
@@ -4,6 +4,8 @@ import {
   normalizeApifyItem,
   mapApifyToFields,
   getApifyProfileUrlKey,
+  fetchApimaestroEducationDates,
+  mergeEducationYears,
 } from "@/lib/linkedin/apify";
 
 // Mirrors the REAL dev_fusion/linkedin-profile-scraper output shape (verified
@@ -205,6 +207,105 @@ test("normalizeApifyItem rejects payloads with no identifying fields", () => {
   assert.equal(normalizeApifyItem({}), null);
   assert.equal(normalizeApifyItem(null), null);
   assert.equal(normalizeApifyItem("nope"), null);
+});
+
+// Mirrors the apimaestro/linkedin-profile-detail shape (verified live): a single
+// dataset item with `education[]` carrying `{school, start_date:{year,month?},
+// end_date:{year,month?}}`. We only consume the years.
+const APIMAESTRO_ITEM = [
+  {
+    basic_info: { fullname: "Jane Doe" },
+    education: [
+      {
+        school: "MIT",
+        start_date: { year: 2014 },
+        end_date: { year: 2018 },
+      },
+      {
+        school: "Phillips Academy",
+        start_date: { year: 2010, month: "Sep" },
+        end_date: { year: 2014, month: "May" },
+      },
+    ],
+  },
+];
+
+function stubFetch(payload: unknown): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+// The fetch helper guards on APIFY_API_TOKEN; provide a dummy for these tests
+// and restore the original so other suites in the shared process are unaffected.
+async function withApifyToken<T>(fn: () => Promise<T>): Promise<T> {
+  const original = process.env.APIFY_API_TOKEN;
+  process.env.APIFY_API_TOKEN = "test-token";
+  try {
+    return await fn();
+  } finally {
+    if (original === undefined) delete process.env.APIFY_API_TOKEN;
+    else process.env.APIFY_API_TOKEN = original;
+  }
+}
+
+test("fetchApimaestroEducationDates keys years by normalized school name", async () => {
+  await withApifyToken(async () => {
+    const dates = await fetchApimaestroEducationDates("https://www.linkedin.com/in/jane-doe/", {
+      fetchFn: stubFetch(APIMAESTRO_ITEM),
+    });
+    assert.equal(dates.size, 2);
+    assert.deepEqual(dates.get("mit"), { start_year: "2014", end_year: "2018" });
+    assert.deepEqual(dates.get("phillips academy"), { start_year: "2010", end_year: "2014" });
+  });
+});
+
+test("fetchApimaestroEducationDates returns empty map on a missing URL", async () => {
+  await withApifyToken(async () => {
+    const dates = await fetchApimaestroEducationDates(null, { fetchFn: stubFetch(APIMAESTRO_ITEM) });
+    assert.equal(dates.size, 0);
+  });
+});
+
+test("fetchApimaestroEducationDates is best-effort on a failed run", async () => {
+  await withApifyToken(async () => {
+    const failing = (async () => new Response("err", { status: 500 })) as unknown as typeof fetch;
+    const dates = await fetchApimaestroEducationDates("https://www.linkedin.com/in/jane-doe/", {
+      fetchFn: failing,
+    });
+    assert.equal(dates.size, 0);
+  });
+});
+
+test("mergeEducationYears fills missing years by school name without overwriting", () => {
+  // dev_fusion gives the school + degree + logo but null years (verified live).
+  const profile = normalizeApifyItem({
+    fullName: "Jane Doe",
+    educations: [
+      { title: "MIT", subtitle: "BSc, Computer Science", period: { startedOn: null, endedOn: null } },
+      { title: "Phillips Academy", subtitle: "High School Diploma", period: { startedOn: "2009", endedOn: "2013" } },
+    ],
+  });
+  assert.ok(profile);
+  assert.equal(profile.education[0].start_year, null);
+  assert.equal(profile.education[1].start_year, "2009");
+
+  mergeEducationYears(
+    profile,
+    new Map([
+      ["mit", { start_year: "2014", end_year: "2018" }],
+      ["phillips academy", { start_year: "2010", end_year: "2014" }],
+    ]),
+  );
+
+  // MIT had no years → filled from apimaestro.
+  assert.equal(profile.education[0].start_year, "2014");
+  assert.equal(profile.education[0].end_year, "2018");
+  // Phillips already had dev_fusion years → left untouched.
+  assert.equal(profile.education[1].start_year, "2009");
+  assert.equal(profile.education[1].end_year, "2013");
 });
 
 test("getApifyProfileUrlKey normalizes the profile URL for run matching", () => {


### PR DESCRIPTION
## Why
The dev_fusion actor returns full skills/certifications/languages but leaves education `period` null for **every** profile (verified across 21 profiles in a real run) — so education start/end years never appeared. apimaestro's profile-detail actor returns education years but only top-5 skills and no certs/languages. Neither alone is sufficient.

## What
Keep dev_fusion as primary and supplement it with a **best-effort** apimaestro call that supplies education **start/end years**, merged by school name into the dev_fusion record before write-back.

- `apify.ts`: `fetchApimaestroEducationDates` + `mergeEducationYears` (reuses `APIFY_API_TOKEN`; optional `APIFY_EDU_DATES_ACTOR_ID` env, defaults to `apimaestro~linkedin-profile-detail`).
- `enrichment-writeback.ts`: prefetch years in parallel only for profiles missing them, merge in place; never blocks or fails the primary write.
- Cost: +$0.005/profile (apimaestro) on top of dev_fusion's $0.010, only when a profile has an education row lacking years.

## Verified
- Unit tests: apimaestro shape parsing, missing-URL + failed-run best-effort, gap-only merge (never overwrites existing years). 12/12 pass.
- Live end-to-end on a real profile: education years went from `null` → Santa Clara 2021–2025, Fordham Prep 2017–2021, with skills (15), degree, and logos preserved.
- typecheck + lint green.