### PR TITLE
fix(mobile/wallet): present .pkpass via share sheet

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -73,6 +73,7 @@
     "expo-quick-actions": "^6.0.1",
     "expo-router": "~6.0.21",
     "expo-secure-store": "^55.0.11",
+    "expo-sharing": "~14.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-updates": "~29.0.16",
     "expo-web-browser": "~15.0.10",

--- a/apps/mobile/src/lib/add-to-wallet.ts
+++ b/apps/mobile/src/lib/add-to-wallet.ts
@@ -1,5 +1,6 @@
-import { Linking, Platform } from "react-native";
+import { Platform } from "react-native";
 import { Directory, File, Paths } from "expo-file-system";
+import * as Sharing from "expo-sharing";
 import { supabase } from "@/lib/supabase";
 import { getWebAppUrl } from "@/lib/web-api";
 
@@ -17,9 +18,13 @@ export type AddToWalletResult =
   | { status: "error"; message: string };
 
 /**
- * Shared helper: downloads a signed `.pkpass` from the platform API and hands
- * it off to iOS Wallet via `Linking.openURL`. Use one of the typed wrappers
- * (`addMemberCardToWallet`, etc.) rather than calling this directly.
+ * Shared helper: downloads a signed `.pkpass` from the platform API and presents
+ * it to iOS Wallet. iOS cannot open a local `.pkpass` `file://` URL via
+ * `Linking.openURL` — passes must go through PassKit/QuickLook — so we hand the
+ * downloaded file to the system share sheet (`Sharing.shareAsync` with the
+ * `com.apple.pkpass` UTI), which previews the pass with an "Add" affordance.
+ * Use one of the typed wrappers (`addMemberCardToWallet`, etc.) rather than
+ * calling this directly.
  */
 export async function addToWallet(input: AddToWalletInput): Promise<AddToWalletResult> {
   if (Platform.OS !== "ios") {
@@ -44,10 +49,17 @@ export async function addToWallet(input: AddToWalletInput): Promise<AddToWalletR
       idempotent: true,
     });
 
-    const opened = await Linking.openURL(downloaded.uri);
-    if (opened === false) {
-      return { status: "error", message: "Could not open the pass in Wallet." };
+    if (!(await Sharing.isAvailableAsync())) {
+      return { status: "error", message: "Sharing is not available on this device." };
     }
+
+    // Resolves when the sheet is dismissed; iOS routes `.pkpass` to the Wallet
+    // "Add" preview. We can't observe whether the user tapped Add, so treat a
+    // successfully presented sheet as success.
+    await Sharing.shareAsync(downloaded.uri, {
+      UTI: "com.apple.pkpass",
+      mimeType: "application/vnd.apple.pkpass",
+    });
     return { status: "added" };
   } catch (e) {
     return {

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "expo-quick-actions": "^6.0.1",
         "expo-router": "~6.0.21",
         "expo-secure-store": "^55.0.11",
+        "expo-sharing": "~14.0.8",
         "expo-splash-screen": "~31.0.13",
         "expo-updates": "~29.0.16",
         "expo-web-browser": "~15.0.10",
@@ -1687,6 +1688,8 @@
     "expo-server": ["expo-server@1.0.6", "", {}, "sha512-vb5TBtskvEdzYuW79lATXutOEBfW5m6U4EFpNjCVZTnI7S//SAsLQkYEpn+EDfn84m6VQfzSGkIVR6YPaScKFA=="],
 
     "expo-server-sdk": ["expo-server-sdk@3.15.0", "", { "dependencies": { "node-fetch": "^2.6.0", "promise-limit": "^2.7.0", "promise-retry": "^2.0.1" } }, "sha512-Y71mQ7yeDhq6miHzn4kwRQOjqvBBsWeFXvyS9PYc6uqO/+UiYvrw3vMQiQqRxg2y0qgn9jMsvjf8T+mukSH85A=="],
+
+    "expo-sharing": ["expo-sharing@14.0.8", "", { "peerDependencies": { "expo": "*" } }, "sha512-A1pPr2iBrxypFDCWVAESk532HK+db7MFXbvO2sCV9ienaFXAk7lIBm6bkqgE6vzRd9O3RGdEGzYx80cYlc089Q=="],
 
     "expo-splash-screen": ["expo-splash-screen@31.0.13", "", { "dependencies": { "@expo/prebuild-config": "^54.0.8" }, "peerDependencies": { "expo": "*" } }, "sha512-1epJLC1cDlwwj089R2h8cxaU5uk4ONVAC+vzGiTZH4YARQhL4Stlz1MbR6yAS173GMosvkE6CAeihR7oIbCkDA=="],
 


### PR DESCRIPTION
## Problem
After the backend pass-generation fixes, the pass downloads successfully but the app fails with `Unable to open URL: file:///.../wallet/event-….pkpass`. iOS can't hand a local `.pkpass` `file://` URL to Wallet via `Linking.openURL`.

## Fix
Present the downloaded pass through `expo-sharing` (`Sharing.shareAsync` with UTI `com.apple.pkpass`), which routes `.pkpass` to the iOS Wallet 'Add' preview. Adds `expo-sharing@14.0.8` (SDK 54 pinned).

Mobile-only; requires a new build (native module added). Backend generation/signing already working.

## Verification
mobile typecheck ✅, 480 jest tests ✅. Device-tested via TestFlight build 65.