### PR TITLE
fix(donations): make iOS donations web-only to pass App Store review

### DIFF
--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/donations/index.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/donations/index.tsx
@@ -125,12 +125,6 @@ export default function DonationsScreen() {
       ...TYPOGRAPHY.titleSmall,
       color: "#ffffff",
     },
-    verifiedNonprofitCaption: {
-      ...TYPOGRAPHY.caption,
-      color: n.secondary,
-      textAlign: "center" as const,
-      marginTop: -SPACING.xs,
-    },
     webNotice: {
       backgroundColor: n.background,
       borderRadius: RADIUS.lg,
@@ -411,17 +405,10 @@ export default function DonationsScreen() {
           donation-eligible (Apple Guideline 3.2.1(vi)); we surface a neutral
           web-managed notice instead so the screen never dead-ends. */}
       {showDonateCta ? (
-        <>
-          <Pressable style={({ pressed }) => [styles.donateButton, pressed && { opacity: 0.7 }]} onPress={handleMakeDonation}>
-            <Plus size={20} color="#ffffff" />
-            <Text style={styles.donateButtonText}>Make a Donation</Text>
-          </Pressable>
-          {Platform.OS === "ios" && donationEligibleIos && (
-            <Text style={styles.verifiedNonprofitCaption}>
-              Contributions go directly to this verified 501(c)(3) nonprofit.
-            </Text>
-          )}
-        </>
+        <Pressable style={({ pressed }) => [styles.donateButton, pressed && { opacity: 0.7 }]} onPress={handleMakeDonation}>
+          <Plus size={20} color="#ffffff" />
+          <Text style={styles.donateButtonText}>Make a Donation</Text>
+        </Pressable>
       ) : (
         <View style={styles.webNotice}>
           <Text style={styles.webNoticeTitle}>Donations are managed on the web</Text>

--- a/apps/mobile/app/(app)/(drawer)/[orgSlug]/donations/new.tsx
+++ b/apps/mobile/app/(app)/(drawer)/[orgSlug]/donations/new.tsx
@@ -12,9 +12,10 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation, useRouter } from "expo-router";
 import { ChevronLeft } from "lucide-react-native";
+import * as Linking from "expo-linking";
 import { supabase } from "@/lib/supabase";
 import { useOrg } from "@/contexts/OrgContext";
-import { getWebAppUrl } from "@/lib/web-api";
+import { getWebAppUrl, getWebPath } from "@/lib/web-api";
 import Turnstile, { type TurnstileRef } from "@/components/Turnstile";
 import { APP_CHROME } from "@/lib/chrome";
 import { SPACING, RADIUS } from "@/lib/design-tokens";
@@ -150,6 +151,28 @@ export default function NewDonationScreen() {
     },
     buttonDisabled: {
       opacity: 0.6,
+    },
+    webNotice: {
+      backgroundColor: n.background,
+      borderRadius: RADIUS.md,
+      borderWidth: 1,
+      borderColor: n.border,
+      padding: SPACING.md,
+      gap: 4,
+    },
+    webNoticeTitle: {
+      ...TYPOGRAPHY.titleSmall,
+      color: n.foreground,
+    },
+    webNoticeBody: {
+      ...TYPOGRAPHY.bodySmall,
+      color: n.secondary,
+    },
+    webNoticeLink: {
+      ...TYPOGRAPHY.labelMedium,
+      color: n.secondary,
+      marginTop: SPACING.xs,
+      textDecorationLine: "underline" as const,
     },
   }));
 
@@ -382,13 +405,29 @@ export default function NewDonationScreen() {
             </Text>
           </View>
 
-          {error && (
+          {/* iOS collects donations on the web (Apple Guideline 3.1.1/3.2.1):
+              the native payment form is never presented on iOS. */}
+          {isIOS && (
+            <View style={styles.webNotice}>
+              <Text style={styles.webNoticeTitle}>Donations are managed on the web</Text>
+              <Text style={styles.webNoticeBody}>
+                Contributions for this organization are handled through its website.
+              </Text>
+              <Pressable
+                onPress={() => Linking.openURL(getWebPath(orgSlug || "", "donations"))}
+              >
+                <Text style={styles.webNoticeLink}>Open on web</Text>
+              </Pressable>
+            </View>
+          )}
+
+          {error && !isIOS && (
             <View style={styles.errorCard}>
               <Text style={styles.errorText}>{error}</Text>
             </View>
           )}
 
-          {succeededAttemptId && (
+          {succeededAttemptId && !isIOS && (
             <>
               {receiptState.kind === "polling" && (
                 <View
@@ -435,7 +474,7 @@ export default function NewDonationScreen() {
             </>
           )}
 
-          {!succeededAttemptId && (
+          {!succeededAttemptId && !isIOS && (
           <>
           <View style={styles.fieldGroup}>
             <Text style={styles.fieldLabel}>Amount (USD)</Text>

--- a/apps/web/src/lib/pricing.ts
+++ b/apps/web/src/lib/pricing.ts
@@ -51,7 +51,7 @@ export const FAQ_ITEMS = [
   },
   {
     question: "Do you take a cut of our donations?",
-    answer: "No. We charge a flat platform fee. You connect your own Stripe account, so 100% of donations (minus standard Stripe processing fees) go directly to your program.",
+    answer: "We apply a small platform fee on donations to keep TeamNetwork running, in addition to standard Stripe processing fees. You connect your own Stripe account, so each donation settles there, minus those fees.",
   },
   {
     question: "How does alumni pricing work?",

--- a/supabase/migrations/20261218000000_donations_disable_ios_until_nonprofit_verified.sql
+++ b/supabase/migrations/20261218000000_donations_disable_ios_until_nonprofit_verified.sql
@@ -1,0 +1,14 @@
+-- Apple App Store review: the native in-app (Apple Pay / card) donation flow is
+-- only permissible for approved, registered nonprofits (Guideline 3.2.1/3.1.1).
+-- None of our organizations are verified 501(c)(3) nonprofits today, so iOS must
+-- collect donations on the web instead. Setting donation_eligible_ios = false for
+-- every org makes the iOS client render its "Donations are managed on the web"
+-- notice (and makes the create-donation API reject any native iOS attempt).
+--
+-- The column default is already false, so future orgs are web-only by default.
+-- To re-enable the native iOS flow later, flip this flag back to true for a
+-- genuinely verified nonprofit org only.
+
+update public.organizations
+set donation_eligible_ios = false
+where donation_eligible_ios is distinct from false;


### PR DESCRIPTION
## Why

Apple rejected the app on the donations page. The reviewer hit **"The client_secret provided does not match any associated PaymentIntent on this account"** when donating to *Villanova Women's Lacrosse*.

Two root causes:
1. **Technical** — the native iOS flow uses a Stripe direct charge on the org's connected account; the reviewed binary confirmed the PaymentSheet against the *platform* account. (A later fix, `9d415656`, landed after that build was cut.)
2. **Compliance (the real blocker)** — non-IAP (Stripe/Apple Pay) in-app collection is only permitted for **approved registered nonprofits** (Apple 3.2.1/3.1.1). Our orgs are **for-profit**, and the app falsely claimed *"verified 501(c)(3) nonprofit"* while taking a 3% fee. Fixing only the payment bug would be re-rejected.

## What

Route **all iOS donations to the web** (payment + the platform fee happen in Safari):

- **DB migration** — `donation_eligible_ios = false` for all orgs. Both the donations and philanthropy screens already gate on this and render the existing *"Donations are managed on the web → Open on web"* notice. (Already applied to prod, so even the in-review build now shows web-only.)
- **`donations/index.tsx`** — remove the inaccurate *"verified 501(c)(3) nonprofit"* caption.
- **`donations/new.tsx`** — never present the native payment form on iOS; show the web notice + "Open on web" link (deep-link safe).
- **`web/pricing.ts`** — correct the FAQ that falsely claimed no platform fee / 100% to the program.

Native flow code stays dormant for a future genuinely-verified nonprofit org.

## Verification
- `bun run --cwd apps/mobile typecheck` ✓ · `bun --cwd apps/mobile test` → 476/476 ✓
- web `typecheck` ✓ · `lint` ✓
- Prod check: 0 of 22 orgs are `donation_eligible_ios` after the update.

## Before resubmitting (manual)
- Confirm production web uses a **live** Stripe secret key and connected account `acct_1SkEaaKv9KV1FrU0` is live + onboarded (the web Checkout must work, since donations now happen there).
- Cut a new EAS production build + submit; in App Review notes state donations are processed on the org's website, not in the app.