### PR TITLE
fix(ai): make assistant workflow shortcuts return usable output

### DIFF
--- a/apps/web/src/app/api/ai/[orgId]/chat/handler/pass1-tools.ts
+++ b/apps/web/src/app/api/ai/[orgId]/chat/handler/pass1-tools.ts
@@ -61,7 +61,10 @@ const RAW_PASS1_TOOL_NAMES: Record<CacheSurface, ToolName[]> = {
     "suggest_mentees",
   ],
   analytics: ["get_org_stats"],
-  events: ["list_events", "find_free_members"],
+  // "announcements" is not its own surface keyword, so prompts pairing events +
+  // announcements (e.g. the "Summarize activity" workflow) route here; keep
+  // list_announcements attached so the model can actually fetch them.
+  events: ["list_events", "list_announcements", "find_free_members"],
 };
 
 // Surface-specific tools come first so per-surface biasing is preserved.

--- a/apps/web/src/components/assistant/AssistantWorkflowShortcuts.tsx
+++ b/apps/web/src/components/assistant/AssistantWorkflowShortcuts.tsx
@@ -39,7 +39,8 @@ export const ASSISTANT_WORKFLOW_SHORTCUTS: AssistantWorkflowShortcut[] = [
   {
     id: "analyze-engagement",
     label: "Analyze engagement",
-    prompt: "Analyze this organization's engagement over the past month.",
+    prompt:
+      "Give me an engagement overview: pull the org stats, then summarize recent events and announcements.",
     icon: BarChart3,
   },
 ];

--- a/apps/web/tests/ai-pass1-tools.test.ts
+++ b/apps/web/tests/ai-pass1-tools.test.ts
@@ -53,6 +53,7 @@ import {
   deriveSearchOrgContentQuery,
   deriveNavigationQuery,
   deriveForcedPass1ToolArgs,
+  PASS1_TOOL_NAMES,
 } from "../src/app/api/ai/[orgId]/chat/handler/pass1-tools";
 import type { CacheSurface } from "../src/lib/ai/semantic-cache-utils";
 import type { TurnExecutionPolicy } from "../src/lib/ai/turn-execution-policy";
@@ -784,6 +785,7 @@ describe("getPass1Tools — surface defaults", () => {
     );
     assert.deepEqual(namesOf(tools), [
       "list_events",
+      "list_announcements",
       "find_free_members",
       "search_org_content",
       "find_navigation_targets",
@@ -1390,5 +1392,23 @@ describe("search and navigation derivation helpers", () => {
       deriveNavigationQuery("where is navigation settings?"),
       "navigation settings",
     );
+  });
+});
+
+
+describe("PASS1_TOOL_NAMES surface coverage", () => {
+  // Regression: the "Summarize upcoming events and recent announcements"
+  // workflow routes to the `events` surface (because "announcements" is not its
+  // own surface keyword). list_announcements must be attached there or the model
+  // cannot fetch announcements and the answer collapses to the empty fallback.
+  it("events surface includes list_announcements", () => {
+    assert.ok(
+      PASS1_TOOL_NAMES.events.includes("list_announcements"),
+      "events surface must expose list_announcements for the summarize-activity workflow",
+    );
+  });
+
+  it("events surface still includes list_events", () => {
+    assert.ok(PASS1_TOOL_NAMES.events.includes("list_events"));
   });
 });


### PR DESCRIPTION
## Problem
Two assistant **workflow shortcut buttons** returned empty / 'I didn't get a usable response' output:
- **Summarize upcoming events and recent announcements**
- **Analyze this organization's engagement over the past month**

Investigated via parallel agents. Root cause is a **routing/toolset gap, independent of the embedding/RAG outage** — both buttons query Postgres directly (`events`/`announcements` tables), not `ai_document_chunks`.

## Root causes
1. **Summarize activity** routes to the `events` surface (because "announcements" is not its own surface keyword), but the `events` pass-1 toolset only had `list_events` — **`list_announcements` was missing** (only the `general` surface had it). The model couldn't fetch announcements → ungroundable → empty fallback (`handler.ts` empty-response path).
2. **Analyze engagement** had **no backing tool** for engagement analysis, so the model emitted "I'll pull data from several sources…" and then had nothing to fetch.

The `{"data":[]}` seen in the Network panel was a red herring — those are the chat-history (threads/feedback) endpoints, legitimately empty for a new thread.

## Fix
1. Attach `list_announcements` to the `events` surface toolset (`pass1-tools.ts`).
2. Rewrite the 'Analyze engagement' shortcut prompt to one the existing tools answer (org stats + recent events/announcements).
3. Regression test: assert the `events` surface exposes `list_announcements`; updated the existing exact-toolset assertion.

## Verification
- `bun run typecheck` ✅  `bun run lint` ✅
- `ai-pass1-tools.test.ts`: **156/156 pass** (incl. new regression tests).
- Note: `tests/mentorship-why.test.ts` fails in this environment, but it is **pre-existing and unrelated** — it asserts a deterministic-template fallback that doesn't trigger when a live `ZAI_API_KEY` is present (the GLM call succeeds and returns `glm-5.2`). Not touched by this PR.

## Risk / rollback
Low — additive tool wiring + a prompt string. Rollback = revert. No schema/migration.