### PR TITLE
fix(ai): deterministic render for multi-suggestion compare queries

### DIFF
--- a/apps/web/src/app/api/ai/[orgId]/chat/handler/formatters/index.ts
+++ b/apps/web/src/app/api/ai/[orgId]/chat/handler/formatters/index.ts
@@ -301,6 +301,43 @@ export function formatGlobalLookupToolResponse(
   return lines.join("\n");
 }
 
+const MULTI_SUGGESTION_TOOL_NAMES = new Set(["suggest_mentors", "suggest_mentees"]);
+
+/**
+ * Deterministic render for "compare A and B" style asks, where pass-1 issues
+ * more than one suggest_mentors / suggest_mentees call. Each list is rendered
+ * with the same grounding-safe single-suggestion formatter and concatenated,
+ * so the answer never depends on the pass-2 compose leg (which returns empty or
+ * fails grounding for multi-tool composes — see issue #272). Mirrors the
+ * multi-tool handling in formatGlobalLookupToolResponse.
+ *
+ * Returns null (falling back to pass-2) unless there are at least two results,
+ * every result is a suggestion tool, and every list renders cleanly.
+ */
+export function formatMultiSuggestionToolResponse(
+  results: Array<{ name: string; data: unknown }>,
+  options?: FormatterOptions,
+): string | null {
+  if (
+    results.length < 2 ||
+    results.some((result) => !MULTI_SUGGESTION_TOOL_NAMES.has(result.name))
+  ) {
+    return null;
+  }
+
+  const blocks: string[] = [];
+  for (const result of results) {
+    const block =
+      result.name === "suggest_mentors"
+        ? formatSuggestMentorsResponse(result.data, options)
+        : formatSuggestMenteesResponse(result.data, options);
+    if (!block) return null;
+    blocks.push(block);
+  }
+
+  return blocks.join("\n\n");
+}
+
 export function formatDeterministicToolResponse(
   name: string,
   data: unknown,

--- a/apps/web/src/app/api/ai/[orgId]/chat/handler/stages/run-model-tools-loop.ts
+++ b/apps/web/src/app/api/ai/[orgId]/chat/handler/stages/run-model-tools-loop.ts
@@ -33,6 +33,7 @@ import {
   formatDeterministicToolResponse,
   formatDeterministicToolErrorResponse,
   formatGlobalLookupToolResponse,
+  formatMultiSuggestionToolResponse,
 } from "../formatters/index";
 import {
   MEMBER_ROSTER_PROMPT_PATTERN,
@@ -392,6 +393,18 @@ export async function runModelToolsLoop(
       deterministicToolContent == null
         ? formatGlobalLookupToolResponse(toolResults, input.promptSafeMessage)
         : null;
+    // "Compare A and B" issues two suggest_mentors/suggest_mentees calls. Render
+    // each list with the grounding-safe single formatter and concatenate, so the
+    // answer never rides on the flaky pass-2 compose leg (issue #272). Only when
+    // every tool call succeeded — a mixed success/error set falls to pass-2 so
+    // the failure is acknowledged.
+    const deterministicMultiSuggestionContent =
+      deterministicToolContent == null &&
+      deterministicGlobalLookupContent == null &&
+      toolResults.length >= 2 &&
+      toolResults.length === input.successfulToolResults.length
+        ? formatMultiSuggestionToolResponse(input.successfulToolResults, { orgSlug })
+        : null;
     const singleToolError =
       toolResults.length === 1 &&
       input.successfulToolResults.length === 0 &&
@@ -424,10 +437,19 @@ export async function runModelToolsLoop(
     // wrongly flag a correct answer). The model never freely composed this text,
     // so there is nothing to ground — skip the check for deterministic paths.
     let renderedDeterministically = false;
-    if (deterministicToolContent || deterministicGlobalLookupContent || deterministicToolErrorContent) {
+    if (
+      deterministicToolContent ||
+      deterministicGlobalLookupContent ||
+      deterministicMultiSuggestionContent ||
+      deterministicToolErrorContent
+    ) {
       skipStage(input.stageTimings, "pass2");
       pass2BufferedContent =
-        deterministicToolContent ?? deterministicGlobalLookupContent ?? deterministicToolErrorContent ?? "";
+        deterministicToolContent ??
+        deterministicGlobalLookupContent ??
+        deterministicMultiSuggestionContent ??
+        deterministicToolErrorContent ??
+        "";
       renderedDeterministically = true;
     } else {
       const hasToolErrors =

--- a/apps/web/tests/mentorship-compare-suggestion-format.test.ts
+++ b/apps/web/tests/mentorship-compare-suggestion-format.test.ts
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { formatMultiSuggestionToolResponse } from "../src/app/api/ai/[orgId]/chat/handler/formatters/index.ts";
+
+function resolvedMentors(menteeName: string, mentorName: string) {
+  return {
+    state: "resolved",
+    mentee: { name: menteeName },
+    suggestions: [
+      {
+        mentor: { name: mentorName, subtitle: "Healthcare Consultant at Pfizer" },
+        confidence: 82,
+        confidenceLabel: "Good",
+        reasons: [
+          { label: "Shared topics", value: "healthcare,operations" },
+          { label: "Same school", value: "villanova university" },
+        ],
+      },
+    ],
+  };
+}
+
+test("compare query: two suggest_mentors results render deterministically and concatenate", () => {
+  const out = formatMultiSuggestionToolResponse([
+    { name: "suggest_mentors", data: resolvedMentors("Brooke Esposito", "Maria Bell") },
+    { name: "suggest_mentors", data: resolvedMentors("Maya Bell", "Ryan Romano") },
+  ]);
+  assert.ok(out, "expected a rendered string");
+  // Both headings present — one per mentee — proving each list was rendered.
+  assert.match(out, /### Top mentors for Brooke Esposito/);
+  assert.match(out, /### Top mentors for Maya Bell/);
+  // Real names from both lists appear; nothing invented.
+  assert.match(out, /\*\*1\. Maria Bell — Healthcare Consultant at Pfizer\*\*/);
+  assert.match(out, /\*\*1\. Ryan Romano — Healthcare Consultant at Pfizer\*\*/);
+  // The first heading precedes the second (stable ordering).
+  assert.ok(out.indexOf("Brooke Esposito") < out.indexOf("Maya Bell"));
+});
+
+test("mixed directions (mentors + mentees) both render", () => {
+  const out = formatMultiSuggestionToolResponse([
+    { name: "suggest_mentors", data: resolvedMentors("Brooke Esposito", "Maria Bell") },
+    {
+      name: "suggest_mentees",
+      data: {
+        state: "resolved",
+        mentor: { name: "Cole Reed" },
+        suggestions: [
+          {
+            mentee: { name: "Talia Rogers", subtitle: null },
+            confidence: 70,
+            confidenceLabel: "Good",
+            reasons: [{ label: "Shared industry", value: "Consulting" }],
+          },
+        ],
+      },
+    },
+  ]);
+  assert.ok(out);
+  assert.match(out, /### Top mentors for Brooke Esposito/);
+  assert.match(out, /### Top mentees for Cole Reed/);
+});
+
+test("returns null for a single result (single-tool path handles it)", () => {
+  const out = formatMultiSuggestionToolResponse([
+    { name: "suggest_mentors", data: resolvedMentors("Brooke Esposito", "Maria Bell") },
+  ]);
+  assert.equal(out, null);
+});
+
+test("returns null when any result is not a suggestion tool (falls back to pass-2)", () => {
+  const out = formatMultiSuggestionToolResponse([
+    { name: "suggest_mentors", data: resolvedMentors("Brooke Esposito", "Maria Bell") },
+    { name: "list_members", data: [{ name: "Someone" }] },
+  ]);
+  assert.equal(out, null);
+});
+
+test("returns null when any list fails to render (falls back to pass-2)", () => {
+  const out = formatMultiSuggestionToolResponse([
+    { name: "suggest_mentors", data: resolvedMentors("Brooke Esposito", "Maria Bell") },
+    { name: "suggest_mentors", data: { not: "a valid payload" } },
+  ]);
+  assert.equal(out, null);
+});
+
+test("non-resolved states still render (e.g. not_found) so the user gets an answer", () => {
+  const out = formatMultiSuggestionToolResponse([
+    { name: "suggest_mentors", data: resolvedMentors("Brooke Esposito", "Maria Bell") },
+    { name: "suggest_mentors", data: { state: "not_found" } },
+  ]);
+  assert.ok(out);
+  assert.match(out, /### Top mentors for Brooke Esposito/);
+  assert.match(out, /couldn't find that person/i);
+});


### PR DESCRIPTION
## Problem

A "compare the best mentor options for A and B" query makes **pass-1 issue two `suggest_mentors` / `suggest_mentees` tool calls** (one per person). The deterministic renderer that makes single-person suggestions reliable only fires when there's exactly **one** tool result (`run-model-tools-loop.ts`), so a compare query always fell through to the **z.ai pass-2 compose** leg.

During #266 live QA that leg failed on **every** attempt (issue #272):
- empty output ×2 → `EMPTY_ASSISTANT_RESPONSE_FALLBACK` ("I didn't get a usable response")
- grounding-rejected ×1 → `TOOL_GROUNDING_FALLBACK` (model leaked `"Let me pull mentor suggestions…"` preamble)

Both suggestion tools resolved fine (`candidate_count: 5` each) — only the final compose failed. It always failed *safe* (never hallucinated), but the feature effectively never worked.

## Fix

Render each suggestion list with the **existing grounding-safe single formatter** (`formatSuggestMentorsResponse` / `formatSuggestMenteesResponse`) and concatenate — mirroring how `formatGlobalLookupToolResponse` already handles multi-tool global lookups (`list_members` + `list_alumni` + `list_parents`).

New `formatMultiSuggestionToolResponse` returns content only when there are ≥2 results, all are suggestion tools, and every list renders cleanly. Wired into `run-model-tools-loop.ts` alongside the other deterministic paths, so:
- **Pass-2 is skipped entirely** for the all-suggestions / all-succeeded case → both the empty-output and grounding-reject failure modes are gone.
- Grounding is correctly skipped (deterministic content, nothing freely composed).
- A **mixed success/error** set still falls to pass-2 so tool failures are acknowledged honestly.
- A **single** suggestion result is untouched (existing single-tool path handles it).

## Why this is the right shape

The per-person renderers are already the trusted, grounding-safe output users see for single queries. Reusing them for compare removes the only fragile dependency (the LLM compose leg) without changing what a correct answer looks like. No new model calls; fully deterministic and unit-testable.

## Tests

New `mentorship-compare-suggestion-format.test.ts` (6 cases): two-list concatenation + stable ordering, mixed mentor/mentee directions, single-result → null, non-suggestion tool → null, malformed payload → null, and non-resolved states (e.g. `not_found`) still rendering. Existing `mentorship-suggestion-format.test.ts` (31) unchanged and green.

`bun run typecheck` (web tsc clean), `bun run lint`, and the mentorship/suggestion test suites (49) all pass.

Closes #272.
