### PR TITLE
Fix AI spend checks in CI without service key

### DIFF
--- a/apps/web/src/lib/ai/spend.ts
+++ b/apps/web/src/lib/ai/spend.ts
@@ -129,7 +129,12 @@ function bypassStatus(): SpendStatus {
 }
 
 function isTestSkip(): boolean {
-  return process.env.NODE_ENV !== "production" && !process.env.NEXT_PUBLIC_SUPABASE_URL;
+  return (
+    process.env.NODE_ENV !== "production" &&
+    (!process.env.NEXT_PUBLIC_SUPABASE_URL ||
+      !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+      !process.env.SUPABASE_SERVICE_ROLE_KEY)
+  );
 }
 
 interface RpcRow {

--- a/apps/web/tests/ai-spend-cap.test.ts
+++ b/apps/web/tests/ai-spend-cap.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   AiCapReachedError,
+  checkAiSpend,
   isAiSpendBypassed,
   __test,
   type SpendStatus,
@@ -76,4 +77,17 @@ test("isAiSpendBypassed: true for DEV_ADMIN_EMAILS, false otherwise", () => {
   assert.equal(isAiSpendBypassed(null), false);
   assert.equal(isAiSpendBypassed(undefined), false);
   assert.equal(isAiSpendBypassed({ email: null }), false);
+});
+
+test("checkAiSpend: non-production bypasses when service role env is absent", async () => {
+  resetEnv();
+  process.env.NODE_ENV = "test";
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://rytsziwekhtjdqzzpdso.supabase.co";
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-placeholder";
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  const status = await checkAiSpend("00000000-0000-4000-8000-000000000001");
+
+  assert.equal(status.allowed, true);
+  assert.equal(status.spendCents, 0);
 });


### PR DESCRIPTION
## Summary
- skip AI spend RPC calls in non-production when Supabase service env is incomplete
- add regression coverage for missing SUPABASE_SERVICE_ROLE_KEY with URL/anon present

## Verification
- bun run typecheck
- bun run lint
- env SUPABASE_SERVICE_ROLE_KEY= NEXT_PUBLIC_SUPABASE_URL=https://rytsziwekhtjdqzzpdso.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-placeholder bun run --cwd apps/web test:ai
- bun run test
- SKIP_STRIPE_VALIDATION=true bun run build:web