### PR TITLE
fix(mobile): prevent iPad splash-screen launch hang (Guideline 2.1(a)) + lock iPad orientation

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -39,6 +39,13 @@ const config: ExpoConfig = {
   },
   ios: {
     supportsTablet: true,
+    // Phone-first, portrait-only app. With requireFullScreen omitted (default
+    // false), Expo's prebuild FORCES all four orientations into
+    // UISupportedInterfaceOrientations~ipad for multitasking compatibility,
+    // so iPadOS rotates the portrait-designed UI into a broken landscape
+    // layout. Requiring full screen disables Split View/Stage Manager and lets
+    // the portrait-only orientation stick on iPad (Apple permits this).
+    requireFullScreen: true,
     appleTeamId: "5GWLTFG43T",
     bundleIdentifier: "com.myteamnetwork.teammeet",
     buildNumber: "29",
@@ -54,6 +61,13 @@ const config: ExpoConfig = {
       NSSupportsLiveActivities: true,
       NSSupportsLiveActivitiesFrequentUpdates: true,
       ITSAppUsesNonExemptEncryption: false,
+      // Explicit portrait-only for iPad. ios.requireFullScreen (above) stops
+      // Expo's prebuild from forcing all four orientations here; this key makes
+      // the portrait lock unambiguous in the shipped plist.
+      "UISupportedInterfaceOrientations~ipad": [
+        "UIInterfaceOrientationPortrait",
+        "UIInterfaceOrientationPortraitUpsideDown",
+      ],
       NSCameraUsageDescription:
         "Scan a TeamNetwork QR code to join your organization or check members in at events.",
       NSCalendarsFullAccessUsageDescription:

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -50,6 +50,13 @@ import { ErrorState } from "@/components/ui/ErrorState";
 export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
   captureException(error, { context: "RootErrorBoundary" });
 
+  // The native splash is locked open at module load (preventAutoHideAsync) and
+  // is normally hidden inside RootLayoutInner. If a provider throws during the
+  // first render, that code never runs and the error screen would sit invisibly
+  // behind a frozen splash — exactly the "only a splash screen" launch hang.
+  // Dismiss it here so the retryable error UI is actually visible.
+  SplashScreen.hideAsync().catch(() => {});
+
   return (
     <ColorSchemeProvider>
       <SafeAreaView style={{ flex: 1, backgroundColor: "#0f172a" }}>
@@ -137,12 +144,16 @@ function RootLayoutInner() {
   const segments = useSegments() as string[];
   const { session, isLoading } = useAuth();
   const prevUserIdRef = useRef<string | undefined>(undefined);
-  const [fontsLoaded] = useFonts({
+  const [fontsLoaded, fontError] = useFonts({
     DMSerifDisplay_400Regular,
     PlusJakartaSans_400Regular,
     PlusJakartaSans_500Medium,
     PlusJakartaSans_600SemiBold,
   });
+  // A font load that errors or never resolves must not pin the app on the
+  // splash screen. Treat an error as "fonts done" and fall back to system
+  // fonts (cosmetic degradation) rather than blocking launch forever.
+  const fontsReady = fontsLoaded || !!fontError;
 
   // Track screen views automatically
   useScreenTracking();
@@ -159,12 +170,25 @@ function RootLayoutInner() {
   // Bump users.last_active_at on sign-in + every foreground.
   useActivityHeartbeat(session?.user?.id ?? null);
 
-  // Hide splash screen once fonts are loaded
+  // Hide splash screen once fonts are loaded — or once a font error makes it
+  // clear they never will. hideAsync() rejects if the splash is already hidden
+  // (e.g. raced with the timeout below), so swallow that rejection.
   useEffect(() => {
-    if (fontsLoaded) {
-      SplashScreen.hideAsync();
+    if (fontsLoaded || fontError) {
+      SplashScreen.hideAsync().catch(() => {});
     }
-  }, [fontsLoaded]);
+  }, [fontsLoaded, fontError]);
+
+  // Hard safety net: never let the splash outlive a stalled/never-resolving
+  // font load. App Review installs fresh (no warmed asset cache), where slow
+  // font I/O surfaces as "only a splash screen appeared on launch". This fires
+  // regardless of font state so the splash is always dismissed within 3s.
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      SplashScreen.hideAsync().catch(() => {});
+    }, 3000);
+    return () => clearTimeout(timeoutId);
+  }, []);
 
   // Initialize analytics on mount
   useEffect(() => {
@@ -279,7 +303,7 @@ function RootLayoutInner() {
     }
   }, [session, isLoading, segments, router]);
 
-  if (!fontsLoaded || isLoading) {
+  if (!fontsReady || isLoading) {
     return <AuthLoadingScreen />;
   }
 

--- a/apps/mobile/src/contexts/AuthContext.tsx
+++ b/apps/mobile/src/contexts/AuthContext.tsx
@@ -36,24 +36,37 @@ export function AuthProvider({ children }: AuthProviderProps) {
   useEffect(() => {
     isMountedRef.current = true;
 
+    // Restore the persisted session, but never let a slow or hung getSession()
+    // pin the app on AuthLoadingScreen at launch. The first of {resolve,
+    // reject, 8s timeout} flips isLoading off exactly once (settled guard). On
+    // timeout we treat it as "no session yet"; onAuthStateChange still delivers
+    // the real session independently if/when it arrives.
+    let settled = false;
+    const finishLoading = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      if (isMountedRef.current) {
+        setIsLoading(false);
+      }
+    };
+
+    const timeoutId = setTimeout(finishLoading, 8000);
+
     supabase.auth
       .getSession()
       .then(({ data: { session } }) => {
-        if (isMountedRef.current) {
+        if (!settled && isMountedRef.current) {
           setSession(session);
         }
       })
       .catch((error: Error) => {
         sentry.captureException(error, { context: "AuthContext.getSession" });
-        if (isMountedRef.current) {
+        if (!settled && isMountedRef.current) {
           setSession(null);
         }
       })
-      .finally(() => {
-        if (isMountedRef.current) {
-          setIsLoading(false);
-        }
-      });
+      .finally(finishLoading);
 
     const {
       data: { subscription },
@@ -66,6 +79,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
     return () => {
       isMountedRef.current = false;
+      clearTimeout(timeoutId);
       subscription?.unsubscribe();
     };
   }, []);


### PR DESCRIPTION
## Why

Apple rejected build **1.0 (62)** under **Guideline 2.1(a) — Performance / App Completeness**: *"only a splash screen appeared on launch"* on **iPad Air 11" (M3), iPadOS 26.5**. This was a new failure (the prior rejection was the Apple Pay 2.1 issue, fixed in #294).

## Root cause

The native splash is locked open at module load (`SplashScreen.preventAutoHideAsync()`) and was dismissed **only** when 4 bundled Google fonts finished loading:

```ts
const [fontsLoaded] = useFonts({ ... });
useEffect(() => { if (fontsLoaded) SplashScreen.hideAsync(); }, [fontsLoaded]);
```

Three gaps, all of which manifest as a frozen splash — especially on a **fresh install** (how App Review tests, with no warmed asset cache):

1. **Font error ignored** — `useFonts` returns `[loaded, error]`, but the error was discarded. A font that fails/stalls leaves `fontsLoaded` false forever → `hideAsync()` never runs.
2. **No timeout** — nothing force-dismisses the splash if font I/O hangs.
3. **ErrorBoundary behind the splash** — a render throw in any provider rendered the error UI invisibly behind the still-locked splash.

A slow `getSession()` was a secondary launch-hang vector (kept `AuthLoadingScreen` mounted indefinitely).

## What changed

- **`app/_layout.tsx`** — hide the splash on `fontsLoaded || fontError`, add a **3s hard-timeout** fallback, render with **system-font fallback** when fonts fail (cosmetic degradation, not a launch failure), and **dismiss the splash from the `ErrorBoundary`** so a render throw shows a retryable screen.
- **`src/contexts/AuthContext.tsx`** — race `getSession()` against an **8s timeout** (settled-guard) so a slow/hung network can't pin `AuthLoadingScreen` at launch; `onAuthStateChange` still delivers the real session.
- **`app.config.ts`** — `ios.requireFullScreen: true` + portrait-only `UISupportedInterfaceOrientations~ipad`. Expo's prebuild otherwise force-injects all four orientations on iPad, so iPadOS was rotating the portrait-designed UI into a broken landscape layout. (`ios/` is gitignored — EAS prebuilds fresh from `app.config.ts`.)

## Verification (iPad Air 11" (M3) simulator, clean install)

- ✅ Splash dismisses in **all** cases: normal, forced font-failure (renders with system fonts), and never-resolve (3s timeout net)
- ✅ Full **login + Turnstile captcha** — rendered, cleared, authenticated into the org list
- ✅ Orientation **stays portrait** on device rotation
- ✅ **Create Organization → "Contact Sales"** (no IAP / pricing) — Guideline 3.1.1
- ✅ Tabs, drawer, donations, and Settings → Delete Account confirmed working on-device
- ✅ `bun run typecheck` clean; 480 unit tests pass

## Resubmission

`ios/buildNumber` auto-increments via EAS. After merge: `bun run eas:ios:production` → `eas submit`, and reply to the App Review thread noting the splash-dismissal hardening.