### PR TITLE
feat(ai): switch assistant to glm-5.2 and harden tool calls

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -100,8 +100,8 @@ IP_HASH_SALT=your-random-salt
 
 # AI Assistant (z.ai)
 ZAI_API_KEY=your-zai-api-key
-# Optional: override default model (e.g. glm-5, glm-4.6v)
-ZAI_MODEL=glm-5
+# Optional: override default model (defaults to glm-5.2; e.g. glm-5.1, glm-5)
+ZAI_MODEL=glm-5.2
 
 # Semantic / embedding features (e.g. AI assistant paths that use embeddings)
 # EMBEDDING_API_KEY=your-gemini-api-key

--- a/apps/web/src/app/api/ai/[orgId]/chat/handler/stages/run-tool-calls.ts
+++ b/apps/web/src/app/api/ai/[orgId]/chat/handler/stages/run-tool-calls.ts
@@ -112,6 +112,20 @@ export function createToolCallHandler(input: CreateToolCallHandlerInput) {
     try {
       parsedArgs = JSON.parse(toolEvent.argsJson);
     } catch {
+      aiLog(
+        "warn",
+        "ai-chat",
+        "tool call dropped: malformed args JSON",
+        {
+          ...input.requestLogContext,
+          threadId: input.threadId ?? undefined,
+        },
+        {
+          toolName: toolEvent.name,
+          // PII-safe: log only the length of the unparseable payload.
+          argsJsonLength: toolEvent.argsJson.length,
+        },
+      );
       input.enqueue({
         type: "tool_status",
         toolName: toolEvent.name,
@@ -501,6 +515,20 @@ export function createToolCallHandler(input: CreateToolCallHandlerInput) {
         });
         return "continue";
       case "tool_error":
+        aiLog(
+          "warn",
+          "ai-chat",
+          "tool call returned tool_error",
+          {
+            ...input.requestLogContext,
+            threadId: input.threadId ?? undefined,
+          },
+          {
+            toolName: toolEvent.name,
+            error_code: result.code,
+            error: result.error,
+          },
+        );
         addToolCallTiming(input.stageTimings, {
           name: toolEvent.name,
           status: "failed",

--- a/apps/web/src/components/assistant/ConversationSidebar.tsx
+++ b/apps/web/src/components/assistant/ConversationSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Plus, MessageSquare, Trash2, ChevronLeft, ChevronRight, Clock } from "lucide-react";
 import type { AIPanelThread } from "@/components/ai-assistant/panel-state";
 import { formatThreadUpdatedAt } from "@/components/ai-assistant/thread-date";
@@ -58,6 +58,19 @@ function groupThreadsByTime(threads: AIPanelThread[]): ThreadGroup[] {
     .map(([label, threads]) => ({ label, threads }));
 }
 
+function ThreadListSkeleton() {
+  return (
+    <div className="space-y-2 px-1 py-2" aria-hidden="true">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex flex-col gap-1.5 rounded-lg px-3 py-2">
+          <div className="h-3 w-3/4 animate-pulse rounded bg-muted/70" />
+          <div className="h-2 w-2/5 animate-pulse rounded bg-muted/40" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function ConversationSidebar({
   threads,
   loading,
@@ -84,7 +97,24 @@ export function ConversationSidebar({
     }
   };
 
-  const groupedThreads = groupThreadsByTime(threads);
+  // Guard against selecting a thread that is mid-deletion.
+  const handleSelect = (threadId: string) => {
+    if (deletingId === threadId) return;
+    onSelectThread(threadId);
+  };
+
+  // role="button" rows are not natively keyboard-activatable; replicate the
+  // native button contract for Enter/Space.
+  const handleRowKeyDown = (threadId: string, e: React.KeyboardEvent) => {
+    if (deletingId === threadId) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onSelectThread(threadId);
+    }
+  };
+
+  // groupThreadsByTime walks every thread; only recompute when threads change.
+  const groupedThreads = useMemo(() => groupThreadsByTime(threads), [threads]);
 
   if (collapsed) {
     return (
@@ -158,9 +188,7 @@ export function ConversationSidebar({
           Previous chats
         </p>
         {loading ? (
-          <div className="flex items-center justify-center py-12">
-            <div className="h-5 w-5 animate-spin rounded-full border-2 border-org-secondary border-t-transparent" />
-          </div>
+          <ThreadListSkeleton />
         ) : threads.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12 text-center">
             <div className="mb-3 rounded-full bg-muted/50 p-3">
@@ -200,15 +228,20 @@ export function ConversationSidebar({
                         }`}
                       />
 
-                      <button
-                        type="button"
-                        onClick={() => onSelectThread(thread.id)}
-                        disabled={deletingId === thread.id}
-                        className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left transition-all ${
+                      {/* Row is a div with role="button" (not a real <button>) so the
+                          delete control can be a sibling instead of an illegal nested
+                          <button>, which triggers a React hydration error. */}
+                      <div
+                        role="button"
+                        tabIndex={deletingId === thread.id ? -1 : 0}
+                        aria-disabled={deletingId === thread.id}
+                        onClick={() => handleSelect(thread.id)}
+                        onKeyDown={(e) => handleRowKeyDown(thread.id, e)}
+                        className={`flex w-full cursor-pointer items-start gap-2 rounded-lg py-2 pl-3 pr-9 text-left transition-all ${
                           activeThreadId === thread.id
                             ? "bg-org-secondary/10"
                             : "hover:bg-muted/50"
-                        } ${deletingId === thread.id ? "opacity-50" : ""}`}
+                        } ${deletingId === thread.id ? "cursor-default opacity-50" : ""}`}
                       >
                         <div className="min-w-0 flex-1">
                           <p
@@ -224,16 +257,18 @@ export function ConversationSidebar({
                             {formatThreadUpdatedAt(thread.updated_at)}
                           </p>
                         </div>
+                      </div>
 
-                        <button
-                          type="button"
-                          onClick={(e) => handleDelete(thread.id, e)}
-                          disabled={deletingId === thread.id}
-                          aria-label="Delete conversation"
-                          className="shrink-0 rounded-md p-1 text-muted-foreground opacity-0 transition-all hover:bg-red-500/10 hover:text-red-500 group-hover:opacity-100"
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </button>
+                      {/* Sibling of the row, not a descendant. Still revealed by the
+                          .group hover on the wrapper, plus on keyboard focus. */}
+                      <button
+                        type="button"
+                        onClick={(e) => handleDelete(thread.id, e)}
+                        disabled={deletingId === thread.id}
+                        aria-label="Delete conversation"
+                        className="absolute right-2 top-2 shrink-0 rounded-md p-1 text-muted-foreground opacity-0 transition-all hover:bg-red-500/10 hover:text-red-500 focus-visible:opacity-100 group-hover:opacity-100"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
                       </button>
                     </div>
                   ))}

--- a/apps/web/src/lib/ai/client.ts
+++ b/apps/web/src/lib/ai/client.ts
@@ -1,6 +1,6 @@
 import OpenAI from "openai";
 
-const DEFAULT_ZAI_MODEL = "glm-5.1";
+const DEFAULT_ZAI_MODEL = "glm-5.2";
 const DEFAULT_ZAI_IMAGE_MODEL = "glm-5v-turbo";
 
 function validateZaiImageModel(value: string): string {

--- a/apps/web/src/lib/ai/semantic-cache-utils.ts
+++ b/apps/web/src/lib/ai/semantic-cache-utils.ts
@@ -102,6 +102,10 @@ const PERSONALIZATION_MARKERS = ["my", "mine", "i am", "i'm", "me", "myself"];
 const LIVE_CONTEXT_MARKERS = [
   "member",
   "members",
+  "admin",
+  "admins",
+  "administrator",
+  "administrators",
   "alumni",
   "parent",
   "parents",

--- a/apps/web/src/lib/ai/tools/executor.ts
+++ b/apps/web/src/lib/ai/tools/executor.ts
@@ -232,7 +232,13 @@ export async function executeToolCall(
   const toolName = call.name as ToolName;
 
   const validation = validateArgs(toolName, call.args);
-  if (!validation.valid) return toolError(validation.error);
+  if (!validation.valid) {
+    aiLog("warn", "ai-tools", "tool args failed validation", logContext, {
+      toolName,
+      error: validation.error,
+    });
+    return toolError(validation.error);
+  }
   const args = validation.args;
 
   if (ctx.authorization.kind === "verify_membership") {

--- a/apps/web/src/lib/ai/tools/registry/suggest-mentees.ts
+++ b/apps/web/src/lib/ai/tools/registry/suggest-mentees.ts
@@ -5,6 +5,9 @@ import { getSafeErrorMessage } from "@/lib/ai/tools/shared";
 import { toolError } from "@/lib/ai/tools/result";
 import type { ToolModule } from "./types";
 
+// NOTE: no `.strict()` — unknown keys emitted by the model are stripped rather
+// than rejected. The `.refine()` below still enforces the real "at least one
+// criterion" contract.
 const suggestMenteesSchema = z
   .object({
     mentor_id: z.string().uuid().optional(),
@@ -26,8 +29,7 @@ const suggestMenteesSchema = z
     {
       message: "Expected mentor_query, mentor_id, or mentorship criteria",
     },
-  )
-  .strict();
+  );
 
 type Args = z.infer<typeof suggestMenteesSchema>;
 

--- a/apps/web/src/lib/ai/tools/registry/suggest-mentors.ts
+++ b/apps/web/src/lib/ai/tools/registry/suggest-mentors.ts
@@ -5,14 +5,26 @@ import { getSafeErrorMessage } from "@/lib/ai/tools/shared";
 import { toolError } from "@/lib/ai/tools/result";
 import type { ToolModule } from "./types";
 
+/**
+ * Accept either a single string or an array of strings, normalizing to an
+ * array. Tolerates glm-5.2 emitting a bare string where the schema expects a
+ * list, without weakening the per-element validation.
+ */
+const stringOrStringArray = z
+  .union([z.string().trim().min(1), z.array(z.string().trim().min(1))])
+  .transform((value) => (Array.isArray(value) ? value : [value]));
+
+// NOTE: no `.strict()` — unknown keys emitted by the model are stripped rather
+// than rejected. The `.refine()` below still enforces the real "at least one
+// criterion" contract.
 const suggestMentorsSchema = z
   .object({
     mentee_id: z.string().uuid().optional(),
     mentee_query: z.string().trim().min(1).optional(),
-    focus_areas: z.array(z.string().trim().min(1)).optional(),
-    topics: z.array(z.string().trim().min(1)).optional(),
-    industries: z.array(z.string().trim().min(1)).optional(),
-    role_families: z.array(z.string().trim().min(1)).optional(),
+    focus_areas: stringOrStringArray.optional(),
+    topics: stringOrStringArray.optional(),
+    industries: stringOrStringArray.optional(),
+    role_families: stringOrStringArray.optional(),
     goals: z.string().trim().min(1).optional(),
     limit: z.number().int().min(1).max(25).optional(),
   })
@@ -28,8 +40,7 @@ const suggestMentorsSchema = z
     {
       message: "Expected mentee_query, mentee_id, or mentorship criteria",
     },
-  )
-  .strict();
+  );
 
 type Args = z.infer<typeof suggestMentorsSchema>;
 

--- a/apps/web/tests/ai-client.test.ts
+++ b/apps/web/tests/ai-client.test.ts
@@ -1,13 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-test("getZaiModel defaults to glm-5.1", async () => {
+test("getZaiModel defaults to glm-5.2", async () => {
   const previous = process.env.ZAI_MODEL;
   delete process.env.ZAI_MODEL;
 
   const { getZaiModel } = await import("../src/lib/ai/client.ts");
 
-  assert.equal(getZaiModel(), "glm-5.1");
+  assert.equal(getZaiModel(), "glm-5.2");
 
   if (previous === undefined) {
     delete process.env.ZAI_MODEL;

--- a/apps/web/tests/ai-semantic-cache.test.ts
+++ b/apps/web/tests/ai-semantic-cache.test.ts
@@ -324,6 +324,15 @@ describe("checkCacheEligibility", () => {
     assert.equal(result.reason, "requires_live_org_context");
   });
 
+  it("returns ineligible with requires_live_org_context for admin-roster questions", () => {
+    const result = checkCacheEligibility({
+      message: "Who are the admins of this organization?",
+      surface: "general",
+    });
+    assert.equal(result.eligible, false);
+    assert.equal(result.reason, "requires_live_org_context");
+  });
+
   it("returns ineligible with implies_write_or_tool for 'Create an annual event'", () => {
     const result = checkCacheEligibility({
       message: "Create a welcome page for the organization",
@@ -385,6 +394,8 @@ describe("checkCacheEligibility", () => {
     { name: "event details", message: "Describe the event for our chapter" },
     { name: "discussion threads", message: "What are people saying in the discussion" },
     { name: "job postings", message: "Show open job postings for our org" },
+    { name: "org admins", message: "Who are the admins of this organization" },
+    { name: "single administrator", message: "Who is the administrator here" },
   ];
 
   for (const tc of liveContextRegressionCases) {

--- a/apps/web/tests/mentorship-suggest-mentees.test.ts
+++ b/apps/web/tests/mentorship-suggest-mentees.test.ts
@@ -48,6 +48,21 @@ describe("suggest_mentees tool schema", () => {
       false
     );
   });
+
+  it("strips unknown keys emitted by the model instead of erroring", () => {
+    const parsed = suggestMenteesModule.argsSchema.safeParse({
+      mentor_query: "Pat",
+      // glm-5.2 sometimes emits stray keys; these must not fail the call.
+      unexpected_extra_key: "ignored",
+    });
+    assert.equal(parsed.success, true);
+    assert.ok(parsed.success);
+    assert.equal(
+      (parsed.data as Record<string, unknown>).unexpected_extra_key,
+      undefined,
+      "unknown key should be stripped, not retained"
+    );
+  });
 });
 
 describe("formatSuggestMenteesResponse", () => {

--- a/apps/web/tests/mentorship-suggest-mentors-schema.test.ts
+++ b/apps/web/tests/mentorship-suggest-mentors-schema.test.ts
@@ -1,18 +1,50 @@
-import { describe, it } from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 
 import { suggestMentorsModule } from "@/lib/ai/tools/registry/suggest-mentors";
 
-describe("suggest_mentors tool schema", () => {
-  it("accepts either a person or criteria", () => {
-    const schema = suggestMentorsModule.argsSchema;
+const schema = suggestMentorsModule.argsSchema;
 
-    assert.equal(schema.safeParse({}).success, false);
-    assert.equal(schema.safeParse({ mentee_query: "Jane" }).success, true);
-    assert.equal(schema.safeParse({ topics: ["marketing"] }).success, true);
-    assert.equal(schema.safeParse({ industries: ["Law"] }).success, true);
-    assert.equal(schema.safeParse({ role_families: ["Legal"] }).success, true);
-    assert.equal(schema.safeParse({ goals: "break into product" }).success, true);
-    assert.equal(schema.safeParse({ topics: ["marketing"], limit: 99 }).success, false);
+test("coerces a single-string focus_areas into a one-element array", () => {
+  const parsed = schema.parse({ focus_areas: "product management" });
+  assert.deepEqual(parsed.focus_areas, ["product management"]);
+});
+
+test("coerces single strings for topics/industries/role_families", () => {
+  const parsed = schema.parse({
+    topics: "leadership",
+    industries: "sports",
+    role_families: "operations",
   });
+  assert.deepEqual(parsed.topics, ["leadership"]);
+  assert.deepEqual(parsed.industries, ["sports"]);
+  assert.deepEqual(parsed.role_families, ["operations"]);
+});
+
+test("leaves an array of strings unchanged", () => {
+  const parsed = schema.parse({ focus_areas: ["pm", "growth"] });
+  assert.deepEqual(parsed.focus_areas, ["pm", "growth"]);
+});
+
+test("strips unknown keys instead of rejecting (glm tolerance)", () => {
+  const parsed = schema.parse({
+    focus_areas: "product",
+    reasoning: "because the user asked about PM",
+  }) as Record<string, unknown>;
+  assert.deepEqual(parsed.focus_areas, ["product"]);
+  assert.equal("reasoning" in parsed, false);
+});
+
+test("accepts a mentee_id alone", () => {
+  const id = "11111111-1111-4111-8111-111111111111";
+  const parsed = schema.parse({ mentee_id: id });
+  assert.equal(parsed.mentee_id, id);
+});
+
+test("rejects empty args (refine: at least one criterion)", () => {
+  assert.throws(() => schema.parse({}), /mentee_query, mentee_id, or mentorship criteria/);
+});
+
+test("rejects an empty-string focus_areas element", () => {
+  assert.throws(() => schema.parse({ focus_areas: ["   "] }));
 });


### PR DESCRIPTION
## Summary

Switches the AI assistant's default model from **glm-5.1 → glm-5.2**, then fixes four bugs surfaced while testing the new model (three were latent, not model-specific). Live testing showed the model upgrade exposed brittle tool-arg handling and a couple of pre-existing pipeline/UI defects.

## Changes

**Model switch**
- `DEFAULT_ZAI_MODEL` → `glm-5.2` (override still honored via `ZAI_MODEL`).
- Pricing keys match by substring, so `glm-5.2` maps to the existing `glm-5` cost entry — no new price row needed.

**Bug fixes (assistant)**
1. **Admin/roster questions got zero tools.** "Who are the admins of this organization?" was classified `static_general` → `toolPolicy: none` → no tools → model replied "I don't have access to member data." Added `admin`/`admins`/`administrator` to `LIVE_CONTEXT_MARKERS` so these turns are treated as live-org-context and get `list_members` (which returns role).
2. **Tool args brittle to glm-5.2 formatting.** `suggest_mentors`/`suggest_mentees` used `.strict()` + array-only criteria; glm-5.2 emitted stray keys / single strings and the call hard-failed. Now: unknown keys are stripped (not rejected) and a single string coerces to a one-element array. The "at least one criterion" `refine` is preserved.
3. **Silent tool failures.** Malformed-args JSON parse, the `tool_error` SSE conversion, and arg-validation rejection emitted `tool_status: error` to the client but logged nothing server-side. They now `aiLog(warn)` with tool name + error context (no raw args / PII).
4. **Hydration error.** `ConversationSidebar` nested a delete `<button>` inside the row `<button>` ("`<button>` cannot be a descendant of `<button>`"). Row is now `div role="button"` with Enter/Space activation + `aria-disabled`; delete is a sibling button. Also memoized thread grouping and added a loading skeleton.

## Notes / honest caveats

- **Perf:** the ~1.8s assistant page load is **mostly Next.js dev-mode compile overhead, not a fetch waterfall** — threads/messages already fetch in parallel and feedback is already deferred. Applied the cheap wins (memo + skeleton); no large waterfall to unwind. Prod load is unaffected.
- `suggest_mentors` keeps all criteria fields (`focus_areas`, `topics`, `industries`, `role_families`, `goals`) — an earlier automated pass tried to drop them; they are used by the tool's `execute`.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- 230 touched + AI regression tests pass (`ai-client`, `ai-semantic-cache`, `mentorship-suggest-mentors-schema`, `mentorship-suggest-mentees`, `ai-pass1-tools`, `ai-tool-grounding`)
- Rebased onto latest `origin/main`; no stale `falkordb` imports after the `lib/people-graph` rename.

## Rollout / rollback

- Model is env-overridable: set `ZAI_MODEL=glm-5.1` to revert without a deploy.
- All other changes are backward-compatible (looser validation, added logging, accessible markup).