### PR TITLE
docs(agent): structure AI docs as an OKF bundle with frontmatter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ packages/
 ├── validation/         # @teammeet/validation — shared Zod schemas
 └── supabase/           # @teammeet/supabase — shared Supabase helpers
 supabase/               # Migrations, config, seeds (symlinked from apps/web/supabase)
-docs/                   # Cross-cutting docs (agent/, db/, stripe-donations.md, ...)
+docs/                   # Cross-cutting docs. AI docs in agent/ are an OKF bundle — start at docs/agent/index.md
 turbo.json              # Pipeline config + globalPassThroughEnv allowlist
 ```
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -118,7 +118,9 @@ Funds route directly to org's connected Stripe account, never touching the app. 
 External schedule URLs validated before import to prevent SSRF. Domain statuses: `denied` → `pending` → `active` / `blocked`. Files: `src/lib/schedule-security/allowlist.ts`, `safe-fetch.ts`, `verifyAndEnroll.ts`.
 
 ### AI Agent
-Architecture, pipeline, and feature docs live in repo-root `docs/agent/`. When modifying AI agent code (`src/lib/ai/`, `src/app/api/ai/`, `src/app/[orgSlug]/chat/`), update the relevant doc in `docs/agent/` to reflect structural changes, new features, or revised taxonomy.
+Architecture, pipeline, and feature docs live in repo-root `docs/agent/`, structured as an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) (OKF) bundle. **Start at `docs/agent/index.md`** — it lists every doc by `type` and links into each. Each doc carries YAML frontmatter (`type`, `title`, `description`, `resource`, `tags`, `timestamp`); the `resource` field points at the primary source file the doc describes, so the bundle doubles as a concept → code index (e.g. `falkor-people-graph.md` → `src/lib/falkordb/suggestions.ts`).
+
+When modifying AI agent code (`src/lib/ai/`, `src/app/api/ai/`, `src/app/[orgSlug]/chat/`), update the relevant doc in `docs/agent/` to reflect structural changes, new features, or revised taxonomy. Keep the frontmatter current too: bump `timestamp`, and if a file moves or is renamed, update the `resource` path so the index does not rot. New docs must include valid OKF frontmatter (only `type` is required) and be linked from `index.md`.
 
 ### Schema Validation
 Centralized Zod schemas in `src/lib/schemas/` — see `index.ts` for all available domains. Usage: `import { schemaName } from "@/lib/schemas"`. Cross-app schemas live in `@teammeet/validation`.

--- a/docs/agent/ai-data-flow.md
+++ b/docs/agent/ai-data-flow.md
@@ -1,3 +1,12 @@
+---
+type: reference
+title: AI Data Flow — Privacy and Compliance
+description: PII entering the AI pipeline, what is stored, and what is sent to the z.ai provider.
+resource: apps/web/src/lib/ai/context-builder.ts
+tags: [ai, privacy, compliance, pii]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 # AI Data Flow — Privacy & Compliance Documentation
 
 **Last Updated:** June 2026

--- a/docs/agent/ai-intent-plan.md
+++ b/docs/agent/ai-intent-plan.md
@@ -1,3 +1,12 @@
+---
+type: codemap
+title: AI Intent Routing and Surface Inference
+description: Message intent routing and per-turn surface inference for context loading, caching, and tool selection.
+resource: apps/web/src/lib/ai/intent-router.ts
+tags: [ai, intent-routing, surface, chat]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 # AI Intent Routing & Surface Inference — Code Map
 
 ## Overview

--- a/docs/agent/assistant.md
+++ b/docs/agent/assistant.md
@@ -1,3 +1,12 @@
+---
+type: architecture
+title: AI Assistant Architecture Overview
+description: Architecture of the admin AI assistant — scope policy, tools, enterprise extension, and pipeline.
+resource: apps/web/src/app/api/ai/[orgId]/chat/handler.ts
+tags: [ai, assistant, architecture, tools]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 # AI Assistant — Architecture Overview
 
 ## Summary

--- a/docs/agent/chat-pipeline-codemap.md
+++ b/docs/agent/chat-pipeline-codemap.md
@@ -1,3 +1,12 @@
+---
+type: codemap
+title: Chat Pipeline
+description: Full chat request lifecycle — auth, policy, RAG, tool execution, SSE streaming, persistence, grounding.
+resource: apps/web/src/app/api/ai/[orgId]/chat/handler.ts
+tags: [ai, chat-pipeline, sse, tools]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 # Chat Pipeline — Code Map
 
 ## Overview

--- a/docs/agent/enterprise-context.md
+++ b/docs/agent/enterprise-context.md
@@ -1,3 +1,12 @@
+---
+type: architecture
+title: Enterprise-Aware AI Context
+description: Activation criteria, prompt-context visibility, capability matrix, and response policy for enterprise AI.
+resource: apps/web/src/lib/ai/context.ts
+tags: [ai, enterprise, authorization, context]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 # Enterprise-Aware AI Context
 
 The enterprise assistant experience is an extension of the existing org assistant. It uses the same `AIPanel`, the same `/api/ai/[orgId]/chat` route, and the same org-scoped thread/message/audit persistence.

--- a/docs/agent/enterprise-parity-audit.md
+++ b/docs/agent/enterprise-parity-audit.md
@@ -1,3 +1,12 @@
+---
+type: audit
+title: Enterprise AI Parity Audit
+description: Tracks enterprise UI mutations against AI tool coverage and role gates.
+resource: apps/web/src/types/enterprise.ts
+tags: [ai, enterprise, parity-audit, write-tools]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 # Enterprise AI Parity Audit
 
 Tracks UI mutations in the enterprise surface against AI tool coverage. The goal: any action an enterprise user can take from the dashboard, the assistant can also take (subject to role gates and human-in-the-loop confirmation for writes).

--- a/docs/agent/falkor-connection-suggestions.md
+++ b/docs/agent/falkor-connection-suggestions.md
@@ -1,3 +1,12 @@
+---
+type: data-flow
+title: Falkor Connection Suggestions Flow
+description: Flow from chat to suggest_connections through Falkor or the SQL fallback to pass-2 render.
+resource: apps/web/src/lib/people-graph/suggestions.ts
+tags: [ai, falkor, connection-suggestions, diagram]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 ```mermaid
 flowchart TD
   subgraph User

--- a/docs/agent/falkor-people-graph.md
+++ b/docs/agent/falkor-people-graph.md
@@ -1,3 +1,12 @@
+---
+type: codemap
+title: Falkor People Graph
+description: Falkor people graph powering suggest_connections — projection, sync, scoring, freshness, and fallback.
+resource: apps/web/src/lib/people-graph/suggestions.ts
+tags: [ai, falkor, graph, connection-suggestions]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 # Falkor People Graph
 
 ## Overview

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -1,0 +1,44 @@
+---
+type: index
+title: TeamNetwork AI Agent Knowledge Bundle
+description: Open Knowledge Format index for the TeamNetwork AI assistant codemaps, architecture, and taxonomies.
+tags: [ai, index, okf]
+timestamp: 2026-06-17T00:00:00Z
+---
+
+# TeamNetwork AI Agent Knowledge Bundle
+
+This directory is an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) (OKF) bundle: plain markdown concept documents, each carrying YAML frontmatter (`type`, `title`, `description`, `resource`, `tags`, `timestamp`). It documents the TeamNetwork AI assistant so that humans and agentic tools (Claude Code, the in-app assistant) can navigate it consistently.
+
+Each document's `resource` field points at the primary source file it describes, giving a concept → code index.
+
+## Architecture
+
+- [AI Assistant Architecture Overview](/docs/agent/assistant.md) — scope policy, tools, enterprise extension, pipeline.
+- [Enterprise-Aware AI Context](/docs/agent/enterprise-context.md) — activation criteria, prompt visibility, capability matrix, response policy.
+
+## Codemaps
+
+- [Chat Pipeline](/docs/agent/chat-pipeline-codemap.md) — auth, policy, RAG, tool execution, SSE streaming, persistence, grounding.
+- [AI Intent Routing and Surface Inference](/docs/agent/ai-intent-plan.md) — intent routing and per-turn surface inference.
+- [Semantic Cache](/docs/agent/semantic-cache-codemap.md) — exact-match cache eligibility, TTLs, invalidation, purge cron.
+- [Thread Management](/docs/agent/threads-codemap.md) — thread/message CRUD, pagination, soft-delete, RLS.
+- [UI Panel](/docs/agent/ui-panel-codemap.md) — slide-out assistant panel and SSE consumer.
+- [Falkor People Graph](/docs/agent/falkor-people-graph.md) — graph powering `suggest_connections`.
+
+## Taxonomies and reference
+
+- [Intent Type Taxonomy](/docs/agent/intent-type-taxonomy.md) — the `intent_type` classification axis.
+- [AI Data Flow — Privacy and Compliance](/docs/agent/ai-data-flow.md) — PII in the pipeline, storage, and external-provider surface.
+
+## Flows
+
+- [Falkor Connection Suggestions Flow](/docs/agent/falkor-connection-suggestions.md) — chat → `suggest_connections` → Falkor/SQL → pass 2.
+
+## Audits
+
+- [Enterprise AI Parity Audit](/docs/agent/enterprise-parity-audit.md) — enterprise UI mutations vs. AI tool coverage.
+
+## Type vocabulary
+
+The bundle uses a deliberately small `type` set: `architecture`, `codemap`, `taxonomy`, `reference`, `data-flow`, `audit`, and `index` (this file).

--- a/docs/agent/intent-type-taxonomy.md
+++ b/docs/agent/intent-type-taxonomy.md
@@ -1,3 +1,12 @@
+---
+type: taxonomy
+title: Intent Type Taxonomy
+description: The intent_type classification axis (knowledge/action/navigation/casual) and its labeled-data pipeline.
+resource: apps/web/src/lib/ai/intent-router.ts
+tags: [ai, intent-type, classification, taxonomy]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 # Intent Type Taxonomy — Code Map
 
 ## Overview

--- a/docs/agent/semantic-cache-codemap.md
+++ b/docs/agent/semantic-cache-codemap.md
@@ -1,3 +1,12 @@
+---
+type: codemap
+title: Semantic Cache
+description: Exact-match semantic cache for general first-turn prompts — eligibility, TTLs, invalidation, purge cron.
+resource: apps/web/src/lib/ai/semantic-cache.ts
+tags: [ai, semantic-cache, caching, ttl]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 # Semantic Cache — Code Map
 
 ## Overview

--- a/docs/agent/threads-codemap.md
+++ b/docs/agent/threads-codemap.md
@@ -1,3 +1,12 @@
+---
+type: codemap
+title: Thread Management
+description: CRUD for AI threads and messages — ownership resolution, cursor pagination, soft-delete, RLS.
+resource: apps/web/src/lib/ai/thread-resolver.ts
+tags: [ai, threads, pagination, crud]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 # Thread Management — Code Map
 
 ## Overview

--- a/docs/agent/ui-panel-codemap.md
+++ b/docs/agent/ui-panel-codemap.md
@@ -1,3 +1,12 @@
+---
+type: codemap
+title: UI Panel
+description: Slide-out AI assistant panel — SSE stream consumer, thread/message display, pending-action review UI.
+resource: apps/web/src/components/ai-assistant/AIPanel.tsx
+tags: [ai, ui, panel, sse]
+timestamp: 2026-06-17T00:00:00Z
+---
+
 # UI Panel — Code Map
 
 ## Overview


### PR DESCRIPTION
## Summary

Structures `docs/agent/` as an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) (OKF) bundle: plain-markdown concept docs that each carry YAML frontmatter (`type`, `title`, `description`, `resource`, `tags`, `timestamp`), plus an `index.md` entry point.

- Adds frontmatter to all 12 `docs/agent/*.md` AI codemaps/architecture/taxonomy docs.
- Adds `docs/agent/index.md` — the bundle entry point; each doc's `resource` field gives a concept → code index.
- Points both `CLAUDE.md` files at the bundle and adds a keep-frontmatter-current rule.

Docs-only change: 15 files, +156/-2. No code, no migrations.

## Why

This is the root of the OKF work. It makes the AI assistant docs navigable by humans and agentic tools (Claude Code, the in-app assistant) via a consistent metadata schema, and gives a stable base for follow-up PRs:

- **Tier 1** (validator + CI gate) stacks on this branch and validates these files.
- **Tier 2** (knowledge_documents RAG source) and **Tier 3** (db-schema OKF bundle + nav skill) build on the same OKF conventions off `main`.

## Risk / rollout / rollback

- Risk: none functional — documentation + two `CLAUDE.md` pointer lines only.
- Rollback: revert this PR; no runtime, schema, or build impact.

Rebased onto current `main` (includes #284, #285) so the diff is docs-only.
