### PR TITLE
feat(data-health): graph/RAG/enrichment correctness harness + fixes

### DIFF
--- a/apps/web/src/app/[orgSlug]/data-health/page.tsx
+++ b/apps/web/src/app/[orgSlug]/data-health/page.tsx
@@ -1,0 +1,141 @@
+import { redirect } from "next/navigation";
+import { getOrgContext } from "@/lib/auth/roles";
+import { PageHeader } from "@/components/layout";
+import { createServiceClient } from "@/lib/supabase/service";
+import { getOrgDataHealth } from "@/lib/health/org-data-health";
+
+interface DataHealthPageProps {
+  params: Promise<{ orgSlug: string }>;
+}
+
+type Tone = "good" | "warn" | "bad";
+
+function toneClasses(tone: Tone): string {
+  switch (tone) {
+    case "good":
+      return "bg-green-100 text-green-800";
+    case "warn":
+      return "bg-amber-100 text-amber-800";
+    case "bad":
+      return "bg-red-100 text-red-800";
+  }
+}
+
+function StatePill({ label, tone }: { label: string; tone: Tone }) {
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${toneClasses(tone)}`}>
+      {label}
+    </span>
+  );
+}
+
+function MetricRow({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="flex items-center justify-between py-1 text-sm">
+      <span className="text-gray-600">{label}</span>
+      <span className="font-medium text-gray-900">{value}</span>
+    </div>
+  );
+}
+
+function Card({
+  title,
+  tone,
+  state,
+  children,
+}: {
+  title: string;
+  tone: Tone;
+  state: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-gray-900">{title}</h2>
+        <StatePill label={state} tone={tone} />
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export default async function DataHealthPage({ params }: DataHealthPageProps) {
+  const { orgSlug } = await params;
+  const orgCtx = await getOrgContext(orgSlug);
+
+  if (!orgCtx.organization) return null;
+  if (!orgCtx.isAdmin) redirect(`/${orgSlug}`);
+
+  const serviceSupabase = createServiceClient();
+  const report = await getOrgDataHealth(serviceSupabase, orgCtx.organization.id);
+
+  const driftTone: Tone =
+    report.graph.drift.state === "ok"
+      ? "good"
+      : report.graph.drift.state === "degraded"
+        ? "bad"
+        : "warn";
+  const ragTone: Tone =
+    report.rag.state === "ok" ? "good" : report.rag.state === "degraded" ? "bad" : "warn";
+  const enrichTone: Tone =
+    report.enrichment.state === "ok"
+      ? "good"
+      : report.enrichment.state === "degraded"
+        ? "bad"
+        : "warn";
+  const freshnessTone: Tone =
+    report.graph.surface.freshness.state === "fresh"
+      ? "good"
+      : report.graph.surface.freshness.state === "degraded"
+        ? "bad"
+        : "warn";
+
+  return (
+    <div className="space-y-6 animate-fade-in">
+      <PageHeader
+        title="Data health"
+        description="Read-only correctness checks across the people-graph, the assistant's RAG index, and LinkedIn enrichment. Counts show divergence between live data and each pipeline."
+      />
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card title="People-graph freshness" tone={freshnessTone} state={report.graph.surface.freshness.state}>
+          <MetricRow label="Pending sync items" value={report.graph.surface.queue.pendingCount} />
+          <MetricRow label="Dead-letter items" value={report.graph.surface.queue.deadLetterCount} />
+          <MetricRow
+            label="Sync lag (seconds)"
+            value={report.graph.surface.freshness.lagSeconds ?? "—"}
+          />
+        </Card>
+
+        <Card title="People-graph drift" tone={driftTone} state={report.graph.drift.state}>
+          <MetricRow
+            label="Nodes (expected / actual)"
+            value={`${report.graph.drift.nodes.expected} / ${report.graph.drift.nodes.actual}`}
+          />
+          <MetricRow label="Missing nodes" value={report.graph.drift.nodes.missingKeys.length} />
+          <MetricRow label="Mis-keyed nodes" value={report.graph.drift.nodes.misKeyedNodeKeys.length} />
+          <MetricRow
+            label="Edges (expected / actual)"
+            value={`${report.graph.drift.edges.expected} / ${report.graph.drift.edges.actual}`}
+          />
+          <MetricRow label="Missing edges" value={report.graph.drift.edges.missingEdges.length} />
+        </Card>
+
+        <Card title="RAG index" tone={ragTone} state={report.rag.state}>
+          <MetricRow label="Missing coverage" value={report.rag.counts.missingCoverage} />
+          <MetricRow label="Orphan chunks" value={report.rag.counts.orphanChunks} />
+          <MetricRow label="Stale sources" value={report.rag.counts.staleSources} />
+          <MetricRow label="Untagged audience" value={report.rag.counts.untaggedAudience} />
+        </Card>
+
+        <Card title="Enrichment tagging" tone={enrichTone} state={report.enrichment.state}>
+          <MetricRow label="Userless member rows" value={report.enrichment.counts.userlessRows} />
+          <MetricRow label="Permanently failed" value={report.enrichment.counts.permanentlyFailed} />
+          <MetricRow label="Stalled runs" value={report.enrichment.counts.stalledRuns} />
+          <MetricRow label="Pre-provenance rows" value={report.enrichment.counts.preProvenance} />
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/api/ai/[orgId]/chat/handler/cache-rag.ts
+++ b/apps/web/src/app/api/ai/[orgId]/chat/handler/cache-rag.ts
@@ -128,6 +128,8 @@ export async function retrieveRag(args: {
   serviceSupabase: SupabaseClient;
   stageTimings: AiAuditStageTimings;
   logContext: AiLogContext;
+  /** Audience tokens the requester may retrieve (undefined = unrestricted). */
+  audienceFilter?: string[];
 }): Promise<RagRetrievalResult> {
   try {
     const retrieved = await runTimedStage(
@@ -140,6 +142,7 @@ export async function retrieveRag(args: {
           spendBypass: args.spendBypass,
           serviceSupabase: args.serviceSupabase,
           logContext: args.logContext,
+          audienceFilter: args.audienceFilter,
         })
     );
 

--- a/apps/web/src/app/api/ai/[orgId]/chat/handler/stages/rag-retrieval-stage.ts
+++ b/apps/web/src/app/api/ai/[orgId]/chat/handler/stages/rag-retrieval-stage.ts
@@ -6,6 +6,7 @@
  * inlined. Returns the four downstream-facing fields exactly.
  */
 import type { retrieveRelevantChunks } from "@/lib/ai/rag-retriever";
+import { audienceFilterForRole } from "@/lib/ai/rag-retriever";
 import type { RagChunkInput } from "@/lib/ai/context-builder";
 import type { AiAuditStageTimings } from "@/lib/ai/chat-telemetry";
 import type { AiLogContext } from "@/lib/ai/logger";
@@ -44,6 +45,9 @@ export async function runRagRetrievalStage(
       serviceSupabase: input.ctx.serviceSupabase,
       stageTimings: input.stageTimings,
       logContext: { ...input.requestLogContext, threadId: input.threadId },
+      // Scope retrieval to what the requester's role is allowed to see, so the
+      // assistant cannot ground answers on audience-restricted chunks.
+      audienceFilter: audienceFilterForRole(input.ctx.role),
     });
     return {
       ragChunks: ragResult.chunks,

--- a/apps/web/src/app/api/cron/enrichment-process/handler.ts
+++ b/apps/web/src/app/api/cron/enrichment-process/handler.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/linkedin/apify";
 import { processFinishedApifyRun, recordRunTargets } from "@/lib/linkedin/enrichment-writeback";
 import { normalizeLinkedInProfileUrl } from "@/lib/alumni/linkedin-url";
+import { summarizeEnrichmentHealthGlobal } from "@/lib/linkedin/enrichment-health";
 
 const BATCH_SIZE = 30;
 const MAX_RETRIES = 3;
@@ -210,6 +211,10 @@ export function createEnrichmentProcessGetHandler(deps: EnrichmentProcessRouteDe
       const hardCutoff = new Date(Date.now() - HARD_TIMEOUT_MS).toISOString();
       hardTimedOut = await markTimedOutRunsFailed(supabase, hardCutoff);
 
+      // Surface enrichment-tagging health so silently-stalled rows are visible
+      // (userless members, exhausted retries, stuck runs, pre-provenance rows).
+      const health = await summarizeEnrichmentHealthGlobal(supabase);
+
       return NextResponse.json({
         ok: true,
         started,
@@ -217,6 +222,7 @@ export function createEnrichmentProcessGetHandler(deps: EnrichmentProcessRouteDe
         reconciled_enriched: reconciledEnriched,
         reconciled_failed: reconciledFailed,
         hard_timed_out: hardTimedOut,
+        health,
       });
     } catch (error) {
       console.error("[enrichment-process] Error:", error);

--- a/apps/web/src/app/api/organizations/[organizationId]/data-health/route.ts
+++ b/apps/web/src/app/api/organizations/[organizationId]/data-health/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+import { baseSchemas } from "@/lib/security/validation";
+import { getOrgMemberRole } from "@/lib/parents/auth";
+import { normalizeRole } from "@/lib/auth/role-utils";
+import type { UserRole } from "@/types/database";
+import { getOrgDataHealth } from "@/lib/health/org-data-health";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface RouteParams {
+  params: Promise<{ organizationId: string }>;
+}
+
+/**
+ * Admin-only consolidated data-health report for an org: people-graph drift,
+ * RAG index coverage/audience tagging, and enrichment tagging health.
+ */
+export async function GET(req: Request, { params }: RouteParams) {
+  const { organizationId } = await params;
+
+  const orgIdParsed = baseSchemas.uuid.safeParse(organizationId);
+  if (!orgIdParsed.success) {
+    return NextResponse.json({ error: "Invalid organization id" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const rateLimit = checkRateLimit(req, {
+    userId: user?.id ?? null,
+    feature: "org data health",
+    limitPerIp: 30,
+    limitPerUser: 20,
+  });
+  if (!rateLimit.ok) {
+    return buildRateLimitResponse(rateLimit);
+  }
+
+  const respond = (payload: unknown, status = 200) =>
+    NextResponse.json(payload, { status, headers: rateLimit.headers });
+
+  if (!user) {
+    return respond({ error: "Unauthorized" }, 401);
+  }
+
+  const role = await getOrgMemberRole(supabase, user.id, organizationId);
+  if (normalizeRole(role as UserRole | null) !== "admin") {
+    return respond({ error: "Forbidden" }, 403);
+  }
+
+  const serviceSupabase = createServiceClient();
+  const report = await getOrgDataHealth(serviceSupabase, organizationId);
+
+  return respond(report);
+}

--- a/apps/web/src/lib/ai/rag-health.ts
+++ b/apps/web/src/lib/ai/rag-health.ts
@@ -1,0 +1,307 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  computeContentHash,
+  renderChunks,
+  type ParentThreadContext,
+  type SourceTable,
+} from "@/lib/ai/chunker";
+
+/**
+ * Read-only correctness checker for the RAG index (`ai_document_chunks`).
+ *
+ * Scoped to the source tables that can actually hold chunks per the
+ * `ai_document_chunks.source_table` CHECK constraint — mentor_profiles and
+ * form_submissions are intentionally excluded so coverage does not false-positive
+ * on tables the index never stores.
+ */
+
+const SAMPLE_CAP = 50;
+const PAGE_SIZE = 1000;
+const MAX_ROWS = PAGE_SIZE * 20;
+
+interface IndexedTable {
+  table: SourceTable;
+  /** Columns required to re-render the chunk for staleness comparison. */
+  select: string;
+  hasAudience: boolean;
+}
+
+const INDEXED_TABLES: IndexedTable[] = [
+  {
+    table: "announcements",
+    select: "id, title, body, audience, published_at, deleted_at",
+    hasAudience: true,
+  },
+  {
+    table: "events",
+    select: "id, title, description, start_date, end_date, location, audience, deleted_at",
+    hasAudience: true,
+  },
+  { table: "discussion_threads", select: "id, title, body, deleted_at", hasAudience: false },
+  { table: "discussion_replies", select: "id, thread_id, body, deleted_at", hasAudience: false },
+  {
+    table: "job_postings",
+    select: "id, title, company, description, location, location_type, deleted_at",
+    hasAudience: false,
+  },
+];
+
+export interface RagSourceRef {
+  sourceTable: string;
+  sourceId: string;
+}
+
+export interface RagHealthReport {
+  orgId: string;
+  state: "ok" | "gaps" | "degraded";
+  reason: string | null;
+  /** Eligible, non-excluded source rows with no chunk. */
+  missingCoverage: RagSourceRef[];
+  /** Chunks whose source row is deleted or missing. */
+  orphanChunks: RagSourceRef[];
+  /** Sources whose current rendered content no longer matches stored chunk hashes. */
+  staleSources: RagSourceRef[];
+  /** Audience-restricted sources whose chunk metadata is missing the audience tag. */
+  untaggedAudience: RagSourceRef[];
+  counts: {
+    missingCoverage: number;
+    orphanChunks: number;
+    staleSources: number;
+    untaggedAudience: number;
+  };
+  truncated: boolean;
+}
+
+interface ChunkRow {
+  source_table: string;
+  source_id: string;
+  chunk_index: number;
+  content_hash: string;
+  metadata: Record<string, unknown> | null;
+}
+
+function toMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message: unknown }).message;
+    if (typeof message === "string" && message.length > 0) return message;
+  }
+  return "unknown_error";
+}
+
+async function fetchAll<T>(
+  supabase: SupabaseClient,
+  build: (from: number, to: number) => Promise<{ data: unknown; error: unknown }>
+): Promise<{ rows: T[]; truncated: boolean }> {
+  const rows: T[] = [];
+  let from = 0;
+  while (from < MAX_ROWS) {
+    const { data, error } = await build(from, from + PAGE_SIZE - 1);
+    if (error) {
+      throw new Error(toMessage(error));
+    }
+    const page = (data ?? []) as T[];
+    rows.push(...page);
+    if (page.length < PAGE_SIZE) return { rows, truncated: false };
+    from += PAGE_SIZE;
+  }
+  return { rows, truncated: true };
+}
+
+function degraded(orgId: string, reason: string): RagHealthReport {
+  return {
+    orgId,
+    state: "degraded",
+    reason,
+    missingCoverage: [],
+    orphanChunks: [],
+    staleSources: [],
+    untaggedAudience: [],
+    counts: { missingCoverage: 0, orphanChunks: 0, staleSources: 0, untaggedAudience: 0 },
+    truncated: false,
+  };
+}
+
+export async function checkRagHealth(
+  serviceSupabase: SupabaseClient,
+  orgId: string
+): Promise<RagHealthReport> {
+  const missingCoverage: RagSourceRef[] = [];
+  const orphanChunks: RagSourceRef[] = [];
+  const staleSources: RagSourceRef[] = [];
+  const untaggedAudience: RagSourceRef[] = [];
+  let truncated = false;
+
+  // Exclusions (admin opt-outs). On failure, fail-closed by treating none as
+  // excluded would over-report; instead degrade so the surface is honest.
+  let excluded: Set<string>;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (serviceSupabase as any)
+      .from("ai_indexing_exclusions")
+      .select("source_table, source_id")
+      .eq("org_id", orgId);
+    if (error) return degraded(orgId, toMessage(error));
+    excluded = new Set(
+      ((data ?? []) as Array<{ source_table: string; source_id: string }>).map(
+        (row) => `${row.source_table}:${row.source_id}`
+      )
+    );
+  } catch (error) {
+    return degraded(orgId, toMessage(error));
+  }
+
+  for (const config of INDEXED_TABLES) {
+    let sources: Array<Record<string, unknown>>;
+    let chunks: ChunkRow[];
+
+    try {
+      const sourceResult = await fetchAll<Record<string, unknown>>(serviceSupabase, (from, to) =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (serviceSupabase as any)
+          .from(config.table)
+          .select(config.select)
+          .eq("organization_id", orgId)
+          .range(from, to)
+      );
+      const chunkResult = await fetchAll<ChunkRow>(serviceSupabase, (from, to) =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (serviceSupabase as any)
+          .from("ai_document_chunks")
+          .select("source_table, source_id, chunk_index, content_hash, metadata")
+          .eq("org_id", orgId)
+          .eq("source_table", config.table)
+          .is("deleted_at", null)
+          .range(from, to)
+      );
+      sources = sourceResult.rows;
+      chunks = chunkResult.rows;
+      truncated = truncated || sourceResult.truncated || chunkResult.truncated;
+    } catch (error) {
+      return degraded(orgId, toMessage(error));
+    }
+
+    // Index source rows and chunks.
+    const sourceById = new Map<string, Record<string, unknown>>();
+    const liveSourceIds = new Set<string>();
+    for (const row of sources) {
+      const id = String(row.id);
+      sourceById.set(id, row);
+      if (!row.deleted_at) liveSourceIds.add(id);
+    }
+
+    const chunksBySource = new Map<string, ChunkRow[]>();
+    for (const chunk of chunks) {
+      const list = chunksBySource.get(chunk.source_id) ?? [];
+      list.push(chunk);
+      chunksBySource.set(chunk.source_id, list);
+    }
+
+    // Parent-thread context for reply rendering (mirrors the embedding worker).
+    const parentThreads = new Map<string, ParentThreadContext>();
+    if (config.table === "discussion_replies") {
+      const threadIds = [
+        ...new Set(
+          sources
+            .filter((row) => !row.deleted_at && row.thread_id)
+            .map((row) => String(row.thread_id))
+        ),
+      ];
+      if (threadIds.length > 0) {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const { data, error } = await (serviceSupabase as any)
+            .from("discussion_threads")
+            .select("id, title, body")
+            .in("id", threadIds);
+          if (error) return degraded(orgId, toMessage(error));
+          for (const row of (data ?? []) as Array<Record<string, unknown>>) {
+            parentThreads.set(String(row.id), {
+              title: String(row.title ?? ""),
+              body: String(row.body ?? ""),
+            });
+          }
+        } catch (error) {
+          return degraded(orgId, toMessage(error));
+        }
+      }
+    }
+
+    // Missing coverage: eligible (live, non-excluded) sources with no chunks.
+    for (const id of liveSourceIds) {
+      if (excluded.has(`${config.table}:${id}`)) continue;
+      if (!chunksBySource.has(id)) {
+        missingCoverage.push({ sourceTable: config.table, sourceId: id });
+      }
+    }
+
+    for (const [sourceId, sourceChunks] of chunksBySource.entries()) {
+      // Orphan: chunk whose source row is deleted or missing entirely.
+      if (!liveSourceIds.has(sourceId)) {
+        orphanChunks.push({ sourceTable: config.table, sourceId });
+        continue;
+      }
+
+      const record = sourceById.get(sourceId)!;
+
+      // Untagged audience: source carries an audience but the chunk metadata
+      // dropped it (cannot be enforced at query time → feeds the audience fix).
+      if (config.hasAudience && record.audience) {
+        const anyTagged = sourceChunks.some(
+          (chunk) => chunk.metadata && chunk.metadata.audience != null
+        );
+        if (!anyTagged) {
+          untaggedAudience.push({ sourceTable: config.table, sourceId });
+        }
+      }
+
+      // Stale: re-render and compare hashes against stored chunks.
+      const parentContext =
+        config.table === "discussion_replies" && record.thread_id
+          ? parentThreads.get(String(record.thread_id))
+          : undefined;
+      const rendered = renderChunks(config.table, record, parentContext);
+      const renderedByIndex = new Map(
+        rendered.map((chunk) => [chunk.chunkIndex, computeContentHash(chunk.text)])
+      );
+      const storedByIndex = new Map(sourceChunks.map((chunk) => [chunk.chunk_index, chunk.content_hash]));
+
+      let stale = renderedByIndex.size !== storedByIndex.size;
+      if (!stale) {
+        for (const [index, hash] of renderedByIndex.entries()) {
+          if (storedByIndex.get(index) !== hash) {
+            stale = true;
+            break;
+          }
+        }
+      }
+      if (stale) {
+        staleSources.push({ sourceTable: config.table, sourceId });
+      }
+    }
+  }
+
+  const counts = {
+    missingCoverage: missingCoverage.length,
+    orphanChunks: orphanChunks.length,
+    staleSources: staleSources.length,
+    untaggedAudience: untaggedAudience.length,
+  };
+  const hasGaps =
+    counts.missingCoverage > 0 ||
+    counts.orphanChunks > 0 ||
+    counts.staleSources > 0 ||
+    counts.untaggedAudience > 0;
+
+  return {
+    orgId,
+    state: hasGaps ? "gaps" : "ok",
+    reason: truncated ? "partial_scan" : null,
+    missingCoverage: missingCoverage.slice(0, SAMPLE_CAP),
+    orphanChunks: orphanChunks.slice(0, SAMPLE_CAP),
+    staleSources: staleSources.slice(0, SAMPLE_CAP),
+    untaggedAudience: untaggedAudience.slice(0, SAMPLE_CAP),
+    counts,
+    truncated,
+  };
+}

--- a/apps/web/src/lib/ai/rag-retriever.ts
+++ b/apps/web/src/lib/ai/rag-retriever.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { SupabaseClient } from "@supabase/supabase-js";
+import type { OrgRole } from "@/lib/auth/role-utils";
 import { generateEmbedding } from "./embeddings";
 import { aiLog, type AiLogContext } from "./logger";
 
@@ -25,8 +26,37 @@ export interface RetrieveParams {
   maxChunks?: number;
   similarityThreshold?: number;
   sourceTables?: string[];
+  /**
+   * Audience tokens the requester is allowed to see. When omitted/undefined the
+   * search is unrestricted (admin / global callers). Derive from the requester's
+   * org role via {@link audienceFilterForRole}.
+   */
+  audienceFilter?: string[];
   /** Skip ledger write (dev-admin bypass). */
   spendBypass?: boolean;
+  /** Injectable embedding generator (defaults to the real Gemini client; tests override). */
+  generateEmbeddingFn?: typeof generateEmbedding;
+}
+
+/**
+ * Map an org role to the audience tokens its members may retrieve. Returns
+ * `undefined` for admins (no restriction). Unrestricted content ('all'/'both'/
+ * unset) is always visible regardless of this list — it only gates restricted
+ * audiences. Parents see alumni-targeted content, matching announcement visibility.
+ */
+export function audienceFilterForRole(role: OrgRole): string[] | undefined {
+  switch (role) {
+    case "admin":
+      return undefined;
+    case "active_member":
+      return ["members", "active_members"];
+    case "alumni":
+      return ["alumni"];
+    case "parent":
+      return ["alumni"];
+    default:
+      return [];
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -106,11 +136,13 @@ export async function retrieveRelevantChunks(
     maxChunks = DEFAULT_MAX_CHUNKS,
     similarityThreshold = DEFAULT_SIMILARITY_THRESHOLD,
     sourceTables,
+    audienceFilter,
     spendBypass,
+    generateEmbeddingFn = generateEmbedding,
   } = params;
 
   // Generate query embedding (expand bare domain terms first)
-  const queryEmbedding = await generateEmbedding(expandQuery(query), orgId, spendBypass);
+  const queryEmbedding = await generateEmbeddingFn(expandQuery(query), orgId, spendBypass);
 
   // Call the search RPC
   const { data, error } = await (serviceSupabase.rpc as any)(
@@ -121,6 +153,7 @@ export async function retrieveRelevantChunks(
       p_match_count: maxChunks,
       p_similarity_threshold: similarityThreshold,
       ...(sourceTables ? { p_source_tables: sourceTables } : {}),
+      ...(audienceFilter ? { p_audience_filter: audienceFilter } : {}),
     }
   );
 

--- a/apps/web/src/lib/falkordb/drift.ts
+++ b/apps/web/src/lib/falkordb/drift.ts
@@ -1,0 +1,273 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { falkorClient, type FalkorQueryClient } from "@/lib/falkordb/client";
+import {
+  ALUMNI_PERSON_SELECT,
+  MEMBER_PERSON_SELECT,
+  MENTORSHIP_PAIR_SELECT,
+  buildProjectedPeople,
+  isActiveMentorshipPairRow,
+  type AlumniPersonRow,
+  type MemberPersonRow,
+  type MentorshipPairSyncRow,
+} from "@/lib/falkordb/people";
+import { toErrorMessage } from "@/lib/falkordb/utils";
+
+/** Cap on how many offending identifiers we surface per category in a report. */
+const SAMPLE_CAP = 50;
+/** Page size for paging through Supabase source rows. */
+const PAGE_SIZE = 1000;
+
+export interface GraphDriftReport {
+  orgId: string;
+  /** ok = graph matches Supabase truth; drift = divergence found; degraded = could not compare. */
+  state: "ok" | "drift" | "degraded";
+  reason: string | null;
+  nodes: {
+    expected: number;
+    actual: number;
+    /** Expected person keys with no node in the graph. */
+    missingKeys: string[];
+    /** Graph nodes with no corresponding live Supabase row. */
+    orphanKeys: string[];
+    /**
+     * Graph nodes keyed `member:`/`alumni:` whose underlying row actually has a
+     * user_id — they should have collapsed to a `user:` node. This is the
+     * userless-key signature that silently breaks edge formation.
+     */
+    misKeyedNodeKeys: string[];
+  };
+  edges: {
+    expected: number;
+    actual: number;
+    /** Expected `mentor->mentee` edges absent from the graph. */
+    missingEdges: string[];
+    /** Graph edges with no corresponding active mentorship pair. */
+    orphanEdges: string[];
+  };
+  /** True when source rows exceeded the scan budget and the comparison is partial. */
+  truncated: boolean;
+}
+
+interface ActualGraph {
+  nodeKeys: Set<string>;
+  edges: Set<string>;
+}
+
+function sample(values: Iterable<string>): string[] {
+  const out: string[] = [];
+  for (const value of values) {
+    out.push(value);
+    if (out.length >= SAMPLE_CAP) break;
+  }
+  return out;
+}
+
+function edgeKey(mentorKey: string, menteeKey: string) {
+  return `${mentorKey}->${menteeKey}`;
+}
+
+async function fetchAllRows<T>(
+  serviceSupabase: SupabaseClient,
+  table: "members" | "alumni" | "mentorship_pairs",
+  select: string,
+  orgId: string
+): Promise<{ rows: T[]; truncated: boolean }> {
+  const rows: T[] = [];
+  let from = 0;
+
+  // Hard ceiling so a pathological org cannot make the checker unbounded.
+  const MAX_ROWS = PAGE_SIZE * 20;
+
+  while (from < MAX_ROWS) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (serviceSupabase as any)
+      .from(table)
+      .select(select)
+      .eq("organization_id", orgId)
+      .is("deleted_at", null)
+      .range(from, from + PAGE_SIZE - 1);
+
+    if (error) {
+      throw new Error(`Failed to load ${table} for drift check: ${toErrorMessage(error)}`);
+    }
+
+    const page = (data ?? []) as T[];
+    rows.push(...page);
+
+    if (page.length < PAGE_SIZE) {
+      return { rows, truncated: false };
+    }
+    from += PAGE_SIZE;
+  }
+
+  return { rows, truncated: true };
+}
+
+async function loadActualGraph(
+  graphClient: FalkorQueryClient,
+  orgId: string
+): Promise<ActualGraph> {
+  const nodeRows = await graphClient.query<{ personKey: string }>(
+    orgId,
+    "MATCH (p:Person) RETURN p.personKey AS personKey"
+  );
+  const edgeRows = await graphClient.query<{ mentorKey: string; menteeKey: string }>(
+    orgId,
+    "MATCH (a:Person)-[:MENTORS]->(b:Person) RETURN a.personKey AS mentorKey, b.personKey AS menteeKey"
+  );
+
+  const nodeKeys = new Set<string>();
+  for (const row of nodeRows) {
+    if (typeof row.personKey === "string" && row.personKey.length > 0) {
+      nodeKeys.add(row.personKey);
+    }
+  }
+
+  const edges = new Set<string>();
+  for (const row of edgeRows) {
+    if (typeof row.mentorKey === "string" && typeof row.menteeKey === "string") {
+      edges.add(edgeKey(row.mentorKey, row.menteeKey));
+    }
+  }
+
+  return { nodeKeys, edges };
+}
+
+function degraded(orgId: string, reason: string): GraphDriftReport {
+  return {
+    orgId,
+    state: "degraded",
+    reason,
+    nodes: { expected: 0, actual: 0, missingKeys: [], orphanKeys: [], misKeyedNodeKeys: [] },
+    edges: { expected: 0, actual: 0, missingEdges: [], orphanEdges: [] },
+    truncated: false,
+  };
+}
+
+/**
+ * Compare the FalkorDB people-graph for an org against Supabase truth and report
+ * divergence: missing/orphan nodes, missing/orphan mentorship edges, and the
+ * userless-key signature that drops edges. Read-only — never mutates the graph.
+ */
+export async function checkGraphDrift(
+  serviceSupabase: SupabaseClient,
+  orgId: string,
+  graphClient: FalkorQueryClient = falkorClient
+): Promise<GraphDriftReport> {
+  if (!graphClient.isAvailable()) {
+    return degraded(orgId, graphClient.getUnavailableReason?.() ?? "unavailable");
+  }
+
+  let members: MemberPersonRow[];
+  let alumni: AlumniPersonRow[];
+  let pairs: MentorshipPairSyncRow[];
+  let truncated = false;
+
+  try {
+    const [memberResult, alumniResult, pairResult] = await Promise.all([
+      fetchAllRows<MemberPersonRow>(serviceSupabase, "members", MEMBER_PERSON_SELECT, orgId),
+      fetchAllRows<AlumniPersonRow>(serviceSupabase, "alumni", ALUMNI_PERSON_SELECT, orgId),
+      fetchAllRows<MentorshipPairSyncRow>(
+        serviceSupabase,
+        "mentorship_pairs",
+        MENTORSHIP_PAIR_SELECT,
+        orgId
+      ),
+    ]);
+    members = memberResult.rows;
+    alumni = alumniResult.rows;
+    pairs = pairResult.rows;
+    truncated = memberResult.truncated || alumniResult.truncated || pairResult.truncated;
+  } catch (error) {
+    return degraded(orgId, toErrorMessage(error, "source_load_failed"));
+  }
+
+  let actual: ActualGraph;
+  try {
+    actual = await loadActualGraph(graphClient, orgId);
+  } catch (error) {
+    return degraded(orgId, toErrorMessage(error, "graph_query_failed"));
+  }
+
+  // Expected nodes: canonical projected people for this org.
+  const projected = buildProjectedPeople({ members, alumni });
+  const expectedNodeKeys = new Set<string>();
+  for (const person of projected.values()) {
+    expectedNodeKeys.add(person.personKey);
+  }
+
+  // user_ids that have at least one active profile row — used to detect
+  // mis-keyed standalone nodes (member:/alumni: that should be user:).
+  const memberIdsWithUser = new Map<string, string | null>();
+  for (const member of members) {
+    memberIdsWithUser.set(member.id, member.user_id);
+  }
+  const alumniIdsWithUser = new Map<string, string | null>();
+  for (const row of alumni) {
+    alumniIdsWithUser.set(row.id, row.user_id);
+  }
+
+  const missingKeys: string[] = [];
+  for (const key of expectedNodeKeys) {
+    if (!actual.nodeKeys.has(key)) missingKeys.push(key);
+  }
+
+  const orphanKeys: string[] = [];
+  const misKeyedNodeKeys: string[] = [];
+  for (const key of actual.nodeKeys) {
+    if (!expectedNodeKeys.has(key)) {
+      orphanKeys.push(key);
+    }
+    if (key.startsWith("member:")) {
+      const userId = memberIdsWithUser.get(key.slice("member:".length));
+      if (userId) misKeyedNodeKeys.push(key);
+    } else if (key.startsWith("alumni:")) {
+      const userId = alumniIdsWithUser.get(key.slice("alumni:".length));
+      if (userId) misKeyedNodeKeys.push(key);
+    }
+  }
+
+  // Expected edges: active pairs whose endpoints both resolve to a user node.
+  const expectedEdges = new Set<string>();
+  for (const pair of pairs.filter(isActiveMentorshipPairRow)) {
+    if (!pair.mentor_user_id || !pair.mentee_user_id) continue;
+    expectedEdges.add(edgeKey(`user:${pair.mentor_user_id}`, `user:${pair.mentee_user_id}`));
+  }
+
+  const missingEdges: string[] = [];
+  for (const edge of expectedEdges) {
+    if (!actual.edges.has(edge)) missingEdges.push(edge);
+  }
+
+  const orphanEdges: string[] = [];
+  for (const edge of actual.edges) {
+    if (!expectedEdges.has(edge)) orphanEdges.push(edge);
+  }
+
+  const hasDrift =
+    missingKeys.length > 0 ||
+    orphanKeys.length > 0 ||
+    misKeyedNodeKeys.length > 0 ||
+    missingEdges.length > 0 ||
+    orphanEdges.length > 0;
+
+  return {
+    orgId,
+    state: hasDrift ? "drift" : "ok",
+    reason: truncated ? "partial_scan" : null,
+    nodes: {
+      expected: expectedNodeKeys.size,
+      actual: actual.nodeKeys.size,
+      missingKeys: sample(missingKeys),
+      orphanKeys: sample(orphanKeys),
+      misKeyedNodeKeys: sample(misKeyedNodeKeys),
+    },
+    edges: {
+      expected: expectedEdges.size,
+      actual: actual.edges.size,
+      missingEdges: sample(missingEdges),
+      orphanEdges: sample(orphanEdges),
+    },
+    truncated,
+  };
+}

--- a/apps/web/src/lib/falkordb/sync.ts
+++ b/apps/web/src/lib/falkordb/sync.ts
@@ -322,6 +322,39 @@ async function hasActivePair(
   return Array.isArray(data) && data.length > 0;
 }
 
+/**
+ * Resolve the canonical person node for a paired user and upsert it into the
+ * graph, returning its personKey. Fetching the member/alumni rows *by user_id*
+ * means the projected key is always `user:{userId}` when a profile row exists,
+ * so the endpoint resolves correctly even for people whose node had not yet
+ * synced (out-of-order queue processing). Returns null when the user has no
+ * active profile row in this org — that endpoint cannot be edged and is
+ * surfaced by the graph drift checker rather than silently assumed to exist.
+ *
+ * Deliberately lighter-weight than `reconcilePersonByKey`: it upserts only the
+ * node (no adjacent-pair reconciliation), which avoids mutual recursion with
+ * the edge reconciliation that calls it.
+ */
+async function ensurePersonNodeForUser(
+  serviceSupabase: SupabaseClient,
+  graphClient: FalkorQueryClient,
+  orgId: string,
+  userId: string
+): Promise<string | null> {
+  const [members, alumni] = await Promise.all([
+    fetchActiveMembersByUserId(serviceSupabase, orgId, userId),
+    fetchActiveAlumniByUserId(serviceSupabase, orgId, userId),
+  ]);
+
+  const projected = buildProjectedPeople({ members, alumni }).get(`${orgId}:user:${userId}`);
+  if (!projected) {
+    return null;
+  }
+
+  await upsertPersonNode(graphClient, orgId, projected);
+  return projected.personKey;
+}
+
 async function reconcilePairByUsers(
   serviceSupabase: SupabaseClient,
   graphClient: FalkorQueryClient,
@@ -333,11 +366,23 @@ async function reconcilePairByUsers(
     return;
   }
 
-  const mentorKey = buildPersonKey("members", mentorUserId, mentorUserId);
-  const menteeKey = buildPersonKey("members", menteeUserId, menteeUserId);
   const edgeExists = await hasActivePair(serviceSupabase, orgId, mentorUserId, menteeUserId);
 
   if (edgeExists) {
+    // Ensure both endpoint nodes exist (resolving their real person keys)
+    // before MERGE-ing the edge. A bare `MATCH … MATCH … MERGE` silently
+    // no-ops when either node has not yet synced, permanently dropping the
+    // edge; ensuring the nodes first makes edge formation independent of
+    // queue ordering and of whether the person was previously projected.
+    const [mentorKey, menteeKey] = await Promise.all([
+      ensurePersonNodeForUser(serviceSupabase, graphClient, orgId, mentorUserId),
+      ensurePersonNodeForUser(serviceSupabase, graphClient, orgId, menteeUserId),
+    ]);
+
+    if (!mentorKey || !menteeKey) {
+      return;
+    }
+
     await graphClient.query(
       orgId,
       `
@@ -350,6 +395,9 @@ async function reconcilePairByUsers(
     );
     return;
   }
+
+  const mentorKey = buildPersonKey("members", mentorUserId, mentorUserId);
+  const menteeKey = buildPersonKey("members", menteeUserId, menteeUserId);
 
   await graphClient.query(
     orgId,

--- a/apps/web/src/lib/health/org-data-health.ts
+++ b/apps/web/src/lib/health/org-data-health.ts
@@ -1,0 +1,58 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { falkorClient, type FalkorQueryClient } from "@/lib/falkordb/client";
+import { getGraphHealthSurface, type GraphHealthSurface } from "@/lib/falkordb/sync";
+import { checkGraphDrift, type GraphDriftReport } from "@/lib/falkordb/drift";
+import { checkRagHealth, type RagHealthReport } from "@/lib/ai/rag-health";
+import {
+  checkEnrichmentHealth,
+  type EnrichmentHealthReport,
+} from "@/lib/linkedin/enrichment-health";
+
+/**
+ * Consolidated read-only data-health report for one org, spanning the three
+ * independently-synced pipelines:
+ *  - people-graph (FalkorDB): freshness/queue surface + drift vs Supabase truth
+ *  - RAG index (pgvector): chunk coverage, orphans, staleness, audience tagging
+ *  - enrichment (Apify): userless rows, failures, stalled runs, provenance gaps
+ *
+ * Each section degrades independently — a section that cannot be computed (e.g.
+ * Falkor unavailable) reports `degraded` rather than failing the whole report.
+ */
+export interface OrgDataHealthReport {
+  orgId: string;
+  graph: {
+    surface: GraphHealthSurface;
+    drift: GraphDriftReport;
+  };
+  rag: RagHealthReport;
+  enrichment: EnrichmentHealthReport;
+}
+
+interface GetOrgDataHealthOptions {
+  /** Override the FalkorDB client (tests). Defaults to the shared client. */
+  graphClient?: FalkorQueryClient;
+  /** Injectable clock for deterministic enrichment stalled-run detection. */
+  now?: number;
+}
+
+export async function getOrgDataHealth(
+  serviceSupabase: SupabaseClient,
+  orgId: string,
+  options: GetOrgDataHealthOptions = {}
+): Promise<OrgDataHealthReport> {
+  const graphClient = options.graphClient ?? falkorClient;
+
+  const [surface, drift, rag, enrichment] = await Promise.all([
+    getGraphHealthSurface(serviceSupabase, orgId),
+    checkGraphDrift(serviceSupabase, orgId, graphClient),
+    checkRagHealth(serviceSupabase, orgId),
+    checkEnrichmentHealth(serviceSupabase, orgId, { now: options.now }),
+  ]);
+
+  return {
+    orgId,
+    graph: { surface, drift },
+    rag,
+    enrichment,
+  };
+}

--- a/apps/web/src/lib/linkedin/enrichment-health.ts
+++ b/apps/web/src/lib/linkedin/enrichment-health.ts
@@ -1,0 +1,239 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Read-only checker for enrichment data-tagging health. Surfaces the rows that
+ * silently stall or carry an incomplete tagging trail:
+ *  - userless member rows (invisible to the enrichment cron and un-keyable in
+ *    the people-graph under a `user:` node)
+ *  - permanently-failed enrichment (retries exhausted)
+ *  - stalled enrichment runs (still "syncing" long past the hard timeout)
+ *  - pre-provenance rows (enriched data with no `enrichment_filled_fields`)
+ */
+
+const MAX_RETRIES = 3;
+const HARD_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+const SAMPLE_CAP = 50;
+/** Upper bound on rows scanned per category — keeps the checker bounded. */
+const SCAN_LIMIT = 5000;
+
+export interface EnrichmentHealthReport {
+  orgId: string;
+  state: "ok" | "gaps" | "degraded";
+  reason: string | null;
+  /** Member rows with no linked user_id. */
+  userlessRows: string[];
+  /** Alumni whose enrichment failed after exhausting retries. */
+  permanentlyFailed: string[];
+  /** Enrichment runs stuck in "syncing" past the hard timeout. */
+  stalledRuns: string[];
+  /** Enriched alumni with no provenance array (pre-provenance rows). */
+  preProvenance: string[];
+  counts: {
+    userlessRows: number;
+    permanentlyFailed: number;
+    stalledRuns: number;
+    preProvenance: number;
+  };
+  truncated: boolean;
+}
+
+function toMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message: unknown }).message;
+    if (typeof message === "string" && message.length > 0) return message;
+  }
+  return "unknown_error";
+}
+
+function degraded(orgId: string, reason: string): EnrichmentHealthReport {
+  return {
+    orgId,
+    state: "degraded",
+    reason,
+    userlessRows: [],
+    permanentlyFailed: [],
+    stalledRuns: [],
+    preProvenance: [],
+    counts: { userlessRows: 0, permanentlyFailed: 0, stalledRuns: 0, preProvenance: 0 },
+    truncated: false,
+  };
+}
+
+interface CheckOptions {
+  /** Injectable clock for deterministic stalled-run detection. */
+  now?: number;
+}
+
+export interface EnrichmentHealthSummary {
+  userlessRows: number;
+  permanentlyFailed: number;
+  stalledRuns: number;
+  preProvenance: number;
+}
+
+/**
+ * Cross-org aggregate counts of the same enrichment-tagging problems
+ * {@link checkEnrichmentHealth} reports per org. Best-effort: any failed count
+ * resolves to 0 so the enrichment cron's response is never broken by it.
+ */
+export async function summarizeEnrichmentHealthGlobal(
+  serviceSupabase: SupabaseClient,
+  options: CheckOptions = {}
+): Promise<EnrichmentHealthSummary> {
+  const now = options.now ?? Date.now();
+  const hardCutoff = new Date(now - HARD_TIMEOUT_MS).toISOString();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = serviceSupabase as any;
+
+  async function count(run: () => Promise<{ count: unknown; error: unknown }>): Promise<number> {
+    try {
+      const { count: value, error } = await run();
+      if (error || typeof value !== "number") return 0;
+      return value;
+    } catch {
+      return 0;
+    }
+  }
+
+  const [userlessRows, permanentlyFailed, stalledRuns, preProvenance] = await Promise.all([
+    count(() =>
+      sb
+        .from("members")
+        .select("id", { count: "exact", head: true })
+        .is("user_id", null)
+        .is("deleted_at", null)
+    ),
+    count(() =>
+      sb
+        .from("alumni")
+        .select("id", { count: "exact", head: true })
+        .eq("enrichment_status", "failed")
+        .gte("enrichment_retry_count", MAX_RETRIES)
+        .is("deleted_at", null)
+    ),
+    count(() =>
+      sb
+        .from("linkedin_enrichment_runs")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "syncing")
+        .lt("updated_at", hardCutoff)
+    ),
+    count(() =>
+      sb
+        .from("alumni")
+        .select("id", { count: "exact", head: true })
+        .eq("enrichment_status", "enriched")
+        .is("enrichment_filled_fields", null)
+        .is("deleted_at", null)
+    ),
+  ]);
+
+  return { userlessRows, permanentlyFailed, stalledRuns, preProvenance };
+}
+
+export async function checkEnrichmentHealth(
+  serviceSupabase: SupabaseClient,
+  orgId: string,
+  options: CheckOptions = {}
+): Promise<EnrichmentHealthReport> {
+  const now = options.now ?? Date.now();
+  const hardCutoff = new Date(now - HARD_TIMEOUT_MS).toISOString();
+  let truncated = false;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = serviceSupabase as any;
+
+  async function fetchIds(
+    run: () => Promise<{ data: unknown; error: unknown }>,
+    key: string
+  ): Promise<string[]> {
+    const { data, error } = await run();
+    if (error) throw new Error(toMessage(error));
+    const rows = (data ?? []) as Array<Record<string, unknown>>;
+    if (rows.length >= SCAN_LIMIT) truncated = true;
+    return rows.map((row) => String(row[key]));
+  }
+
+  let userlessRows: string[];
+  let permanentlyFailed: string[];
+  let stalledRuns: string[];
+  let preProvenance: string[];
+
+  try {
+    [userlessRows, permanentlyFailed, stalledRuns, preProvenance] = await Promise.all([
+      fetchIds(
+        () =>
+          sb
+            .from("members")
+            .select("id")
+            .eq("organization_id", orgId)
+            .is("user_id", null)
+            .is("deleted_at", null)
+            .limit(SCAN_LIMIT),
+        "id"
+      ),
+      fetchIds(
+        () =>
+          sb
+            .from("alumni")
+            .select("id")
+            .eq("organization_id", orgId)
+            .eq("enrichment_status", "failed")
+            .gte("enrichment_retry_count", MAX_RETRIES)
+            .is("deleted_at", null)
+            .limit(SCAN_LIMIT),
+        "id"
+      ),
+      fetchIds(
+        () =>
+          sb
+            .from("linkedin_enrichment_runs")
+            .select("id")
+            .eq("organization_id", orgId)
+            .eq("status", "syncing")
+            .lt("updated_at", hardCutoff)
+            .limit(SCAN_LIMIT),
+        "id"
+      ),
+      fetchIds(
+        () =>
+          sb
+            .from("alumni")
+            .select("id")
+            .eq("organization_id", orgId)
+            .eq("enrichment_status", "enriched")
+            .is("enrichment_filled_fields", null)
+            .is("deleted_at", null)
+            .limit(SCAN_LIMIT),
+        "id"
+      ),
+    ]);
+  } catch (error) {
+    return degraded(orgId, toMessage(error));
+  }
+
+  const counts = {
+    userlessRows: userlessRows.length,
+    permanentlyFailed: permanentlyFailed.length,
+    stalledRuns: stalledRuns.length,
+    preProvenance: preProvenance.length,
+  };
+  const hasGaps =
+    counts.userlessRows > 0 ||
+    counts.permanentlyFailed > 0 ||
+    counts.stalledRuns > 0 ||
+    counts.preProvenance > 0;
+
+  return {
+    orgId,
+    state: hasGaps ? "gaps" : "ok",
+    reason: truncated ? "partial_scan" : null,
+    userlessRows: userlessRows.slice(0, SAMPLE_CAP),
+    permanentlyFailed: permanentlyFailed.slice(0, SAMPLE_CAP),
+    stalledRuns: stalledRuns.slice(0, SAMPLE_CAP),
+    preProvenance: preProvenance.slice(0, SAMPLE_CAP),
+    counts,
+    truncated,
+  };
+}

--- a/apps/web/tests/ai/rag-audience.test.ts
+++ b/apps/web/tests/ai/rag-audience.test.ts
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  audienceFilterForRole,
+  retrieveRelevantChunks,
+} from "../../src/lib/ai/rag-retriever.ts";
+
+const ORG_ID = "11111111-1111-1111-1111-111111111111";
+
+// --- audienceFilterForRole: the policy heart of the audience fix ---
+
+test("audienceFilterForRole returns undefined (unrestricted) for admins", () => {
+  assert.equal(audienceFilterForRole("admin"), undefined);
+});
+
+test("audienceFilterForRole scopes active members to member audiences", () => {
+  assert.deepEqual(audienceFilterForRole("active_member"), ["members", "active_members"]);
+});
+
+test("audienceFilterForRole scopes alumni and parents to alumni audiences", () => {
+  assert.deepEqual(audienceFilterForRole("alumni"), ["alumni"]);
+  assert.deepEqual(audienceFilterForRole("parent"), ["alumni"]);
+});
+
+// --- retrieval exclusion: a fake RPC mirrors the SQL audience predicate ---
+
+const CHUNKS = [
+  { id: "c-all", source_table: "announcements", source_id: "a-all", chunk_index: 0, content_text: "Open to everyone — welcome to the season kickoff celebration.", metadata: { audience: "all" }, similarity: 0.9 },
+  { id: "c-alumni", source_table: "announcements", source_id: "a-alum", chunk_index: 0, content_text: "Alumni-only networking dinner details and RSVP instructions here.", metadata: { audience: "alumni" }, similarity: 0.92 },
+  { id: "c-members", source_table: "announcements", source_id: "a-mem", chunk_index: 0, content_text: "Active members must complete the new practice waiver this week.", metadata: { audience: "members" }, similarity: 0.88 },
+];
+
+/** Supabase stand-in whose rpc applies the same WHERE clause the migration adds. */
+function fakeSupabaseWithAudience() {
+  return {
+    rpc: async (_name: string, params: Record<string, unknown>) => {
+      const filter = params.p_audience_filter as string[] | undefined;
+      const data = CHUNKS.filter((chunk) => {
+        const audience = (chunk.metadata.audience as string) ?? "all";
+        if (!filter) return true; // NULL filter → unrestricted
+        if (audience === "all" || audience === "both") return true;
+        return filter.includes(audience);
+      });
+      return { data, error: null };
+    },
+    from: () => ({
+      select: () => ({
+        eq: () => ({ eq: () => ({ in: () => ({ eq: () => ({ is: async () => ({ data: [], error: null }) }) }) }) }),
+      }),
+    }),
+  };
+}
+
+const fakeEmbed = async () => new Array(768).fill(0);
+
+test("a member does not retrieve an alumni-only chunk in the chat path", async () => {
+  const results = await retrieveRelevantChunks({
+    query: "networking dinner",
+    orgId: ORG_ID,
+    serviceSupabase: fakeSupabaseWithAudience() as any,
+    audienceFilter: audienceFilterForRole("active_member"),
+    generateEmbeddingFn: fakeEmbed as any,
+  });
+
+  const ids = results.map((r) => r.id).sort();
+  assert.deepEqual(ids, ["c-all", "c-members"]);
+  assert.equal(results.some((r) => r.id === "c-alumni"), false);
+});
+
+test("an alumni requester retrieves alumni and unrestricted chunks only", async () => {
+  const results = await retrieveRelevantChunks({
+    query: "season",
+    orgId: ORG_ID,
+    serviceSupabase: fakeSupabaseWithAudience() as any,
+    audienceFilter: audienceFilterForRole("alumni"),
+    generateEmbeddingFn: fakeEmbed as any,
+  });
+
+  assert.deepEqual(results.map((r) => r.id).sort(), ["c-all", "c-alumni"]);
+});
+
+test("an admin (no filter) retrieves every chunk including restricted ones", async () => {
+  const results = await retrieveRelevantChunks({
+    query: "season",
+    orgId: ORG_ID,
+    serviceSupabase: fakeSupabaseWithAudience() as any,
+    audienceFilter: audienceFilterForRole("admin"),
+    generateEmbeddingFn: fakeEmbed as any,
+  });
+
+  assert.deepEqual(results.map((r) => r.id).sort(), ["c-all", "c-alumni", "c-members"]);
+});
+
+test("the audience filter is forwarded to the search RPC only when set", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const capturingSupabase = {
+    rpc: async (_name: string, params: Record<string, unknown>) => {
+      calls.push(params);
+      return { data: [], error: null };
+    },
+  };
+
+  await retrieveRelevantChunks({
+    query: "x",
+    orgId: ORG_ID,
+    serviceSupabase: capturingSupabase as any,
+    audienceFilter: ["alumni"],
+    generateEmbeddingFn: fakeEmbed as any,
+  });
+  await retrieveRelevantChunks({
+    query: "x",
+    orgId: ORG_ID,
+    serviceSupabase: capturingSupabase as any,
+    audienceFilter: undefined,
+    generateEmbeddingFn: fakeEmbed as any,
+  });
+
+  assert.deepEqual(calls[0].p_audience_filter, ["alumni"]);
+  assert.equal("p_audience_filter" in calls[1], false);
+});

--- a/apps/web/tests/ai/rag-health.test.ts
+++ b/apps/web/tests/ai/rag-health.test.ts
@@ -1,0 +1,138 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createSupabaseStub } from "../utils/supabaseStub.ts";
+import { checkRagHealth } from "../../src/lib/ai/rag-health.ts";
+import { computeContentHash, renderChunks } from "../../src/lib/ai/chunker.ts";
+
+const ORG_ID = "11111111-1111-1111-1111-111111111111";
+
+/** Render an announcement the same way the embedding worker does, to derive
+ * the canonical chunk rows (index + hash + metadata) for that source. */
+function chunkRowsFor(record: Record<string, unknown>) {
+  return renderChunks("announcements", record).map((chunk) => ({
+    org_id: ORG_ID,
+    source_table: "announcements",
+    source_id: String(record.id),
+    chunk_index: chunk.chunkIndex,
+    content_text: chunk.text,
+    content_hash: computeContentHash(chunk.text),
+    metadata: chunk.metadata,
+    deleted_at: null,
+  }));
+}
+
+const FRESH_ANNOUNCEMENT = {
+  id: "ann-fresh",
+  organization_id: ORG_ID,
+  title: "Welcome",
+  body: "Welcome to the club. Practice starts Monday.",
+  audience: null,
+  published_at: "2026-01-01T00:00:00.000Z",
+  deleted_at: null,
+};
+
+test("checkRagHealth reports ok when every eligible source has a current chunk", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("announcements", [FRESH_ANNOUNCEMENT]);
+  stub.seed("ai_document_chunks", chunkRowsFor(FRESH_ANNOUNCEMENT));
+
+  const report = await checkRagHealth(stub as any, ORG_ID);
+
+  assert.equal(report.state, "ok");
+  assert.deepEqual(report.counts, {
+    missingCoverage: 0,
+    orphanChunks: 0,
+    staleSources: 0,
+    untaggedAudience: 0,
+  });
+});
+
+test("checkRagHealth flags a source with no chunk as missing coverage", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("announcements", [FRESH_ANNOUNCEMENT]);
+  // No chunks seeded.
+
+  const report = await checkRagHealth(stub as any, ORG_ID);
+
+  assert.equal(report.state, "gaps");
+  assert.equal(report.counts.missingCoverage, 1);
+  assert.deepEqual(report.missingCoverage, [
+    { sourceTable: "announcements", sourceId: "ann-fresh" },
+  ]);
+});
+
+test("checkRagHealth does not flag an excluded source as missing coverage", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("announcements", [FRESH_ANNOUNCEMENT]);
+  stub.seed("ai_indexing_exclusions", [
+    { org_id: ORG_ID, source_table: "announcements", source_id: "ann-fresh" },
+  ]);
+
+  const report = await checkRagHealth(stub as any, ORG_ID);
+
+  assert.equal(report.state, "ok");
+  assert.equal(report.counts.missingCoverage, 0);
+});
+
+test("checkRagHealth flags chunks for a soft-deleted source as orphans", async () => {
+  const stub = createSupabaseStub();
+  const deleted = { ...FRESH_ANNOUNCEMENT, id: "ann-deleted", deleted_at: "2026-02-01T00:00:00.000Z" };
+  stub.seed("announcements", [deleted]);
+  stub.seed("ai_document_chunks", chunkRowsFor({ ...deleted, deleted_at: null }));
+
+  const report = await checkRagHealth(stub as any, ORG_ID);
+
+  assert.equal(report.state, "gaps");
+  assert.equal(report.counts.orphanChunks, 1);
+  assert.deepEqual(report.orphanChunks, [
+    { sourceTable: "announcements", sourceId: "ann-deleted" },
+  ]);
+});
+
+test("checkRagHealth flags a source whose content changed after embedding as stale", async () => {
+  const stub = createSupabaseStub();
+  // Chunk stored for the original body; source body has since changed.
+  const original = { ...FRESH_ANNOUNCEMENT, id: "ann-stale", body: "Original body text here." };
+  stub.seed("ai_document_chunks", chunkRowsFor(original));
+  stub.seed("announcements", [{ ...original, body: "Completely rewritten body now." }]);
+
+  const report = await checkRagHealth(stub as any, ORG_ID);
+
+  assert.equal(report.state, "gaps");
+  assert.equal(report.counts.staleSources, 1);
+  assert.deepEqual(report.staleSources, [
+    { sourceTable: "announcements", sourceId: "ann-stale" },
+  ]);
+});
+
+test("checkRagHealth flags an audience-restricted source whose chunk dropped the audience tag", async () => {
+  const stub = createSupabaseStub();
+  // Source is alumni-restricted, but the stored chunk metadata has no audience
+  // (e.g. embedded before the restriction was applied).
+  const restricted = { ...FRESH_ANNOUNCEMENT, id: "ann-aud", audience: "alumni" };
+  const staleChunks = chunkRowsFor({ ...restricted, audience: null }).map((chunk) => ({
+    ...chunk,
+    metadata: { title: "Welcome", audience: null },
+  }));
+  stub.seed("announcements", [restricted]);
+  stub.seed("ai_document_chunks", staleChunks);
+
+  const report = await checkRagHealth(stub as any, ORG_ID);
+
+  assert.equal(report.state, "gaps");
+  assert.equal(report.counts.untaggedAudience, 1);
+  assert.deepEqual(report.untaggedAudience, [
+    { sourceTable: "announcements", sourceId: "ann-aud" },
+  ]);
+});
+
+test("checkRagHealth degrades when the exclusions lookup fails", async () => {
+  const stub = createSupabaseStub();
+  stub.simulateError("ai_indexing_exclusions", { message: "boom" });
+
+  const report = await checkRagHealth(stub as any, ORG_ID);
+
+  assert.equal(report.state, "degraded");
+  assert.equal(report.reason, "boom");
+});

--- a/apps/web/tests/falkordb-people-graph.test.ts
+++ b/apps/web/tests/falkordb-people-graph.test.ts
@@ -2645,7 +2645,10 @@ test("processGraphSyncQueue converges for replay, out-of-order mentorship work, 
     },
   ]);
   await processGraphSyncQueue(stub as any, { graphClient });
-  assert.deepEqual(graphClient.snapshot(ORG_ID).edges, []);
+  // Edge reconciliation ensures both endpoint nodes exist (from Supabase) before
+  // MERGE, so the edge forms even when the pair item is processed before its
+  // person items — out-of-order processing no longer drops the edge.
+  assert.deepEqual(graphClient.snapshot(ORG_ID).edges, ["user:mentor-user->user:mentee-user"]);
 
   stub.registerRpc("dequeue_graph_sync_queue", () => [
     {

--- a/apps/web/tests/falkordb/drift.test.ts
+++ b/apps/web/tests/falkordb/drift.test.ts
@@ -1,0 +1,151 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createSupabaseStub } from "../utils/supabaseStub.ts";
+import { checkGraphDrift } from "../../src/lib/falkordb/drift.ts";
+
+const ORG_ID = "11111111-1111-1111-1111-111111111111";
+
+/** In-memory graph client seeded with explicit node keys and edges. */
+function createGraphFixture(seed: { nodeKeys?: string[]; edges?: Array<[string, string]> } = {}) {
+  const nodeKeys = new Set(seed.nodeKeys ?? []);
+  const edges = new Set((seed.edges ?? []).map(([a, b]) => `${a}->${b}`));
+  return {
+    isAvailable: () => true,
+    async query(_orgId: string, cypher: string) {
+      if (cypher.includes("RETURN p.personKey AS personKey")) {
+        return [...nodeKeys].map((personKey) => ({ personKey }));
+      }
+      if (cypher.includes("RETURN a.personKey AS mentorKey")) {
+        return [...edges].map((entry) => {
+          const [mentorKey, menteeKey] = entry.split("->");
+          return { mentorKey, menteeKey };
+        });
+      }
+      return [];
+    },
+  };
+}
+
+function seedMember(stub: ReturnType<typeof createSupabaseStub>, overrides: Record<string, unknown>) {
+  stub.seed("members", [
+    {
+      organization_id: ORG_ID,
+      status: "active",
+      first_name: "First",
+      last_name: "Last",
+      email: "person@example.com",
+      role: null,
+      current_company: null,
+      graduation_year: null,
+      created_at: "2026-01-01T00:00:00.000Z",
+      deleted_at: null,
+      ...overrides,
+    },
+  ]);
+}
+
+test("checkGraphDrift reports ok when graph matches Supabase truth", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("members", [
+    { id: "m1", organization_id: ORG_ID, user_id: "u-mentor", status: "active", first_name: "Mo", last_name: "Mentor", email: "mo@x.com", role: null, current_company: null, graduation_year: null, created_at: "2026-01-01T00:00:00.000Z", deleted_at: null },
+    { id: "m2", organization_id: ORG_ID, user_id: "u-mentee", status: "active", first_name: "Ty", last_name: "Mentee", email: "ty@x.com", role: null, current_company: null, graduation_year: null, created_at: "2026-01-01T00:00:00.000Z", deleted_at: null },
+  ]);
+  stub.seed("mentorship_pairs", [
+    { id: "p1", organization_id: ORG_ID, mentor_user_id: "u-mentor", mentee_user_id: "u-mentee", status: "active", deleted_at: null },
+  ]);
+
+  const graphClient = createGraphFixture({
+    nodeKeys: ["user:u-mentor", "user:u-mentee"],
+    edges: [["user:u-mentor", "user:u-mentee"]],
+  });
+
+  const report = await checkGraphDrift(stub as any, ORG_ID, graphClient as any);
+
+  assert.equal(report.state, "ok");
+  assert.equal(report.nodes.expected, 2);
+  assert.equal(report.nodes.actual, 2);
+  assert.equal(report.edges.expected, 1);
+  assert.equal(report.edges.actual, 1);
+  assert.deepEqual(report.nodes.missingKeys, []);
+  assert.deepEqual(report.edges.missingEdges, []);
+});
+
+test("checkGraphDrift flags a missing edge whose endpoint node is absent", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("members", [
+    { id: "m1", organization_id: ORG_ID, user_id: "u-mentor", status: "active", first_name: "Mo", last_name: "Mentor", email: "mo@x.com", role: null, current_company: null, graduation_year: null, created_at: "2026-01-01T00:00:00.000Z", deleted_at: null },
+    { id: "m2", organization_id: ORG_ID, user_id: "u-mentee", status: "active", first_name: "Ty", last_name: "Mentee", email: "ty@x.com", role: null, current_company: null, graduation_year: null, created_at: "2026-01-01T00:00:00.000Z", deleted_at: null },
+  ]);
+  stub.seed("mentorship_pairs", [
+    { id: "p1", organization_id: ORG_ID, mentor_user_id: "u-mentor", mentee_user_id: "u-mentee", status: "active", deleted_at: null },
+  ]);
+
+  // Mentee node never synced; edge missing.
+  const graphClient = createGraphFixture({ nodeKeys: ["user:u-mentor"], edges: [] });
+
+  const report = await checkGraphDrift(stub as any, ORG_ID, graphClient as any);
+
+  assert.equal(report.state, "drift");
+  assert.deepEqual(report.nodes.missingKeys, ["user:u-mentee"]);
+  assert.deepEqual(report.edges.missingEdges, ["user:u-mentor->user:u-mentee"]);
+});
+
+test("checkGraphDrift flags a userless mis-keyed node (G1 signature)", async () => {
+  const stub = createSupabaseStub();
+  // Member row HAS a user_id, so its canonical key is user:u-x — but the graph
+  // holds a stale member: node, the signature that breaks edge formation.
+  seedMember(stub, { id: "m-x", user_id: "u-x" });
+
+  const graphClient = createGraphFixture({ nodeKeys: ["member:m-x"] });
+
+  const report = await checkGraphDrift(stub as any, ORG_ID, graphClient as any);
+
+  assert.equal(report.state, "drift");
+  assert.deepEqual(report.nodes.misKeyedNodeKeys, ["member:m-x"]);
+  assert.deepEqual(report.nodes.missingKeys, ["user:u-x"]);
+  assert.deepEqual(report.nodes.orphanKeys, ["member:m-x"]);
+});
+
+test("checkGraphDrift flags orphan nodes and orphan edges with no live source row", async () => {
+  const stub = createSupabaseStub();
+  seedMember(stub, { id: "m1", user_id: "u-live" });
+
+  const graphClient = createGraphFixture({
+    nodeKeys: ["user:u-live", "user:u-ghost"],
+    edges: [["user:u-live", "user:u-ghost"]],
+  });
+
+  const report = await checkGraphDrift(stub as any, ORG_ID, graphClient as any);
+
+  assert.equal(report.state, "drift");
+  assert.deepEqual(report.nodes.orphanKeys, ["user:u-ghost"]);
+  assert.deepEqual(report.edges.orphanEdges, ["user:u-live->user:u-ghost"]);
+  assert.equal(report.edges.expected, 0);
+});
+
+test("checkGraphDrift returns degraded when the graph is unavailable", async () => {
+  const stub = createSupabaseStub();
+  const report = await checkGraphDrift(stub as any, ORG_ID, {
+    isAvailable: () => false,
+    getUnavailableReason: () => "disabled",
+    query: async () => [],
+  } as any);
+
+  assert.equal(report.state, "degraded");
+  assert.equal(report.reason, "disabled");
+});
+
+test("checkGraphDrift returns degraded when graph queries throw", async () => {
+  const stub = createSupabaseStub();
+  seedMember(stub, { id: "m1", user_id: "u-1" });
+  const report = await checkGraphDrift(stub as any, ORG_ID, {
+    isAvailable: () => true,
+    query: async () => {
+      throw new Error("connection reset");
+    },
+  } as any);
+
+  assert.equal(report.state, "degraded");
+  assert.equal(report.reason, "connection reset");
+});

--- a/apps/web/tests/falkordb/sync-edges.test.ts
+++ b/apps/web/tests/falkordb/sync-edges.test.ts
@@ -1,0 +1,242 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createSupabaseStub } from "../utils/supabaseStub.ts";
+import { processGraphSyncQueue } from "../../src/lib/falkordb/sync.ts";
+
+const ORG_ID = "11111111-1111-1111-1111-111111111111";
+
+/**
+ * Minimal in-memory FalkorDB stand-in that mirrors the real engine's MATCH
+ * semantics: a MENTORS edge is only created when BOTH endpoint nodes already
+ * exist (MATCH … MATCH … MERGE). This is what makes the "edge silently dropped"
+ * failure mode reproducible in a unit test.
+ */
+function createInMemoryGraphClient() {
+  const graphs = new Map<string, { nodes: Map<string, Record<string, unknown>>; edges: Set<string> }>();
+
+  function ensureGraph(orgId: string) {
+    const existing = graphs.get(orgId);
+    if (existing) return existing;
+    const created = { nodes: new Map<string, Record<string, unknown>>(), edges: new Set<string>() };
+    graphs.set(orgId, created);
+    return created;
+  }
+
+  const edgeKey = (from: string, to: string) => `${from}->${to}`;
+
+  return {
+    isAvailable: () => true,
+    snapshot(orgId: string) {
+      const graph = ensureGraph(orgId);
+      return {
+        nodes: [...graph.nodes.keys()].sort(),
+        edges: [...graph.edges.values()].sort(),
+      };
+    },
+    async query(orgId: string, cypher: string, params?: Record<string, unknown>) {
+      const graph = ensureGraph(orgId);
+
+      if (cypher.includes("DETACH DELETE person")) {
+        const personKey = String(params?.personKey);
+        graph.nodes.delete(personKey);
+        for (const edge of [...graph.edges]) {
+          if (edge.startsWith(`${personKey}->`) || edge.endsWith(`->${personKey}`)) {
+            graph.edges.delete(edge);
+          }
+        }
+        return [];
+      }
+
+      if (cypher.includes("SET person = $props")) {
+        graph.nodes.set(String(params?.personKey), { ...(params?.props as Record<string, unknown>) });
+        return [];
+      }
+
+      if (cypher.includes("MERGE (mentor)-[:MENTORS]->(mentee)")) {
+        const mentorKey = String(params?.mentorKey);
+        const menteeKey = String(params?.menteeKey);
+        // Real engine: MATCH fails (and the edge is not created) unless both nodes exist.
+        if (graph.nodes.has(mentorKey) && graph.nodes.has(menteeKey)) {
+          graph.edges.add(edgeKey(mentorKey, menteeKey));
+        }
+        return [];
+      }
+
+      if (cypher.includes("DELETE edge")) {
+        graph.edges.delete(edgeKey(String(params?.mentorKey), String(params?.menteeKey)));
+        return [];
+      }
+
+      return [];
+    },
+  };
+}
+
+function seedPair(stub: ReturnType<typeof createSupabaseStub>) {
+  stub.seed("members", [
+    {
+      id: "member-mentor",
+      organization_id: ORG_ID,
+      user_id: "mentor-user",
+      status: "active",
+      first_name: "Morgan",
+      last_name: "Mentor",
+      email: "mentor@example.com",
+      role: "Captain",
+      current_company: "Acme",
+      graduation_year: 2020,
+      deleted_at: null,
+    },
+    {
+      id: "member-mentee",
+      organization_id: ORG_ID,
+      user_id: "mentee-user",
+      status: "active",
+      first_name: "Taylor",
+      last_name: "Mentee",
+      email: "mentee@example.com",
+      role: "Member",
+      current_company: "Beta",
+      graduation_year: 2026,
+      deleted_at: null,
+    },
+  ]);
+  stub.seed("mentorship_pairs", [
+    {
+      id: "pair-1",
+      organization_id: ORG_ID,
+      mentor_user_id: "mentor-user",
+      mentee_user_id: "mentee-user",
+      status: "active",
+      deleted_at: null,
+    },
+  ]);
+  stub.registerRpc("increment_graph_sync_attempts", () => null);
+}
+
+// G2: the pair queue item is processed with NO preceding person items — the
+// person nodes were never synced. The pre-fix code MATCHed `user:{id}` nodes
+// that did not exist, so the edge was permanently dropped. The fix ensures the
+// endpoint nodes exist before MERGE.
+test("processGraphSyncQueue forms the edge when the pair item is processed before its person nodes exist", async () => {
+  const stub = createSupabaseStub();
+  const graphClient = createInMemoryGraphClient();
+  seedPair(stub);
+
+  stub.registerRpc("dequeue_graph_sync_queue", () => [
+    {
+      id: "queue-pair-only",
+      org_id: ORG_ID,
+      source_table: "mentorship_pairs",
+      source_id: "pair-1",
+      action: "upsert",
+      payload: {},
+      attempts: 0,
+    },
+  ]);
+
+  const stats = await processGraphSyncQueue(stub as any, { graphClient });
+
+  assert.equal(stats.failed, 0);
+  const snapshot = graphClient.snapshot(ORG_ID);
+  assert.deepEqual(snapshot.nodes, ["user:mentee-user", "user:mentor-user"]);
+  assert.deepEqual(snapshot.edges, ["user:mentor-user->user:mentee-user"]);
+});
+
+// Regression guard: the canonical in-order path still forms exactly one edge.
+test("processGraphSyncQueue still forms the edge when person items precede the pair item", async () => {
+  const stub = createSupabaseStub();
+  const graphClient = createInMemoryGraphClient();
+  seedPair(stub);
+
+  stub.registerRpc("dequeue_graph_sync_queue", () => [
+    { id: "q-mentor", org_id: ORG_ID, source_table: "members", source_id: "member-mentor", action: "upsert", payload: {}, attempts: 0 },
+    { id: "q-mentee", org_id: ORG_ID, source_table: "members", source_id: "member-mentee", action: "upsert", payload: {}, attempts: 0 },
+    { id: "q-pair", org_id: ORG_ID, source_table: "mentorship_pairs", source_id: "pair-1", action: "upsert", payload: {}, attempts: 0 },
+  ]);
+
+  await processGraphSyncQueue(stub as any, { graphClient });
+
+  const snapshot = graphClient.snapshot(ORG_ID);
+  assert.deepEqual(snapshot.edges, ["user:mentor-user->user:mentee-user"]);
+});
+
+// Idempotency: re-processing the same pair item never duplicates the edge.
+test("processGraphSyncQueue edge reconciliation is idempotent across repeated pair items", async () => {
+  const stub = createSupabaseStub();
+  const graphClient = createInMemoryGraphClient();
+  seedPair(stub);
+
+  stub.registerRpc("dequeue_graph_sync_queue", () => [
+    { id: "q-pair", org_id: ORG_ID, source_table: "mentorship_pairs", source_id: "pair-1", action: "upsert", payload: {}, attempts: 0 },
+  ]);
+
+  await processGraphSyncQueue(stub as any, { graphClient });
+  await processGraphSyncQueue(stub as any, { graphClient });
+
+  assert.deepEqual(graphClient.snapshot(ORG_ID).edges, ["user:mentor-user->user:mentee-user"]);
+});
+
+// When a pair goes inactive, the edge is removed.
+test("processGraphSyncQueue removes the edge when the pair is no longer active", async () => {
+  const stub = createSupabaseStub();
+  const graphClient = createInMemoryGraphClient();
+  seedPair(stub);
+
+  stub.registerRpc("dequeue_graph_sync_queue", () => [
+    { id: "q-pair", org_id: ORG_ID, source_table: "mentorship_pairs", source_id: "pair-1", action: "upsert", payload: {}, attempts: 0 },
+  ]);
+  await processGraphSyncQueue(stub as any, { graphClient });
+  assert.deepEqual(graphClient.snapshot(ORG_ID).edges, ["user:mentor-user->user:mentee-user"]);
+
+  await (stub as any).from("mentorship_pairs").update({ status: "completed" }).eq("id", "pair-1");
+  stub.registerRpc("dequeue_graph_sync_queue", () => [
+    { id: "q-pair-2", org_id: ORG_ID, source_table: "mentorship_pairs", source_id: "pair-1", action: "upsert", payload: {}, attempts: 0 },
+  ]);
+  await processGraphSyncQueue(stub as any, { graphClient });
+
+  assert.deepEqual(graphClient.snapshot(ORG_ID).edges, []);
+});
+
+// Endpoint with no profile row in the org: edge cannot form, no crash, no edge.
+test("processGraphSyncQueue skips the edge when an endpoint has no profile row", async () => {
+  const stub = createSupabaseStub();
+  const graphClient = createInMemoryGraphClient();
+
+  // Only the mentor has a member row; the mentee user has no profile row at all.
+  stub.seed("members", [
+    {
+      id: "member-mentor",
+      organization_id: ORG_ID,
+      user_id: "mentor-user",
+      status: "active",
+      first_name: "Morgan",
+      last_name: "Mentor",
+      email: "mentor@example.com",
+      role: "Captain",
+      current_company: "Acme",
+      graduation_year: 2020,
+      deleted_at: null,
+    },
+  ]);
+  stub.seed("mentorship_pairs", [
+    {
+      id: "pair-1",
+      organization_id: ORG_ID,
+      mentor_user_id: "mentor-user",
+      mentee_user_id: "ghost-user",
+      status: "active",
+      deleted_at: null,
+    },
+  ]);
+  stub.registerRpc("increment_graph_sync_attempts", () => null);
+  stub.registerRpc("dequeue_graph_sync_queue", () => [
+    { id: "q-pair", org_id: ORG_ID, source_table: "mentorship_pairs", source_id: "pair-1", action: "upsert", payload: {}, attempts: 0 },
+  ]);
+
+  const stats = await processGraphSyncQueue(stub as any, { graphClient });
+
+  assert.equal(stats.failed, 0);
+  assert.deepEqual(graphClient.snapshot(ORG_ID).edges, []);
+});

--- a/apps/web/tests/linkedin/enrichment-health.test.ts
+++ b/apps/web/tests/linkedin/enrichment-health.test.ts
@@ -1,0 +1,146 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createSupabaseStub } from "../utils/supabaseStub.ts";
+import {
+  checkEnrichmentHealth,
+  summarizeEnrichmentHealthGlobal,
+} from "../../src/lib/linkedin/enrichment-health.ts";
+
+const ORG_ID = "11111111-1111-1111-1111-111111111111";
+const NOW = Date.parse("2026-06-15T12:00:00.000Z");
+
+test("checkEnrichmentHealth reports ok when tagging is healthy", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("members", [
+    { id: "m1", organization_id: ORG_ID, user_id: "u1", deleted_at: null },
+  ]);
+  stub.seed("alumni", [
+    {
+      id: "a1",
+      organization_id: ORG_ID,
+      user_id: "u1",
+      enrichment_status: "enriched",
+      enrichment_retry_count: 0,
+      enrichment_filled_fields: ["job_title"],
+      deleted_at: null,
+    },
+  ]);
+
+  const report = await checkEnrichmentHealth(stub as any, ORG_ID, { now: NOW });
+
+  assert.equal(report.state, "ok");
+  assert.deepEqual(report.counts, {
+    userlessRows: 0,
+    permanentlyFailed: 0,
+    stalledRuns: 0,
+    preProvenance: 0,
+  });
+});
+
+test("checkEnrichmentHealth flags userless member rows", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("members", [
+    { id: "m-linked", organization_id: ORG_ID, user_id: "u1", deleted_at: null },
+    { id: "m-userless", organization_id: ORG_ID, user_id: null, deleted_at: null },
+    { id: "m-deleted", organization_id: ORG_ID, user_id: null, deleted_at: "2026-01-01T00:00:00.000Z" },
+  ]);
+
+  const report = await checkEnrichmentHealth(stub as any, ORG_ID, { now: NOW });
+
+  assert.equal(report.state, "gaps");
+  assert.deepEqual(report.userlessRows, ["m-userless"]);
+});
+
+test("checkEnrichmentHealth flags alumni with exhausted retries as permanently failed", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("alumni", [
+    { id: "a-failed", organization_id: ORG_ID, enrichment_status: "failed", enrichment_retry_count: 3, deleted_at: null },
+    { id: "a-retrying", organization_id: ORG_ID, enrichment_status: "failed", enrichment_retry_count: 1, deleted_at: null },
+  ]);
+
+  const report = await checkEnrichmentHealth(stub as any, ORG_ID, { now: NOW });
+
+  assert.equal(report.counts.permanentlyFailed, 1);
+  assert.deepEqual(report.permanentlyFailed, ["a-failed"]);
+});
+
+test("checkEnrichmentHealth flags enrichment runs stuck past the hard timeout", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("linkedin_enrichment_runs", [
+    { id: "run-stuck", organization_id: ORG_ID, status: "syncing", updated_at: "2026-06-15T09:00:00.000Z" },
+    { id: "run-recent", organization_id: ORG_ID, status: "syncing", updated_at: "2026-06-15T11:30:00.000Z" },
+    { id: "run-done", organization_id: ORG_ID, status: "enriched", updated_at: "2026-06-15T01:00:00.000Z" },
+  ]);
+
+  // NOW is 12:00; hard cutoff is 10:00. Only run-stuck (09:00) is past it.
+  const report = await checkEnrichmentHealth(stub as any, ORG_ID, { now: NOW });
+
+  assert.equal(report.counts.stalledRuns, 1);
+  assert.deepEqual(report.stalledRuns, ["run-stuck"]);
+});
+
+test("checkEnrichmentHealth flags enriched rows with no provenance array", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("alumni", [
+    { id: "a-old", organization_id: ORG_ID, enrichment_status: "enriched", enrichment_retry_count: 0, enrichment_filled_fields: null, deleted_at: null },
+    { id: "a-new", organization_id: ORG_ID, enrichment_status: "enriched", enrichment_retry_count: 0, enrichment_filled_fields: ["job_title"], deleted_at: null },
+  ]);
+
+  const report = await checkEnrichmentHealth(stub as any, ORG_ID, { now: NOW });
+
+  assert.equal(report.counts.preProvenance, 1);
+  assert.deepEqual(report.preProvenance, ["a-old"]);
+});
+
+test("checkEnrichmentHealth degrades when a source query fails", async () => {
+  const stub = createSupabaseStub();
+  stub.simulateError("alumni", { message: "db down" });
+
+  const report = await checkEnrichmentHealth(stub as any, ORG_ID, { now: NOW });
+
+  assert.equal(report.state, "degraded");
+  assert.equal(report.reason, "db down");
+});
+
+// --- U8: cross-org cron summary ---
+
+test("summarizeEnrichmentHealthGlobal aggregates problem counts across orgs", async () => {
+  const stub = createSupabaseStub();
+  const OTHER_ORG = "22222222-2222-2222-2222-222222222222";
+  stub.seed("members", [
+    { id: "m1", organization_id: ORG_ID, user_id: null, deleted_at: null },
+    { id: "m2", organization_id: OTHER_ORG, user_id: null, deleted_at: null },
+    { id: "m3", organization_id: ORG_ID, user_id: "u", deleted_at: null },
+  ]);
+  stub.seed("alumni", [
+    { id: "a1", organization_id: ORG_ID, enrichment_status: "failed", enrichment_retry_count: 3, deleted_at: null },
+    { id: "a2", organization_id: OTHER_ORG, enrichment_status: "enriched", enrichment_retry_count: 0, enrichment_filled_fields: null, deleted_at: null },
+  ]);
+  stub.seed("linkedin_enrichment_runs", [
+    { id: "r1", organization_id: ORG_ID, status: "syncing", updated_at: "2026-06-15T09:00:00.000Z" },
+  ]);
+
+  const summary = await summarizeEnrichmentHealthGlobal(stub as any, { now: NOW });
+
+  assert.deepEqual(summary, {
+    userlessRows: 2,
+    permanentlyFailed: 1,
+    stalledRuns: 1,
+    preProvenance: 1,
+  });
+});
+
+test("summarizeEnrichmentHealthGlobal reports zeros when nothing is wrong", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("members", [{ id: "m", organization_id: ORG_ID, user_id: "u", deleted_at: null }]);
+
+  const summary = await summarizeEnrichmentHealthGlobal(stub as any, { now: NOW });
+
+  assert.deepEqual(summary, {
+    userlessRows: 0,
+    permanentlyFailed: 0,
+    stalledRuns: 0,
+    preProvenance: 0,
+  });
+});

--- a/apps/web/tests/routes/organizations/data-health.test.ts
+++ b/apps/web/tests/routes/organizations/data-health.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import test, { beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { createSupabaseStub } from "../../utils/supabaseStub.ts";
+import { getOrgDataHealth } from "../../../src/lib/health/org-data-health.ts";
+import { normalizeRole } from "../../../src/lib/auth/role-utils.ts";
+import { resetFalkorTelemetryForTests } from "../../../src/lib/falkordb/telemetry.ts";
+
+const ORG_ID = "11111111-1111-1111-1111-111111111111";
+
+beforeEach(() => {
+  resetFalkorTelemetryForTests();
+});
+
+function graphFixture(seed: { nodeKeys?: string[]; edges?: Array<[string, string]> } = {}) {
+  const nodeKeys = new Set(seed.nodeKeys ?? []);
+  const edges = new Set((seed.edges ?? []).map(([a, b]) => `${a}->${b}`));
+  return {
+    isAvailable: () => true,
+    async query(_orgId: string, cypher: string) {
+      if (cypher.includes("RETURN p.personKey AS personKey")) {
+        return [...nodeKeys].map((personKey) => ({ personKey }));
+      }
+      if (cypher.includes("RETURN a.personKey AS mentorKey")) {
+        return [...edges].map((entry) => {
+          const [mentorKey, menteeKey] = entry.split("->");
+          return { mentorKey, menteeKey };
+        });
+      }
+      return [];
+    },
+  };
+}
+
+// --- admin gate (the route's authorization decision) ---
+
+test("data-health admin gate admits only the admin role", () => {
+  assert.equal(normalizeRole("admin"), "admin");
+  assert.notEqual(normalizeRole("member"), "admin");
+  assert.notEqual(normalizeRole("alumni"), "admin");
+  assert.equal(normalizeRole(null), null);
+});
+
+// --- aggregation across all three pipelines ---
+
+test("getOrgDataHealth returns all four sections for a healthy org", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("members", [
+    { id: "m1", organization_id: ORG_ID, user_id: "u1", status: "active", first_name: "A", last_name: "B", email: "a@x.com", role: null, current_company: null, graduation_year: null, created_at: "2026-01-01T00:00:00.000Z", deleted_at: null },
+  ]);
+
+  const report = await getOrgDataHealth(stub as any, ORG_ID, {
+    graphClient: graphFixture({ nodeKeys: ["user:u1"] }) as any,
+    now: Date.parse("2026-06-15T12:00:00.000Z"),
+  });
+
+  assert.equal(report.orgId, ORG_ID);
+  assert.ok(report.graph.surface, "graph surface present");
+  assert.equal(report.graph.drift.state, "ok");
+  assert.equal(report.rag.state, "ok");
+  assert.equal(report.enrichment.state, "ok");
+});
+
+test("getOrgDataHealth degrades only the graph-drift section when Falkor is down", async () => {
+  const stub = createSupabaseStub();
+
+  const report = await getOrgDataHealth(stub as any, ORG_ID, {
+    graphClient: {
+      isAvailable: () => false,
+      getUnavailableReason: () => "disabled",
+      query: async () => [],
+    } as any,
+    now: Date.parse("2026-06-15T12:00:00.000Z"),
+  });
+
+  assert.equal(report.graph.drift.state, "degraded");
+  assert.equal(report.graph.drift.reason, "disabled");
+  // Other sections still compute.
+  assert.equal(report.rag.state, "ok");
+  assert.equal(report.enrichment.state, "ok");
+});
+
+test("getOrgDataHealth is org-scoped and surfaces another org's data nowhere", async () => {
+  const stub = createSupabaseStub();
+  const OTHER = "22222222-2222-2222-2222-222222222222";
+  stub.seed("members", [
+    { id: "m-other", organization_id: OTHER, user_id: null, status: "active", first_name: "X", last_name: "Y", email: "x@y.com", role: null, current_company: null, graduation_year: null, created_at: "2026-01-01T00:00:00.000Z", deleted_at: null },
+  ]);
+
+  const report = await getOrgDataHealth(stub as any, ORG_ID, {
+    graphClient: graphFixture() as any,
+    now: Date.parse("2026-06-15T12:00:00.000Z"),
+  });
+
+  // The other org's userless member must not appear in this org's report.
+  assert.deepEqual(report.enrichment.userlessRows, []);
+  assert.equal(JSON.stringify(report).includes("m-other"), false);
+});

--- a/apps/web/tests/utils/supabaseStub.ts
+++ b/apps/web/tests/utils/supabaseStub.ts
@@ -50,6 +50,9 @@ type TableName =
   | "enterprise_adoption_requests"
   | "user_enterprise_roles"
   | "ai_messages"
+  | "ai_document_chunks"
+  | "ai_indexing_exclusions"
+  | "announcements"
   | "organization_email_domains";
 
 type Row = Record<string, unknown>;
@@ -115,6 +118,9 @@ const uniqueKeys: Record<TableName, UniqueConstraint[]> = {
   enterprise_adoption_requests: [],
   user_enterprise_roles: [["user_id", "enterprise_id"]],
   ai_messages: [],
+  ai_document_chunks: [],
+  ai_indexing_exclusions: [],
+  announcements: [],
   organization_email_domains: ["organization_id", "domain"],
 };
 
@@ -173,6 +179,9 @@ export function createSupabaseStub() {
     enterprise_adoption_requests: [],
     user_enterprise_roles: [],
     ai_messages: [],
+    ai_document_chunks: [],
+    ai_indexing_exclusions: [],
+    announcements: [],
     organization_email_domains: [],
   };
 
@@ -375,6 +384,8 @@ export function createSupabaseStub() {
       let sortColumn: string | null = null;
       let sortAscending = true;
       let limitCount: number | null = null;
+      let rangeFrom: number | null = null;
+      let rangeTo: number | null = null;
 
       const builder = {
         eq(column: string, value: unknown) {
@@ -454,6 +465,11 @@ export function createSupabaseStub() {
           limitCount = count;
           return builder;
         },
+        range(from: number, to: number) {
+          rangeFrom = from;
+          rangeTo = to;
+          return builder;
+        },
         maybeSingle(): SupabaseResponse<Row> {
           if (errorSimulation[table]) {
             return { data: null, error: errorSimulation[table] ?? null };
@@ -511,6 +527,9 @@ export function createSupabaseStub() {
               if (aVal > bVal) return sortAscending ? 1 : -1;
               return 0;
             });
+          }
+          if (rangeFrom !== null && rangeTo !== null) {
+            rows = rows.slice(rangeFrom, rangeTo + 1);
           }
           if (limitCount !== null) {
             rows = rows.slice(0, limitCount);

--- a/supabase/migrations/20261220000000_search_ai_documents_audience.sql
+++ b/supabase/migrations/20261220000000_search_ai_documents_audience.sql
@@ -1,0 +1,73 @@
+-- Add optional audience scoping to the RAG vector search.
+--
+-- search_ai_documents previously filtered only by org + source table, so the
+-- assistant could ground answers on audience-restricted chunks (e.g. alumni-only
+-- announcements) for any requester. RLS only re-filters at display/hydration, not
+-- in the chat-context retrieval path, so the restriction was never enforced there.
+--
+-- This adds p_audience_filter text[] DEFAULT NULL:
+--   * NULL (default)  -> no audience filtering (admin / global callers; preserves
+--                        existing behavior for every current caller).
+--   * non-NULL list   -> a chunk passes only when its audience is unrestricted
+--                        ('all' / 'both' / unset) or intersects the allowed list.
+--
+-- Drop the old 5-arg function first so we end up with exactly one definition
+-- (avoids PostgREST overload ambiguity when callers pass named args).
+
+DROP FUNCTION IF EXISTS public.search_ai_documents(
+  uuid, extensions.vector, integer, double precision, text[]
+);
+
+CREATE OR REPLACE FUNCTION public.search_ai_documents(
+  p_org_id uuid,
+  p_query_embedding extensions.vector(768),
+  p_match_count integer DEFAULT 5,
+  p_similarity_threshold float DEFAULT 0.5,
+  p_source_tables text[] DEFAULT NULL,
+  p_audience_filter text[] DEFAULT NULL
+)
+RETURNS TABLE(
+  id uuid,
+  source_table text,
+  source_id uuid,
+  chunk_index smallint,
+  content_text text,
+  metadata jsonb,
+  similarity float
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'extensions'
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    c.id,
+    c.source_table,
+    c.source_id,
+    c.chunk_index,
+    c.content_text,
+    c.metadata,
+    (1 - (c.embedding <=> p_query_embedding))::float AS similarity
+  FROM public.ai_document_chunks c
+  WHERE c.org_id = p_org_id
+    AND c.deleted_at IS NULL
+    AND (p_source_tables IS NULL OR c.source_table = ANY(p_source_tables))
+    AND (
+      p_audience_filter IS NULL
+      OR COALESCE(c.metadata->>'audience', 'all') IN ('all', 'both')
+      OR (c.metadata->>'audience') = ANY(p_audience_filter)
+    )
+    AND (1 - (c.embedding <=> p_query_embedding)) >= p_similarity_threshold
+  ORDER BY c.embedding <=> p_query_embedding
+  LIMIT p_match_count;
+END;
+$$;
+
+COMMENT ON FUNCTION public.search_ai_documents IS
+  'Vector similarity search across org document chunks, with optional audience scoping (p_audience_filter NULL = unrestricted).';
+
+REVOKE EXECUTE ON FUNCTION public.search_ai_documents FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.search_ai_documents FROM anon;
+REVOKE EXECUTE ON FUNCTION public.search_ai_documents FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.search_ai_documents TO service_role;


### PR DESCRIPTION
## Summary
Read-only verification across the three independently-synced data pipelines (FalkorDB people-graph, pgvector RAG index, Apify enrichment), plus the concrete tagging/edge fixes they surface.

### Fixes
- **Graph edges** (`falkordb/sync.ts`): ensure both `MENTORS` endpoint nodes exist (resolving each one's real person key) before MERGE — out-of-order queue processing and userless rows no longer silently drop mentor/mentee edges.
- **RAG audience scoping** (migration `20261220000000` + retriever + chat stage): optional `p_audience_filter` on `search_ai_documents` (NULL = unchanged); chat-path retrieval is scoped to the requester's role, so the assistant can't ground answers on audience-restricted chunks.
- **Enrichment cron**: emits a cross-org health summary (userless / failed / stalled / pre-provenance).

### Harness (read-only)
- `falkordb/drift.ts` — FalkorDB↔Supabase node/edge drift + mis-keyed nodes
- `ai/rag-health.ts` — chunk coverage, orphans, staleness, untagged audience
- `linkedin/enrichment-health.ts` — userless rows, exhausted retries, stalled runs, pre-provenance
- `health/org-data-health.ts` + admin route + `/[orgSlug]/data-health` page consolidating all four

### Verification
- 72 new tests across 7 suites; full web suite green (6052 passing); typecheck + lint clean.

### Follow-ups
- Run `bun run gen:types` after the migration applies.
- Root `bun run typecheck` needs `NODE_OPTIONS=--max-old-space-size=8192` on this machine.