### PR TITLE
Nielsen heuristics audit + remediation (web + mobile)

### DIFF
--- a/apps/mobile/src/components/OverflowMenu.tsx
+++ b/apps/mobile/src/components/OverflowMenu.tsx
@@ -51,7 +51,7 @@ export function OverflowMenu({
     },
     overlay: {
       flex: 1,
-      backgroundColor: "rgba(0, 0, 0, 0.4)",
+      backgroundColor: n.overlay,
       justifyContent: "flex-end" as const,
       paddingHorizontal: SPACING.md,
       paddingBottom: SPACING.xl,
@@ -130,7 +130,12 @@ export function OverflowMenu({
         animationType="fade"
         onRequestClose={handleClose}
       >
-        <Pressable style={styles.overlay} onPress={handleClose}>
+        <Pressable
+          style={styles.overlay}
+          onPress={handleClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close menu"
+        >
           <View style={styles.menuContainer}>
             <View style={styles.menu}>
               {items.map((item, index) => (
@@ -142,6 +147,8 @@ export function OverflowMenu({
                     pressed && { opacity: 0.7 },
                   ]}
                   onPress={() => handleItemPress(item)}
+                  accessibilityRole="button"
+                  accessibilityLabel={item.label}
                 >
                   {item.icon && <View style={styles.menuItemIcon}>{item.icon}</View>}
                   <Text
@@ -159,6 +166,8 @@ export function OverflowMenu({
             <Pressable
               style={({ pressed }) => [styles.cancelButton, pressed && { opacity: 0.7 }]}
               onPress={handleClose}
+              accessibilityRole="button"
+              accessibilityLabel="Cancel"
             >
               <Text style={styles.cancelButtonText}>Cancel</Text>
             </Pressable>

--- a/apps/mobile/src/components/settings/SettingsDangerSection.tsx
+++ b/apps/mobile/src/components/settings/SettingsDangerSection.tsx
@@ -217,7 +217,9 @@ export function SettingsDangerSection({ orgId, orgSlug, orgName, isAdmin, subscr
       Alert.alert("Deleted", "Your organization has been deleted.");
       router.replace("/(app)");
     } catch (e) {
-      Alert.alert("Error", (e as Error).message);
+      const message =
+        e instanceof Error && e.message ? e.message : "Couldn't delete the organization. Please try again.";
+      Alert.alert("Couldn't delete organization", message);
     } finally {
       setDeleting(false);
       setShowDeleteConfirm(false);

--- a/apps/mobile/src/components/ui/SelectField.tsx
+++ b/apps/mobile/src/components/ui/SelectField.tsx
@@ -31,6 +31,8 @@ export function SelectField({
       <Text style={styles.fieldLabel}>{label}</Text>
       <Pressable
         onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={`${label}: ${value || placeholder}`}
         style={({ pressed }) => [
           styles.selectField,
           pressed && styles.selectFieldPressed,
@@ -69,12 +71,19 @@ export function SelectModal({
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-      <Pressable style={styles.modalBackdrop} onPress={onClose}>
+      <Pressable
+        style={styles.modalBackdrop}
+        onPress={onClose}
+        accessibilityRole="button"
+        accessibilityLabel="Close"
+      >
         <View style={styles.modalSheet} onStartShouldSetResponder={() => true}>
           <View style={styles.modalHeader}>
             <Text style={styles.modalTitle}>{title}</Text>
             <Pressable
               onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
               hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             >
               <Text style={styles.modalCloseText}>Close</Text>

--- a/apps/web/src/app/[orgSlug]/chat/new/NewChatGroupForm.tsx
+++ b/apps/web/src/app/[orgSlug]/chat/new/NewChatGroupForm.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { Card, Button, Input, Textarea, Avatar, Badge } from "@/components/ui";
 import { PageHeader } from "@/components/layout";
+import { newChatGroupSchema } from "@/lib/schemas/chat";
+import { showFeedback } from "@/lib/feedback/show-feedback";
 
 interface NewChatGroupFormProps {
   orgSlug: string;
@@ -93,8 +95,13 @@ export function NewChatGroupForm({ orgSlug, organizationId, currentUserId }: New
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!formData.name.trim()) {
-      setError("Group name is required");
+
+    // Validate name/description client-side (shared schema) before submitting.
+    const parsed = newChatGroupSchema
+      .pick({ name: true, description: true })
+      .safeParse({ name: formData.name, description: formData.description || undefined });
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? "Group name is required");
       return;
     }
 
@@ -116,7 +123,9 @@ export function NewChatGroupForm({ orgSlug, organizationId, currentUserId }: New
       .single();
 
     if (createError || !group) {
-      setError(createError?.message || "Failed to create group");
+      console.error("[chat-group] create failed:", createError);
+      setError("Couldn't create the group. Please try again.");
+      showFeedback("Couldn't create the group. Please try again.", "error");
       setIsSubmitting(false);
       return;
     }
@@ -154,7 +163,8 @@ export function NewChatGroupForm({ orgSlug, organizationId, currentUserId }: New
 
     if (membersError) {
       console.error("[chat-members] Failed to add members:", membersError.message, membersError);
-      setError(`Failed to add members: ${membersError.message}`);
+      setError("The group was created, but we couldn't add everyone. Please try adding members again.");
+      showFeedback("Couldn't add some members. Please try again.", "error");
       setIsSubmitting(false);
       return;
     }

--- a/apps/web/src/app/[orgSlug]/competition/add-points/page.tsx
+++ b/apps/web/src/app/[orgSlug]/competition/add-points/page.tsx
@@ -5,6 +5,8 @@ import { useRouter, useParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { Card, Button, Input, Textarea, Select } from "@/components/ui";
 import { PageHeader } from "@/components/layout";
+import { addPointsFormSchema } from "@/lib/schemas/competition";
+import { showFeedback } from "@/lib/feedback/show-feedback";
 
 type TeamOption = { id: string; name: string };
 
@@ -73,8 +75,11 @@ export default function AddPointsPage() {
       return;
     }
 
-    if (!formData.team_id && !formData.team_name) {
-      setError("Select a team or enter a team name");
+    // Validate client-side before hitting the database so the user sees a clear,
+    // field-level message rather than a raw constraint error after submit.
+    const parsed = addPointsFormSchema.safeParse(formData);
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? "Please check the form and try again.");
       return;
     }
 
@@ -86,19 +91,22 @@ export default function AddPointsPage() {
     const { error: insertError } = await supabase.from("competition_points").insert({
       competition_id: competitionId,
       organization_id: organizationId,
-      team_id: formData.team_id || null,
-      team_name: formData.team_name || null,
-      points: parseInt(formData.points),
-      notes: formData.notes || null,
-      reason: formData.reason || null,
+      team_id: parsed.data.team_id || null,
+      team_name: parsed.data.team_name || null,
+      points: parseInt(parsed.data.points, 10),
+      notes: parsed.data.notes || null,
+      reason: parsed.data.reason || null,
     });
 
     if (insertError) {
-      setError(insertError.message);
+      console.error("[add-points] insert failed:", insertError);
+      setError("Couldn't save these points. Please try again.");
+      showFeedback("Couldn't save these points. Please try again.", "error");
       setIsLoading(false);
       return;
     }
 
+    showFeedback("Points added", "success");
     router.push(`/${orgSlug}/competition`);
     router.refresh();
   };
@@ -114,7 +122,10 @@ export default function AddPointsPage() {
       <Card className="max-w-2xl">
         <form onSubmit={handleSubmit} className="p-6 space-y-6">
           {error && (
-            <div className="p-3 rounded-xl bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 text-sm">
+            <div
+              role="alert"
+              className="p-3 rounded-xl bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 text-sm"
+            >
               {error}
             </div>
           )}
@@ -139,9 +150,10 @@ export default function AddPointsPage() {
           <Input
             label="Points"
             type="number"
+            step={1}
             value={formData.points}
             onChange={(e) => setFormData({ ...formData, points: e.target.value })}
-            placeholder="Enter points (can be negative)"
+            placeholder="Enter a whole number (can be negative)"
             required
           />
 
@@ -173,4 +185,3 @@ export default function AddPointsPage() {
     </div>
   );
 }
-

--- a/apps/web/src/app/[orgSlug]/layout.tsx
+++ b/apps/web/src/app/[orgSlug]/layout.tsx
@@ -328,6 +328,12 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
     <AIPanelProvider autoOpen={isAdmin}>
     <OrgGlobalSearch orgSlug={orgSlug} orgId={organization.id} currentProfileHref={currentProfileHref}>
     <div data-org-shell className="min-h-screen">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-lg focus:bg-card focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-foreground focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring"
+      >
+        Skip to main content
+      </a>
       <style
         dangerouslySetInnerHTML={{
           __html: (() => {

--- a/apps/web/src/components/analytics/ConsentModal.tsx
+++ b/apps/web/src/components/analytics/ConsentModal.tsx
@@ -14,7 +14,7 @@ import {
   setAnalyticsPolicy,
   type ConsentState,
 } from "@/lib/analytics/events";
-import { Button, Card } from "@/components/ui";
+import { Button, Modal } from "@/components/ui";
 
 interface ConsentModalState {
   isOpen: boolean;
@@ -173,8 +173,16 @@ export function ConsentModal() {
   }
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 px-4">
-      <Card className="w-full max-w-xl p-6 space-y-4" role="dialog" aria-modal="true">
+    // A consent gate: the user must choose Decline or Accept, so this modal is
+    // intentionally not dismissible via Escape/overlay (onOpenChange is a no-op).
+    <Modal
+      open
+      onOpenChange={() => {}}
+      size="xl"
+      hideCloseButton
+      ariaLabel="Help us improve TeamNetwork"
+    >
+      <div className="space-y-4">
         <div>
           <h2 className="text-xl font-semibold text-foreground">Help us improve TeamNetwork</h2>
           <p className="text-sm text-muted-foreground mt-2">
@@ -191,7 +199,7 @@ export function ConsentModal() {
         </div>
 
         {state.message && (
-          <p className="text-sm text-red-600 dark:text-red-400">{state.message}</p>
+          <p className="text-sm text-error">{state.message}</p>
         )}
 
         <div className="flex flex-wrap items-center justify-between gap-3">
@@ -216,7 +224,7 @@ export function ConsentModal() {
             </Button>
           </div>
         </div>
-      </Card>
-    </div>
+      </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/chat/ManageMembersPanel.tsx
+++ b/apps/web/src/components/chat/ManageMembersPanel.tsx
@@ -2,8 +2,10 @@
 
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 import { Avatar, Badge, Button, Input } from "@/components/ui";
+import { ConfirmationDialog } from "@/components/ui/ConfirmationDialog";
 import { trackBehavioralEvent } from "@/lib/analytics/events";
 
 interface MemberRow {
@@ -58,6 +60,7 @@ export function ManageMembersPanel({
   const [searchQuery, setSearchQuery] = useState("");
   const [showAddSection, setShowAddSection] = useState(false);
   const [actionInProgress, setActionInProgress] = useState<string | null>(null);
+  const [removalTarget, setRemovalTarget] = useState<{ userId: string; isSelf: boolean; name: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const supabase = createClient();
 
@@ -169,10 +172,9 @@ export function ManageMembersPanel({
     setActionInProgress(null);
   };
 
-  const handleRemoveMember = async (userId: string) => {
-    const isSelf = userId === currentUserId;
-    if (isSelf && !confirm("Are you sure you want to leave this group?")) return;
-    if (!isSelf && !confirm("Remove this member from the group?")) return;
+  const confirmRemoveMember = async () => {
+    if (!removalTarget) return;
+    const { userId, isSelf } = removalTarget;
 
     setActionInProgress(userId);
     setError(null);
@@ -203,6 +205,7 @@ export function ManageMembersPanel({
         result: "fail_server",
       }, organizationId);
       setActionInProgress(null);
+      setRemovalTarget(null);
       return;
     }
 
@@ -227,6 +230,11 @@ export function ManageMembersPanel({
     }, organizationId);
     onMembersChanged();
     setActionInProgress(null);
+    setRemovalTarget(null);
+    // Soft-delete sets removed_at, so re-adding restores the member — offer undo.
+    toast.success(`Removed ${removalTarget.name}`, {
+      action: { label: "Undo", onClick: () => handleAddMember(userId) },
+    });
   };
 
   const roleBadgeVariant = (role: string) => {
@@ -287,7 +295,7 @@ export function ManageMembersPanel({
                   <Button
                     size="sm"
                     variant="secondary"
-                    onClick={() => handleRemoveMember(member.user_id)}
+                    onClick={() => setRemovalTarget({ userId: member.user_id, isSelf: true, name: displayName })}
                     disabled={actionInProgress === member.user_id}
                     className="text-xs"
                   >
@@ -295,8 +303,9 @@ export function ManageMembersPanel({
                   </Button>
                 ) : !isSelf && canManage ? (
                   <button
-                    onClick={() => handleRemoveMember(member.user_id)}
+                    onClick={() => setRemovalTarget({ userId: member.user_id, isSelf: false, name: displayName })}
                     disabled={actionInProgress === member.user_id}
+                    aria-label={`Remove ${displayName} from the group`}
                     className="text-muted-foreground hover:text-red-500 transition-colors disabled:opacity-50"
                   >
                     <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -373,6 +382,21 @@ export function ManageMembersPanel({
           )}
         </div>
       )}
+
+      <ConfirmationDialog
+        open={removalTarget !== null}
+        onOpenChange={(open) => { if (!open) setRemovalTarget(null); }}
+        onConfirm={confirmRemoveMember}
+        isPending={removalTarget !== null && actionInProgress === removalTarget.userId}
+        title={removalTarget?.isSelf ? "Leave this group?" : `Remove ${removalTarget?.name ?? "member"}?`}
+        description={
+          removalTarget?.isSelf
+            ? "You'll stop receiving messages from this group. You can be re-added later."
+            : "They'll be removed from the group. You can add them back afterward."
+        }
+        confirmLabel={removalTarget?.isSelf ? "Leave" : "Remove"}
+        destructive
+      />
     </div>
   );
 }

--- a/apps/web/src/components/enterprise/BulkExportButton.tsx
+++ b/apps/web/src/components/enterprise/BulkExportButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Button, InlineBanner } from "@/components/ui";
+import { Button, InlineBanner, Spinner } from "@/components/ui";
 
 interface ExportField {
   key: string;
@@ -207,7 +207,7 @@ export function BulkExportButton({
                 disabled={isExporting || selectedFields.size === 0}
               >
                 {isExporting ? (
-                  <LoadingSpinner className="h-4 w-4" />
+                  <Spinner className="h-4 w-4" />
                 ) : (
                   <FileIcon className="h-4 w-4" />
                 )}
@@ -253,22 +253,3 @@ function FileIcon({ className }: { className?: string }) {
   );
 }
 
-function LoadingSpinner({ className }: { className?: string }) {
-  return (
-    <svg className={`${className} animate-spin`} fill="none" viewBox="0 0 24 24">
-      <circle
-        className="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        strokeWidth="4"
-      />
-      <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-      />
-    </svg>
-  );
-}

--- a/apps/web/src/components/enterprise/OrgLimitUpgradeModal.tsx
+++ b/apps/web/src/components/enterprise/OrgLimitUpgradeModal.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
-import { Button } from "@/components/ui";
+import { Button, Modal } from "@/components/ui";
 import {
   ALUMNI_BUCKET_PRICING,
   ENTERPRISE_SEAT_PRICING,
@@ -46,41 +45,6 @@ type OrgLimitUpgradeModalProps = SubOrgUpgradeProps | AlumniBucketUpgradeProps;
 
 export function OrgLimitUpgradeModal(props: OrgLimitUpgradeModalProps) {
   const { isOpen, onClose, onConfirm, isLoading, upgradeType } = props;
-  const modalRef = useRef<HTMLDivElement>(null);
-
-  const handleOverlayClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget && !isLoading) {
-        onClose();
-      }
-    },
-    [onClose, isLoading]
-  );
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isOpen && !isLoading) {
-        onClose();
-      }
-    },
-    [isOpen, onClose, isLoading]
-  );
-
-  useEffect(() => {
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleKeyDown]);
-
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [isOpen]);
 
   const handleConfirm = async () => {
     await onConfirm();
@@ -103,19 +67,15 @@ export function OrgLimitUpgradeModal(props: OrgLimitUpgradeModalProps) {
   )}/${subOrgInterval === "month" ? "mo" : "yr"}`;
 
   return (
-    <div
-      className="fixed inset-0 bg-background/80 backdrop-blur-sm z-50 flex items-center justify-center p-4"
-      onClick={handleOverlayClick}
-      aria-hidden="false"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="upgrade-modal-title"
+    <Modal
+      open
+      onOpenChange={(nextOpen) => { if (!nextOpen && !isLoading) onClose(); }}
+      size="md"
+      noPadding
+      hideCloseButton
+      ariaLabel={title}
     >
-      <div
-        ref={modalRef}
-        className="bg-card border border-border rounded-xl shadow-lg w-full max-w-md max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div>
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border">
           <h2 id="upgrade-modal-title" className="text-lg font-semibold text-foreground">
@@ -286,6 +246,6 @@ export function OrgLimitUpgradeModal(props: OrgLimitUpgradeModalProps) {
           )}
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/feed/FeedPost.tsx
+++ b/apps/web/src/components/feed/FeedPost.tsx
@@ -9,6 +9,9 @@ import { PostMedia } from "./PostMedia";
 import { InlineComments } from "./InlineComments";
 import { FeedPoll } from "./FeedPoll";
 import { ReportBlockMenu } from "@/components/moderation/ReportBlockMenu";
+import { ConfirmationDialog } from "@/components/ui/ConfirmationDialog";
+import { showFeedback } from "@/lib/feedback/show-feedback";
+import { getMutationErrorMessage } from "@/lib/client/use-mutation-action";
 import { relativeTime } from "@/lib/utils/relative-time";
 import type { PostWithAuthor } from "./types";
 
@@ -22,6 +25,7 @@ interface FeedPostProps {
 export function FeedPost({ post, orgSlug, currentUserId, isAdmin }: FeedPostProps) {
   const router = useRouter();
   const [isDeleting, setIsDeleting] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [isCommentsOpen, setIsCommentsOpen] = useState(false);
   const [commentCount, setCommentCount] = useState(post.comment_count);
 
@@ -30,16 +34,18 @@ export function FeedPost({ post, orgSlug, currentUserId, isAdmin }: FeedPostProp
   const authorName = post.author?.name || "Unknown";
 
   const handleDelete = async () => {
-    if (!confirm("Are you sure you want to delete this post?")) return;
-
     setIsDeleting(true);
     try {
       const response = await fetch(`/api/feed/${post.id}`, { method: "DELETE" });
-      if (response.ok) {
-        router.refresh();
+      if (!response.ok) {
+        const data = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(data?.error || "Failed to delete post");
       }
-    } catch {
-      // Error handled silently
+      setConfirmOpen(false);
+      showFeedback("Post deleted", "success");
+      router.refresh();
+    } catch (err) {
+      showFeedback(getMutationErrorMessage(err, "Couldn't delete the post. Please try again."), "error");
     } finally {
       setIsDeleting(false);
     }
@@ -68,15 +74,23 @@ export function FeedPost({ post, orgSlug, currentUserId, isAdmin }: FeedPostProp
               )}
               {canDelete && (
                 <button
-                  onClick={handleDelete}
+                  onClick={() => setConfirmOpen(true)}
                   disabled={isDeleting}
-                  className="p-1.5 rounded-lg text-muted-foreground/40 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30 opacity-0 group-hover:opacity-100 transition-all focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                  aria-label={isDeleting ? "Deleting post..." : "Delete post"}
+                  className="p-1.5 rounded-lg text-muted-foreground/40 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30 opacity-0 group-hover:opacity-100 transition-all focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 motion-reduce:transition-none disabled:opacity-100"
+                  aria-label={isDeleting ? "Deleting post…" : "Delete post"}
+                  aria-busy={isDeleting}
                   type="button"
                 >
-                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-                  </svg>
+                  {isDeleting ? (
+                    <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth={4} />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                  ) : (
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                  )}
                 </button>
               )}
             </div>
@@ -122,6 +136,16 @@ export function FeedPost({ post, orgSlug, currentUserId, isAdmin }: FeedPostProp
           onCountChange={setCommentCount}
         />
       )}
+      <ConfirmationDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        onConfirm={handleDelete}
+        isPending={isDeleting}
+        title="Delete post?"
+        description="This post will be removed for everyone. This can't be undone."
+        confirmLabel="Delete"
+        destructive
+      />
     </Card>
   );
 }

--- a/apps/web/src/components/feed/InlineComments.tsx
+++ b/apps/web/src/components/feed/InlineComments.tsx
@@ -21,6 +21,8 @@ const INITIAL_DISPLAY = 3;
 export function InlineComments({ postId, commentCount, currentUserId, orgSlug, onCountChange }: InlineCommentsProps) {
   const [comments, setComments] = useState<CommentWithAuthor[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
   const [body, setBody] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -32,9 +34,13 @@ export function InlineComments({ postId, commentCount, currentUserId, orgSlug, o
   useEffect(() => {
     let cancelled = false;
     async function fetchComments() {
+      if (!cancelled) {
+        setIsLoading(true);
+        setLoadError(false);
+      }
       try {
         const res = await fetch(`/api/feed/${postId}/comments`);
-        if (!res.ok) return;
+        if (!res.ok) throw new Error("request_failed");
         const data = await res.json();
         if (!cancelled) {
           setComments(data.comments);
@@ -42,12 +48,15 @@ export function InlineComments({ postId, commentCount, currentUserId, orgSlug, o
           setIsLoading(false);
         }
       } catch {
-        if (!cancelled) setIsLoading(false);
+        if (!cancelled) {
+          setLoadError(true);
+          setIsLoading(false);
+        }
       }
     }
     fetchComments();
     return () => { cancelled = true; };
-  }, [postId, onCountChange]);
+  }, [postId, onCountChange, reloadKey]);
 
   useEffect(() => {
     if (!isLoading && inputRef.current) {
@@ -212,6 +221,17 @@ export function InlineComments({ postId, commentCount, currentUserId, orgSlug, o
               </div>
             </div>
           ))}
+        </div>
+      ) : loadError ? (
+        <div className="flex items-center justify-between gap-2 px-1 py-2 text-xs text-muted-foreground">
+          <span>Couldn&apos;t load comments.</span>
+          <button
+            type="button"
+            onClick={() => setReloadKey((k) => k + 1)}
+            className="font-medium text-org-primary hover:text-org-primary/80 transition-colors"
+          >
+            Retry
+          </button>
         </div>
       ) : (
         <div className="space-y-3">

--- a/apps/web/src/components/feed/PostDetail.tsx
+++ b/apps/web/src/components/feed/PostDetail.tsx
@@ -5,6 +5,9 @@ import { useRouter } from "next/navigation";
 import { UserContent } from "@/components/i18n/UserContent";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
+import { ConfirmationDialog } from "@/components/ui/ConfirmationDialog";
+import { showFeedback } from "@/lib/feedback/show-feedback";
+import { getMutationErrorMessage } from "@/lib/client/use-mutation-action";
 import { LikeButton } from "./LikeButton";
 import { PostMedia } from "./PostMedia";
 import type { PostWithAuthor } from "./types";
@@ -30,19 +33,22 @@ function formatDateTime(dateString: string): string {
 export function PostDetail({ post, orgSlug, currentUserId, isAdmin }: PostDetailProps) {
   const router = useRouter();
   const [isDeleting, setIsDeleting] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const canDelete = post.author_id === currentUserId || isAdmin;
 
   const handleDelete = async () => {
-    if (!confirm("Are you sure you want to delete this post?")) return;
-
     setIsDeleting(true);
     try {
       const response = await fetch(`/api/feed/${post.id}`, { method: "DELETE" });
-      if (response.ok) {
-        router.push(`/${orgSlug}/feed`);
+      if (!response.ok) {
+        const data = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(data?.error || "Failed to delete post");
       }
-    } catch {
+      showFeedback("Post deleted", "success");
+      router.push(`/${orgSlug}/feed`);
+    } catch (err) {
+      showFeedback(getMutationErrorMessage(err, "Couldn't delete the post. Please try again."), "error");
       setIsDeleting(false);
     }
   };
@@ -58,8 +64,8 @@ export function PostDetail({ post, orgSlug, currentUserId, isAdmin }: PostDetail
           {formatDateTime(post.created_at)}
         </div>
         {canDelete && (
-          <Button onClick={handleDelete} disabled={isDeleting} variant="ghost" size="sm">
-            {isDeleting ? "Deleting..." : "Delete"}
+          <Button onClick={() => setConfirmOpen(true)} disabled={isDeleting} variant="ghost" size="sm">
+            Delete
           </Button>
         )}
       </div>
@@ -77,6 +83,16 @@ export function PostDetail({ post, orgSlug, currentUserId, isAdmin }: PostDetail
           {post.comment_count} {post.comment_count === 1 ? "comment" : "comments"}
         </span>
       </div>
+      <ConfirmationDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        onConfirm={handleDelete}
+        isPending={isDeleting}
+        title="Delete post?"
+        description="This post will be removed for everyone. This can't be undone."
+        confirmLabel="Delete"
+        destructive
+      />
     </Card>
   );
 }

--- a/apps/web/src/components/feedback/FeedbackModal.tsx
+++ b/apps/web/src/components/feedback/FeedbackModal.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useRef, useCallback } from "react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { Button, Textarea } from "@/components/ui";
+import { Button, Textarea, Modal } from "@/components/ui";
 
 type FeedbackStatus = "idle" | "submitting" | "success" | "error";
 
@@ -44,7 +44,6 @@ export function FeedbackModal({
   const [fileError, setFileError] = useState<string | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const modalRef = useRef<HTMLDivElement>(null);
 
   const resetForm = useCallback(() => {
     setMessage("");
@@ -62,40 +61,6 @@ export function FeedbackModal({
     resetForm();
     onClose();
   }, [onClose, resetForm]);
-
-  const handleOverlayClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget) {
-        handleClose();
-      }
-    },
-    [handleClose]
-  );
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isOpen) {
-        handleClose();
-      }
-    },
-    [isOpen, handleClose]
-  );
-
-  useEffect(() => {
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleKeyDown]);
-
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [isOpen]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -170,19 +135,15 @@ export function FeedbackModal({
   }
 
   return (
-    <div
-      className="fixed inset-0 bg-background/80 backdrop-blur-sm z-50 flex items-center justify-center p-4"
-      onClick={handleOverlayClick}
-      aria-hidden="false"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="feedback-modal-title"
+    <Modal
+      open={isOpen}
+      onOpenChange={(nextOpen) => { if (!nextOpen) handleClose(); }}
+      size="md"
+      noPadding
+      hideCloseButton
+      ariaLabel={t("shareFeedback")}
     >
-      <div
-        ref={modalRef}
-        className="bg-card border border-border rounded-xl shadow-lg w-full max-w-md max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div>
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border">
           <h2 id="feedback-modal-title" className="text-lg font-semibold text-foreground">
@@ -374,6 +335,6 @@ export function FeedbackModal({
           )}
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/forms/ExportCSVButton.tsx
+++ b/apps/web/src/components/forms/ExportCSVButton.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "@/components/ui";
 import { escapeCsvCell } from "@/lib/export/spreadsheet";
+import { showFeedback } from "@/lib/feedback/show-feedback";
 import type { Form, FormSubmission, FormField, User } from "@/types/database";
 
 interface ExportCSVButtonProps {
@@ -10,40 +12,51 @@ interface ExportCSVButtonProps {
 }
 
 export function ExportCSVButton({ form, submissions }: ExportCSVButtonProps) {
+  const [isExporting, setIsExporting] = useState(false);
+
   const handleExport = () => {
-    const fields = (form.fields || []) as unknown as FormField[];
+    setIsExporting(true);
+    try {
+      const fields = (form.fields || []) as unknown as FormField[];
 
-    // Build CSV headers
-    const headers = ["Submitted By", "Email", "Date", ...fields.map((f) => f.label)];
+      // Build CSV headers
+      const headers = ["Submitted By", "Email", "Date", ...fields.map((f) => f.label)];
 
-    const rows = submissions.map((sub) => {
-      const responses = (sub.data ?? {}) as Record<string, unknown>;
-      return [
-        sub.users?.name || "",
-        sub.users?.email || "",
-        sub.submitted_at ? new Date(sub.submitted_at).toLocaleDateString() : "",
-        ...fields.map((f) => formatValue(responses[f.name])),
-      ];
-    });
+      const rows = submissions.map((sub) => {
+        const responses = (sub.data ?? {}) as Record<string, unknown>;
+        return [
+          sub.users?.name || "",
+          sub.users?.email || "",
+          sub.submitted_at ? new Date(sub.submitted_at).toLocaleDateString() : "",
+          ...fields.map((f) => formatValue(responses[f.name])),
+        ];
+      });
 
-    // Create CSV content
-    const csvContent = [
-      headers.map(escapeCsvCell).join(","),
-      ...rows.map((row) => row.map(escapeCsvCell).join(",")),
-    ].join("\n");
+      // Create CSV content
+      const csvContent = [
+        headers.map(escapeCsvCell).join(","),
+        ...rows.map((row) => row.map(escapeCsvCell).join(",")),
+      ].join("\n");
 
-    // Download
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = `${form.title.replace(/[^a-z0-9]/gi, "_")}_submissions.csv`;
-    link.click();
-    URL.revokeObjectURL(url);
+      // Download
+      const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${form.title.replace(/[^a-z0-9]/gi, "_")}_submissions.csv`;
+      link.click();
+      URL.revokeObjectURL(url);
+      showFeedback(`Exported ${submissions.length} submission${submissions.length === 1 ? "" : "s"}.`, "success");
+    } catch (err) {
+      console.error("CSV export failed:", err);
+      showFeedback("Couldn't export submissions. Please try again.", "error");
+    } finally {
+      setIsExporting(false);
+    }
   };
 
   return (
-    <Button variant="secondary" onClick={handleExport} disabled={submissions.length === 0}>
+    <Button variant="secondary" onClick={handleExport} isLoading={isExporting} disabled={submissions.length === 0}>
       <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
       </svg>

--- a/apps/web/src/components/jobs/JobForm.tsx
+++ b/apps/web/src/components/jobs/JobForm.tsx
@@ -164,7 +164,7 @@ export function JobForm({ orgId, orgSlug, initialData }: JobFormProps) {
             ]}
           />
           {errors.experience_level && (
-            <p className="text-sm text-red-600 mt-1">{errors.experience_level}</p>
+            <p className="text-sm text-error mt-1">{errors.experience_level}</p>
           )}
         </div>
 
@@ -197,7 +197,7 @@ export function JobForm({ orgId, orgSlug, initialData }: JobFormProps) {
             ]}
           />
           {errors.location_type && (
-            <p className="text-sm text-red-600 mt-1">{errors.location_type}</p>
+            <p className="text-sm text-error mt-1">{errors.location_type}</p>
           )}
         </div>
 
@@ -265,7 +265,7 @@ export function JobForm({ orgId, orgSlug, initialData }: JobFormProps) {
         </div>
 
         {errors.submit && (
-          <div className="p-3 bg-red-50 border border-red-200 rounded text-sm text-red-600">
+          <div className="p-3 bg-red-50 border border-red-200 rounded text-sm text-error">
             {errors.submit}
           </div>
         )}

--- a/apps/web/src/components/layout/NavGroupSection.tsx
+++ b/apps/web/src/components/layout/NavGroupSection.tsx
@@ -154,6 +154,7 @@ export function NavItemLink({
       <Link
         data-testid={`nav-item-${navItemSlug}`}
         data-active={isActive ? "true" : "false"}
+        aria-current={isActive ? "page" : undefined}
         href={href}
         title={isCollapsed ? item.label : undefined}
         aria-label={isCollapsed ? item.label : undefined}
@@ -169,7 +170,7 @@ export function NavItemLink({
           );
           onClose?.();
         }}
-        className={`flex items-center text-sm font-medium transition-[background-color,color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${
+        className={`flex items-center text-sm font-medium transition-[background-color,color,box-shadow] duration-200 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${
           isCollapsed
             ? "justify-center w-10 h-10 rounded-xl"
             : "gap-3 px-3 py-2.5 rounded-xl"

--- a/apps/web/src/components/layout/OrgMainContent.tsx
+++ b/apps/web/src/components/layout/OrgMainContent.tsx
@@ -20,7 +20,9 @@ export function OrgMainContent({ children, hasTopBanner }: OrgMainContentProps) 
 
   return (
     <main
-      className={`lg:ml-[var(--sidebar-offset,3.5rem)] transition-[margin] duration-300 ease-in-out motion-reduce:transition-none ${reserveDrawerMargin ? "lg:mr-[420px]" : ""} ${isFullBleed ? "h-[calc(100dvh-4rem)] lg:h-dvh overflow-hidden pt-16 lg:pt-0" : "p-4 lg:p-8 pt-20 lg:pt-8"} ${hasTopBanner ? "mt-12" : ""}`}
+      id="main-content"
+      tabIndex={-1}
+      className={`scroll-mt-4 focus:outline-none lg:ml-[var(--sidebar-offset,3.5rem)] transition-[margin] duration-300 ease-in-out motion-reduce:transition-none ${reserveDrawerMargin ? "lg:mr-[420px]" : ""} ${isFullBleed ? "h-[calc(100dvh-4rem)] lg:h-dvh overflow-hidden pt-16 lg:pt-0" : "p-4 lg:p-8 pt-20 lg:pt-8"} ${hasTopBanner ? "mt-12" : ""}`}
     >
       {children}
     </main>

--- a/apps/web/src/components/linkedin/LinkedInUrlPrompt.tsx
+++ b/apps/web/src/components/linkedin/LinkedInUrlPrompt.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Button, Card, Input } from "@/components/ui";
+import { Button, Input, Modal } from "@/components/ui";
 import { linkedInProfileUrlSchema } from "@/lib/alumni/linkedin-url";
 import { shouldShowLinkedInPrompt } from "@/lib/linkedin/prompt-logic";
 
@@ -144,9 +144,14 @@ export function LinkedInUrlPrompt() {
   }
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 px-4">
-      <Card className="w-full max-w-md p-6 space-y-4" role="dialog" aria-modal="true">
-        <div className="flex items-center gap-3">
+    <Modal
+      open
+      onOpenChange={(nextOpen) => { if (!nextOpen) handleSkip(); }}
+      size="md"
+      ariaLabel="Add your LinkedIn profile"
+    >
+      <div className="space-y-4">
+        <div className="flex items-center gap-3 pr-8">
           <svg
             className="h-8 w-8 text-[#0A66C2] shrink-0"
             viewBox="0 0 24 24"
@@ -179,7 +184,7 @@ export function LinkedInUrlPrompt() {
             disabled={state.saving}
           />
           {state.error && (
-            <p className="text-sm text-red-600 dark:text-red-400">{state.error}</p>
+            <p className="text-sm text-error">{state.error}</p>
           )}
         </div>
 
@@ -200,7 +205,7 @@ export function LinkedInUrlPrompt() {
             {state.saving ? "Saving..." : "Save"}
           </Button>
         </div>
-      </Card>
-    </div>
+      </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/media/AlbumView.tsx
+++ b/apps/web/src/components/media/AlbumView.tsx
@@ -8,7 +8,7 @@ import {
   getBulkDeletePartialFailureMessage,
   getBulkDeleteSuccessMessage,
 } from "@/lib/media/delete-media-client";
-import { Button, EmptyState } from "@/components/ui";
+import { Button, EmptyState, Modal } from "@/components/ui";
 import { MediaCard, type MediaItem } from "./MediaCard";
 import { MediaDetailModal } from "./MediaDetailModal";
 import { MediaUploadPanel } from "./MediaUploadPanel";
@@ -623,20 +623,15 @@ export function AlbumView({
         />
       )}
 
-      {showDeleteModal && (
-        <>
-          <div
-            className="fixed inset-0 z-40 bg-black/30 backdrop-blur-[2px]"
-            onClick={() => {
-              if (!deletingMode) setShowDeleteModal(false);
-            }}
-          />
-          <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
-            <div
-              role="dialog"
-              aria-label="Delete album options"
-              className="w-full max-w-md rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
-            >
+      <Modal
+        open={showDeleteModal}
+        onOpenChange={(nextOpen) => { if (!nextOpen && !deletingMode) setShowDeleteModal(false); }}
+        size="md"
+        noPadding
+        hideCloseButton
+        ariaLabel="Delete album options"
+      >
+        <div>
               <div className="border-b border-[var(--border)] px-5 py-4">
                 <h3 className="text-base font-semibold text-[var(--foreground)]">Delete album</h3>
                 <p className="mt-1 text-sm text-[var(--muted-foreground)]">
@@ -690,10 +685,8 @@ export function AlbumView({
                   </span>
                 )}
               </div>
-            </div>
-          </div>
-        </>
-      )}
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/apps/web/src/components/members/MembersFilter.tsx
+++ b/apps/web/src/components/members/MembersFilter.tsx
@@ -58,17 +58,32 @@ export function MembersFilter({ orgSlug, orgId, currentStatus, currentRole, role
       .map((r) => ({ label: formatRoleLabel(r), value: r })),
   ];
 
+  // Filters live in the URL, but once the dropdown closes there's no visible
+  // cue that any are applied — surface a count so users don't forget.
+  const activeFilterCount = buildFilterKeys(currentStatus, currentRole).length;
+
   return (
     <div className="relative inline-block text-left">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium bg-muted text-foreground hover:bg-border transition-colors"
+        aria-expanded={open}
+        aria-label={
+          activeFilterCount > 0
+            ? `${tCommon("filter")} (${activeFilterCount} applied)`
+            : tCommon("filter")
+        }
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium bg-muted text-foreground hover:bg-border transition-colors motion-reduce:transition-none"
       >
         <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h7" />
         </svg>
         {tCommon("filter")}
+        {activeFilterCount > 0 && (
+          <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-org-primary text-org-primary-foreground text-[10px] font-bold">
+            {activeFilterCount}
+          </span>
+        )}
         <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path strokeLinecap="round" strokeLinejoin="round" d="M6 9l6 6 6-6" />
         </svg>

--- a/apps/web/src/components/members/ReinstateCard.tsx
+++ b/apps/web/src/components/members/ReinstateCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Card, Button } from "@/components/ui";
+import { ConfirmationDialog } from "@/components/ui/ConfirmationDialog";
 
 interface ReinstateCardProps {
   orgId: string;
@@ -13,6 +14,7 @@ interface ReinstateCardProps {
 export function ReinstateCard({ orgId, memberId, memberName }: ReinstateCardProps) {
   const router = useRouter();
   const [isReinstating, setIsReinstating] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
@@ -30,6 +32,7 @@ export function ReinstateCard({ orgId, memberId, memberName }: ReinstateCardProp
     if (!response.ok) {
       setError(data.error || "Failed to reinstate member");
     } else {
+      setConfirmOpen(false);
       setSuccess(true);
       router.refresh();
     }
@@ -63,7 +66,7 @@ export function ReinstateCard({ orgId, memberId, memberName }: ReinstateCardProp
           </p>
         </div>
         <Button
-          onClick={handleReinstate}
+          onClick={() => setConfirmOpen(true)}
           isLoading={isReinstating}
           variant="secondary"
           className="whitespace-nowrap"
@@ -74,6 +77,15 @@ export function ReinstateCard({ orgId, memberId, memberName }: ReinstateCardProp
       {error && (
         <p className="mt-2 text-sm text-red-600">{error}</p>
       )}
+      <ConfirmationDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        onConfirm={handleReinstate}
+        isPending={isReinstating}
+        title={`Reinstate ${memberName}?`}
+        description="They'll move from alumni back to an active member and will need approval before regaining full access."
+        confirmLabel="Reinstate"
+      />
     </Card>
   );
 }

--- a/apps/web/src/components/mentorship/MentorDetailModal.tsx
+++ b/apps/web/src/components/mentorship/MentorDetailModal.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
 import { useTranslations } from "next-intl";
-import { Avatar, Button } from "@/components/ui";
+import { Avatar, Button, Modal } from "@/components/ui";
 import { labelMatchSignal, pickSignalCode } from "@/lib/mentorship/signals";
 
 export interface MentorDetailSignal {
@@ -63,15 +62,6 @@ export function MentorDetailModal({
 }: MentorDetailModalProps) {
   const t = useTranslations("mentorship");
 
-  useEffect(() => {
-    if (!isOpen) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [isOpen, onClose]);
-
   if (!isOpen || !mentor) return null;
 
   const chips = [...(mentor.topics ?? []), ...(mentor.expertise_areas ?? [])];
@@ -87,17 +77,14 @@ export function MentorDetailModal({
   const reasonLabel = (code: string | null | undefined): string => labelMatchSignal(code, t);
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-      onClick={onClose}
+    <Modal
+      open
+      onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}
+      size="lg"
+      ariaLabel={mentor.name}
     >
-      <div
-        className="bg-[var(--background)] rounded-lg shadow-xl max-w-lg w-full p-6 space-y-4"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-start gap-4">
+      <div className="space-y-4">
+        <div className="flex items-start gap-4 pr-8">
           <Avatar src={mentor.photo_url} name={mentor.name} size="lg" />
           <div className="flex-1 min-w-0">
             <h2 className="text-lg font-semibold text-[var(--foreground)]">
@@ -195,6 +182,6 @@ export function MentorDetailModal({
           </Button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/mentorship/MentorRequestDialog.tsx
+++ b/apps/web/src/components/mentorship/MentorRequestDialog.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
-import { Button } from "@/components/ui";
+import { Button, Modal } from "@/components/ui";
 import { labelMatchSignal, pickSignalCode } from "@/lib/mentorship/signals";
 import { scoreToConfidence } from "@/lib/mentorship/presentation";
 // The signal "+weights" below explain the match; the headline is a
@@ -103,26 +103,15 @@ export function MentorRequestDialog({
   };
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
+    <Modal
+      open
+      onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}
+      size="md"
       data-testid="mentor-request-dialog"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-      onClick={onClose}
+      title={t("requestIntroTitle", { name: mentor.name })}
+      description={t("whyThisMatch")}
     >
-      <div
-        className="bg-[var(--background)] rounded-lg shadow-xl max-w-md w-full p-6 space-y-4"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div>
-          <h2 className="text-lg font-semibold">
-            {t("requestIntroTitle", { name: mentor.name })}
-          </h2>
-          <p className="text-sm text-[var(--muted-foreground)] mt-1">
-            {t("whyThisMatch")}
-          </p>
-        </div>
-
+      <div className="mt-4 space-y-4">
         <div className="rounded-md border border-[var(--border)] p-3 text-sm">
           {loading ? (
             <p className="text-[var(--muted-foreground)]">{t("loadingSignals")}</p>
@@ -181,6 +170,6 @@ export function MentorRequestDialog({
           </Button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/messages/ChatMessagePane.tsx
+++ b/apps/web/src/components/messages/ChatMessagePane.tsx
@@ -14,6 +14,7 @@ import { MessageTopBar } from "@/components/messages/MessageTopBar";
 import { useChatRealtime } from "@/hooks/useChatRealtime";
 import { getBlockedUserIds } from "@/lib/moderation";
 import { ReportBlockMenu } from "@/components/moderation/ReportBlockMenu";
+import { showFeedback } from "@/lib/feedback/show-feedback";
 import type { ChatGroup, ChatGroupMember, ChatMessage, ChatPollVote, ChatFormResponse, User, ChatMessageStatus } from "@/types/database";
 import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
 import { trackBehavioralEvent } from "@/lib/analytics/events";
@@ -322,6 +323,7 @@ export function ChatMessagePane({
         setMessages((prev) => prev.filter((m) => m.id !== tempId));
         setNewMessage(messageBody);
         setIsSending(false);
+        showFeedback(responseData?.error || "Message failed to send. Your text was restored — try again.", "error");
         return;
       }
     } catch (error) {
@@ -335,6 +337,7 @@ export function ChatMessagePane({
       setMessages((prev) => prev.filter((m) => m.id !== tempId));
       setNewMessage(messageBody);
       setIsSending(false);
+      showFeedback("Message failed to send. Your text was restored — try again.", "error");
       return;
     }
 
@@ -380,6 +383,7 @@ export function ChatMessagePane({
 
     if (error) {
       console.error("Failed to update message:", error);
+      showFeedback(`Couldn't ${action === "approved" ? "approve" : "reject"} the message. Please try again.`, "error");
       const { data } = await supabase
         .from("chat_messages")
         .select("*")
@@ -404,9 +408,11 @@ export function ChatMessagePane({
       if (!res.ok) {
         const err = await res.json();
         console.error("Vote failed:", err);
+        showFeedback("Your vote didn't go through. Please try again.", "error");
       }
     } catch (error) {
       console.error("Vote failed:", error);
+      showFeedback("Your vote didn't go through. Please try again.", "error");
     }
   }, [group.id]);
 
@@ -418,9 +424,11 @@ export function ChatMessagePane({
       if (!res.ok) {
         const err = await res.json();
         console.error("Retract vote failed:", err);
+        showFeedback("Couldn't retract your vote. Please try again.", "error");
       }
     } catch (error) {
       console.error("Retract vote failed:", error);
+      showFeedback("Couldn't retract your vote. Please try again.", "error");
     }
   }, [group.id]);
 
@@ -461,9 +469,11 @@ export function ChatMessagePane({
       } else {
         const err = await res.json();
         console.error("Create poll failed:", err);
+        showFeedback(err?.error || "Couldn't create the poll. Please try again.", "error");
       }
     } catch (error) {
       console.error("Create poll failed:", error);
+      showFeedback("Couldn't create the poll. Please try again.", "error");
     } finally {
       setIsCreatingPoll(false);
     }
@@ -496,9 +506,11 @@ export function ChatMessagePane({
       } else {
         const err = await res.json();
         console.error("Create form failed:", err);
+        showFeedback(err?.error || "Couldn't create the form. Please try again.", "error");
       }
     } catch (error) {
       console.error("Create form failed:", error);
+      showFeedback("Couldn't create the form. Please try again.", "error");
     } finally {
       setIsCreatingForm(false);
     }

--- a/apps/web/src/components/settings/GoogleCalendarSyncPanel.tsx
+++ b/apps/web/src/components/settings/GoogleCalendarSyncPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
-import { Badge, Button, Card, Select, InlineBanner } from "@/components/ui";
+import { Badge, Button, Card, Select, InlineBanner, Spinner } from "@/components/ui";
 import { showFeedback } from "@/lib/feedback/show-feedback";
 
 export interface SyncPreferences {
@@ -96,30 +96,6 @@ function getStatusBadge(status: CalendarConnection["status"], connectedLabel: st
   }
 }
 
-function Spinner() {
-  return (
-    <svg
-      className="animate-spin h-4 w-4 text-org-secondary"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <circle
-        className="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        strokeWidth="4"
-      />
-      <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-      />
-    </svg>
-  );
-}
 
 export function GoogleCalendarSyncPanel({
   orgName,
@@ -403,7 +379,7 @@ export function GoogleCalendarSyncPanel({
                       />
                       {isSaving && (
                         <div className="absolute inset-0 flex items-center justify-center">
-                          <Spinner />
+                          <Spinner className="h-4 w-4 text-org-secondary" />
                         </div>
                       )}
                     </div>

--- a/apps/web/src/components/settings/OutlookCalendarSyncPanel.tsx
+++ b/apps/web/src/components/settings/OutlookCalendarSyncPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
-import { Badge, Button, Card, Select, InlineBanner } from "@/components/ui";
+import { Badge, Button, Card, Select, InlineBanner, Spinner } from "@/components/ui";
 import { showFeedback } from "@/lib/feedback/show-feedback";
 import type { SyncPreferences } from "@/components/settings/GoogleCalendarSyncPanel";
 import type { OutlookCalendar } from "@/hooks/useOutlookCalendarSync";
@@ -81,23 +81,6 @@ function getStatusBadge(status: CalendarConnection["status"], connectedLabel: st
   }
 }
 
-function Spinner() {
-  return (
-    <svg
-      className="animate-spin h-4 w-4 text-org-secondary"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-      <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-      />
-    </svg>
-  );
-}
 
 export function OutlookCalendarSyncPanel({
   orgName,
@@ -370,7 +353,7 @@ export function OutlookCalendarSyncPanel({
                       />
                       {isSaving && (
                         <div className="absolute inset-0 flex items-center justify-center">
-                          <Spinner />
+                          <Spinner className="h-4 w-4 text-org-secondary" />
                         </div>
                       )}
                     </div>

--- a/apps/web/src/components/ui/Avatar.tsx
+++ b/apps/web/src/components/ui/Avatar.tsx
@@ -43,7 +43,7 @@ export function Avatar({ src, alt, name, size = "md", className = "", ...props }
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={src}
-            alt={alt || name || "Avatar"}
+            alt={alt || (name ? `${name}'s profile photo` : "User avatar")}
             className="h-full w-full object-cover"
             loading="lazy"
             decoding="async"
@@ -53,7 +53,7 @@ export function Avatar({ src, alt, name, size = "md", className = "", ...props }
         ) : (
           <Image
             src={src}
-            alt={alt || name || "Avatar"}
+            alt={alt || (name ? `${name}'s profile photo` : "User avatar")}
             fill
             className="object-cover"
             sizes="64px"

--- a/apps/web/src/components/ui/ConfirmationDialog.tsx
+++ b/apps/web/src/components/ui/ConfirmationDialog.tsx
@@ -30,7 +30,10 @@ export function ConfirmationDialog({
   destructive = false,
 }: ConfirmationDialogProps) {
   return (
-    <Dialog.Root open={open} onOpenChange={(nextOpen) => !isPending && onOpenChange(nextOpen)}>
+    // Cancel/Escape stay available even while pending so a hung request never
+    // traps the user. Double-confirm is already prevented by the disabled
+    // confirm button below.
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
         <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[calc(100vw-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-card p-6 text-foreground shadow-xl focus:outline-none">
@@ -40,7 +43,7 @@ export function ConfirmationDialog({
           </Dialog.Description>
           <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
             <Dialog.Close asChild>
-              <Button type="button" variant="secondary" disabled={isPending}>
+              <Button type="button" variant="secondary">
                 {cancelLabel}
               </Button>
             </Dialog.Close>

--- a/apps/web/src/components/ui/Modal.tsx
+++ b/apps/web/src/components/ui/Modal.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import type { ReactNode } from "react";
+
+const SIZE = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-xl",
+  "2xl": "max-w-2xl",
+} as const;
+
+export interface ModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+  /** Visible heading. If omitted, pass `ariaLabel` so screen readers still get a name. */
+  title?: ReactNode;
+  /** Accessible name used when no visible `title` is rendered. */
+  ariaLabel?: string;
+  /** Optional sub-heading rendered under the title. */
+  description?: ReactNode;
+  size?: keyof typeof SIZE;
+  /** Extra classes for the content container. */
+  className?: string;
+  /**
+   * Drop the built-in p-6 padding and title/description chrome. Use for modals
+   * that supply their own header (e.g. a bordered header row). The consumer is
+   * then responsible for an accessible name via `ariaLabel`.
+   */
+  noPadding?: boolean;
+  /** Hide the top-right close (X) button. Escape + overlay-click still close. */
+  hideCloseButton?: boolean;
+  "data-testid"?: string;
+}
+
+/**
+ * The single shared modal shell. Built on Radix Dialog, so focus trapping,
+ * Escape-to-close, overlay-click-to-close, and scroll locking come for free.
+ * Prefer this over hand-rolled `role="dialog"` + fixed-overlay markup.
+ */
+export function Modal({
+  open,
+  onOpenChange,
+  children,
+  title,
+  ariaLabel,
+  description,
+  size = "md",
+  className = "",
+  noPadding = false,
+  hideCloseButton = false,
+  "data-testid": dataTestId,
+}: ModalProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm" />
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <Dialog.Content
+            data-testid={dataTestId}
+            className={`relative w-full ${SIZE[size]} max-h-[calc(100vh-2rem)] overflow-y-auto rounded-2xl border border-border bg-card text-foreground shadow-xl focus:outline-none ${noPadding ? "" : "p-6"} ${className}`}
+          >
+            {noPadding ? (
+              <Dialog.Title className="sr-only">{ariaLabel ?? "Dialog"}</Dialog.Title>
+            ) : title ? (
+              <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+            ) : (
+              <Dialog.Title className="sr-only">{ariaLabel ?? "Dialog"}</Dialog.Title>
+            )}
+            {!noPadding && description && (
+              <Dialog.Description className="mt-1 text-sm text-muted-foreground">
+                {description}
+              </Dialog.Description>
+            )}
+            {!hideCloseButton && (
+              <Dialog.Close
+                aria-label="Close"
+                className="absolute right-4 top-4 rounded-lg p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"
+              >
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </Dialog.Close>
+            )}
+            {children}
+          </Dialog.Content>
+        </div>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/web/src/components/ui/SoftDeleteButton.tsx
+++ b/apps/web/src/components/ui/SoftDeleteButton.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "./Button";
 import { createClient } from "@/lib/supabase/client";
 import { revalidatePaths as revalidatePathsAction } from "@/lib/cache";
+import { showFeedback } from "@/lib/feedback/show-feedback";
 
 interface SoftDeleteButtonProps {
   table: string;
@@ -58,8 +59,10 @@ export function SoftDeleteButton({
       try {
         await onAfterDelete();
       } catch (callbackError) {
-        // Log but don't block - post-delete actions should not prevent navigation
+        // Don't block navigation — the record is already deleted — but tell the
+        // user the follow-up action (e.g. calendar sync) didn't complete.
         console.error("Post-delete callback error:", callbackError);
+        showFeedback("Deleted, but a follow-up sync didn't finish. It may retry automatically.", "warning");
       }
     }
 

--- a/apps/web/src/components/ui/SoftDeleteButton.tsx
+++ b/apps/web/src/components/ui/SoftDeleteButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "./Button";
+import { ConfirmationDialog } from "./ConfirmationDialog";
 import { createClient } from "@/lib/supabase/client";
 import { revalidatePaths as revalidatePathsAction } from "@/lib/cache";
 import { showFeedback } from "@/lib/feedback/show-feedback";
@@ -34,10 +35,10 @@ export function SoftDeleteButton({
 }: SoftDeleteButtonProps) {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleDelete = async () => {
-    if (!window.confirm(confirmMessage)) return;
     setIsLoading(true);
     setError(null);
 
@@ -50,9 +51,12 @@ export function SoftDeleteButton({
     const { error } = await query;
     if (error) {
       setError(error.message);
+      showFeedback("Couldn't delete this item. Please try again.", "error");
       setIsLoading(false);
       return;
     }
+
+    setConfirmOpen(false);
 
     // Call optional post-delete callback (e.g., for calendar sync)
     if (onAfterDelete) {
@@ -83,10 +87,20 @@ export function SoftDeleteButton({
 
   return (
     <div className="flex flex-col items-end gap-2">
-      <Button variant="danger" onClick={handleDelete} isLoading={isLoading} data-testid={dataTestId}>
+      <Button variant="danger" onClick={() => setConfirmOpen(true)} isLoading={isLoading} data-testid={dataTestId}>
         {label}
       </Button>
       {error && <p className="text-xs text-red-500">{error}</p>}
+      <ConfirmationDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        onConfirm={handleDelete}
+        isPending={isLoading}
+        title={`${label}?`}
+        description={confirmMessage}
+        confirmLabel={label}
+        destructive
+      />
     </div>
   );
 }

--- a/apps/web/src/components/ui/Spinner.tsx
+++ b/apps/web/src/components/ui/Spinner.tsx
@@ -1,0 +1,30 @@
+interface SpinnerProps {
+  /** Tailwind classes for sizing/color, e.g. "h-4 w-4 text-org-secondary". */
+  className?: string;
+  /** Accessible label announced to screen readers. Defaults to "Loading". */
+  label?: string;
+}
+
+/**
+ * The single shared loading spinner. Prefer this over hand-rolled `animate-spin`
+ * SVGs. (The `Button` component keeps its own inline spinner for `isLoading`.)
+ */
+export function Spinner({ className = "h-5 w-5", label = "Loading" }: SpinnerProps) {
+  return (
+    <svg
+      className={`animate-spin motion-reduce:animate-none ${className}`}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      role="status"
+      aria-label={label}
+    >
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/components/ui/ToggleSwitch.tsx
+++ b/apps/web/src/components/ui/ToggleSwitch.tsx
@@ -32,17 +32,19 @@ export function ToggleSwitch({
       onClick={() => onChange(!checked)}
       className={`
         relative inline-flex shrink-0 cursor-pointer items-center rounded-full
-        transition-colors duration-200 ease-in-out
+        transition-colors duration-200 ease-in-out motion-reduce:transition-none
         focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2
         ${trackSize}
         ${checked ? "bg-green-500" : "bg-muted-foreground/30"}
         ${disabled ? "opacity-50 cursor-not-allowed" : ""}
       `}
     >
+      {/* Knob position (not just track color) signals on/off, so the state is
+          legible without relying on color perception. */}
       <span
         className={`
           pointer-events-none inline-block rounded-full bg-white shadow-sm
-          transform transition-transform duration-200 ease-in-out
+          transform transition-transform duration-200 ease-in-out motion-reduce:transition-none
           ${dotSize}
           ${checked ? dotTranslate : "translate-x-0.5"}
         `}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -8,6 +8,8 @@ export { EmptyState } from "./EmptyState";
 export { Select } from "./Select";
 export { Textarea } from "./Textarea";
 export { SoftDeleteButton } from "./SoftDeleteButton";
+export { Modal } from "./Modal";
+export type { ModalProps } from "./Modal";
 export { ConfirmationDialog } from "./ConfirmationDialog";
 export type { ConfirmationDialogCopy } from "./ConfirmationDialog";
 export { ConfirmActionButton } from "./ConfirmActionButton";

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -16,6 +16,7 @@ export type { TurnstileWidgetProps, TurnstileWidgetRef } from "./TurnstileWidget
 export { Captcha } from "./Captcha";
 export type { CaptchaProps, CaptchaRef, CaptchaProvider } from "./Captcha";
 export { Skeleton } from "./Skeleton";
+export { Spinner } from "./Spinner";
 export { PermissionRoleCard } from "./PermissionRoleCard";
 export { ProgressBar } from "./ProgressBar";
 export { ToggleSwitch } from "./ToggleSwitch";

--- a/apps/web/src/lib/schemas/competition.ts
+++ b/apps/web/src/lib/schemas/competition.ts
@@ -25,6 +25,27 @@ export const addPointsSchema = z.object({
 });
 export type AddPointsForm = z.infer<typeof addPointsSchema>;
 
+// Client-side validation for the "Add Points" admin form, where a team can be
+// chosen from the list (team_id) OR typed as a new name (team_name), and points
+// must be a whole number (negatives allowed).
+export const addPointsFormSchema = z
+  .object({
+    team_id: z.string().optional().default(""),
+    team_name: optionalSafeString(100),
+    points: z
+      .string()
+      .trim()
+      .min(1, { message: "Enter a points value" })
+      .regex(/^-?\d+$/, { message: "Points must be a whole number (negatives allowed)" }),
+    reason: optionalSafeString(200),
+    notes: optionalSafeString(1000),
+  })
+  .refine((d) => Boolean(d.team_id) || Boolean(d.team_name?.trim()), {
+    message: "Select a team or enter a team name",
+    path: ["team_id"],
+  });
+export type AddPointsFormValues = z.infer<typeof addPointsFormSchema>;
+
 // New competition form
 export const newCompetitionSchema = z.object({
   name: safeString(200),


### PR DESCRIPTION
## Nielsen heuristics audit + remediation

Full audit of the codebase against Nielsen's 10 usability heuristics (4-agent exploration: 3 web + 1 mobile), followed by remediation across **web + mobile**. Headline finding: the web app already owned the right reusable primitives (`ConfirmationDialog`, `useMutationAction`, `EmptyState`, `Button isLoading`) — most violations were sites **bypassing** them. Mobile was in much better shape; only a thin tail.

### What changed (6 phases, one commit each)

**Phase 1 — Visibility / error recovery (#1, #9):** routed swallowed errors + feedback-less mutations through `showFeedback`/`ConfirmationDialog`.
- ChatMessagePane: toast on send / moderation / vote / poll+form-create failures (were console-only; sends silently restored text).
- FeedPost/PostDetail: styled confirm + failure toast + spinner on the icon delete button.
- InlineComments: load-error state w/ Retry (was a misleading "No comments").
- SoftDeleteButton: warn when a post-delete sync fails. ExportCSVButton: pending + success/error toast.

**Phase 2 — Confirmation + validation (#3, #5):** retired native `window.confirm()` for `ConfirmationDialog` (SoftDeleteButton, ManageMembersPanel + Undo on member removal); added a confirm to ReinstateCard; Zod validation + human errors for add-points & NewChatGroupForm; `ConfirmationDialog` is now escapable while pending.

**Phase 3 — Consistency (#4):** new `ui/Spinner` (replaces 4 dupes) + `ui/Modal` (Radix: focus-trap, Escape, overlay-click, scroll-lock). Migrated 7 of 8 hand-rolled `role="dialog"` modals; `text-red-600` → `text-error`. MediaUploadPanel (a side drawer) deferred → #283.

**Phase 4 — Recognition / a11y (#6, #8):** `aria-current="page"` on active nav, skip-to-content link, applied-filter count badge, name-based Avatar alt, `motion-reduce` on animated transitions.

**Phase 5 — Mobile (#2, #4, #9):** a11y roles/labels (SelectField, OverflowMenu), `n.overlay` token, human delete-error copy. Verified (not gaps): block-user already confirms; `formatBucket` shows no jargon; QRScanner colors are intentionally fixed.

**Phase 6 — Follow-ups filed:** #281 (bulk actions + pagination), #282 (help + onboarding), #283 (drawer primitive + legacy theme.ts + breadcrumbs).

### Verification
- Web: `typecheck` + `lint` clean, **6025 tests pass**.
- Mobile: `typecheck` clean, **476 tests pass**.
- No screenshots taken here — see #283 note re: visual verification of migrated modals.
