### PR TITLE
fix(ai): complete RAG source table sync

### DIFF
--- a/apps/web/src/lib/ai/embedding-worker.ts
+++ b/apps/web/src/lib/ai/embedding-worker.ts
@@ -44,9 +44,9 @@ const SOURCE_SELECTS: Record<SourceTable, string> = {
   job_postings:
     "id, title, company, description, location, location_type, organization_id, deleted_at",
   mentor_profiles:
-    "id, user_id, bio, topics, organization_id",
+    "id, user_id, bio, topics, industries, is_active, organization_id",
   form_submissions:
-    "id, form_id, user_id, responses, organization_id, deleted_at",
+    "id, form_id, user_id, data, organization_id, deleted_at",
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/ai/rag-health.ts
+++ b/apps/web/src/lib/ai/rag-health.ts
@@ -8,11 +8,6 @@ import {
 
 /**
  * Read-only correctness checker for the RAG index (`ai_document_chunks`).
- *
- * Scoped to the source tables that can actually hold chunks per the
- * `ai_document_chunks.source_table` CHECK constraint — mentor_profiles and
- * form_submissions are intentionally excluded so coverage does not false-positive
- * on tables the index never stores.
  */
 
 const SAMPLE_CAP = 50;
@@ -42,6 +37,16 @@ const INDEXED_TABLES: IndexedTable[] = [
   {
     table: "job_postings",
     select: "id, title, company, description, location, location_type, deleted_at",
+    hasAudience: false,
+  },
+  {
+    table: "mentor_profiles",
+    select: "id, user_id, bio, topics, industries, is_active",
+    hasAudience: false,
+  },
+  {
+    table: "form_submissions",
+    select: "id, form_id, user_id, data, deleted_at",
     hasAudience: false,
   },
 ];
@@ -122,6 +127,13 @@ function degraded(orgId: string, reason: string): RagHealthReport {
   };
 }
 
+function isLiveSource(table: SourceTable, row: Record<string, unknown>): boolean {
+  if (table === "mentor_profiles") {
+    return row.is_active !== false;
+  }
+  return !row.deleted_at;
+}
+
 export async function checkRagHealth(
   serviceSupabase: SupabaseClient,
   orgId: string
@@ -187,7 +199,7 @@ export async function checkRagHealth(
     for (const row of sources) {
       const id = String(row.id);
       sourceById.set(id, row);
-      if (!row.deleted_at) liveSourceIds.add(id);
+      if (isLiveSource(config.table, row)) liveSourceIds.add(id);
     }
 
     const chunksBySource = new Map<string, ChunkRow[]>();
@@ -203,7 +215,7 @@ export async function checkRagHealth(
       const threadIds = [
         ...new Set(
           sources
-            .filter((row) => !row.deleted_at && row.thread_id)
+            .filter((row) => isLiveSource(config.table, row) && row.thread_id)
             .map((row) => String(row.thread_id))
         ),
       ];

--- a/apps/web/tests/ai-embedding-worker.test.ts
+++ b/apps/web/tests/ai-embedding-worker.test.ts
@@ -20,6 +20,8 @@ const VALID_SOURCE_TABLES: SourceTable[] = [
   "discussion_replies",
   "events",
   "job_postings",
+  "mentor_profiles",
+  "form_submissions",
 ];
 
 describe("embedding-worker components", () => {
@@ -31,6 +33,8 @@ describe("embedding-worker components", () => {
         discussion_threads: "id, title, body",
         discussion_replies: "id, thread_id, body",
         job_postings: "id, title, description",
+        mentor_profiles: "id, bio, topics",
+        form_submissions: "id, data",
       };
 
       for (const table of VALID_SOURCE_TABLES) {
@@ -129,6 +133,32 @@ describe("embedding-worker components", () => {
       });
       assert.ok(chunks.length >= 1);
       assert.ok(chunks[0].text.includes("Engineer"));
+    });
+
+    it("renders mentor profile chunks", () => {
+      const chunks = renderChunks("mentor_profiles", {
+        id: "mp1",
+        bio: "I mentor students interested in product leadership.",
+        topics: ["product", "leadership"],
+        industries: ["technology"],
+        is_active: true,
+        organization_id: "org1",
+      });
+      assert.ok(chunks.length >= 1);
+      assert.ok(chunks[0].text.includes("Mentor profile"));
+      assert.ok(chunks[0].text.includes("product"));
+    });
+
+    it("renders form submission chunks from the live data column", () => {
+      const chunks = renderChunks("form_submissions", {
+        id: "fs1",
+        form_id: "form1",
+        data: { goal: "Find a mentor in finance" },
+        organization_id: "org1",
+        deleted_at: null,
+      });
+      assert.ok(chunks.length >= 1);
+      assert.ok(chunks[0].text.includes("Find a mentor in finance"));
     });
   });
 

--- a/apps/web/tests/ai-rag-migration-contract.test.ts
+++ b/apps/web/tests/ai-rag-migration-contract.test.ts
@@ -197,6 +197,45 @@ describe("RAG migration contract", () => {
     });
   });
 
+  describe("20261223000000_ai_chunks_source_table_check_sync.sql", () => {
+    let sql: string;
+
+    it("migration file exists", () => {
+      sql = readMigration("20261223000000_ai_chunks_source_table_check_sync.sql");
+      assert.ok(sql.length > 0);
+    });
+
+    it("adds the widened source_table CHECK as NOT VALID before validation", () => {
+      assert.match(sql, /ADD CONSTRAINT ai_document_chunks_source_table_check[\s\S]*NOT VALID/);
+      assert.match(sql, /VALIDATE CONSTRAINT ai_document_chunks_source_table_check/);
+    });
+
+    it("allows all worker source tables", () => {
+      const tables = [
+        "announcements",
+        "discussion_threads",
+        "discussion_replies",
+        "events",
+        "job_postings",
+        "mentor_profiles",
+        "form_submissions",
+      ];
+      for (const table of tables) {
+        assert.ok(sql.includes(`'${table}'`), `Missing source table: ${table}`);
+      }
+    });
+
+    it("adds triggers for mentor profiles and form submissions", () => {
+      assert.ok(sql.includes("trg_ai_embed_mentor_profiles"));
+      assert.ok(sql.includes("trg_ai_embed_form_submissions"));
+    });
+
+    it("backfill includes mentor profiles and form submissions", () => {
+      assert.match(sql, /SELECT p_org_id, 'mentor_profiles', mp\.id, 'upsert'/);
+      assert.match(sql, /SELECT p_org_id, 'form_submissions', fs\.id, 'upsert'/);
+    });
+  });
+
   describe("20260807000000_fix_ai_embedding_trigger_field_access.sql", () => {
     let sql: string;
 

--- a/apps/web/tests/ai/rag-health.test.ts
+++ b/apps/web/tests/ai/rag-health.test.ts
@@ -3,16 +3,16 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createSupabaseStub } from "../utils/supabaseStub.ts";
 import { checkRagHealth } from "../../src/lib/ai/rag-health.ts";
-import { computeContentHash, renderChunks } from "../../src/lib/ai/chunker.ts";
+import { computeContentHash, renderChunks, type SourceTable } from "../../src/lib/ai/chunker.ts";
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111";
 
 /** Render an announcement the same way the embedding worker does, to derive
  * the canonical chunk rows (index + hash + metadata) for that source. */
-function chunkRowsFor(record: Record<string, unknown>) {
-  return renderChunks("announcements", record).map((chunk) => ({
+function chunkRowsFor(record: Record<string, unknown>, table: SourceTable = "announcements") {
+  return renderChunks(table, record).map((chunk) => ({
     org_id: ORG_ID,
-    source_table: "announcements",
+    source_table: table,
     source_id: String(record.id),
     chunk_index: chunk.chunkIndex,
     content_text: chunk.text,
@@ -46,6 +46,59 @@ test("checkRagHealth reports ok when every eligible source has a current chunk",
     staleSources: 0,
     untaggedAudience: 0,
   });
+});
+
+test("checkRagHealth includes mentor profiles and treats inactive mentors as orphans", async () => {
+  const stub = createSupabaseStub();
+  const activeMentor = {
+    id: "mentor-active",
+    organization_id: ORG_ID,
+    user_id: "user-1",
+    bio: "I help students prepare for careers in finance.",
+    topics: ["finance"],
+    industries: ["finance"],
+    is_active: true,
+  };
+  const inactiveMentor = {
+    ...activeMentor,
+    id: "mentor-inactive",
+    is_active: false,
+  };
+  stub.seed("mentor_profiles", [activeMentor, inactiveMentor]);
+  stub.seed("ai_document_chunks", [
+    ...chunkRowsFor(activeMentor, "mentor_profiles"),
+    ...chunkRowsFor(inactiveMentor, "mentor_profiles"),
+  ]);
+
+  const report = await checkRagHealth(stub as any, ORG_ID);
+
+  assert.equal(report.state, "gaps");
+  assert.equal(report.counts.orphanChunks, 1);
+  assert.deepEqual(report.orphanChunks, [
+    { sourceTable: "mentor_profiles", sourceId: "mentor-inactive" },
+  ]);
+});
+
+test("checkRagHealth includes form submissions in coverage checks", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("form_submissions", [
+    {
+      id: "submission-missing",
+      organization_id: ORG_ID,
+      form_id: "form-1",
+      user_id: "user-1",
+      data: { goals: "Find a mentor in healthcare." },
+      deleted_at: null,
+    },
+  ]);
+
+  const report = await checkRagHealth(stub as any, ORG_ID);
+
+  assert.equal(report.state, "gaps");
+  assert.equal(report.counts.missingCoverage, 1);
+  assert.deepEqual(report.missingCoverage, [
+    { sourceTable: "form_submissions", sourceId: "submission-missing" },
+  ]);
 });
 
 test("checkRagHealth flags a source with no chunk as missing coverage", async () => {

--- a/supabase/migrations/20261223000000_ai_chunks_source_table_check_sync.sql
+++ b/supabase/migrations/20261223000000_ai_chunks_source_table_check_sync.sql
@@ -9,4 +9,265 @@ ALTER TABLE public.ai_document_chunks
   CHECK (source_table IN (
     'announcements', 'discussion_threads', 'discussion_replies',
     'events', 'job_postings', 'mentor_profiles', 'form_submissions'
-  ));
+  ))
+  NOT VALID;
+
+ALTER TABLE public.ai_document_chunks
+  VALIDATE CONSTRAINT ai_document_chunks_source_table_check;
+
+CREATE OR REPLACE FUNCTION public.enqueue_ai_embedding()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF TG_TABLE_NAME = 'mentor_profiles' THEN
+    IF TG_OP = 'UPDATE'
+       AND NEW.is_active = false
+       AND OLD.is_active = true
+    THEN
+      INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+      VALUES (NEW.organization_id, TG_TABLE_NAME, NEW.id, 'delete')
+      ON CONFLICT DO NOTHING;
+      RETURN NEW;
+    END IF;
+
+    IF NEW.is_active = false THEN
+      RETURN NEW;
+    END IF;
+
+    IF TG_OP = 'UPDATE'
+       AND NEW.bio IS NOT DISTINCT FROM OLD.bio
+       AND NEW.topics IS NOT DISTINCT FROM OLD.topics
+       AND NEW.industries IS NOT DISTINCT FROM OLD.industries
+       AND NEW.is_active IS NOT DISTINCT FROM OLD.is_active
+    THEN
+      RETURN NEW;
+    END IF;
+
+    INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+    VALUES (NEW.organization_id, TG_TABLE_NAME, NEW.id, 'upsert')
+    ON CONFLICT DO NOTHING;
+    RETURN NEW;
+  END IF;
+
+  -- Soft-delete: deleted_at changed from NULL to non-NULL.
+  IF TG_OP = 'UPDATE'
+     AND NEW.deleted_at IS NOT NULL
+     AND OLD.deleted_at IS NULL
+  THEN
+    INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+    VALUES (NEW.organization_id, TG_TABLE_NAME, NEW.id, 'delete')
+    ON CONFLICT DO NOTHING;
+    RETURN NEW;
+  END IF;
+
+  -- Skip inserts or updates where deleted_at is already set.
+  IF NEW.deleted_at IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- For UPDATE: only enqueue if indexed content for this source table changed.
+  IF TG_OP = 'UPDATE' THEN
+    IF TG_TABLE_NAME = 'announcements' THEN
+      IF NEW.title IS NOT DISTINCT FROM OLD.title
+         AND NEW.body IS NOT DISTINCT FROM OLD.body
+         AND NEW.audience IS NOT DISTINCT FROM OLD.audience
+         AND NEW.published_at IS NOT DISTINCT FROM OLD.published_at
+      THEN
+        RETURN NEW;
+      END IF;
+    ELSIF TG_TABLE_NAME = 'events' THEN
+      IF NEW.title IS NOT DISTINCT FROM OLD.title
+         AND NEW.description IS NOT DISTINCT FROM OLD.description
+         AND NEW.start_date IS NOT DISTINCT FROM OLD.start_date
+         AND NEW.end_date IS NOT DISTINCT FROM OLD.end_date
+         AND NEW.location IS NOT DISTINCT FROM OLD.location
+         AND NEW.audience IS NOT DISTINCT FROM OLD.audience
+      THEN
+        RETURN NEW;
+      END IF;
+    ELSIF TG_TABLE_NAME = 'discussion_threads' THEN
+      IF NEW.title IS NOT DISTINCT FROM OLD.title
+         AND NEW.body IS NOT DISTINCT FROM OLD.body
+      THEN
+        RETURN NEW;
+      END IF;
+    ELSIF TG_TABLE_NAME = 'discussion_replies' THEN
+      IF NEW.body IS NOT DISTINCT FROM OLD.body
+         AND NEW.thread_id IS NOT DISTINCT FROM OLD.thread_id
+      THEN
+        RETURN NEW;
+      END IF;
+    ELSIF TG_TABLE_NAME = 'job_postings' THEN
+      IF NEW.title IS NOT DISTINCT FROM OLD.title
+         AND NEW.company IS NOT DISTINCT FROM OLD.company
+         AND NEW.description IS NOT DISTINCT FROM OLD.description
+         AND NEW.location IS NOT DISTINCT FROM OLD.location
+         AND NEW.location_type IS NOT DISTINCT FROM OLD.location_type
+      THEN
+        RETURN NEW;
+      END IF;
+    ELSIF TG_TABLE_NAME = 'form_submissions' THEN
+      IF NEW.form_id IS NOT DISTINCT FROM OLD.form_id
+         AND NEW.user_id IS NOT DISTINCT FROM OLD.user_id
+         AND NEW.data IS NOT DISTINCT FROM OLD.data
+      THEN
+        RETURN NEW;
+      END IF;
+    END IF;
+  END IF;
+
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  VALUES (NEW.organization_id, TG_TABLE_NAME, NEW.id, 'upsert')
+  ON CONFLICT DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.enqueue_ai_embedding() IS 'Trigger function: enqueues embedding work only when source-table-specific indexed content changes';
+
+DROP TRIGGER IF EXISTS trg_ai_embed_mentor_profiles ON public.mentor_profiles;
+CREATE TRIGGER trg_ai_embed_mentor_profiles
+  AFTER INSERT OR UPDATE ON public.mentor_profiles
+  FOR EACH ROW EXECUTE FUNCTION public.enqueue_ai_embedding();
+
+DROP TRIGGER IF EXISTS trg_ai_embed_form_submissions ON public.form_submissions;
+CREATE TRIGGER trg_ai_embed_form_submissions
+  AFTER INSERT OR UPDATE ON public.form_submissions
+  FOR EACH ROW EXECUTE FUNCTION public.enqueue_ai_embedding();
+
+CREATE OR REPLACE FUNCTION public.backfill_ai_embedding_queue(p_org_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  total_enqueued integer := 0;
+  batch_count integer;
+BEGIN
+  -- Announcements
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'announcements', a.id, 'upsert'
+  FROM public.announcements a
+  WHERE a.organization_id = p_org_id
+    AND a.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id
+        AND c.source_table = 'announcements'
+        AND c.source_id = a.id
+        AND c.deleted_at IS NULL
+    );
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  -- Events
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'events', e.id, 'upsert'
+  FROM public.events e
+  WHERE e.organization_id = p_org_id
+    AND e.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id
+        AND c.source_table = 'events'
+        AND c.source_id = e.id
+        AND c.deleted_at IS NULL
+    );
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  -- Discussion threads
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'discussion_threads', dt.id, 'upsert'
+  FROM public.discussion_threads dt
+  WHERE dt.organization_id = p_org_id
+    AND dt.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id
+        AND c.source_table = 'discussion_threads'
+        AND c.source_id = dt.id
+        AND c.deleted_at IS NULL
+    );
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  -- Discussion replies
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'discussion_replies', dr.id, 'upsert'
+  FROM public.discussion_replies dr
+  WHERE dr.organization_id = p_org_id
+    AND dr.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id
+        AND c.source_table = 'discussion_replies'
+        AND c.source_id = dr.id
+        AND c.deleted_at IS NULL
+    );
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  -- Job postings
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'job_postings', jp.id, 'upsert'
+  FROM public.job_postings jp
+  WHERE jp.organization_id = p_org_id
+    AND jp.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id
+        AND c.source_table = 'job_postings'
+        AND c.source_id = jp.id
+        AND c.deleted_at IS NULL
+    );
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  -- Mentor profiles
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'mentor_profiles', mp.id, 'upsert'
+  FROM public.mentor_profiles mp
+  WHERE mp.organization_id = p_org_id
+    AND mp.is_active = true
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id
+        AND c.source_table = 'mentor_profiles'
+        AND c.source_id = mp.id
+        AND c.deleted_at IS NULL
+    );
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  -- Form submissions
+  INSERT INTO public.ai_embedding_queue(org_id, source_table, source_id, action)
+  SELECT p_org_id, 'form_submissions', fs.id, 'upsert'
+  FROM public.form_submissions fs
+  WHERE fs.organization_id = p_org_id
+    AND fs.deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.ai_document_chunks c
+      WHERE c.org_id = p_org_id
+        AND c.source_table = 'form_submissions'
+        AND c.source_id = fs.id
+        AND c.deleted_at IS NULL
+    );
+  GET DIAGNOSTICS batch_count = ROW_COUNT;
+  total_enqueued := total_enqueued + batch_count;
+
+  RETURN jsonb_build_object('enqueued', total_enqueued);
+END;
+$$;
+
+COMMENT ON FUNCTION public.backfill_ai_embedding_queue IS 'Enqueues all unindexed content for an org across all source tables';
+
+REVOKE EXECUTE ON FUNCTION public.backfill_ai_embedding_queue FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.backfill_ai_embedding_queue FROM anon;
+REVOKE EXECUTE ON FUNCTION public.backfill_ai_embedding_queue FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.backfill_ai_embedding_queue TO service_role;


### PR DESCRIPTION
## Summary

- Make the widened ai_document_chunks source_table CHECK use NOT VALID before validation
- Wire mentor_profiles and form_submissions into RAG queue triggers, backfill, worker selects, and health checks
- Use mentor is_active as the live/deleted signal and select form_submissions.data instead of the old responses column

## Verification

- bun test apps/web/tests/ai-rag-migration-contract.test.ts apps/web/tests/ai-embedding-worker.test.ts apps/web/tests/ai/rag-health.test.ts
- bun run typecheck
- bun run lint
- bun run test

Build note: bun run build is blocked in this worktree before compilation because NEXT_PUBLIC_SUPABASE_URL is not configured locally.