### PR TITLE
chore(graph): retire dormant FalkorDB sync triggers + cron (Option A)

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -42,10 +42,6 @@
       "schedule": "*/5 * * * *"
     },
     {
-      "path": "/api/cron/graph-sync-process",
-      "schedule": "* * * * *"
-    },
-    {
       "path": "/api/cron/enrichment-process",
       "schedule": "*/5 * * * *"
     },

--- a/supabase/migrations/20261221000000_retire_graph_sync_triggers.sql
+++ b/supabase/migrations/20261221000000_retire_graph_sync_triggers.sql
@@ -1,0 +1,31 @@
+-- Retire the FalkorDB people-graph sync pipeline (Option A: serve the graph from Postgres).
+--
+-- WHY: FalkorDB was never enabled in production (no FALKOR_* config / instance), so the
+-- `graph_sync_queue` triggers enqueued member/alumni/pair changes that nothing ever drained
+-- (~358 rows accrued, oldest 2026-06-01). The mentor-suggestion feature already runs entirely
+-- on Postgres + pgvector via the SQL-fallback path, and `get_mentorship_distances()` provides
+-- recursive-CTE graph traversal natively. We are making that the permanent architecture.
+--
+-- This migration stops the write side of the dormant pipeline:
+--   * drops the three enqueue triggers + their trigger functions (the source of the leak)
+--   * clears the orphaned backlog (no consumer exists under Option A — these rows are dead weight)
+--
+-- Intentionally KEPT (still referenced or useful):
+--   * graph_sync_queue table + dequeue/increment/purge/backfill RPCs (removed in the code-cleanup
+--     follow-up, once the cron route and sync.ts reader are deleted together)
+--   * get_mentorship_distances() — the Postgres-native traversal we are standardizing on
+--
+-- Reversible: re-running 20260715000000_falkor_people_graph_foundation.sql recreates the triggers.
+
+-- 1. Drop triggers first (they depend on the functions).
+DROP TRIGGER IF EXISTS trg_graph_sync_members ON public.members;
+DROP TRIGGER IF EXISTS trg_graph_sync_alumni ON public.alumni;
+DROP TRIGGER IF EXISTS trg_graph_sync_mentorship_pairs ON public.mentorship_pairs;
+
+-- 2. Drop the now-unused trigger functions.
+DROP FUNCTION IF EXISTS public.enqueue_graph_sync_member();
+DROP FUNCTION IF EXISTS public.enqueue_graph_sync_alumni();
+DROP FUNCTION IF EXISTS public.enqueue_graph_sync_mentorship_pair();
+
+-- 3. Clear the orphaned backlog. Under Option A nothing will ever process these rows.
+DELETE FROM public.graph_sync_queue;


### PR DESCRIPTION
## Why
FalkorDB was never enabled in production (no `FALKOR_*` config/instance), so the `graph_sync_queue` triggers kept enqueuing member/alumni/pair changes that **nothing ever drained** — ~358 orphaned rows accrued (oldest 2026-06-01), and the `data-health` harness flagged the org graph as permanently `stale`.

We're standardizing on **Postgres as the people-graph store** (Option A):
- Mentor suggestions already run 100% on Postgres + pgvector via the existing `sql_fallback` path.
- `get_mentorship_distances()` already provides native recursive-CTE traversal (shortest-path/intro-path style queries).

## What this PR does (Phase 1 — stop the leak)
- **Migration** `20261221000000_retire_graph_sync_triggers.sql`: drops the 3 enqueue triggers + their trigger functions, and clears the orphaned backlog.
- **vercel.json**: removes the per-minute `graph-sync-process` cron (it drains a queue nothing fills).

Zero TS logic changed; the live suggestion path is untouched.

### Intentionally kept
- `graph_sync_queue` table + dequeue/increment/purge/backfill RPCs (removed alongside the cron route + `sync.ts` reader in the Phase 2 cleanup PR).
- `get_mentorship_distances()` — the Postgres traversal we're keeping.

## Applied to prod
This migration was applied to production via the Supabase MCP. Verified post-apply: `graph_triggers_remaining=0`, `queue_rows=0`, `get_mentorship_distances` present.

## Follow-up (Phase 2)
Collapse `suggestions.ts` to the Supabase path, delete the dead cron route + `processGraphSyncQueue`/drift code, repoint the `data-health` graph section, drop the queue table/RPCs, and prune the FalkorDB tests.