### PR TITLE
Fix: v2 org checkout provisioning (unapplied pricing_v2 migration)

### DIFF
--- a/docs/db/schema-audit.md
+++ b/docs/db/schema-audit.md
@@ -429,3 +429,19 @@ This doc is currently hand-maintained. Drift is inevitable. Two small scripts wo
 2. **Policy + index matrix** — dump `pg_policies` and `pg_indexes` from a staging DB to `docs/db/rls-matrix.generated.md` and `docs/db/indexes.generated.md`. Link from this audit. Keeps "who can SELECT on X" and "is column Y indexed" out of human memory.
 
 Both are deferred (YAGNI) until drift becomes painful again.
+
+---
+
+## Production Incidents
+
+### 2026-06-02 — v2 org checkout provisioning broken by an unapplied migration
+
+**Symptom.** A customer paid for an org (`New York Edge MS 127X – THE CASTLE HILL`, slug `new-york-edge-ms-127x-the-castle-hill`) via the v2 self-serve flow, was charged on Stripe, but the org never appeared on their orgs page. The org row existed with **zero `user_organization_roles`** and **no `organization_subscriptions` row**, and the `payment_attempts` row was stuck in `processing`.
+
+**Root cause.** Migration `20260429120000_pricing_v2_subscription_columns.sql` (adds `pricing_model_version` + `pricing_v2_snapshot` to `organization_subscriptions` **and** `enterprise_subscriptions`) was committed to the repo but **never applied to production**. The `org_v2` / `enterprise_v2` branches in `apps/web/src/app/api/stripe/webhook/handler.ts` write those columns via `ensureSubscriptionSeedV2`. With the columns missing, `checkout.session.completed` threw `Could not find the 'pricing_model_version' column of 'organization_subscriptions' in the schema cache` *after* the org was created but *before* the subscription row, the admin-role grant, and the `payment_attempts` finalization. The failure is deterministic, so every Stripe retry hit the same wall and the `stripe_events` row never reached `processed_at`. Net effect: **every actually-paid v2 checkout would half-provision** (blast radius at the time was a single live paid org; all other stuck `*_v2_checkout` attempts were unpaid/abandoned dev tests).
+
+**Fix.** Applied the missing migration to production, then manually replayed the webhook's provisioning steps for the affected org (insert the v2 `organization_subscriptions` row, grant the purchaser `admin`/`active`, mark the `payment_attempts` row `succeeded` + linked to the org, mark the `stripe_events` row processed). `stripe_customer_id` and `current_period_end` were backfilled approximately and will be corrected by the next subscription webhook (noted in `pricing_v2_snapshot.backfilled_by`).
+
+**Follow-ups to look into.**
+- **Migration-ledger drift.** `supabase_migrations.schema_migrations` is missing ~116 repo migration *version strings*. This is **mostly renumbering noise, not missing schema** — the repo's migration history appears to have been rebased/renumbered to later dates, and spot-checked "missing" migrations (`reactions`, `enterprise_deletion_requests`, `bulk_import_alumni_rich` birth_year, `enterprise_hard_org_limit`) already exist in prod under their original version numbers. The pricing_v2 migration is the one case confirmed to be *genuinely* unapplied schema. Worth a proper reconciliation pass (`supabase migration repair`) plus an object-level audit to confirm nothing else is truly missing, and a CI guard so a committed-but-unapplied migration can't silently ship again.
+- **Webhook resilience.** A deterministic handler error half-provisions a paid org with no alerting surfaced to an operator. Consider failing *before* org creation when required schema is absent, and/or an alert when a `checkout.session.completed` for a paid session never reaches `processed_at`.


### PR DESCRIPTION
## Summary

Investigated a report that a customer paid for an org but it never showed up on their orgs page. Root cause was a **migration that was committed to the repo but never applied to production**, which silently broke **every v2 paid checkout's provisioning**.

The production fixes (DDL + data recovery) were applied directly via the Supabase MCP. This PR carries the **incident writeup** so the finding is recorded and the follow-ups don't get lost.

## What broke

Org `New York Edge MS 127X – THE CASTLE HILL` (user `mckillopm25@gmail.com`):
- Customer was charged $361.55/yr on Stripe (`invoice.paid` + `customer.subscription.created` processed fine), and the org row was created.
- The `checkout.session.completed` webhook then **threw and never finished**:
  > `Failed to create v2 subscription row: Could not find the 'pricing_model_version' column of 'organization_subscriptions' in the schema cache`
- Result: org had **0 members/roles** (so it never appeared on the orgs page), **no `organization_subscriptions` row**, and the `payment_attempts` row was stuck in `processing`. The error is deterministic, so Stripe retries never recovered it.

## Root cause

Migration `20260429120000_pricing_v2_subscription_columns.sql` — which adds `pricing_model_version` + `pricing_v2_snapshot` to `organization_subscriptions` **and** `enterprise_subscriptions` — was in the repo but **not applied to prod**. The `org_v2` / `enterprise_v2` webhook branches write those columns, so the missing schema broke provisioning after org creation but before the subscription row / admin-role grant / payment finalization. Blast radius of *actually-paid* failures: a single live org (all other stuck `*_v2_checkout` attempts were unpaid/abandoned dev tests).

## Fix applied to production (via Supabase MCP)

1. Applied the missing `pricing_v2` columns migration.
2. Replayed the webhook's provisioning for the affected org: inserted the v2 `organization_subscriptions` row (active, yearly, `sub_1TdgfU…`), granted the purchaser `admin`/`active`, marked the `payment_attempts` row `succeeded` + linked to the org, and marked the stuck `stripe_events` row processed.
3. Verified: the user now has an `admin`/`active` membership → **the org shows on their orgs page** (`app/page.tsx` lists `user_organization_roles` where `status === 'active'`).

> Note: `stripe_customer_id` / `current_period_end` were backfilled approximately and will self-correct on the next subscription webhook (flagged in `pricing_v2_snapshot.backfilled_by`).

## Migration-ledger drift — worth a look (per request)

While investigating, I found `supabase_migrations.schema_migrations` is missing **~116 repo migration version strings**. This is **mostly renumbering noise, not missing schema** — the repo's migration history appears to have been rebased/renumbered to later dates, and spot-checked "missing" migrations (`reactions`, `enterprise_deletion_requests`, `bulk_import_alumni_rich` birth_year, `enterprise_hard_org_limit`) already exist in prod under their original version numbers. The pricing_v2 migration is the **only** case I confirmed to be genuinely unapplied schema. Still worth a proper reconciliation pass (`supabase migration repair`) + an object-level audit to be sure nothing else is truly missing, and ideally a CI guard so a committed-but-unapplied migration can't silently ship again.

## Changes in this PR

- `docs/db/schema-audit.md`: incident record + the follow-ups above (ledger drift, webhook resilience).

https://claude.ai/code/session_019sV8YkPK1LFdCUh62qeKWu

---
_Generated by [Claude Code](https://claude.ai/code/session_019sV8YkPK1LFdCUh62qeKWu)_