### PR TITLE
fix(mentorship): source enrichment from each person's own profile row

### DIFF
--- a/apps/web/src/lib/mentorship/queries.ts
+++ b/apps/web/src/lib/mentorship/queries.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database";
+import { resolveEnrichedProfiles } from "@/lib/profile/enriched-fields";
 
 /**
  * Coerce a jsonb column into a typed array. supabase-js returns jsonb already
@@ -14,15 +15,6 @@ function asStringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((v): v is string => typeof v === "string" && v.trim().length > 0)
     : [];
-}
-
-/**
- * Alumni-wins merge: prefer the alumni value, fall back to the members value
- * only when the alumni side is empty. Mirrors the people-graph projection rule
- * where alumni career data is authoritative over members.
- */
-function pickEnriched<T>(alumniValue: T[], membersValue: T[]): T[] {
-  return alumniValue.length > 0 ? alumniValue : membersValue;
 }
 
 export interface PairableOrgMember {
@@ -144,21 +136,14 @@ export async function loadMentorInputs(
 
   if (mentorUserIds.length === 0) return [];
 
-  const alumniRes = await sb
-    .from("alumni")
-    .select(
-      "user_id, industry, job_title, position_title, current_company, current_city, graduation_year, work_history, education_history, skills"
-    )
-    .eq("organization_id", orgId)
-    .in("user_id", mentorUserIds);
-
-  const alumniByUser = new Map<string, Record<string, unknown>>();
-  for (const row of (alumniRes.data ?? []) as Array<{ user_id: string } & Record<string, unknown>>) {
-    alumniByUser.set(row.user_id, row);
-  }
+  // Resolve each mentor's career signals from the row that backs their own
+  // profile (members → alumni → parents), keyed by their own user_id, so a
+  // stray/colliding alumni row can never inject another person's data into the
+  // matcher. See resolveEnrichedProfiles for the single-row selection rule.
+  const enrichedByUser = await resolveEnrichedProfiles(supabase, orgId, mentorUserIds);
 
   return mentorProfiles.map((p) => {
-    const alumni = alumniByUser.get(p.user_id as string) ?? {};
+    const enriched = enrichedByUser.get(p.user_id as string);
     return {
       userId: p.user_id as string,
       orgId,
@@ -168,19 +153,19 @@ export async function loadMentorInputs(
       nativePositions: (p.positions as string[] | null) ?? [],
       nativeIndustries: (p.industries as string[] | null) ?? [],
       nativeRoleFamilies: (p.role_families as string[] | null) ?? [],
-      industry: (alumni.industry as string | null) ?? null,
-      jobTitle: (alumni.job_title as string | null) ?? null,
-      positionTitle: (alumni.position_title as string | null) ?? null,
-      currentCompany: (alumni.current_company as string | null) ?? null,
-      currentCity: (alumni.current_city as string | null) ?? null,
-      graduationYear: (alumni.graduation_year as number | null) ?? null,
+      industry: enriched?.industry ?? null,
+      jobTitle: enriched?.job_title ?? null,
+      positionTitle: enriched?.position_title ?? null,
+      currentCompany: enriched?.current_company ?? null,
+      currentCity: enriched?.current_city ?? null,
+      graduationYear: enriched?.graduation_year ?? null,
       workHistory: asJsonArray<import("@/lib/mentorship/matching-signals").EnrichedWorkEntry>(
-        alumni.work_history
+        enriched?.work_history
       ),
       educationHistory: asJsonArray<
         import("@/lib/mentorship/matching-signals").EnrichedEducationEntry
-      >(alumni.education_history),
-      skills: asStringArray(alumni.skills),
+      >(enriched?.education_history),
+      skills: asStringArray(enriched?.skills),
       maxMentees: (p.max_mentees as number | null) ?? 3,
       currentMenteeCount: (p.current_mentee_count as number | null) ?? 0,
       acceptingNew: (p.accepting_new as boolean | null) ?? true,
@@ -218,7 +203,11 @@ export async function loadMenteePreferences(
     };
   };
 
-  const [prefsRes, alumniRes, memberRes] = await Promise.all([
+  // Native preferences come from `mentee_preferences`. The mentee's own profile
+  // facts (city/company/grad year + work/education history) are resolved from
+  // the row that backs their profile (members → alumni → parents) via the shared
+  // resolver, so a colliding alumni row can never leak another person's facts.
+  const [prefsRes, enrichedByUser] = await Promise.all([
     sb
       .from("mentee_preferences")
       .select(
@@ -227,24 +216,11 @@ export async function loadMenteePreferences(
       .eq("organization_id", orgId)
       .eq("user_id", menteeUserId)
       .maybeSingle(),
-    sb
-      .from("alumni")
-      .select("current_city, current_company, graduation_year, work_history, education_history")
-      .eq("organization_id", orgId)
-      .eq("user_id", menteeUserId)
-      .maybeSingle(),
-    // Mentees are active members — their enriched data lives on `members`.
-    sb
-      .from("members")
-      .select("work_history, education_history")
-      .eq("organization_id", orgId)
-      .eq("user_id", menteeUserId)
-      .maybeSingle(),
+    resolveEnrichedProfiles(supabase, orgId, [menteeUserId]),
   ]);
 
   const prefs = (prefsRes.data as Record<string, unknown> | null) ?? null;
-  const alumni = (alumniRes.data as Record<string, unknown> | null) ?? null;
-  const member = (memberRes.data as Record<string, unknown> | null) ?? null;
+  const enriched = enrichedByUser.get(menteeUserId) ?? null;
 
   type WorkEntry = import("@/lib/mentorship/matching-signals").EnrichedWorkEntry;
   type EduEntry = import("@/lib/mentorship/matching-signals").EnrichedEducationEntry;
@@ -258,16 +234,10 @@ export async function loadMenteePreferences(
     preferredSports: asStringArray(prefs?.preferred_sports),
     preferredPositions: asStringArray(prefs?.preferred_positions),
     requiredMentorAttributes: asStringArray(prefs?.required_attributes),
-    currentCity: (alumni?.current_city as string | null) ?? null,
-    graduationYear: (alumni?.graduation_year as number | null) ?? null,
-    currentCompany: (alumni?.current_company as string | null) ?? null,
-    workHistory: pickEnriched(
-      asJsonArray<WorkEntry>(alumni?.work_history),
-      asJsonArray<WorkEntry>(member?.work_history)
-    ),
-    educationHistory: pickEnriched(
-      asJsonArray<EduEntry>(alumni?.education_history),
-      asJsonArray<EduEntry>(member?.education_history)
-    ),
+    currentCity: enriched?.current_city ?? null,
+    graduationYear: enriched?.graduation_year ?? null,
+    currentCompany: enriched?.current_company ?? null,
+    workHistory: asJsonArray<WorkEntry>(enriched?.work_history),
+    educationHistory: asJsonArray<EduEntry>(enriched?.education_history),
   };
 }

--- a/apps/web/src/lib/mentorship/tab-data.ts
+++ b/apps/web/src/lib/mentorship/tab-data.ts
@@ -1,5 +1,6 @@
 import { canLogMentorshipActivity } from "@/lib/mentorship/presentation";
 import { decryptToken } from "@/lib/crypto/token-encryption";
+import { resolveEnrichedProfiles } from "@/lib/profile/enriched-fields";
 import { createClient } from "@/lib/supabase/server";
 import type { MembershipStatus, Database } from "@/types/database";
 import type { MentorshipTab } from "@/lib/mentorship/view-state";
@@ -31,15 +32,6 @@ type MentorshipLogRow = Database["public"]["Tables"]["mentorship_logs"]["Row"];
 type MentorshipTaskRow = Database["public"]["Tables"]["mentorship_tasks"]["Row"];
 type MentorshipMeetingRow = Database["public"]["Tables"]["mentorship_meetings"]["Row"];
 type UserRow = { id: string; name: string | null; email: string | null };
-type AlumniDirectoryRow = Pick<
-  Database["public"]["Tables"]["alumni"]["Row"],
-  | "user_id"
-  | "photo_url"
-  | "industry"
-  | "graduation_year"
-  | "current_company"
-  | "current_city"
->;
 type ActivityTask = {
   id: string;
   pair_id: string;
@@ -484,33 +476,23 @@ export async function loadMentorshipTabView({
     ).sort();
     const orgHasAthleticData = sportOptions.length > 0 || positionOptions.length > 0;
 
-    const { data: mentorAlumniRaw } =
-      mentorUserIds.length > 0
-        ? await db
-            .from("alumni")
-            .select(
-              "user_id, photo_url, industry, graduation_year, current_company, current_city"
-            )
-            .eq("organization_id", orgId)
-            .is("deleted_at", null)
-            .in("user_id", mentorUserIds)
-        : { data: [] as AlumniDirectoryRow[] };
-
-    const alumniMap = new Map(
-      ((mentorAlumniRaw ?? []) as AlumniDirectoryRow[]).map((alumni) => [alumni.user_id, alumni])
-    );
+    // Source each mentor's company/industry from the row that backs THEIR OWN
+    // profile (members → alumni → parents), never an alumni row that merely
+    // shares their user_id. Keeps the card consistent with the profile page and
+    // prevents a colliding/stray alumni record from surfacing a stranger's data.
+    const enrichedByUser = await resolveEnrichedProfiles(db, orgId, mentorUserIds);
     const mentorsForDirectory = mentorProfiles.map((profile) => {
-      const alumni = alumniMap.get(profile.user_id);
+      const enriched = enrichedByUser.get(profile.user_id);
       return {
         id: profile.id,
         user_id: profile.user_id,
         name: profile.users?.name ?? "Unknown",
         email: profile.users?.email ?? null,
-        photo_url: alumni?.photo_url ?? null,
-        industry: alumni?.industry ?? null,
-        graduation_year: alumni?.graduation_year ?? null,
-        current_company: alumni?.current_company ?? null,
-        current_city: alumni?.current_city ?? null,
+        photo_url: enriched?.photo_url ?? null,
+        industry: enriched?.industry ?? null,
+        graduation_year: enriched?.graduation_year ?? null,
+        current_company: enriched?.current_company ?? null,
+        current_city: enriched?.current_city ?? null,
         expertise_areas: profile.expertise_areas ?? null,
         topics: profile.topics ?? null,
         sports: profile.sports ?? null,

--- a/apps/web/src/lib/profile/enriched-fields.ts
+++ b/apps/web/src/lib/profile/enriched-fields.ts
@@ -1,0 +1,134 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database";
+
+/**
+ * Flat + rich enrichment fields used to render a person's profile anywhere in
+ * the app (mentorship directory cards, mentor/mentee matching inputs). These
+ * mirror the columns populated by the LinkedIn enrichment writeback
+ * (`sync_user_linkedin_enrichment` / `enrich_alumni_by_id`).
+ *
+ * `job_title` / `position_title` exist only on `alumni` and `parents` (not on
+ * `members`), so they are `null` when a person's primary row is a member.
+ */
+export interface EnrichedProfileFields {
+  current_company: string | null;
+  industry: string | null;
+  current_city: string | null;
+  graduation_year: number | null;
+  photo_url: string | null;
+  job_title: string | null;
+  position_title: string | null;
+  work_history: unknown;
+  education_history: unknown;
+  skills: unknown;
+}
+
+type EnrichedRow = Partial<EnrichedProfileFields> & { user_id?: string | null };
+
+/**
+ * Resolve each user's enrichment fields from the row that backs *their own*
+ * profile, keyed by `user_id` within one organization.
+ *
+ * A `user_id` maps to a single person per org (modeled by
+ * `user_organization_roles`), and that person's enrichment lives on exactly one
+ * of `members` / `alumni` / `parents`. We therefore pick a SINGLE primary row
+ * per user_id in that priority order and return only that row's fields — we
+ * never fall back field-by-field across tables.
+ *
+ * This is deliberate: members own profile (active members) takes precedence and
+ * matches what the member profile page shows. Crucially, single-row selection
+ * is collision-resistant — if a stray `alumni` row were ever stamped with a
+ * member's `user_id` (a data-integrity bug we also guard against in the DB), a
+ * sparse member row can never "fall through" and surface that other person's
+ * company/industry on the member's card.
+ *
+ * Members are preferred over alumni/parents; alumni over parents.
+ */
+export async function resolveEnrichedProfiles(
+  supabase: SupabaseClient<Database>,
+  orgId: string,
+  userIds: string[]
+): Promise<Map<string, EnrichedProfileFields>> {
+  const uniqueIds = Array.from(new Set(userIds.filter((id): id is string => !!id)));
+  if (uniqueIds.length === 0) return new Map();
+
+  // Structural client cast: `members`/`parents` enriched columns may lag the
+  // generated DB types, and we only need the loose select/eq/in/is chain.
+  const sb = supabase as unknown as {
+    from: (table: string) => {
+      select: (cols: string) => {
+        eq: (col: string, val: string) => {
+          is: (col: string, val: null) => {
+            in: (col: string, vals: string[]) => Promise<{ data: EnrichedRow[] | null }>;
+          };
+          in: (col: string, vals: string[]) => Promise<{ data: EnrichedRow[] | null }>;
+        };
+      };
+    };
+  };
+
+  const [membersRes, alumniRes, parentsRes] = await Promise.all([
+    sb
+      .from("members")
+      .select(
+        "user_id, photo_url, graduation_year, current_company, current_city, industry, work_history, education_history, skills"
+      )
+      .eq("organization_id", orgId)
+      .is("deleted_at", null)
+      .in("user_id", uniqueIds),
+    sb
+      .from("alumni")
+      .select(
+        "user_id, photo_url, graduation_year, current_company, current_city, industry, job_title, position_title, work_history, education_history, skills"
+      )
+      .eq("organization_id", orgId)
+      .is("deleted_at", null)
+      .in("user_id", uniqueIds),
+    sb
+      .from("parents")
+      .select(
+        "user_id, photo_url, current_company, current_city, industry, job_title, position_title, work_history, education_history, skills"
+      )
+      .eq("organization_id", orgId)
+      .is("deleted_at", null)
+      .in("user_id", uniqueIds),
+  ]);
+
+  const indexByUser = (rows: EnrichedRow[] | null): Map<string, EnrichedRow> => {
+    const map = new Map<string, EnrichedRow>();
+    for (const row of rows ?? []) {
+      if (row.user_id) map.set(row.user_id, row);
+    }
+    return map;
+  };
+
+  const membersByUser = indexByUser(membersRes.data);
+  const alumniByUser = indexByUser(alumniRes.data);
+  const parentsByUser = indexByUser(parentsRes.data);
+
+  const resolved = new Map<string, EnrichedProfileFields>();
+  for (const userId of uniqueIds) {
+    const row =
+      membersByUser.get(userId) ??
+      alumniByUser.get(userId) ??
+      parentsByUser.get(userId) ??
+      null;
+    resolved.set(userId, toFields(row));
+  }
+  return resolved;
+}
+
+function toFields(row: EnrichedRow | null): EnrichedProfileFields {
+  return {
+    current_company: (row?.current_company as string | null) ?? null,
+    industry: (row?.industry as string | null) ?? null,
+    current_city: (row?.current_city as string | null) ?? null,
+    graduation_year: (row?.graduation_year as number | null) ?? null,
+    photo_url: (row?.photo_url as string | null) ?? null,
+    job_title: (row?.job_title as string | null) ?? null,
+    position_title: (row?.position_title as string | null) ?? null,
+    work_history: row?.work_history ?? null,
+    education_history: row?.education_history ?? null,
+    skills: row?.skills ?? null,
+  };
+}

--- a/apps/web/tests/mentorship-enrichment-attribution.test.ts
+++ b/apps/web/tests/mentorship-enrichment-attribution.test.ts
@@ -1,0 +1,122 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveEnrichedProfiles } from "@/lib/profile/enriched-fields";
+import { createSupabaseStub } from "./utils/supabaseStub";
+
+const ORG = "11111111-1111-1111-1111-111111111111";
+// Reproduces the real "CHSFL" collision: a member (Keoleian) and a DIFFERENT
+// person's alumni record (Marcus Reed, Goldman Sachs) sharing one user_id.
+const KEOLEIAN = "79c0c61f-ff37-44e5-868d-bc676be69115";
+
+type Stub = ReturnType<typeof createSupabaseStub>;
+const asClient = (stub: Stub) => stub as never;
+
+test("cross-person collision: mentor card shows the member's OWN profile, not the colliding alumni's", async () => {
+  const stub = createSupabaseStub();
+  // Member Keoleian — his own profile has no enriched company yet.
+  stub.seed("members", [
+    {
+      organization_id: ORG,
+      user_id: KEOLEIAN,
+      first_name: "Michael",
+      last_name: "Keoleian",
+      current_company: null,
+      industry: null,
+      current_city: null,
+      deleted_at: null,
+    },
+  ]);
+  // A different person's alumni record wrongly stamped with Keoleian's user_id.
+  stub.seed("alumni", [
+    {
+      organization_id: ORG,
+      user_id: KEOLEIAN,
+      first_name: "Marcus",
+      last_name: "Reed",
+      current_company: "Goldman Sachs",
+      industry: "Finance",
+      current_city: "New York",
+      deleted_at: null,
+    },
+  ]);
+
+  const resolved = await resolveEnrichedProfiles(asClient(stub), ORG, [KEOLEIAN]);
+  const fields = resolved.get(KEOLEIAN);
+
+  assert.ok(fields, "expected resolved fields for the mentor");
+  // The bug: card rendered "Goldman Sachs / Finance" (Marcus Reed's data).
+  // The fix: the member's own row wins — no foreign data bleeds in.
+  assert.equal(fields.current_company, null);
+  assert.equal(fields.industry, null);
+  assert.notEqual(fields.current_company, "Goldman Sachs");
+});
+
+test("alumni-only person (no member row) still resolves from their own alumni record", async () => {
+  const stub = createSupabaseStub();
+  const alum = "22222222-2222-2222-2222-222222222222";
+  stub.seed("alumni", [
+    {
+      organization_id: ORG,
+      user_id: alum,
+      first_name: "Jane",
+      last_name: "Doe",
+      current_company: "Acme Corp",
+      industry: "Manufacturing",
+      job_title: "Engineer",
+      deleted_at: null,
+    },
+  ]);
+
+  const resolved = await resolveEnrichedProfiles(asClient(stub), ORG, [alum]);
+  const fields = resolved.get(alum);
+
+  assert.equal(fields?.current_company, "Acme Corp");
+  assert.equal(fields?.industry, "Manufacturing");
+  assert.equal(fields?.job_title, "Engineer");
+});
+
+test("members row is preferred over a same-user alumni row (profile-page consistency)", async () => {
+  const stub = createSupabaseStub();
+  const user = "33333333-3333-3333-3333-333333333333";
+  stub.seed("members", [
+    {
+      organization_id: ORG,
+      user_id: user,
+      current_company: "Current Employer",
+      industry: "Tech",
+      deleted_at: null,
+    },
+  ]);
+  stub.seed("alumni", [
+    {
+      organization_id: ORG,
+      user_id: user,
+      current_company: "Old Employer",
+      industry: "Other",
+      deleted_at: null,
+    },
+  ]);
+
+  const resolved = await resolveEnrichedProfiles(asClient(stub), ORG, [user]);
+  assert.equal(resolved.get(user)?.current_company, "Current Employer");
+  assert.equal(resolved.get(user)?.industry, "Tech");
+});
+
+test("soft-deleted rows are ignored", async () => {
+  const stub = createSupabaseStub();
+  const user = "44444444-4444-4444-4444-444444444444";
+  stub.seed("members", [
+    {
+      organization_id: ORG,
+      user_id: user,
+      current_company: "Deleted Co",
+      industry: "Gone",
+      deleted_at: "2026-01-01T00:00:00Z",
+    },
+  ]);
+
+  const resolved = await resolveEnrichedProfiles(asClient(stub), ORG, [user]);
+  // No live row → empty fields, never the soft-deleted company.
+  assert.equal(resolved.get(user)?.current_company, null);
+});

--- a/supabase/migrations/20261215000000_fix_cross_person_enrichment_collisions.sql
+++ b/supabase/migrations/20261215000000_fix_cross_person_enrichment_collisions.sql
@@ -1,0 +1,44 @@
+-- Fix cross-person user_id collisions that made the mentorship directory render
+-- one person's enriched company/industry on a different person's card.
+--
+-- Root cause: some `alumni` rows were stamped with a real member's `user_id`
+-- while describing a DIFFERENT person (sample/import artifacts). Surfaces that
+-- join enrichment by `user_id` (e.g. the mentorship directory) then attributed
+-- the stray alumni record's company/industry to the member.
+--
+-- Part A — detach the mismatched alumni rows (keep them as manual alumni
+--          entries; just stop them impersonating the member's account).
+-- Part B — add partial unique indexes so a person can never have duplicate
+--          rows per org going forward.
+
+-- ---------------------------------------------------------------------------
+-- Part A: detach alumni rows whose user_id collides with a DIFFERENT-named
+-- member in the same org. The name-mismatch guard ensures legitimately linked
+-- alumni (same person as the member) are never touched.
+-- ---------------------------------------------------------------------------
+UPDATE public.alumni a
+SET user_id = NULL,
+    updated_at = now()
+FROM public.members m
+WHERE m.organization_id = a.organization_id
+  AND m.user_id = a.user_id
+  AND m.deleted_at IS NULL
+  AND a.deleted_at IS NULL
+  AND a.user_id IS NOT NULL
+  AND lower(trim(coalesce(m.first_name, '') || ' ' || coalesce(m.last_name, '')))
+      <> lower(trim(coalesce(a.first_name, '') || ' ' || coalesce(a.last_name, '')));
+
+-- ---------------------------------------------------------------------------
+-- Part B: enforce one live row per (organization_id, user_id) per table. These
+-- prevent duplicate member/alumni rows for the same person; the cross-table
+-- member<->alumni collision is additionally guarded operationally by reading a
+-- person's enrichment from their own role-appropriate row (members -> alumni ->
+-- parents) in application code (see lib/profile/enriched-fields.ts).
+-- ---------------------------------------------------------------------------
+CREATE UNIQUE INDEX IF NOT EXISTS alumni_org_user_id_live_unique
+  ON public.alumni (organization_id, user_id)
+  WHERE deleted_at IS NULL AND user_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS members_org_user_id_live_unique
+  ON public.members (organization_id, user_id)
+  WHERE deleted_at IS NULL AND user_id IS NOT NULL;


### PR DESCRIPTION
## Problem
Mentorship cards rendered a different person's company/industry. The directory joined `alumni` on `user_id` assuming one user_id == one person, but several alumni rows were stamped with a real member's user_id while describing a different person (e.g. Michael Keoleian showed Marcus Reed's "Goldman Sachs / Finance"; Elena Torres showed Carl Benson's "ADT / Operations").

## Fix
- New `resolveEnrichedProfiles` (`lib/profile/enriched-fields.ts`): single primary row per user_id, priority **members → alumni → parents**, no cross-table per-field fallback — a colliding alumni row can't bleed onto a card.
- Route directory (`tab-data.ts`) and matching (`queries.ts`) through the resolver.
- Migration `20261215000000`: detach the 4 mismatched `alumni.user_id` rows (name-mismatch guarded) + partial unique indexes on `members`/`alumni (organization_id, user_id)`.
- Repro test for the cross-person collision.

## Verification
- Migration applied to DB: remaining collisions = 0, Keoleian resolves to his own (empty) data, both unique indexes present.
- typecheck ✅, lint ✅, full suite 5744 pass / 0 fail ✅.