### PR TITLE
fix(ai): sync ai_document_chunks source_table CHECK to 7 sources

### DIFF
--- a/supabase/migrations/20261223000000_ai_chunks_source_table_check_sync.sql
+++ b/supabase/migrations/20261223000000_ai_chunks_source_table_check_sync.sql
@@ -1,0 +1,12 @@
+-- Sync ai_document_chunks.source_table CHECK to the 7 sources chunker.ts actually inserts.
+-- The original foundation migration listed only 5; mentor_profiles + form_submissions
+-- were added to the worker/chunker without updating the constraint. Data-integrity fix.
+ALTER TABLE public.ai_document_chunks
+  DROP CONSTRAINT IF EXISTS ai_document_chunks_source_table_check;
+
+ALTER TABLE public.ai_document_chunks
+  ADD CONSTRAINT ai_document_chunks_source_table_check
+  CHECK (source_table IN (
+    'announcements', 'discussion_threads', 'discussion_replies',
+    'events', 'job_postings', 'mentor_profiles', 'form_submissions'
+  ));


### PR DESCRIPTION
## Problem

The `ai_document_chunks.source_table` inline CHECK constraint in `20260711000000_ai_rag_foundation.sql` (lines 13-16) lists only 5 allowed values:

```
'announcements', 'discussion_threads', 'discussion_replies', 'events', 'job_postings'
```

But `SourceTable` in `apps/web/src/lib/ai/chunker.ts` (and the live chunker/worker inserts) also includes `mentor_profiles` and `form_submissions`. Any row inserted for those two sources violates the constraint — a data-integrity bug.

## Change

One new migration: `supabase/migrations/20261223000000_ai_chunks_source_table_check_sync.sql`

Drops the auto-named constraint (`ai_document_chunks_source_table_check`) with `IF EXISTS` for rename-safety, then recreates it with all 7 values matching the `SourceTable` union in `chunker.ts` exactly.

## Rollback

Drop this migration file and apply the inverse: drop the new constraint, re-add the original 5-value one.

## Verification

- `check:migration-drift` script ran; exited cleanly with "credentials unset — skipping" (no live DB in CI). Manual DB verify requires credentials.
- SQL linting not configured (SQL files are not in the lint pipeline); reviewed manually.