### PR TITLE
feat(okf): frontmatter validator + CI gate, log.md, visualizer note

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,30 @@ jobs:
         run: bun install --frozen-lockfile
       - run: bun run --cwd apps/web check:migration-drift
 
+  validate-okf:
+    name: Validate OKF
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+      - name: Cache bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-install-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-install-${{ runner.os }}-
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - run: bun run validate:okf
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -196,7 +220,7 @@ jobs:
   all-checks:
     name: All Checks
     runs-on: ubuntu-latest
-    needs: [test-unit, test-ai, test-mobile, migration-drift, build]
+    needs: [test-unit, test-ai, test-mobile, migration-drift, validate-okf, build]
     if: always()
     steps:
       - name: Verify all required jobs succeeded

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "teammeet",
       "devDependencies": {
+        "js-yaml": "^4.1.0",
         "prettier": "^3.8.1",
         "turbo": "^2",
         "typescript": "^5",

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -41,4 +41,12 @@ Each document's `resource` field points at the primary source file it describes,
 
 ## Type vocabulary
 
-The bundle uses a deliberately small `type` set: `architecture`, `codemap`, `taxonomy`, `reference`, `data-flow`, `audit`, and `index` (this file).
+The bundle uses a deliberately small `type` set: `architecture`, `codemap`, `taxonomy`, `reference`, `data-flow`, `audit`, `index` (this file), and `log` (the history file below).
+
+## History
+
+- [OKF Bundle History](/docs/agent/log.md) — reserved change log: when documents were added, restructured, and when resource paths drifted or were repaired.
+
+## Visualizing this bundle
+
+Because this bundle is plain markdown with YAML frontmatter, it can be rendered by Google's Open Knowledge Format static HTML visualizer. Point the visualizer in [GoogleCloudPlatform/knowledge-catalog](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) at this directory (`docs/agent/`) to browse the documents and their `resource` links interactively. No build step or server is required — the visualizer reads the frontmatter directly.

--- a/docs/agent/log.md
+++ b/docs/agent/log.md
@@ -1,0 +1,17 @@
+---
+type: log
+title: OKF Bundle History
+description: Reserved change history for the TeamNetwork AI agent OKF bundle — when documents were added, restructured, and when resource paths drifted or were repaired.
+tags: [ai, okf, history, changelog]
+timestamp: 2026-06-17T00:00:00Z
+---
+
+# OKF Bundle History
+
+A reserved history file for the `docs/agent/` Open Knowledge Format bundle. Entries are grouped by ISO date, newest first. This log exists so that drift in the bundle (renamed source files, restructured docs) leaves a paper trail next to the validator that catches it.
+
+## 2026-06-17
+
+- **Bundle created.** Structured `docs/agent/` as an OKF bundle: added YAML frontmatter (`type`, `title`, `description`, `resource`, `tags`, `timestamp`) to the 12 concept documents and to `index.md`. Each document's `resource` field points at the primary source file it describes, giving a concept → code index. `type` is the only required field; the bundle uses a small `type` vocabulary (`architecture`, `codemap`, `taxonomy`, `reference`, `data-flow`, `audit`, `index`, `log`).
+
+- **Resource-path rot from the `lib/falkordb` → `lib/people-graph` rename.** The `refactor(graph): rename lib/falkordb -> lib/people-graph` change moved `suggestions.ts` out of `apps/web/src/lib/falkordb/`. Two documents — `falkor-people-graph.md` and `falkor-connection-suggestions.md` — carried `resource:` paths under the old `lib/falkordb/` directory, which silently broke when the directory was removed. Both `resource` fields were repaired to `apps/web/src/lib/people-graph/suggestions.ts`. This class of silent drift is the motivation for the frontmatter validator: `scripts/validate-okf-frontmatter.mjs` now asserts every `resource:` path resolves on disk, and gates merges via the `validate-okf` CI job in the `all-checks` aggregate.

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "turbo run test --filter=@teammeet/web",
-    "test:e2e": "bun run --cwd apps/web test:e2e"
+    "test:e2e": "bun run --cwd apps/web test:e2e",
+    "validate:okf": "node scripts/validate-okf-frontmatter.mjs docs/agent"
   },
   "devDependencies": {
+    "js-yaml": "^4.1.0",
     "prettier": "^3.8.1",
     "turbo": "^2",
     "typescript": "^5"

--- a/scripts/validate-okf-frontmatter.mjs
+++ b/scripts/validate-okf-frontmatter.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+// Validates the Open Knowledge Format (OKF) frontmatter of a markdown bundle.
+//
+// Why: docs/agent/ is an OKF bundle whose `resource:` fields point at source
+// files. When code is renamed (e.g. lib/falkordb -> lib/people-graph) those
+// paths silently rot. This script is the rot-catcher: it asserts every doc has
+// valid frontmatter, no misspelled reserved keys, and that every `resource:`
+// path (and every index.md bundle link) still resolves on disk.
+//
+// Usage:
+//   node scripts/validate-okf-frontmatter.mjs <dir> [<dir> ...]
+//   bun run validate:okf            # -> node scripts/... docs/agent
+//
+// Exits non-zero with a per-file reason list on any failure; zero when clean.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+
+// Repo root is one level up from this script's scripts/ directory.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// OKF's reserved frontmatter keys. `type` is the only required one.
+const RESERVED_KEYS = ["type", "title", "description", "resource", "tags", "timestamp"];
+const REQUIRED_KEYS = ["type"];
+
+// Flag keys that look like typos of a reserved key (e.g. `tag`, `timestmp`,
+// `resourse`) while leaving genuinely new keys alone. A non-reserved key is a
+// likely typo when it is within this edit distance of a reserved key.
+const TYPO_EDIT_DISTANCE = 2;
+
+const dirs = process.argv.slice(2);
+if (dirs.length === 0) {
+  console.error("Usage: node scripts/validate-okf-frontmatter.mjs <dir> [<dir> ...]");
+  process.exit(1);
+}
+
+for (const dir of dirs) {
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    console.error(`Not a directory: ${dir}`);
+    process.exit(1);
+  }
+}
+
+// Levenshtein edit distance between two strings (iterative, O(a*b) space-lean).
+function editDistance(a, b) {
+  const prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    let diag = prev[0];
+    prev[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      const next = Math.min(
+        prev[j] + 1, // deletion
+        prev[j - 1] + 1, // insertion
+        diag + cost // substitution
+      );
+      diag = prev[j];
+      prev[j] = next;
+    }
+  }
+  return prev[b.length];
+}
+
+// Split the leading `---` fenced YAML block. Returns { frontmatter, error }.
+// The first line must be `---`; the block ends at the next `---` line.
+function extractFrontmatter(raw) {
+  const lines = raw.split(/\r?\n/);
+  if (lines[0]?.trim() !== "---") {
+    return { error: "no frontmatter: first line is not '---'" };
+  }
+  let close = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      close = i;
+      break;
+    }
+  }
+  if (close === -1) {
+    return { error: "no frontmatter: missing closing '---'" };
+  }
+  const block = lines.slice(1, close).join("\n");
+  let parsed;
+  try {
+    parsed = yaml.load(block);
+  } catch (err) {
+    return { error: `frontmatter is not valid YAML: ${err.message}` };
+  }
+  if (parsed === null || parsed === undefined) {
+    return { error: "frontmatter block is empty" };
+  }
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { error: "frontmatter must be a YAML mapping" };
+  }
+  return { frontmatter: parsed };
+}
+
+// `resource:` paths may be repo-root-absolute (leading `/`) or relative to the
+// doc. Resolve both forms and report whichever exists; return null if neither.
+function resolveResourcePath(resource, fileDir) {
+  const candidates = resource.startsWith("/")
+    ? [path.join(REPO_ROOT, resource.slice(1))]
+    : [path.resolve(fileDir, resource), path.join(REPO_ROOT, resource)];
+  return candidates.find((c) => fs.existsSync(c)) ?? null;
+}
+
+// An ISO-8601 timestamp must both parse to a real Date and look like ISO-8601
+// (date, optionally with time/offset) — `new Date()` alone is too lenient.
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+function isIso8601(value) {
+  // js-yaml resolves YAML 1.1 timestamps to a Date; an unparseable timestamp
+  // stays a string. A real Date is valid as long as it is not Invalid Date.
+  if (value instanceof Date) return !Number.isNaN(value.getTime());
+  if (typeof value !== "string") return false;
+  if (!ISO_8601.test(value)) return false;
+  return !Number.isNaN(new Date(value).getTime());
+}
+
+// Validate one document's frontmatter. Returns an array of failure strings.
+function validateDoc(filePath, frontmatter) {
+  const failures = [];
+  const fileDir = path.dirname(filePath);
+  const keys = Object.keys(frontmatter);
+
+  for (const required of REQUIRED_KEYS) {
+    if (!(required in frontmatter)) {
+      failures.push(`missing required key '${required}'`);
+    }
+  }
+
+  for (const key of keys) {
+    if (RESERVED_KEYS.includes(key)) continue;
+    for (const reserved of RESERVED_KEYS) {
+      if (editDistance(key, reserved) <= TYPO_EDIT_DISTANCE) {
+        failures.push(`key '${key}' looks like a typo of reserved key '${reserved}'`);
+        break;
+      }
+    }
+  }
+
+  if ("tags" in frontmatter && !Array.isArray(frontmatter.tags)) {
+    failures.push(`'tags' must be a list, got ${typeof frontmatter.tags}`);
+  }
+
+  if ("timestamp" in frontmatter && !isIso8601(frontmatter.timestamp)) {
+    failures.push(
+      `'timestamp' is not a valid ISO-8601 string: ${JSON.stringify(frontmatter.timestamp)}`
+    );
+  }
+
+  if ("resource" in frontmatter) {
+    const resource = frontmatter.resource;
+    if (typeof resource !== "string" || resource.length === 0) {
+      failures.push(`'resource' must be a non-empty string`);
+    } else if (resolveResourcePath(resource, fileDir) === null) {
+      failures.push(`'resource' path does not exist on disk: ${resource}`);
+    }
+  }
+
+  return failures;
+}
+
+// index.md additionally links into the bundle with markdown `[label](target)`
+// links. Bundle-internal targets (repo-root-absolute `/docs/...` or relative
+// `.md`) must resolve on disk — this catches dangling links after a rename.
+function validateIndexLinks(filePath, raw) {
+  const failures = [];
+  const fileDir = path.dirname(filePath);
+  const linkRe = /\]\(([^)]+)\)/g;
+  let match;
+  while ((match = linkRe.exec(raw)) !== null) {
+    const target = match[1].split("#")[0].trim();
+    if (target.length === 0) continue;
+    // Only check bundle-internal links: absolute /docs/... or relative *.md.
+    const isInternalAbsolute = target.startsWith("/docs/");
+    const isRelativeMd =
+      !target.startsWith("/") && !/^[a-z]+:/i.test(target) && target.endsWith(".md");
+    if (!isInternalAbsolute && !isRelativeMd) continue;
+    const resolved = isInternalAbsolute
+      ? path.join(REPO_ROOT, target.slice(1))
+      : path.resolve(fileDir, target);
+    if (!fs.existsSync(resolved)) {
+      failures.push(`index link target does not exist: ${target}`);
+    }
+  }
+  return failures;
+}
+
+let totalFiles = 0;
+let failedFiles = 0;
+const allDirsLabel = dirs.join(", ");
+
+for (const dir of dirs) {
+  const entries = fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith(".md"))
+    .map((e) => path.join(dir, e.name))
+    .sort();
+
+  for (const filePath of entries) {
+    totalFiles++;
+    const raw = fs.readFileSync(filePath, "utf8");
+    const { frontmatter, error } = extractFrontmatter(raw);
+
+    const failures = [];
+    if (error) {
+      failures.push(error);
+    } else {
+      failures.push(...validateDoc(filePath, frontmatter));
+      if (path.basename(filePath) === "index.md") {
+        failures.push(...validateIndexLinks(filePath, raw));
+      }
+    }
+
+    if (failures.length > 0) {
+      failedFiles++;
+      console.error(`✗ ${filePath}`);
+      for (const f of failures) {
+        console.error(`    - ${f}`);
+      }
+    }
+  }
+}
+
+if (failedFiles > 0) {
+  console.error(
+    `\nOKF validation FAILED: ${failedFiles} of ${totalFiles} file(s) invalid in ${allDirsLabel}`
+  );
+  process.exit(1);
+}
+
+console.log(`✓ OKF valid: ${totalFiles} files in ${allDirsLabel}`);


### PR DESCRIPTION
## Summary

Tier 1 of the OKF continuation: a frontmatter validator for the `docs/agent/` Open Knowledge Format bundle, wired into CI so resource-path rot fails the build.

> [!IMPORTANT]
> **Base is the unmerged `worktree-okf-frontmatter` branch**, not `main`. That branch carries the OKF bundle (the 12 docs + `index.md` frontmatter) this validator validates. **This PR must merge AFTER the `worktree-okf-frontmatter` base PR.** Retarget to `main` once the base has merged.

## What the validator asserts

`scripts/validate-okf-frontmatter.mjs` runs over every `*.md` in each target dir (default: `docs/agent`) and asserts, collecting all failures per file:

- A leading `---` fenced YAML frontmatter block exists and parses as a mapping.
- The required `type` key is present (OKF's only required field).
- No frontmatter key is a near-miss (Levenshtein ≤ 2) of a reserved key (`type`/`title`/`description`/`resource`/`tags`/`timestamp`) — catches `timestmp`, `resourse`, `tag`, etc., while leaving genuinely new keys alone.
- `tags`, when present, is a list.
- `timestamp`, when present, is a valid ISO-8601 value (js-yaml `Date` or ISO string; rejects Invalid Date).
- `resource`, when present, resolves on disk (repo-root-absolute `/…` or relative-to-file). **This is the rot-catcher.**
- For `index.md`, every bundle-internal markdown link (`/docs/…` or relative `.md`) resolves on disk.

Fails loud with a per-file reason list and a non-zero exit; prints a one-line green summary on success.

## Why — the rot it catches

The `refactor(graph): rename lib/falkordb -> lib/people-graph` change moved `suggestions.ts` and silently broke the `resource:` paths in `falkor-people-graph.md` and `falkor-connection-suggestions.md` (since repaired). A break-test confirmed the validator goes RED naming the exact missing path (`apps/web/src/lib/falkordb/suggestions.ts`) and naming a dangling `index.md` link, then GREEN once reverted.

## Wiring

- Root script `validate:okf` → `node scripts/validate-okf-frontmatter.mjs docs/agent`.
- `js-yaml` added to root `devDependencies`.
- New `validate-okf` CI job (mirrors the existing job shape), added to the `all-checks` `needs:` array so it gates merges.

## Docs

- `docs/agent/log.md` — reserved `type: log` history file recording bundle creation and the people-graph rename rot.
- `index.md` — new **History** section linking `log.md`, and a **Visualizing this bundle** note (point the OKF visualizer in GoogleCloudPlatform/knowledge-catalog at `docs/agent/`).

## Verification

- `bun run validate:okf` → green (14 files).
- Break-test: broke a `resource:` path and an `index.md` link → RED with clear per-file reasons → reverted → green.
- `bun run typecheck` (7/7) and `bun run lint` (5/5) clean. The `.mjs` script lives in root `scripts/`, which is not covered by any turbo lint task (lint runs only inside `apps/*` / `packages/*`); it is prettier-clean and runs under both `node` and `bun`.