### PR TITLE
feat(ai): add knowledge_documents as RAG source for the assistant

### DIFF
--- a/apps/web/src/app/api/organizations/[organizationId]/ai/knowledge/route.ts
+++ b/apps/web/src/app/api/organizations/[organizationId]/ai/knowledge/route.ts
@@ -1,0 +1,192 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { requireOrgRole } from "@/lib/auth/roles";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+import {
+  knowledgeDocumentCreateSchema,
+  knowledgeDocumentDeleteSchema,
+} from "@/lib/schemas/ai-knowledge";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Admin-only authoring API for org knowledge documents (an 8th RAG source).
+ * POST creates a document; DELETE soft-deletes one. Both flow into the existing
+ * embedding pipeline via the knowledge_documents trigger. No GET/list — authoring
+ * is API/seed-driven for now. Audience gating is enforced downstream in the RAG
+ * search RPC via the document's audience token.
+ */
+
+async function authorize(
+  req: Request,
+  organizationId: string,
+  feature: string
+): Promise<
+  | { ok: true; userId: string; headers: Record<string, string> }
+  | { ok: false; response: NextResponse }
+> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const rateLimit = checkRateLimit(req, {
+    userId: user?.id ?? null,
+    feature,
+    limitPerIp: 30,
+    limitPerUser: 20,
+  });
+  if (!rateLimit.ok) {
+    return { ok: false, response: buildRateLimitResponse(rateLimit) };
+  }
+
+  if (!user) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401, headers: rateLimit.headers }
+      ),
+    };
+  }
+
+  try {
+    await requireOrgRole({ orgId: organizationId, allowedRoles: ["admin"] });
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Admin access required" },
+        { status: 403, headers: rateLimit.headers }
+      ),
+    };
+  }
+
+  return { ok: true, userId: user.id, headers: rateLimit.headers };
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ organizationId: string }> }
+) {
+  const { organizationId } = await params;
+
+  const auth = await authorize(req, organizationId, "ai-knowledge-create");
+  if (!auth.ok) return auth.response;
+
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400, headers: auth.headers }
+    );
+  }
+
+  const parsed = knowledgeDocumentCreateSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 400, headers: auth.headers }
+    );
+  }
+
+  const input = parsed.data;
+  // knowledge_documents is not yet in generated DB types; cast like the worker
+  // and other pre-type-regen routes (e.g. parents) do.
+  const serviceSupabase = createServiceClient() as any;
+
+  const { data, error } = await serviceSupabase
+    .from("knowledge_documents")
+    .insert({
+      organization_id: organizationId,
+      created_by: auth.userId,
+      title: input.title,
+      body: input.body,
+      description: input.description ?? null,
+      type: input.type ?? null,
+      resource: input.resource ?? null,
+      tags: input.tags ?? null,
+      audience: input.audience,
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    console.error("[ai-knowledge] insert failed:", {
+      organizationId,
+      error: error?.message,
+    });
+    return NextResponse.json(
+      { error: "Failed to create knowledge document" },
+      { status: 500, headers: auth.headers }
+    );
+  }
+
+  return NextResponse.json({ id: data.id }, { status: 201, headers: auth.headers });
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ organizationId: string }> }
+) {
+  const { organizationId } = await params;
+
+  const auth = await authorize(req, organizationId, "ai-knowledge-delete");
+  if (!auth.ok) return auth.response;
+
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400, headers: auth.headers }
+    );
+  }
+
+  const parsed = knowledgeDocumentDeleteSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 400, headers: auth.headers }
+    );
+  }
+
+  // knowledge_documents is not yet in generated DB types; cast as above.
+  const serviceSupabase = createServiceClient() as any;
+
+  const { data, error } = await serviceSupabase
+    .from("knowledge_documents")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("organization_id", organizationId)
+    .eq("id", parsed.data.id)
+    .is("deleted_at", null)
+    .select("id")
+    .maybeSingle();
+
+  if (error) {
+    console.error("[ai-knowledge] soft-delete failed:", {
+      organizationId,
+      id: parsed.data.id,
+      error: error.message,
+    });
+    return NextResponse.json(
+      { error: "Failed to delete knowledge document" },
+      { status: 500, headers: auth.headers }
+    );
+  }
+
+  if (!data) {
+    return NextResponse.json(
+      { error: "Knowledge document not found" },
+      { status: 404, headers: auth.headers }
+    );
+  }
+
+  return NextResponse.json({ id: data.id }, { status: 200, headers: auth.headers });
+}

--- a/apps/web/src/lib/ai/chunker.ts
+++ b/apps/web/src/lib/ai/chunker.ts
@@ -17,7 +17,8 @@ export type SourceTable =
   | "events"
   | "job_postings"
   | "mentor_profiles"
-  | "form_submissions";
+  | "form_submissions"
+  | "knowledge_documents";
 
 /** Parent thread context passed for discussion_replies rendering. */
 export interface ParentThreadContext {
@@ -172,6 +173,26 @@ function renderFormSubmission(record: Record<string, unknown>): ChunkInput[] {
   return splitIfNeeded(`Form submission: ${text}`, {});
 }
 
+function renderKnowledgeDocument(record: Record<string, unknown>): ChunkInput[] {
+  const title = String(record.title ?? "");
+  const body = String(record.body ?? "");
+  const type = record.type ? String(record.type) : null;
+  const description = record.description ? String(record.description) : null;
+  const tags = Array.isArray(record.tags) ? (record.tags as string[]) : [];
+  // Audience gates retrieval — always carry it into metadata so the search RPC
+  // (metadata->>'audience') can filter restricted docs per requester role.
+  const audience = record.audience ? String(record.audience) : "all";
+
+  const lines = [`Knowledge: ${title}`];
+  if (type) lines.push(`Type: ${type}`);
+  if (tags.length > 0) lines.push(`Tags: ${tags.join(", ")}`);
+  if (description) lines.push(description);
+  if (body) lines.push(body);
+
+  const text = lines.join("\n");
+  return splitIfNeeded(text, { title, type, tags, audience });
+}
+
 // ---------------------------------------------------------------------------
 // Splitting
 // ---------------------------------------------------------------------------
@@ -284,6 +305,8 @@ export function renderChunks(
       return renderMentorProfile(record);
     case "form_submissions":
       return renderFormSubmission(record);
+    case "knowledge_documents":
+      return renderKnowledgeDocument(record);
     default: {
       const _exhaustive: never = sourceTable;
       throw new Error(`Unknown source table: ${_exhaustive}`);

--- a/apps/web/src/lib/ai/embedding-worker.ts
+++ b/apps/web/src/lib/ai/embedding-worker.ts
@@ -47,6 +47,8 @@ const SOURCE_SELECTS: Record<SourceTable, string> = {
     "id, user_id, bio, topics, organization_id",
   form_submissions:
     "id, form_id, user_id, responses, organization_id, deleted_at",
+  knowledge_documents:
+    "id, type, title, description, tags, body, audience, source_timestamp, organization_id, deleted_at",
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/ai/rag-retriever.ts
+++ b/apps/web/src/lib/ai/rag-retriever.ts
@@ -86,6 +86,10 @@ const QUERY_EXPANSIONS: Record<string, string> = {
   discussions: "discussion threads conversations",
   thread: "discussion thread conversation",
   threads: "discussion threads conversations",
+  knowledge: "knowledge base handbook documentation reference",
+  policy: "policy handbook guideline rule procedure",
+  handbook: "handbook knowledge base policy guide",
+  faq: "faq frequently asked questions help",
 };
 
 export function expandQuery(query: string): string {

--- a/apps/web/src/lib/schemas/ai-knowledge.ts
+++ b/apps/web/src/lib/schemas/ai-knowledge.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+/**
+ * Audience tokens for knowledge documents. These align with the RAG audience
+ * gate: non-admin roles get explicit allowlists from audienceFilterForRole()
+ * (members / active_members / alumni). 'all' is unrestricted (visible to every
+ * role). 'admins' is an admin-only token deliberately absent from every
+ * non-admin allowlist, so only admins (who pass no audience filter) retrieve it.
+ */
+export const KNOWLEDGE_AUDIENCES = [
+  "all",
+  "members",
+  "active_members",
+  "alumni",
+  "admins",
+] as const;
+
+export const knowledgeAudienceSchema = z.enum(KNOWLEDGE_AUDIENCES);
+
+const MAX_TAGS = 20;
+const MAX_TAG_LENGTH = 50;
+
+export const knowledgeDocumentCreateSchema = z.object({
+  title: z.string().trim().min(1, "Title is required").max(200, "Title is too long"),
+  body: z.string().trim().min(1, "Body is required").max(50_000, "Body is too long"),
+  description: z.string().trim().max(2_000, "Description is too long").optional(),
+  type: z.string().trim().max(100, "Type is too long").optional(),
+  resource: z.string().trim().max(2_000, "Resource is too long").optional(),
+  tags: z
+    .array(z.string().trim().min(1).max(MAX_TAG_LENGTH))
+    .max(MAX_TAGS, `At most ${MAX_TAGS} tags`)
+    .optional(),
+  audience: knowledgeAudienceSchema.default("all"),
+});
+
+export const knowledgeDocumentDeleteSchema = z.object({
+  id: z.string().uuid("Invalid knowledge document id"),
+});
+
+export type KnowledgeDocumentCreateInput = z.infer<typeof knowledgeDocumentCreateSchema>;
+export type KnowledgeDocumentDeleteInput = z.infer<typeof knowledgeDocumentDeleteSchema>;
+export type KnowledgeAudience = z.infer<typeof knowledgeAudienceSchema>;

--- a/apps/web/src/lib/schemas/index.ts
+++ b/apps/web/src/lib/schemas/index.ts
@@ -90,3 +90,6 @@ export * from "./moderation";
 
 // Org custom email sending domain schemas
 export * from "./email-domain";
+
+// AI knowledge base (RAG authoring) schemas
+export * from "./ai-knowledge";

--- a/apps/web/tests/ai-knowledge-audience-gating.test.ts
+++ b/apps/web/tests/ai-knowledge-audience-gating.test.ts
@@ -1,0 +1,88 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { audienceFilterForRole } from "../src/lib/ai/rag-retriever";
+import type { OrgRole } from "../src/lib/auth/role-utils";
+
+/**
+ * Audience-gating invariant for the knowledge_documents RAG source.
+ *
+ * The search_ai_documents RPC filters chunks with this exact logic
+ * (20261220000000_search_ai_documents_audience.sql):
+ *
+ *   p_audience_filter IS NULL
+ *   OR COALESCE(metadata->>'audience', 'all') IN ('all','both')
+ *   OR (metadata->>'audience') = ANY(p_audience_filter)
+ *
+ * We reproduce that predicate here and feed it the outputs of
+ * audienceFilterForRole() to prove, in JS, the must-not-leak invariant:
+ * an 'admins'-audience knowledge doc is visible ONLY to admins, while an
+ * 'all'-audience doc is visible to everyone.
+ */
+function rpcChunkVisible(
+  chunkAudience: string | undefined,
+  audienceFilter: string[] | undefined
+): boolean {
+  // p_audience_filter IS NULL -> no filtering (admin / global callers)
+  if (audienceFilter === undefined) return true;
+  const effective = chunkAudience ?? "all";
+  if (effective === "all" || effective === "both") return true;
+  return audienceFilter.includes(effective);
+}
+
+const NON_ADMIN_ROLES: OrgRole[] = ["active_member", "alumni", "parent"];
+
+describe("knowledge audience gating", () => {
+  describe("'all' audience is universally visible", () => {
+    it("is visible to admin", () => {
+      assert.equal(rpcChunkVisible("all", audienceFilterForRole("admin")), true);
+    });
+    for (const role of NON_ADMIN_ROLES) {
+      it(`is visible to ${role}`, () => {
+        assert.equal(rpcChunkVisible("all", audienceFilterForRole(role)), true);
+      });
+    }
+    it("unset audience defaults to visible for a non-admin", () => {
+      assert.equal(
+        rpcChunkVisible(undefined, audienceFilterForRole("active_member")),
+        true
+      );
+    });
+  });
+
+  describe("'admins' audience is admin-only (must-not-leak)", () => {
+    it("is visible to admin (admin filter is undefined = no restriction)", () => {
+      assert.equal(audienceFilterForRole("admin"), undefined);
+      assert.equal(rpcChunkVisible("admins", audienceFilterForRole("admin")), true);
+    });
+
+    for (const role of NON_ADMIN_ROLES) {
+      it(`is HIDDEN from ${role}`, () => {
+        const filter = audienceFilterForRole(role);
+        // Sanity: the admin token must not appear in any non-admin allowlist.
+        assert.ok(filter !== undefined);
+        assert.ok(!filter!.includes("admins"));
+        assert.equal(rpcChunkVisible("admins", filter), false);
+      });
+    }
+
+    it("default-role caller (empty allowlist) cannot see admin docs", () => {
+      // audienceFilterForRole returns [] for unknown roles -> only unrestricted.
+      const emptyFilter: string[] = [];
+      assert.equal(rpcChunkVisible("admins", emptyFilter), false);
+      assert.equal(rpcChunkVisible("all", emptyFilter), true);
+    });
+  });
+
+  describe("member-targeted audience respects role allowlists", () => {
+    it("'members' is visible to active_member but not alumni", () => {
+      assert.equal(
+        rpcChunkVisible("members", audienceFilterForRole("active_member")),
+        true
+      );
+      assert.equal(
+        rpcChunkVisible("members", audienceFilterForRole("alumni")),
+        false
+      );
+    });
+  });
+});

--- a/apps/web/tests/ai-knowledge-chunker.test.ts
+++ b/apps/web/tests/ai-knowledge-chunker.test.ts
@@ -1,0 +1,61 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { renderChunks } from "../src/lib/ai/chunker";
+
+describe("chunker — knowledge_documents", () => {
+  it("renders title, type, tags, and body into chunk text", () => {
+    const chunks = renderChunks("knowledge_documents", {
+      title: "Refund Policy",
+      type: "policy",
+      tags: ["billing", "refunds"],
+      description: "How refunds work",
+      body: "Refunds are processed within 30 days of request.",
+      audience: "all",
+    });
+
+    assert.equal(chunks.length, 1);
+    assert.equal(chunks[0].chunkIndex, 0);
+    assert.ok(chunks[0].text.includes("Knowledge: Refund Policy"));
+    assert.ok(chunks[0].text.includes("Type: policy"));
+    assert.ok(chunks[0].text.includes("Tags: billing, refunds"));
+    assert.ok(chunks[0].text.includes("Refunds are processed within 30 days"));
+  });
+
+  it("carries type, title, tags, and audience into chunk metadata", () => {
+    const chunks = renderChunks("knowledge_documents", {
+      title: "Admin Runbook",
+      type: "runbook",
+      tags: ["ops"],
+      body: "Internal operational steps for admins only.",
+      audience: "admins",
+    });
+
+    assert.equal(chunks.length, 1);
+    assert.equal(chunks[0].metadata.title, "Admin Runbook");
+    assert.equal(chunks[0].metadata.type, "runbook");
+    assert.deepEqual(chunks[0].metadata.tags, ["ops"]);
+    // Audience MUST be in metadata so the search RPC can gate retrieval.
+    assert.equal(chunks[0].metadata.audience, "admins");
+  });
+
+  it("defaults audience to 'all' when unset", () => {
+    const chunks = renderChunks("knowledge_documents", {
+      title: "General Info",
+      body: "Open to everyone.",
+    });
+
+    assert.equal(chunks[0].metadata.audience, "all");
+  });
+
+  it("handles missing optional fields gracefully", () => {
+    const chunks = renderChunks("knowledge_documents", {
+      title: "Bare Doc",
+      body: "Just a body.",
+    });
+
+    assert.equal(chunks.length, 1);
+    assert.ok(chunks[0].text.includes("Knowledge: Bare Doc"));
+    assert.ok(!chunks[0].text.includes("Type:"));
+    assert.ok(!chunks[0].text.includes("Tags:"));
+  });
+});

--- a/apps/web/tests/ai-knowledge-migration-contract.test.ts
+++ b/apps/web/tests/ai-knowledge-migration-contract.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const MIGRATIONS_DIR = join(__dirname, "..", "supabase", "migrations");
+
+const FILE = "20261224000000_knowledge_documents.sql";
+
+describe("knowledge_documents migration contract", () => {
+  const sql = readFileSync(join(MIGRATIONS_DIR, FILE), "utf-8");
+
+  it("creates the knowledge_documents table with required pipeline columns", () => {
+    assert.ok(sql.includes("CREATE TABLE public.knowledge_documents"));
+    for (const col of [
+      "organization_id",
+      "title",
+      "body",
+      "audience",
+      "deleted_at",
+      "created_by",
+    ]) {
+      assert.ok(sql.includes(col), `missing column: ${col}`);
+    }
+  });
+
+  it("defaults audience to the broadly-visible 'all' token", () => {
+    assert.match(sql, /audience\s+text\s+NOT NULL\s+DEFAULT\s+'all'/);
+  });
+
+  it("enables RLS and adds an admin-only policy", () => {
+    assert.ok(
+      sql.includes(
+        "ALTER TABLE public.knowledge_documents ENABLE ROW LEVEL SECURITY"
+      )
+    );
+    assert.ok(sql.includes("knowledge_documents_admin"));
+    assert.ok(sql.includes("has_active_role(organization_id, array['admin'])"));
+  });
+
+  it("rebuilds the source_table CHECK idempotently with all 8 tables (timing-safe)", () => {
+    assert.ok(
+      sql.includes(
+        "DROP CONSTRAINT IF EXISTS ai_document_chunks_source_table_check"
+      ),
+      "must DROP IF EXISTS before re-adding (timing-safe vs the CHECK-sync PR)"
+    );
+    for (const table of [
+      "announcements",
+      "discussion_threads",
+      "discussion_replies",
+      "events",
+      "job_postings",
+      "mentor_profiles",
+      "form_submissions",
+      "knowledge_documents",
+    ]) {
+      assert.ok(
+        sql.includes(`'${table}'`),
+        `CHECK rebuild missing table: ${table}`
+      );
+    }
+  });
+
+  it("adds the embedding trigger on knowledge_documents", () => {
+    assert.ok(sql.includes("trg_ai_embed_knowledge_documents"));
+    assert.ok(
+      sql.includes(
+        "AFTER INSERT OR UPDATE ON public.knowledge_documents"
+      )
+    );
+    assert.ok(sql.includes("EXECUTE FUNCTION public.enqueue_ai_embedding()"));
+  });
+
+  it("recreates enqueue_ai_embedding with a knowledge_documents change-detection branch", () => {
+    assert.ok(
+      sql.includes("CREATE OR REPLACE FUNCTION public.enqueue_ai_embedding()")
+    );
+    assert.ok(sql.includes("TG_TABLE_NAME = 'knowledge_documents'"));
+  });
+
+  it("extends backfill_ai_embedding_queue with a knowledge_documents scan block", () => {
+    assert.ok(
+      sql.includes(
+        "CREATE OR REPLACE FUNCTION public.backfill_ai_embedding_queue"
+      )
+    );
+    assert.match(
+      sql,
+      /'knowledge_documents', kd\.id, 'upsert'\s+FROM public\.knowledge_documents kd/
+    );
+  });
+
+  it("reuses the shared updated_at trigger function", () => {
+    assert.ok(
+      sql.includes("EXECUTE FUNCTION public.update_updated_at_column()")
+    );
+  });
+});

--- a/apps/web/tests/ai-knowledge-worker.test.ts
+++ b/apps/web/tests/ai-knowledge-worker.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * The embedding worker maps each SourceTable to a Postgres column select string
+ * in SOURCE_SELECTS, and validates incoming queue rows via `t in SOURCE_SELECTS`.
+ * We assert (by reading the source, since the symbol is module-private) that the
+ * knowledge_documents entry exists, is a valid comma-separated select string with
+ * the columns the renderer + worker require, and that 'audience' is selected so it
+ * can be carried into chunk metadata for audience gating.
+ */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const WORKER_PATH = join(
+  __dirname,
+  "..",
+  "src",
+  "lib",
+  "ai",
+  "embedding-worker.ts"
+);
+
+describe("embedding-worker — knowledge_documents source select", () => {
+  const source = readFileSync(WORKER_PATH, "utf-8");
+
+  it("defines a knowledge_documents SOURCE_SELECTS entry", () => {
+    assert.match(source, /knowledge_documents:\s*\n?\s*"[^"]+"/);
+  });
+
+  it("selects the columns the worker + renderer require", () => {
+    const match = source.match(/knowledge_documents:\s*\n?\s*"([^"]+)"/);
+    assert.ok(match, "expected a knowledge_documents select string");
+    const cols = match![1].split(",").map((c) => c.trim());
+    for (const required of [
+      "id",
+      "organization_id",
+      "deleted_at",
+      "title",
+      "body",
+      "audience",
+      "type",
+      "tags",
+    ]) {
+      assert.ok(
+        cols.includes(required),
+        `knowledge_documents select missing column: ${required}`
+      );
+    }
+  });
+
+  it("includes audience so chunk metadata can gate retrieval", () => {
+    const match = source.match(/knowledge_documents:\s*\n?\s*"([^"]+)"/);
+    assert.ok(match![1].includes("audience"));
+  });
+});

--- a/supabase/migrations/20261224000000_knowledge_documents.sql
+++ b/supabase/migrations/20261224000000_knowledge_documents.sql
@@ -1,0 +1,291 @@
+-- knowledge_documents — org-curated knowledge base as an 8th RAG source.
+--
+-- Adds an admin-managed table whose rows flow through the existing
+-- source-agnostic embedding pipeline (trigger -> queue -> worker -> chunks).
+-- Audience gating reuses the same metadata->>'audience' contract enforced by
+-- search_ai_documents (see 20261220000000_search_ai_documents_audience.sql):
+--   * 'all' (default) / 'both' / unset  -> visible to every role.
+--   * 'admins'                          -> a token absent from every non-admin
+--                                          audienceFilterForRole() allowlist, so
+--                                          only admins (who pass NULL = no filter)
+--                                          can retrieve it.
+--
+-- Timing-safe vs the separate CHECK-sync PR: the source_table CHECK is rebuilt
+-- idempotently (DROP IF EXISTS + re-ADD with all 8 tables), so this migration is
+-- correct whether the live constraint listed 5 or 7 tables beforehand.
+
+-- =============================================================================
+-- 1. knowledge_documents table
+-- =============================================================================
+
+CREATE TABLE public.knowledge_documents (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id  uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  type             text,
+  title            text NOT NULL,
+  description      text,
+  resource         text,
+  tags             text[],
+  body             text NOT NULL,
+  audience         text NOT NULL DEFAULT 'all',
+  source_timestamp timestamptz,
+  created_by       uuid REFERENCES auth.users(id),
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  deleted_at       timestamptz
+);
+
+COMMENT ON TABLE public.knowledge_documents IS 'Admin-curated org knowledge base; indexed for RAG via the ai_embedding_queue pipeline';
+COMMENT ON COLUMN public.knowledge_documents.audience IS 'Audience gating token surfaced into chunk metadata. ''all''/''both''/unset = visible to all; ''admins'' = admin-only (absent from every non-admin allowlist)';
+COMMENT ON COLUMN public.knowledge_documents.resource IS 'Optional link/reference to a source document or external resource';
+
+-- Org-scoped lookup of live rows (backfill + admin listing)
+CREATE INDEX idx_knowledge_documents_org
+  ON public.knowledge_documents(organization_id)
+  WHERE deleted_at IS NULL;
+
+-- =============================================================================
+-- 2. RLS — admin-managed, mirroring ai_indexing_exclusions_admin
+-- =============================================================================
+
+ALTER TABLE public.knowledge_documents ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "knowledge_documents_admin"
+  ON public.knowledge_documents
+  FOR ALL
+  USING (
+    has_active_role(organization_id, array['admin'])
+  )
+  WITH CHECK (
+    has_active_role(organization_id, array['admin'])
+  );
+
+-- =============================================================================
+-- 3. updated_at maintenance (reuses shared trigger fn)
+-- =============================================================================
+
+CREATE TRIGGER trg_knowledge_documents_updated_at
+  BEFORE UPDATE ON public.knowledge_documents
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- =============================================================================
+-- 4. Idempotent source_table CHECK rebuild on ai_document_chunks (all 8 tables)
+-- =============================================================================
+
+ALTER TABLE public.ai_document_chunks
+  DROP CONSTRAINT IF EXISTS ai_document_chunks_source_table_check;
+
+ALTER TABLE public.ai_document_chunks
+  ADD CONSTRAINT ai_document_chunks_source_table_check
+  CHECK (source_table IN (
+    'announcements', 'discussion_threads', 'discussion_replies',
+    'events', 'job_postings', 'mentor_profiles', 'form_submissions',
+    'knowledge_documents'
+  ));
+
+-- =============================================================================
+-- 5. enqueue_ai_embedding() — add a knowledge_documents change-detection branch
+--
+-- Recreated from the 20260807000000 source-table-aware version so a new table is
+-- handled without referencing fields it lacks. INSERTs and meaningful UPDATEs
+-- still enqueue; the new branch skips no-op UPDATEs for knowledge_documents.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.enqueue_ai_embedding()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  -- Soft-delete: deleted_at changed from NULL to non-NULL.
+  IF TG_OP = 'UPDATE'
+     AND NEW.deleted_at IS NOT NULL
+     AND OLD.deleted_at IS NULL
+  THEN
+    INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+    VALUES (NEW.organization_id, TG_TABLE_NAME, NEW.id, 'delete')
+    ON CONFLICT DO NOTHING;
+    RETURN NEW;
+  END IF;
+
+  -- Skip updates where deleted_at is already set.
+  IF NEW.deleted_at IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- For UPDATE: only enqueue if indexed content for this source table changed.
+  IF TG_OP = 'UPDATE' THEN
+    IF TG_TABLE_NAME = 'announcements' THEN
+      IF NEW.title IS NOT DISTINCT FROM OLD.title
+         AND NEW.body IS NOT DISTINCT FROM OLD.body
+         AND NEW.audience IS NOT DISTINCT FROM OLD.audience
+         AND NEW.published_at IS NOT DISTINCT FROM OLD.published_at
+      THEN
+        RETURN NEW;
+      END IF;
+    ELSIF TG_TABLE_NAME = 'events' THEN
+      IF NEW.title IS NOT DISTINCT FROM OLD.title
+         AND NEW.description IS NOT DISTINCT FROM OLD.description
+         AND NEW.start_date IS NOT DISTINCT FROM OLD.start_date
+         AND NEW.end_date IS NOT DISTINCT FROM OLD.end_date
+         AND NEW.location IS NOT DISTINCT FROM OLD.location
+         AND NEW.audience IS NOT DISTINCT FROM OLD.audience
+      THEN
+        RETURN NEW;
+      END IF;
+    ELSIF TG_TABLE_NAME = 'discussion_threads' THEN
+      IF NEW.title IS NOT DISTINCT FROM OLD.title
+         AND NEW.body IS NOT DISTINCT FROM OLD.body
+      THEN
+        RETURN NEW;
+      END IF;
+    ELSIF TG_TABLE_NAME = 'discussion_replies' THEN
+      IF NEW.body IS NOT DISTINCT FROM OLD.body
+         AND NEW.thread_id IS NOT DISTINCT FROM OLD.thread_id
+      THEN
+        RETURN NEW;
+      END IF;
+    ELSIF TG_TABLE_NAME = 'job_postings' THEN
+      IF NEW.title IS NOT DISTINCT FROM OLD.title
+         AND NEW.company IS NOT DISTINCT FROM OLD.company
+         AND NEW.description IS NOT DISTINCT FROM OLD.description
+         AND NEW.location IS NOT DISTINCT FROM OLD.location
+         AND NEW.location_type IS NOT DISTINCT FROM OLD.location_type
+      THEN
+        RETURN NEW;
+      END IF;
+    ELSIF TG_TABLE_NAME = 'knowledge_documents' THEN
+      IF NEW.title IS NOT DISTINCT FROM OLD.title
+         AND NEW.body IS NOT DISTINCT FROM OLD.body
+         AND NEW.description IS NOT DISTINCT FROM OLD.description
+         AND NEW.type IS NOT DISTINCT FROM OLD.type
+         AND NEW.tags IS NOT DISTINCT FROM OLD.tags
+         AND NEW.audience IS NOT DISTINCT FROM OLD.audience
+      THEN
+        RETURN NEW;
+      END IF;
+    END IF;
+  END IF;
+
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  VALUES (NEW.organization_id, TG_TABLE_NAME, NEW.id, 'upsert')
+  ON CONFLICT DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.enqueue_ai_embedding() IS 'Trigger function: enqueues embedding work only when source-table-specific indexed content changes';
+
+-- =============================================================================
+-- 6. Embedding trigger on knowledge_documents
+-- =============================================================================
+
+CREATE TRIGGER trg_ai_embed_knowledge_documents
+  AFTER INSERT OR UPDATE ON public.knowledge_documents
+  FOR EACH ROW EXECUTE FUNCTION public.enqueue_ai_embedding();
+
+-- =============================================================================
+-- 7. backfill_ai_embedding_queue() — add a knowledge_documents scan block
+--
+-- Recreated from the latest hardened version (20260712000000) plus a new block.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.backfill_ai_embedding_queue(p_org_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  total_enqueued integer := 0;
+  batch_count integer;
+BEGIN
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'announcements', a.id, 'upsert'
+  FROM public.announcements a
+  WHERE a.organization_id = p_org_id
+    AND a.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id AND c.source_table = 'announcements'
+        AND c.source_id = a.id AND c.deleted_at IS NULL
+    )
+  ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'events', e.id, 'upsert'
+  FROM public.events e
+  WHERE e.organization_id = p_org_id
+    AND e.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id AND c.source_table = 'events'
+        AND c.source_id = e.id AND c.deleted_at IS NULL
+    )
+  ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'discussion_threads', dt.id, 'upsert'
+  FROM public.discussion_threads dt
+  WHERE dt.organization_id = p_org_id
+    AND dt.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id AND c.source_table = 'discussion_threads'
+        AND c.source_id = dt.id AND c.deleted_at IS NULL
+    )
+  ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'discussion_replies', dr.id, 'upsert'
+  FROM public.discussion_replies dr
+  WHERE dr.organization_id = p_org_id
+    AND dr.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id AND c.source_table = 'discussion_replies'
+        AND c.source_id = dr.id AND c.deleted_at IS NULL
+    )
+  ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'job_postings', jp.id, 'upsert'
+  FROM public.job_postings jp
+  WHERE jp.organization_id = p_org_id
+    AND jp.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id AND c.source_table = 'job_postings'
+        AND c.source_id = jp.id AND c.deleted_at IS NULL
+    )
+  ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'knowledge_documents', kd.id, 'upsert'
+  FROM public.knowledge_documents kd
+  WHERE kd.organization_id = p_org_id
+    AND kd.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id AND c.source_table = 'knowledge_documents'
+        AND c.source_id = kd.id AND c.deleted_at IS NULL
+    )
+  ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  RETURN jsonb_build_object('enqueued', total_enqueued);
+END;
+$$;


### PR DESCRIPTION
## What this adds

An **8th RAG source** — an admin-curated org knowledge base (`knowledge_documents`) — wired into the existing source-agnostic embedding pipeline. Backend ingest only; **no admin UI** (deferred).

- **Migration `20261223000000_knowledge_documents.sql`**: table with the pipeline-required `organization_id`/`id`/`deleted_at` plus `title`/`body`/`audience`/`type`/`tags`/`description`/`resource`/`source_timestamp`/`created_by`; admin-only RLS policy mirroring `ai_indexing_exclusions_admin`; embedding trigger `trg_ai_embed_knowledge_documents`; a `knowledge_documents` change-detection branch added to `enqueue_ai_embedding()`; a `knowledge_documents` scan block added to `backfill_ai_embedding_queue()`; `updated_at` trigger reusing `update_updated_at_column()`.
- **Chunker**: `renderKnowledgeDocument()` surfaces `title`/`type`/`tags` into chunk text and carries `type`/`title`/`tags`/`audience` into chunk metadata.
- **Worker**: a `knowledge_documents` entry in `SOURCE_SELECTS` (incl. `audience`).
- **Authoring API**: `POST` (create) + `DELETE` (soft-delete) at `/api/organizations/[organizationId]/ai/knowledge`, admin-gated via `requireOrgRole` and rate-limited, with **Zod validation at the boundary** (`src/lib/schemas/ai-knowledge.ts`). No GET/list.
- A few knowledge-domain `QUERY_EXPANSIONS` terms.

## Audience-gating invariant (must-not-leak)

A doc's `audience` is carried into chunk metadata and read by `search_ai_documents` via `metadata->>'audience'`. Unrestricted (`'all'`/`'both'`/unset) is always visible. The admin-only token `'admins'` is **absent from every non-admin `audienceFilterForRole()` allowlist**, so it passes the RPC filter only for admins (who send no filter → `NULL` → unrestricted). The chat RAG stage (`rag-retrieval-stage.ts`) derives the filter from the requester's role, so **admin-only knowledge cannot surface to a non-admin**.

`ai-knowledge-audience-gating.test.ts` reproduces the exact RPC predicate and proves an `'admins'` doc is **HIDDEN** from `active_member`/`alumni`/`parent`/default and visible only to `admin`.

## Migration timing-safety (vs the CHECK-sync PR)

The `ai_document_chunks` `source_table` CHECK is rebuilt **idempotently** — `DROP CONSTRAINT IF EXISTS` then re-`ADD` with all 8 tables (the 7 existing + `knowledge_documents`). Correct whether the live constraint listed 5 or 7 tables. Should merge **after** the CHECK-sync PR, but is safe regardless.

## Risk / rollout / rollback

- **User-facing**: the assistant can ground answers on org knowledge docs once authored + backfilled. Existing sources unaffected.
- **Rollout**: new docs index via the existing trigger → queue → cron worker; `backfill_ai_embedding_queue` picks up pre-existing rows.
- **Rollback**: revert the migration (drops `knowledge_documents`, its trigger, and the backfill/trigger-fn additions) and restore the `source_table` CHECK to the prior table set; revert the TS changes.

## Verification

- `bun run --cwd apps/web typecheck` — clean (exit 0)
- `bun run --cwd apps/web lint` — clean (exit 0)
- `test:ai` — 1359 pass / 0 fail; `test:unit` — 3946 pass / 0 fail
- `check:migration-drift` — skipped (no DB creds in CI-less env), exit 0
- New tests (26 assertions): `ai-knowledge-chunker`, `ai-knowledge-audience-gating`, `ai-knowledge-worker`, `ai-knowledge-migration-contract`