### PR TITLE
fix(linkedin): throttle apimaestro education-date calls in write-back

### DIFF
--- a/apps/web/src/lib/linkedin/enrichment-writeback.ts
+++ b/apps/web/src/lib/linkedin/enrichment-writeback.ts
@@ -136,16 +136,23 @@ export async function processFinishedApifyRun(
   }
 
   // Hybrid supplement: the primary actor leaves education years null, so fetch
-  // them from apimaestro (in parallel, best-effort) and merge in place before
-  // mapping. Only for profiles that actually have an education row missing years.
-  await Promise.all(
-    profiles.map(async (profile) => {
-      if (profile.education.length === 0) return;
-      if (profile.education.every((e) => e.start_year && e.end_year)) return;
-      const years = await fetchApimaestroEducationDates(profile.profile_url);
-      mergeEducationYears(profile, years);
-    }),
+  // them from apimaestro (best-effort) and merge in place before mapping. Only
+  // for profiles that actually have an education row missing years. Throttled —
+  // apimaestro's run-sync counts against the Apify account's concurrent-run cap,
+  // so a wide bulk run would silently fail most calls if fired all at once.
+  const profilesNeedingYears = profiles.filter(
+    (p) => p.education.length > 0 && p.education.some((e) => !e.start_year || !e.end_year),
   );
+  const EDU_DATES_CONCURRENCY = 4;
+  for (let i = 0; i < profilesNeedingYears.length; i += EDU_DATES_CONCURRENCY) {
+    const batch = profilesNeedingYears.slice(i, i + EDU_DATES_CONCURRENCY);
+    await Promise.all(
+      batch.map(async (profile) => {
+        const years = await fetchApimaestroEducationDates(profile.profile_url);
+        mergeEducationYears(profile, years);
+      }),
+    );
+  }
 
   for (const target of targets) {
     let profile = byUrl.get(safeNormalize(target.linkedin_url) ?? "");


### PR DESCRIPTION
Follow-up to the education-years hybrid (#244).

## Bug
The hybrid prefetch fired one apimaestro `run-sync` per profile via a single `Promise.all`. For a wide bulk run (40+ URLs) that exceeds the Apify account's concurrent-run cap, so most calls failed silently (best-effort) and years were dropped for ~70% of profiles. Observed: only 10/33 education rows got years on the first backfill; a profile whose apimaestro data clearly had years (UPenn 2019–2023) still landed with none.

## Fix
Bound the apimaestro prefetch to 4 concurrent calls so every profile's call actually completes. After re-running, **46/48** education rows now carry years — the rest are high schools LinkedIn has no dates for (genuine absence, confirmed against apimaestro).

typecheck green; 20/20 LinkedIn unit tests pass.