### PR TITLE
fix(members): render full LinkedIn work history from members columns

### DIFF
--- a/apps/web/src/app/[orgSlug]/members/[memberId]/page.tsx
+++ b/apps/web/src/app/[orgSlug]/members/[memberId]/page.tsx
@@ -10,6 +10,11 @@ import type { Member } from "@/types/database";
 import { LinkedInProfileLink, formatPersonHeadline, EnrichmentSections } from "@/components/shared";
 import { ConnectedAccountsSection } from "@/components/members/ConnectedAccountsSection";
 import { sanitizeRichTextToPlainText } from "@/lib/security/rich-text";
+import {
+  resolveMemberExperience,
+  resolveMemberEducation,
+  resolveMemberBio,
+} from "@/lib/profile/member-enrichment";
 
 interface MemberDetailPageProps {
   params: Promise<{ orgSlug: string; memberId: string }>;
@@ -87,35 +92,20 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
     }
   }
 
-  // Extract enrichment data from LinkedIn connection (stored by Apify sync)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const m = member as Member & Record<string, any>;
+
+  // Extract enrichment data from the LinkedIn self-connection (stored by Apify sync).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const linkedinData = (enrichmentResult as any)?.data?.linkedin_data;
   const enrichment = linkedinData?.enrichment;
-  const linkedinBio: string | null = enrichment?.about || enrichment?.summary || null;
 
-  // Experience and education from enrichment JSON
-  interface EnrichmentExperience {
-    title?: string | null;
-    company?: string | null;
-    company_id?: string | null;
-    location?: string | null;
-    start_date?: string | null;
-    end_date?: string | null;
-    description_html?: string | null;
-    company_logo_url?: string | null;
-  }
-  interface EnrichmentEducation {
-    title?: string | null; // school name
-    degree?: string | null;
-    field_of_study?: string | null;
-    start_year?: string | null;
-    end_year?: string | null;
-    description?: string | null;
-    institute_logo_url?: string | null;
-  }
-
-  const enrichmentExperience: EnrichmentExperience[] = Array.isArray(enrichment?.experience) ? enrichment.experience : [];
-  const enrichmentEducation: EnrichmentEducation[] = Array.isArray(enrichment?.education) ? enrichment.education : [];
+  // Experience/education/bio prefer the self-connection blob and fall back to the
+  // admin-enriched `members` columns (identical shape) — so members enriched only
+  // by the Apify admin pipeline (no self-connection) still render full history.
+  const linkedinBio: string | null = resolveMemberBio(enrichment, m);
+  const enrichmentExperience = resolveMemberExperience(enrichment, m);
+  const enrichmentEducation = resolveMemberEducation(enrichment, m);
 
   const currentUserId = user?.id ?? null;
   const isAdmin = ctx.isAdmin;
@@ -123,9 +113,6 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
   const canModifyExisting = canEdit && !ctx.isReadOnly;
   const canDelete = ctx.isAdmin && !ctx.isReadOnly;
   const isOwnProfile = currentUserId !== null && currentUserId === memberUserId;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const m = member as Member & Record<string, any>;
 
   // member.role is the job title field (confusingly named "role" in the members table)
   const jobTitle = m.role || null;

--- a/apps/web/src/lib/profile/member-enrichment.ts
+++ b/apps/web/src/lib/profile/member-enrichment.ts
@@ -1,0 +1,100 @@
+/**
+ * Member profile enrichment resolution.
+ *
+ * Member experience/education/bio can come from two independent sources:
+ *
+ *  1. `user_linkedin_connections.linkedin_data.enrichment` — written only when
+ *     the member personally OAuth-connects their own LinkedIn account.
+ *  2. The `members` table columns (`work_history`, `education_history`,
+ *     `summary`, `headline`) — written by the Apify admin enrichment pipeline
+ *     (`sync_user_linkedin_enrichment`), independent of any self-connection.
+ *
+ * The detail page historically read only source #1, so members enriched solely
+ * by the admin pipeline (no self-connection) rendered a degenerate single-job,
+ * logo-less fallback even though their column data was fully populated. These
+ * helpers coalesce blob → column with the same blob-first precedence already
+ * used for skills/certs/languages (`enrichment?.skills ?? m.skills`). The two
+ * sources share an identical JSON shape, so callers render them interchangeably.
+ */
+
+export interface EnrichmentExperience {
+  title?: string | null;
+  company?: string | null;
+  company_id?: string | null;
+  location?: string | null;
+  start_date?: string | null;
+  end_date?: string | null;
+  description_html?: string | null;
+  company_logo_url?: string | null;
+}
+
+export interface EnrichmentEducation {
+  title?: string | null; // school name
+  degree?: string | null;
+  field_of_study?: string | null;
+  start_year?: string | null;
+  end_year?: string | null;
+  description?: string | null;
+  institute_logo_url?: string | null;
+}
+
+export interface MemberEnrichmentBlob {
+  about?: string | null;
+  summary?: string | null;
+  experience?: unknown;
+  education?: unknown;
+}
+
+export interface MemberEnrichmentColumns {
+  work_history?: unknown;
+  education_history?: unknown;
+  summary?: string | null;
+  headline?: string | null;
+}
+
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+/**
+ * Resolve a member's work experience, preferring the self-connection blob and
+ * falling back to the `members.work_history` column.
+ */
+export function resolveMemberExperience(
+  enrichment: MemberEnrichmentBlob | null | undefined,
+  member: MemberEnrichmentColumns,
+): EnrichmentExperience[] {
+  const fromBlob = asArray<EnrichmentExperience>(enrichment?.experience);
+  if (fromBlob.length > 0) return fromBlob;
+  return asArray<EnrichmentExperience>(member.work_history);
+}
+
+/**
+ * Resolve a member's education, preferring the self-connection blob and falling
+ * back to the `members.education_history` column.
+ */
+export function resolveMemberEducation(
+  enrichment: MemberEnrichmentBlob | null | undefined,
+  member: MemberEnrichmentColumns,
+): EnrichmentEducation[] {
+  const fromBlob = asArray<EnrichmentEducation>(enrichment?.education);
+  if (fromBlob.length > 0) return fromBlob;
+  return asArray<EnrichmentEducation>(member.education_history);
+}
+
+/**
+ * Resolve a member's LinkedIn bio/about text, preferring the self-connection
+ * blob and falling back to the enriched `members.summary` / `headline` columns.
+ */
+export function resolveMemberBio(
+  enrichment: MemberEnrichmentBlob | null | undefined,
+  member: MemberEnrichmentColumns,
+): string | null {
+  return (
+    enrichment?.about ||
+    enrichment?.summary ||
+    member.summary ||
+    member.headline ||
+    null
+  );
+}

--- a/apps/web/tests/member-enrichment.test.ts
+++ b/apps/web/tests/member-enrichment.test.ts
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveMemberExperience,
+  resolveMemberEducation,
+  resolveMemberBio,
+} from "@/lib/profile/member-enrichment";
+
+// Regression: member profiles rendered only one logo-less job unless the person
+// personally OAuth-connected LinkedIn, because experience/education/bio read only
+// the `user_linkedin_connections.linkedin_data.enrichment` blob and ignored the
+// admin-enriched `members` columns. These tests pin the blob → column fallback.
+
+const blobExperience = [
+  { title: "AI Engineer", company: "Glia", company_logo_url: "https://logo/glia.png" },
+  { title: "Intern", company: "Acme", company_logo_url: null },
+];
+const columnExperience = [
+  { title: "Software Engineer", company: "Palo Alto Networks", company_logo_url: "https://logo/pan.png" },
+  { title: "SWE Intern", company: "Initech", company_logo_url: "https://logo/initech.png" },
+  { title: "TA", company: "State U", company_logo_url: null },
+];
+
+test("experience: prefers the self-connection blob when present", () => {
+  const result = resolveMemberExperience(
+    { experience: blobExperience },
+    { work_history: columnExperience },
+  );
+  assert.equal(result.length, 2);
+  assert.equal(result[0].company, "Glia");
+});
+
+test("experience: falls back to members.work_history when blob is absent", () => {
+  const result = resolveMemberExperience(null, { work_history: columnExperience });
+  assert.equal(result.length, 3);
+  assert.equal(result[0].company, "Palo Alto Networks");
+  assert.equal(result[0].company_logo_url, "https://logo/pan.png");
+});
+
+test("experience: falls back when blob exists but has an empty experience array", () => {
+  const result = resolveMemberExperience(
+    { experience: [] },
+    { work_history: columnExperience },
+  );
+  assert.equal(result.length, 3);
+});
+
+test("experience: returns [] when neither source has data", () => {
+  assert.deepEqual(resolveMemberExperience(null, {}), []);
+  assert.deepEqual(resolveMemberExperience({ experience: null }, { work_history: null }), []);
+});
+
+test("education: prefers blob, falls back to members.education_history", () => {
+  const blobEdu = [{ title: "MIT", degree: "BS" }];
+  const colEdu = [{ title: "State U", degree: "BA" }];
+  assert.equal(resolveMemberEducation({ education: blobEdu }, { education_history: colEdu })[0].title, "MIT");
+  assert.equal(resolveMemberEducation(null, { education_history: colEdu })[0].title, "State U");
+  assert.equal(resolveMemberEducation({ education: [] }, { education_history: colEdu })[0].title, "State U");
+});
+
+test("bio: prefers blob about/summary, falls back to member summary then headline", () => {
+  assert.equal(resolveMemberBio({ about: "blob about" }, { summary: "col summary" }), "blob about");
+  assert.equal(resolveMemberBio({ summary: "blob summary" }, { summary: "col summary" }), "blob summary");
+  assert.equal(resolveMemberBio(null, { summary: "col summary", headline: "head" }), "col summary");
+  assert.equal(resolveMemberBio(null, { headline: "head" }), "head");
+  assert.equal(resolveMemberBio(null, {}), null);
+});


### PR DESCRIPTION
## Problem
The member detail page sourced experience/education/bio **only** from the `user_linkedin_connections.linkedin_data.enrichment` blob, which is populated only when a person OAuth-connects their own LinkedIn. Members enriched solely by the Apify admin pipeline (which writes `members.work_history`/`education_history` columns) rendered a single, logo-less job fallback despite having full column data — e.g. Matt Leonard showed 1 job/no logo while Louis Ciccone (self-connected) looked complete.

## Fix
Add `resolveMemberExperience/Education/Bio` helpers (`apps/web/src/lib/profile/member-enrichment.ts`) that coalesce the self-connection blob → `members` columns (blob-first, matching the existing `enrichment?.skills ?? m.skills` convention) and wire the member page to them. Alumni/parents pages already read columns directly, so no change needed there.

## Verification
- Playwright-verified all 13 LinkedIn-connected profiles render full jobs+logos (Matt Leonard now 5 jobs/5 logos, was 1/0).
- New unit test covers blob-preferred, column-fallback, and empty-source behavior.
- `tsc` 0 errors · lint clean · 6/6 unit tests.