### PR TITLE
feat(chat): direct message from member & alumni profiles

### DIFF
--- a/apps/web/src/app/[orgSlug]/alumni/[alumniId]/page.tsx
+++ b/apps/web/src/app/[orgSlug]/alumni/[alumniId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { MessageSquare } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import { Card, Badge, Avatar, Button } from "@/components/ui";
 import { PageHeader } from "@/components/layout";
@@ -14,6 +15,7 @@ import { EnrichmentStatusBadge } from "@/components/alumni/EnrichmentStatusBadge
 import { ClaimAlumniBanner } from "@/components/alumni/ClaimAlumniBanner";
 import { ReportBlockMenu } from "@/components/moderation/ReportBlockMenu";
 import { LinkedInProfileLink, formatPersonHeadline, EnrichmentSections } from "@/components/shared";
+import { CHAT_ELIGIBLE_ORG_ROLES } from "@/lib/chat/recipient-eligibility";
 
 interface AlumniDetailPageProps {
   params: Promise<{ orgSlug: string; alumniId: string }>;
@@ -93,7 +95,29 @@ export default async function AlumniDetailPage({ params }: AlumniDetailPageProps
   // U12: enrichment status surfacing. Validate the raw column value so an
   // unexpected DB value degrades to "render nothing" instead of a bad pill.
   const isAdmin = role === "admin";
-  const isSelf = Boolean(user?.id && alumUserId === user.id);
+  const currentUserId = user?.id ?? null;
+  const isSelf = Boolean(currentUserId && alumUserId === currentUserId);
+  const chatEligibleUserIds = new Set<string>();
+  if (currentUserId && alumUserId && currentUserId !== alumUserId) {
+    const { data: chatEligibleRoles } = await dataClient
+      .from("user_organization_roles")
+      .select("user_id")
+      .eq("organization_id", orgId)
+      .eq("status", "active")
+      .in("role", CHAT_ELIGIBLE_ORG_ROLES)
+      .in("user_id", [currentUserId, alumUserId]);
+
+    for (const row of chatEligibleRoles || []) {
+      if (row.user_id) chatEligibleUserIds.add(row.user_id);
+    }
+  }
+  const canMessageProfile = Boolean(
+    currentUserId &&
+      alumUserId &&
+      !isSelf &&
+      chatEligibleUserIds.has(currentUserId) &&
+      chatEligibleUserIds.has(alumUserId),
+  );
   const enrichmentStatus =
     alum.enrichment_status === "pending" ||
     alum.enrichment_status === "enriched" ||
@@ -272,6 +296,20 @@ export default async function AlumniDetailPage({ params }: AlumniDetailPageProps
 
             {/* Contact actions */}
             <div className="flex flex-wrap gap-2 pt-3 border-t border-border">
+              {canMessageProfile && (
+                <form action={`/api/organizations/${orgId}/direct-chat/profile`} method="post">
+                  <input type="hidden" name="profileType" value="alumni" />
+                  <input type="hidden" name="profileId" value={alumniId} />
+                  <input type="hidden" name="orgSlug" value={orgSlug} />
+                  <button
+                    type="submit"
+                    className="inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg bg-[var(--muted)]/50 text-foreground hover:bg-[var(--muted)] transition-colors"
+                  >
+                    <MessageSquare className="h-4 w-4 opacity-70" aria-hidden="true" />
+                    Message
+                  </button>
+                </form>
+              )}
               {alum.email && (
                 <a
                   href={`mailto:${alum.email}`}

--- a/apps/web/src/app/[orgSlug]/chat/new/NewChatGroupForm.tsx
+++ b/apps/web/src/app/[orgSlug]/chat/new/NewChatGroupForm.tsx
@@ -7,6 +7,12 @@ import { Card, Button, Input, Textarea, Avatar, Badge } from "@/components/ui";
 import { PageHeader } from "@/components/layout";
 import { newChatGroupSchema } from "@/lib/schemas/chat";
 import { showFeedback } from "@/lib/feedback/show-feedback";
+import {
+  CHAT_ELIGIBLE_ORG_ROLES,
+  mergeChatProfileCandidates,
+  uniqueChatEligibleUserIds,
+  type ChatProfileCandidate,
+} from "@/lib/chat/recipient-eligibility";
 
 interface NewChatGroupFormProps {
   orgSlug: string;
@@ -14,15 +20,7 @@ interface NewChatGroupFormProps {
   currentUserId: string;
 }
 
-interface OrgMember {
-  id: string;
-  user_id: string;
-  first_name: string;
-  last_name: string;
-  email: string | null;
-  photo_url: string | null;
-  role: string | null;
-}
+type OrgMember = ChatProfileCandidate;
 
 export function NewChatGroupForm({ orgSlug, organizationId, currentUserId }: NewChatGroupFormProps) {
   const router = useRouter();
@@ -45,18 +43,44 @@ export function NewChatGroupForm({ orgSlug, organizationId, currentUserId }: New
   useEffect(() => {
     async function loadMembers() {
       setIsLoadingMembers(true);
-      const { data } = await supabase
-        .from("members")
-        .select("id, user_id, first_name, last_name, email, photo_url, role")
+      const { data: activeRoles } = await supabase
+        .from("user_organization_roles")
+        .select("user_id")
         .eq("organization_id", organizationId)
         .eq("status", "active")
-        .is("deleted_at", null)
-        .order("last_name");
+        .in("role", CHAT_ELIGIBLE_ORG_ROLES);
 
-      if (data) {
-        // Filter out members without user_id (not linked to auth)
-        setOrgMembers(data.filter(m => m.user_id) as OrgMember[]);
+      const activeUserIds = uniqueChatEligibleUserIds(activeRoles || []);
+
+      if (activeUserIds.length === 0) {
+        setOrgMembers([]);
+        setIsLoadingMembers(false);
+        return;
       }
+
+      const [membersResult, alumniResult] = await Promise.all([
+        supabase
+          .from("members")
+          .select("id, user_id, first_name, last_name, email, photo_url, role")
+          .eq("organization_id", organizationId)
+          .is("deleted_at", null)
+          .in("user_id", activeUserIds)
+          .order("last_name"),
+        supabase
+          .from("alumni")
+          .select("id, user_id, first_name, last_name, email, photo_url, job_title, position_title")
+          .eq("organization_id", organizationId)
+          .is("deleted_at", null)
+          .in("user_id", activeUserIds)
+          .order("last_name"),
+      ]);
+
+      setOrgMembers(
+        mergeChatProfileCandidates({
+          members: membersResult.data || [],
+          alumni: alumniResult.data || [],
+        }),
+      );
       setIsLoadingMembers(false);
     }
     loadMembers();
@@ -276,7 +300,9 @@ export function NewChatGroupForm({ orgSlug, organizationId, currentUserId }: New
                         {member.first_name} {member.last_name}
                       </p>
                       <p className="text-xs text-muted-foreground truncate">
-                        {member.role || member.email || "Member"}
+                        {member.profileType === "alumni"
+                          ? `Alumni${member.role ? ` • ${member.role}` : ""}`
+                          : member.role || member.email || "Member"}
                       </p>
                     </div>
                     <svg className="h-5 w-5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/apps/web/src/app/[orgSlug]/members/[memberId]/page.tsx
+++ b/apps/web/src/app/[orgSlug]/members/[memberId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
+import { MessageSquare } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import { Card, Badge, Avatar, Button, SoftDeleteButton } from "@/components/ui";
 import { PageHeader } from "@/components/layout";
@@ -16,6 +17,7 @@ import {
   resolveMemberEducation,
   resolveMemberBio,
 } from "@/lib/profile/member-enrichment";
+import { CHAT_ELIGIBLE_ORG_ROLES } from "@/lib/chat/recipient-eligibility";
 
 interface MemberDetailPageProps {
   params: Promise<{ orgSlug: string; memberId: string }>;
@@ -109,11 +111,33 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
   const enrichmentEducation = resolveMemberEducation(enrichment, m);
 
   const currentUserId = user?.id ?? null;
+  const chatEligibleUserIds = new Set<string>();
+  if (currentUserId && memberUserId && currentUserId !== memberUserId) {
+    const { data: chatEligibleRoles } = await dataClient
+      .from("user_organization_roles")
+      .select("user_id")
+      .eq("organization_id", org.id)
+      .eq("status", "active")
+      .in("role", CHAT_ELIGIBLE_ORG_ROLES)
+      .in("user_id", [currentUserId, memberUserId]);
+
+    for (const row of chatEligibleRoles || []) {
+      if (row.user_id) chatEligibleUserIds.add(row.user_id);
+    }
+  }
+
   const isAdmin = ctx.isAdmin;
   const canEdit = ctx.canEditPerson(memberUserId);
   const canModifyExisting = canEdit && !ctx.isReadOnly;
   const canDelete = ctx.isAdmin && !ctx.isReadOnly;
   const isOwnProfile = currentUserId !== null && currentUserId === memberUserId;
+  const canMessageProfile = Boolean(
+    currentUserId &&
+      memberUserId &&
+      !isOwnProfile &&
+      chatEligibleUserIds.has(currentUserId) &&
+      chatEligibleUserIds.has(memberUserId),
+  );
 
   // member.role is the job title field (confusingly named "role" in the members table)
   const jobTitle = m.role || null;
@@ -268,6 +292,20 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
 
             {/* Contact actions */}
             <div className="flex flex-wrap gap-2 pt-3 border-t border-border">
+              {canMessageProfile && (
+                <form action={`/api/organizations/${org.id}/direct-chat/profile`} method="post">
+                  <input type="hidden" name="profileType" value="member" />
+                  <input type="hidden" name="profileId" value={memberId} />
+                  <input type="hidden" name="orgSlug" value={orgSlug} />
+                  <button
+                    type="submit"
+                    className="inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg bg-[var(--muted)]/50 text-foreground hover:bg-[var(--muted)] transition-colors"
+                  >
+                    <MessageSquare className="h-4 w-4 opacity-70" aria-hidden="true" />
+                    Message
+                  </button>
+                </form>
+              )}
               {member.email && (
                 <a
                   href={`mailto:${member.email}`}

--- a/apps/web/src/app/api/chat/[groupId]/members/route.ts
+++ b/apps/web/src/app/api/chat/[groupId]/members/route.ts
@@ -4,6 +4,7 @@ import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limi
 import { baseSchemas, validateJson, ValidationError } from "@/lib/security/validation";
 import { addChatMembersSchema, removeChatMemberSchema } from "@/lib/schemas/chat";
 import { getChatGroupContext } from "@/lib/auth/chat-helpers";
+import { CHAT_ELIGIBLE_ORG_ROLES } from "@/lib/chat/recipient-eligibility";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -110,14 +111,24 @@ export async function POST(req: Request, { params }: RouteParams) {
     return respond({ error: "Forbidden" }, 403);
   }
 
-  // Validate all user_ids are active org members
-  const { data: activeMembers } = await supabase
-    .from("members")
+  // Validate all user_ids are active org users. This intentionally includes
+  // linked alumni, who may not have an active row in `members`.
+  const { data: activeMembers, error: activeMembersError } = await supabase
+    .from("user_organization_roles")
     .select("user_id")
     .eq("organization_id", ctx.group.organization_id)
     .eq("status", "active")
-    .is("deleted_at", null)
+    .in("role", CHAT_ELIGIBLE_ORG_ROLES)
     .in("user_id", user_ids);
+
+  if (activeMembersError) {
+    console.error("[chat/members POST] Failed to validate members", {
+      organizationId: ctx.group.organization_id,
+      groupId,
+      error: activeMembersError,
+    });
+    return respond({ error: "Failed to validate members" }, 500);
+  }
 
   const activeUserIds = new Set((activeMembers || []).map(m => m.user_id));
   const invalidIds = user_ids.filter(id => !activeUserIds.has(id));

--- a/apps/web/src/app/api/organizations/[organizationId]/direct-chat/profile/route.ts
+++ b/apps/web/src/app/api/organizations/[organizationId]/direct-chat/profile/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+import { baseSchemas } from "@/lib/security/validation";
+import {
+  startProfileDirectChat,
+  type ProfileDirectChatSupabase,
+  type ProfileDirectChatType,
+} from "@/lib/chat/profile-direct-chat";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface RouteParams {
+  params: Promise<{ organizationId: string }>;
+}
+
+type RequestBody = {
+  profileType: ProfileDirectChatType;
+  profileId: string;
+  orgSlug?: string;
+};
+
+function isProfileType(value: unknown): value is ProfileDirectChatType {
+  return value === "member" || value === "alumni";
+}
+
+async function parseRequestBody(req: Request): Promise<RequestBody | null> {
+  const contentType = req.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+    if (!body || !isProfileType(body.profileType) || typeof body.profileId !== "string") {
+      return null;
+    }
+
+    return {
+      profileType: body.profileType,
+      profileId: body.profileId,
+      orgSlug: typeof body.orgSlug === "string" ? body.orgSlug : undefined,
+    };
+  }
+
+  const form = await req.formData().catch(() => null);
+  const profileType = form?.get("profileType");
+  const profileId = form?.get("profileId");
+  const orgSlug = form?.get("orgSlug");
+
+  if (!isProfileType(profileType) || typeof profileId !== "string") {
+    return null;
+  }
+
+  return {
+    profileType,
+    profileId,
+    orgSlug: typeof orgSlug === "string" ? orgSlug : undefined,
+  };
+}
+
+export async function POST(req: Request, { params }: RouteParams) {
+  const { organizationId } = await params;
+  if (!baseSchemas.uuid.safeParse(organizationId).success) {
+    return NextResponse.json({ error: "Invalid organization id" }, { status: 400 });
+  }
+
+  const body = await parseRequestBody(req);
+  if (!body || !baseSchemas.uuid.safeParse(body.profileId).success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+  // Normalize the slug through the schema (trim + lowercase) and redirect with
+  // the canonical value — the raw body slug may carry casing/whitespace that
+  // passes validation but resolves to a 404 on the case-sensitive slug lookup.
+  let canonicalOrgSlug: string | undefined;
+  if (body.orgSlug !== undefined) {
+    const parsedSlug = baseSchemas.slug.safeParse(body.orgSlug);
+    if (!parsedSlug.success) {
+      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+    }
+    canonicalOrgSlug = parsedSlug.data;
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  const rateLimit = checkRateLimit(req, {
+    userId: user?.id ?? null,
+    orgId: organizationId,
+    feature: "profile-direct-chat",
+    limitPerIp: 30,
+    limitPerUser: 20,
+  });
+  if (!rateLimit.ok) return buildRateLimitResponse(rateLimit);
+
+  const respond = (payload: unknown, status = 200) =>
+    NextResponse.json(payload, { status, headers: rateLimit.headers });
+
+  if (!user) {
+    return respond({ error: "Unauthorized" }, 401);
+  }
+
+  const result = await startProfileDirectChat(supabase as ProfileDirectChatSupabase, {
+    organizationId,
+    viewerUserId: user.id,
+    profileType: body.profileType,
+    profileId: body.profileId,
+  });
+
+  if (!result.ok) {
+    if (result.status >= 500) {
+      console.error("[direct-chat/profile POST] Failed to start profile chat", {
+        organizationId,
+        viewerUserId: user.id,
+        profileType: body.profileType,
+        profileId: body.profileId,
+        code: result.code,
+      });
+    }
+    return respond({ error: result.error, code: result.code }, result.status);
+  }
+
+  if (canonicalOrgSlug) {
+    const redirectUrl = new URL(
+      `/${canonicalOrgSlug}/messages/chat/${result.chatGroupId}`,
+      req.url,
+    );
+    return NextResponse.redirect(redirectUrl, { status: 303 });
+  }
+
+  return respond({
+    chatGroupId: result.chatGroupId,
+    reused: result.reused,
+  });
+}

--- a/apps/web/src/app/api/organizations/[organizationId]/direct-chat/profile/route.ts
+++ b/apps/web/src/app/api/organizations/[organizationId]/direct-chat/profile/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
 import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
 import { baseSchemas } from "@/lib/security/validation";
 import {
@@ -98,7 +99,13 @@ export async function POST(req: Request, { params }: RouteParams) {
     return respond({ error: "Unauthorized" }, 401);
   }
 
-  const result = await startProfileDirectChat(supabase as ProfileDirectChatSupabase, {
+  // startProfileDirectChat authorizes the viewer (active chat-eligible role)
+  // and the target in app code, then writes the chat group. chat_groups INSERT
+  // is admin-only under RLS, so the privileged write runs on the service-role
+  // client — matching mentorship auto-pairing and the AI direct-chat path.
+  const serviceSupabase = createServiceClient();
+
+  const result = await startProfileDirectChat(serviceSupabase as ProfileDirectChatSupabase, {
     organizationId,
     viewerUserId: user.id,
     profileType: body.profileType,

--- a/apps/web/src/components/chat/ManageMembersPanel.tsx
+++ b/apps/web/src/components/chat/ManageMembersPanel.tsx
@@ -7,6 +7,12 @@ import { createClient } from "@/lib/supabase/client";
 import { Avatar, Badge, Button, Input } from "@/components/ui";
 import { ConfirmationDialog } from "@/components/ui/ConfirmationDialog";
 import { trackBehavioralEvent } from "@/lib/analytics/events";
+import {
+  CHAT_ELIGIBLE_ORG_ROLES,
+  mergeChatProfileCandidates,
+  uniqueChatEligibleUserIds,
+  type ChatProfileCandidate,
+} from "@/lib/chat/recipient-eligibility";
 
 interface MemberRow {
   id: string;
@@ -22,14 +28,7 @@ interface MemberRow {
   };
 }
 
-interface OrgMember {
-  id: string;
-  user_id: string;
-  first_name: string;
-  last_name: string;
-  email: string | null;
-  photo_url: string | null;
-}
+type OrgMember = ChatProfileCandidate;
 
 interface ManageMembersPanelProps {
   orgSlug: string;
@@ -87,17 +86,44 @@ export function ManageMembersPanel({
 
   const loadOrgMembers = useCallback(async () => {
     setIsLoadingOrg(true);
-    const { data } = await supabase
-      .from("members")
-      .select("id, user_id, first_name, last_name, email, photo_url")
+    const { data: activeRoles } = await supabase
+      .from("user_organization_roles")
+      .select("user_id")
       .eq("organization_id", organizationId)
       .eq("status", "active")
-      .is("deleted_at", null)
-      .order("last_name");
+      .in("role", CHAT_ELIGIBLE_ORG_ROLES);
 
-    if (data) {
-      setOrgMembers(data.filter(m => m.user_id) as OrgMember[]);
+    const activeUserIds = uniqueChatEligibleUserIds(activeRoles || []);
+
+    if (activeUserIds.length === 0) {
+      setOrgMembers([]);
+      setIsLoadingOrg(false);
+      return;
     }
+
+    const [membersResult, alumniResult] = await Promise.all([
+      supabase
+        .from("members")
+        .select("id, user_id, first_name, last_name, email, photo_url")
+        .eq("organization_id", organizationId)
+        .is("deleted_at", null)
+        .in("user_id", activeUserIds)
+        .order("last_name"),
+      supabase
+        .from("alumni")
+        .select("id, user_id, first_name, last_name, email, photo_url")
+        .eq("organization_id", organizationId)
+        .is("deleted_at", null)
+        .in("user_id", activeUserIds)
+        .order("last_name"),
+    ]);
+
+    setOrgMembers(
+      mergeChatProfileCandidates({
+        members: membersResult.data || [],
+        alumni: alumniResult.data || [],
+      }),
+    );
     setIsLoadingOrg(false);
   }, [supabase, organizationId]);
 

--- a/apps/web/src/lib/chat/direct-chat.ts
+++ b/apps/web/src/lib/chat/direct-chat.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { CHAT_ELIGIBLE_ORG_ROLES } from "@/lib/chat/recipient-eligibility";
 
 export type DirectChatSupabase = Pick<SupabaseClient, "from">;
 
@@ -11,6 +12,17 @@ interface MemberRow {
   status?: string | null;
   deleted_at?: string | null;
 }
+
+interface AlumniRow {
+  id: string;
+  user_id: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  deleted_at?: string | null;
+}
+
+type ChatPersonRow = MemberRow & { profile_kind: "member" | "alumni" };
 
 interface ChatGroupRow {
   id: string;
@@ -70,11 +82,31 @@ export type SendAiAssistedDirectChatMessageResult =
         | "message_insert_failed";
     };
 
+type DirectChatForUserFailureCode =
+  | "sender_inactive"
+  | "recipient_inactive"
+  | "recipient_self"
+  | "recipient_lookup_failed"
+  | "chat_lookup_failed"
+  | "chat_create_failed"
+  | "membership_sync_failed";
+
+export type EnsureDirectChatForUserResult =
+  | { ok: true; chatGroupId: string; reused: boolean }
+  | {
+      ok: false;
+      status: number;
+      error: string;
+      code: DirectChatForUserFailureCode;
+    };
+
 function normalizeMatchValue(value: string | null | undefined): string {
   return (value ?? "").trim().toLowerCase().replace(/\s+/g, " ");
 }
 
-function formatMemberDisplayName(member: MemberRow): string {
+function formatMemberDisplayName(
+  member: Pick<MemberRow, "first_name" | "last_name" | "email">,
+): string {
   const name = [member.first_name, member.last_name]
     .map((value) => value?.trim() ?? "")
     .filter((value) => value.length > 0)
@@ -99,7 +131,7 @@ function dedupeCandidates(values: string[]): string[] {
 async function loadActiveLinkedMembers(
   supabase: DirectChatSupabase,
   organizationId: string,
-): Promise<{ data: MemberRow[] | null; error: unknown }> {
+): Promise<{ data: ChatPersonRow[] | null; error: unknown }> {
   const { data, error } = await supabase
     .from("members")
     .select("id, user_id, first_name, last_name, email, status, deleted_at")
@@ -108,13 +140,123 @@ async function loadActiveLinkedMembers(
     .is("deleted_at", null)
     .order("last_name", { ascending: true });
 
-  return { data: (data as MemberRow[] | null) ?? null, error };
+  if (error) {
+    return { data: null, error };
+  }
+
+  const linkedMembers = ((data as MemberRow[] | null) ?? []).filter(
+    (row): row is MemberRow & { user_id: string } => Boolean(row.user_id)
+  );
+  if (linkedMembers.length === 0) {
+    return { data: [], error: null };
+  }
+
+  const { data: memberships, error: membershipsError } = await supabase
+    .from("user_organization_roles")
+    .select("user_id, status")
+    .eq("organization_id", organizationId)
+    .eq("status", "active")
+    .in("role", CHAT_ELIGIBLE_ORG_ROLES)
+    .in("user_id", linkedMembers.map((row) => row.user_id));
+
+  if (membershipsError) {
+    return { data: null, error: membershipsError };
+  }
+
+  const activeUserIds = new Set(
+    ((memberships as Array<{ user_id?: string | null }> | null) ?? [])
+      .map((row) => row.user_id)
+      .filter((value): value is string => Boolean(value))
+  );
+
+  return {
+    data: linkedMembers
+      .filter((row) => activeUserIds.has(row.user_id))
+      .map((row) => ({ ...row, profile_kind: "member" as const })),
+    error: null,
+  };
 }
 
-function isChatEligibleMember(
-  member: MemberRow,
+async function loadActiveLinkedAlumni(
+  supabase: DirectChatSupabase,
+  organizationId: string,
+): Promise<{ data: ChatPersonRow[] | null; error: unknown }> {
+  const { data: alumni, error } = await supabase
+    .from("alumni")
+    .select("id, user_id, first_name, last_name, email, deleted_at")
+    .eq("organization_id", organizationId)
+    .is("deleted_at", null)
+    .order("last_name", { ascending: true });
+
+  if (error) {
+    return { data: null, error };
+  }
+
+  const linkedAlumni = ((alumni as AlumniRow[] | null) ?? []).filter(
+    (row): row is AlumniRow & { user_id: string } => Boolean(row.user_id)
+  );
+  if (linkedAlumni.length === 0) {
+    return { data: [], error: null };
+  }
+
+  const { data: memberships, error: membershipsError } = await supabase
+    .from("user_organization_roles")
+    .select("user_id, status")
+    .eq("organization_id", organizationId)
+    .eq("status", "active")
+    .in("role", CHAT_ELIGIBLE_ORG_ROLES)
+    .in("user_id", linkedAlumni.map((row) => row.user_id));
+
+  if (membershipsError) {
+    return { data: null, error: membershipsError };
+  }
+
+  const activeUserIds = new Set(
+    ((memberships as Array<{ user_id?: string | null }> | null) ?? [])
+      .map((row) => row.user_id)
+      .filter((value): value is string => Boolean(value))
+  );
+
+  return {
+    data: linkedAlumni
+      .filter((row) => activeUserIds.has(row.user_id))
+      .map((row) => ({
+        ...row,
+        status: "active",
+        profile_kind: "alumni" as const,
+      })),
+    error: null,
+  };
+}
+
+async function loadActiveLinkedChatPeople(
+  supabase: DirectChatSupabase,
+  organizationId: string,
+): Promise<{ data: ChatPersonRow[] | null; error: unknown }> {
+  const [membersResult, alumniResult] = await Promise.all([
+    loadActiveLinkedMembers(supabase, organizationId),
+    loadActiveLinkedAlumni(supabase, organizationId),
+  ]);
+
+  if (membersResult.error) return membersResult;
+  if (alumniResult.error) return alumniResult;
+
+  const peopleByUserId = new Map<string, ChatPersonRow>();
+  for (const person of [...(membersResult.data ?? []), ...(alumniResult.data ?? [])]) {
+    if (!person.user_id) continue;
+    const existing = peopleByUserId.get(person.user_id);
+    if (!existing || existing.profile_kind === "alumni") {
+      peopleByUserId.set(person.user_id, person);
+    }
+  }
+
+  return { data: Array.from(peopleByUserId.values()), error: null };
+}
+
+function isChatEligibleMember<T extends MemberRow>(
+  member: T,
   senderUserId: string,
-): member is MemberRow & { user_id: string } {
+): member is T & { user_id: string } {
   return Boolean(member.user_id && member.user_id !== senderUserId);
 }
 
@@ -122,7 +264,7 @@ async function loadMemberById(
   supabase: DirectChatSupabase,
   organizationId: string,
   memberId: string,
-): Promise<{ data: MemberRow | null; error: unknown }> {
+): Promise<{ data: ChatPersonRow | null; error: unknown }> {
   const { data, error } = await supabase
     .from("members")
     .select("id, user_id, first_name, last_name, email, status, deleted_at")
@@ -130,7 +272,107 @@ async function loadMemberById(
     .eq("id", memberId)
     .maybeSingle();
 
-  return { data: (data as MemberRow | null) ?? null, error };
+  if (error) {
+    return { data: null, error };
+  }
+
+  const member = (data as MemberRow | null) ?? null;
+  if (member) {
+    if (!member.user_id || member.deleted_at != null || member.status !== "active") {
+      return { data: { ...member, profile_kind: "member" }, error: null };
+    }
+
+    const membership = await hasActiveOrgMembership(supabase, {
+      organizationId,
+      userId: member.user_id,
+    });
+    if (!membership.ok) {
+      return { data: null, error: membership };
+    }
+
+    return {
+      data: {
+        ...member,
+        status: membership.active ? "active" : "inactive",
+        profile_kind: "member",
+      },
+      error: null,
+    };
+  }
+
+  const { data: alumni, error: alumniError } = await supabase
+    .from("alumni")
+    .select("id, user_id, first_name, last_name, email, deleted_at")
+    .eq("organization_id", organizationId)
+    .eq("id", memberId)
+    .maybeSingle();
+
+  if (alumniError) {
+    return { data: null, error: alumniError };
+  }
+
+  const alumniRow = (alumni as AlumniRow | null) ?? null;
+  if (!alumniRow) {
+    return { data: null, error: null };
+  }
+
+  if (!alumniRow.user_id || alumniRow.deleted_at != null) {
+    return {
+      data: {
+        ...alumniRow,
+        status: alumniRow.deleted_at == null ? "active" : "inactive",
+        profile_kind: "alumni",
+      },
+      error: null,
+    };
+  }
+
+  const { data: membership, error: membershipError } = await supabase
+    .from("user_organization_roles")
+    .select("status")
+    .eq("organization_id", organizationId)
+    .eq("user_id", alumniRow.user_id)
+    .eq("status", "active")
+    .in("role", CHAT_ELIGIBLE_ORG_ROLES)
+    .maybeSingle();
+
+  if (membershipError) {
+    return { data: null, error: membershipError };
+  }
+
+  return {
+    data: {
+      ...alumniRow,
+      status: membership ? "active" : "inactive",
+      profile_kind: "alumni",
+    },
+    error: null,
+  };
+}
+
+async function hasActiveOrgMembership(
+  supabase: DirectChatSupabase,
+  input: { organizationId: string; userId: string },
+): Promise<{ ok: true; active: boolean } | { ok: false }> {
+  const { data, error } = await supabase
+    .from("user_organization_roles")
+    .select("role, status")
+    .eq("organization_id", input.organizationId)
+    .eq("user_id", input.userId)
+    .eq("status", "active")
+    .in("role", CHAT_ELIGIBLE_ORG_ROLES)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[direct-chat] hasActiveOrgMembership lookup failed", {
+      organizationId: input.organizationId,
+      userId: input.userId,
+      error,
+    });
+    return { ok: false };
+  }
+
+  return { ok: true, active: Boolean(data) };
 }
 
 export async function findExactDirectChatGroup(
@@ -314,7 +556,7 @@ export async function resolveChatMessageRecipient(
     };
   }
 
-  const { data: members, error } = await loadActiveLinkedMembers(supabase, input.organizationId);
+  const { data: members, error } = await loadActiveLinkedChatPeople(supabase, input.organizationId);
   if (error) {
     return {
       kind: "unavailable",
@@ -325,7 +567,7 @@ export async function resolveChatMessageRecipient(
 
   const query = normalizeMatchValue(requestedRecipient);
   const rows = (members ?? []).filter((member) => member.user_id !== input.senderUserId);
-  const eligibleRows = rows.filter((member): member is MemberRow & { user_id: string } =>
+  const eligibleRows = rows.filter((member): member is ChatPersonRow & { user_id: string } =>
     isChatEligibleMember(member, input.senderUserId)
   );
   const exactMatches = eligibleRows.filter((member) => {
@@ -570,6 +812,78 @@ export async function ensureDirectChatGroup(
   if (!bMembership.ok) return { ok: false, code: bMembership.code };
 
   return { ok: true, chatGroupId, reused: false };
+}
+
+export async function ensureDirectChatForUser(
+  supabase: DirectChatSupabase,
+  input: { organizationId: string; senderUserId: string; recipientUserId: string },
+): Promise<EnsureDirectChatForUserResult> {
+  if (input.senderUserId === input.recipientUserId) {
+    return {
+      ok: false,
+      status: 409,
+      error: "You cannot message yourself.",
+      code: "recipient_self",
+    };
+  }
+
+  const [senderMembership, recipientMembership] = await Promise.all([
+    hasActiveOrgMembership(supabase, {
+      organizationId: input.organizationId,
+      userId: input.senderUserId,
+    }),
+    hasActiveOrgMembership(supabase, {
+      organizationId: input.organizationId,
+      userId: input.recipientUserId,
+    }),
+  ]);
+
+  if (!senderMembership.ok || !recipientMembership.ok) {
+    return {
+      ok: false,
+      status: 500,
+      error: "Failed to verify chat access.",
+      code: "recipient_lookup_failed",
+    };
+  }
+
+  if (!senderMembership.active) {
+    return {
+      ok: false,
+      status: 403,
+      error: "You do not have access to message people in this organization.",
+      code: "sender_inactive",
+    };
+  }
+
+  if (!recipientMembership.active) {
+    return {
+      ok: false,
+      status: 404,
+      error: "This person is not available for in-app chat.",
+      code: "recipient_inactive",
+    };
+  }
+
+  const result = await ensureDirectChatGroup(supabase, {
+    orgId: input.organizationId,
+    userAId: input.senderUserId,
+    userBId: input.recipientUserId,
+  });
+
+  if (!result.ok) {
+    // ensureDirectChatGroup only returns recipient_lookup_failed when the two
+    // user ids are equal, which the self-message guard above already rejects —
+    // so every code reachable here is a genuine 500 (lookup/create/sync failure).
+    return {
+      ok: false,
+      status: 500,
+      error: "Failed to open the chat.",
+      code: result.code,
+    };
+  }
+
+  return result;
 }
 
 export async function sendAiAssistedDirectChatMessage(

--- a/apps/web/src/lib/chat/profile-direct-chat.ts
+++ b/apps/web/src/lib/chat/profile-direct-chat.ts
@@ -1,0 +1,197 @@
+import {
+  ensureDirectChatForUser,
+  type DirectChatSupabase,
+} from "./direct-chat";
+import { CHAT_ELIGIBLE_ORG_ROLES } from "./recipient-eligibility";
+
+export type ProfileDirectChatSupabase = DirectChatSupabase;
+
+export type ProfileDirectChatType = "member" | "alumni";
+
+export type StartProfileDirectChatResult =
+  | {
+      ok: true;
+      chatGroupId: string;
+      reused: boolean;
+    }
+  | {
+      ok: false;
+      status: number;
+      code:
+        | "forbidden"
+        | "profile_not_found"
+        | "profile_lookup_failed"
+        | "profile_inactive"
+        | "profile_unlinked"
+        | "profile_self"
+        | "chat_start_failed";
+      error: string;
+    };
+
+type ProfileRow = {
+  id: string;
+  user_id: string | null;
+  status?: string | null;
+  deleted_at?: string | null;
+};
+
+type LoadProfileUserResult =
+  | { profile: ProfileRow | null; error: null }
+  | { profile: null; error: "profile_lookup_failed" };
+
+async function loadProfileUser(
+  supabase: ProfileDirectChatSupabase,
+  input: {
+    organizationId: string;
+    profileType: ProfileDirectChatType;
+    profileId: string;
+  },
+): Promise<LoadProfileUserResult> {
+  if (input.profileType === "member") {
+    const { data, error } = await supabase
+      .from("members")
+      .select("id, user_id, status, deleted_at")
+      .eq("id", input.profileId)
+      .eq("organization_id", input.organizationId)
+      .is("deleted_at", null)
+      .maybeSingle();
+
+    if (error) {
+      console.error("[profile-direct-chat] member profile lookup failed", {
+        organizationId: input.organizationId,
+        profileId: input.profileId,
+        error,
+      });
+      return { profile: null, error: "profile_lookup_failed" };
+    }
+    return { profile: (data as ProfileRow | null) ?? null, error: null };
+  }
+
+  const { data, error } = await supabase
+    .from("alumni")
+    .select("id, user_id, deleted_at")
+    .eq("id", input.profileId)
+    .eq("organization_id", input.organizationId)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[profile-direct-chat] alumni profile lookup failed", {
+      organizationId: input.organizationId,
+      profileId: input.profileId,
+      error,
+    });
+    return { profile: null, error: "profile_lookup_failed" };
+  }
+  return { profile: (data as ProfileRow | null) ?? null, error: null };
+}
+
+export async function startProfileDirectChat(
+  supabase: ProfileDirectChatSupabase,
+  input: {
+    organizationId: string;
+    viewerUserId: string;
+    profileType: ProfileDirectChatType;
+    profileId: string;
+  },
+): Promise<StartProfileDirectChatResult> {
+  const { data: membership, error: membershipError } = await supabase
+    .from("user_organization_roles")
+    .select("role")
+    .eq("organization_id", input.organizationId)
+    .eq("user_id", input.viewerUserId)
+    .eq("status", "active")
+    .in("role", CHAT_ELIGIBLE_ORG_ROLES)
+    .maybeSingle();
+
+  if (membershipError) {
+    console.error("[profile-direct-chat] viewer membership lookup failed", {
+      organizationId: input.organizationId,
+      viewerUserId: input.viewerUserId,
+      error: membershipError,
+    });
+    return {
+      ok: false,
+      status: 500,
+      code: "profile_lookup_failed",
+      error: "Failed to verify chat access.",
+    };
+  }
+
+  if (!membership) {
+    return {
+      ok: false,
+      status: 403,
+      code: "forbidden",
+      error: "You must be an active member of this organization to start a chat.",
+    };
+  }
+
+  const loadedProfile = await loadProfileUser(supabase, input);
+  if (loadedProfile.error) {
+    return {
+      ok: false,
+      status: 500,
+      code: "profile_lookup_failed",
+      error: "Failed to load this profile for chat.",
+    };
+  }
+
+  const profile = loadedProfile.profile;
+  if (!profile) {
+    return {
+      ok: false,
+      status: 404,
+      code: "profile_not_found",
+      error: "Profile not found.",
+    };
+  }
+
+  if (input.profileType === "member" && profile.status !== "active") {
+    return {
+      ok: false,
+      status: 409,
+      code: "profile_inactive",
+      error: "This member profile is not available for in-app chat.",
+    };
+  }
+
+  if (!profile.user_id) {
+    return {
+      ok: false,
+      status: 409,
+      code: "profile_unlinked",
+      error: "This profile is not linked to an in-app user account.",
+    };
+  }
+
+  if (profile.user_id === input.viewerUserId) {
+    return {
+      ok: false,
+      status: 409,
+      code: "profile_self",
+      error: "You cannot start a direct chat with yourself.",
+    };
+  }
+
+  const chat = await ensureDirectChatForUser(supabase, {
+    organizationId: input.organizationId,
+    senderUserId: input.viewerUserId,
+    recipientUserId: profile.user_id,
+  });
+
+  if (!chat.ok) {
+    return {
+      ok: false,
+      status: chat.status,
+      code: "chat_start_failed",
+      error: chat.error,
+    };
+  }
+
+  return {
+    ok: true,
+    chatGroupId: chat.chatGroupId,
+    reused: chat.reused,
+  };
+}

--- a/apps/web/src/lib/chat/recipient-eligibility.ts
+++ b/apps/web/src/lib/chat/recipient-eligibility.ts
@@ -1,0 +1,84 @@
+export const CHAT_ELIGIBLE_ORG_ROLES = ["admin", "active_member", "alumni", "parent"] as const;
+
+export type ChatEligibleOrgRole = (typeof CHAT_ELIGIBLE_ORG_ROLES)[number];
+
+export type ChatProfileCandidate = {
+  id: string;
+  user_id: string;
+  first_name: string;
+  last_name: string;
+  email: string | null;
+  photo_url: string | null;
+  role: string | null;
+  profileType: "member" | "alumni";
+};
+
+export type ChatMemberProfileRow = {
+  id: string;
+  user_id: string | null;
+  first_name: string;
+  last_name: string;
+  email: string | null;
+  photo_url: string | null;
+  role?: string | null;
+};
+
+export type ChatAlumniProfileRow = {
+  id: string;
+  user_id: string | null;
+  first_name: string;
+  last_name: string;
+  email: string | null;
+  photo_url: string | null;
+  job_title?: string | null;
+  position_title?: string | null;
+};
+
+export function uniqueChatEligibleUserIds(
+  activeRoles: Array<{ user_id?: string | null }>,
+): string[] {
+  return [
+    ...new Set(
+      activeRoles
+        .map((row) => row.user_id)
+        .filter((userId): userId is string => Boolean(userId)),
+    ),
+  ];
+}
+
+export function mergeChatProfileCandidates(input: {
+  members: ChatMemberProfileRow[];
+  alumni: ChatAlumniProfileRow[];
+}): ChatProfileCandidate[] {
+  const peopleByUserId = new Map<string, ChatProfileCandidate>();
+
+  for (const member of input.members) {
+    if (!member.user_id) continue;
+    peopleByUserId.set(member.user_id, {
+      id: member.id,
+      user_id: member.user_id,
+      first_name: member.first_name,
+      last_name: member.last_name,
+      email: member.email,
+      photo_url: member.photo_url,
+      role: member.role ?? null,
+      profileType: "member",
+    });
+  }
+
+  for (const alum of input.alumni) {
+    if (!alum.user_id || peopleByUserId.has(alum.user_id)) continue;
+    peopleByUserId.set(alum.user_id, {
+      id: alum.id,
+      user_id: alum.user_id,
+      first_name: alum.first_name,
+      last_name: alum.last_name,
+      email: alum.email,
+      photo_url: alum.photo_url,
+      role: alum.position_title || alum.job_title || "Alumni",
+      profileType: "alumni",
+    });
+  }
+
+  return Array.from(peopleByUserId.values());
+}

--- a/apps/web/tests/direct-chat.test.ts
+++ b/apps/web/tests/direct-chat.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { createSupabaseStub } from "./utils/supabaseStub.ts";
 import {
   type DirectChatSupabase,
+  ensureDirectChatForUser,
   findExactDirectChatGroup,
   resolveChatMessageRecipient,
   sendAiAssistedDirectChatMessage,
@@ -119,6 +120,14 @@ test("findExactDirectChatGroup refuses chats with extra active members or remove
 
 test("sendAiAssistedDirectChatMessage creates a new 1:1 chat and records ai_assisted metadata", async () => {
   const supabase = createSupabaseStub();
+  supabase.seed("user_organization_roles", [
+    {
+      organization_id: ORG_ID,
+      user_id: RECIPIENT_USER_ID,
+      role: "active_member",
+      status: "active",
+    },
+  ]);
   supabase.seed("members", [
     {
       id: RECIPIENT_MEMBER_ID,
@@ -160,6 +169,14 @@ test("sendAiAssistedDirectChatMessage creates a new 1:1 chat and records ai_assi
 
 test("resolveChatMessageRecipient ignores duplicate org rows that are not chat-eligible", async () => {
   const supabase = createSupabaseStub();
+  supabase.seed("user_organization_roles", [
+    {
+      organization_id: ORG_ID,
+      user_id: RECIPIENT_USER_ID,
+      role: "active_member",
+      status: "active",
+    },
+  ]);
   supabase.seed("members", [
     {
       id: "00000000-0000-4000-8000-000000000020",
@@ -196,4 +213,115 @@ test("resolveChatMessageRecipient ignores duplicate org rows that are not chat-e
     displayName: "Louis Ciccone",
     existingChatGroupId: null,
   });
+});
+
+test("resolveChatMessageRecipient rejects explicit recipients without active org membership", async () => {
+  const supabase = createSupabaseStub();
+  supabase.seed("user_organization_roles", [
+    {
+      organization_id: ORG_ID,
+      user_id: RECIPIENT_USER_ID,
+      role: "alumni",
+      status: "revoked",
+    },
+  ]);
+  supabase.seed("members", [
+    {
+      id: RECIPIENT_MEMBER_ID,
+      organization_id: ORG_ID,
+      user_id: RECIPIENT_USER_ID,
+      status: "active",
+      deleted_at: null,
+      first_name: "Jason",
+      last_name: "Leonard",
+      email: "jason@example.com",
+      role: "alumni",
+    },
+  ]);
+
+  const result = await resolveChatMessageRecipient(supabase as DirectChatSupabase, {
+    organizationId: ORG_ID,
+    senderUserId: SENDER_USER_ID,
+    recipientMemberId: RECIPIENT_MEMBER_ID,
+  });
+
+  assert.deepEqual(result, {
+    kind: "unavailable",
+    requestedRecipient: "Jason Leonard",
+    reason: "recipient_inactive",
+  });
+});
+
+test("resolveChatMessageRecipient can resolve linked active alumni by name", async () => {
+  const supabase = createSupabaseStub();
+  supabase.seed("alumni", [
+    {
+      id: "00000000-0000-4000-8000-000000000030",
+      organization_id: ORG_ID,
+      user_id: RECIPIENT_USER_ID,
+      deleted_at: null,
+      first_name: "Taylor",
+      last_name: "Alum",
+      email: "taylor@example.com",
+    },
+  ]);
+  supabase.seed("user_organization_roles", [
+    {
+      user_id: RECIPIENT_USER_ID,
+      organization_id: ORG_ID,
+      role: "alumni",
+      status: "active",
+    },
+  ]);
+
+  const result = await resolveChatMessageRecipient(supabase as DirectChatSupabase, {
+    organizationId: ORG_ID,
+    senderUserId: SENDER_USER_ID,
+    personQuery: "Taylor Alum",
+  });
+
+  assert.deepEqual(result, {
+    kind: "resolved",
+    memberId: "00000000-0000-4000-8000-000000000030",
+    userId: RECIPIENT_USER_ID,
+    displayName: "Taylor Alum",
+    existingChatGroupId: null,
+  });
+});
+
+test("ensureDirectChatForUser creates a 1:1 chat for active org users", async () => {
+  const supabase = createSupabaseStub();
+  supabase.seed("user_organization_roles", [
+    {
+      user_id: SENDER_USER_ID,
+      organization_id: ORG_ID,
+      role: "active_member",
+      status: "active",
+    },
+    {
+      user_id: RECIPIENT_USER_ID,
+      organization_id: ORG_ID,
+      role: "alumni",
+      status: "active",
+    },
+  ]);
+  supabase.seed("users", [
+    {
+      id: RECIPIENT_USER_ID,
+      name: "Taylor Alum",
+      email: "taylor@example.com",
+    },
+  ]);
+
+  const result = await ensureDirectChatForUser(supabase as DirectChatSupabase, {
+    organizationId: ORG_ID,
+    senderUserId: SENDER_USER_ID,
+    recipientUserId: RECIPIENT_USER_ID,
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.reused, false);
+  assert.equal(supabase.getRows("chat_groups").length, 1);
+  assert.equal(supabase.getRows("chat_group_members").length, 2);
 });

--- a/apps/web/tests/profile-direct-chat.test.ts
+++ b/apps/web/tests/profile-direct-chat.test.ts
@@ -1,0 +1,212 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createSupabaseStub } from "./utils/supabaseStub.ts";
+import {
+  startProfileDirectChat,
+  type ProfileDirectChatSupabase,
+} from "../src/lib/chat/profile-direct-chat.ts";
+
+const ORG_ID = "00000000-0000-4000-8000-000000000101";
+const VIEWER_USER_ID = "00000000-0000-4000-8000-000000000102";
+const TARGET_USER_ID = "00000000-0000-4000-8000-000000000103";
+const TARGET_MEMBER_ID = "00000000-0000-4000-8000-000000000104";
+const TARGET_ALUMNI_ID = "00000000-0000-4000-8000-000000000105";
+
+test("startProfileDirectChat lets an active non-admin org member open a linked member profile chat", async () => {
+  const supabase = createSupabaseStub();
+  supabase.seed("user_organization_roles", [
+    {
+      organization_id: ORG_ID,
+      user_id: VIEWER_USER_ID,
+      role: "active_member",
+      status: "active",
+    },
+    {
+      organization_id: ORG_ID,
+      user_id: TARGET_USER_ID,
+      role: "active_member",
+      status: "active",
+    },
+  ]);
+  supabase.seed("users", [
+    {
+      id: TARGET_USER_ID,
+      name: "Jason Leonard",
+      email: "jason@example.com",
+    },
+  ]);
+  supabase.seed("members", [
+    {
+      id: TARGET_MEMBER_ID,
+      organization_id: ORG_ID,
+      user_id: TARGET_USER_ID,
+      status: "active",
+      deleted_at: null,
+      first_name: "Jason",
+      last_name: "Leonard",
+      email: "jason@example.com",
+    },
+  ]);
+
+  const result = await startProfileDirectChat(supabase as ProfileDirectChatSupabase, {
+    organizationId: ORG_ID,
+    viewerUserId: VIEWER_USER_ID,
+    profileType: "member",
+    profileId: TARGET_MEMBER_ID,
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+
+  assert.equal(result.reused, false);
+  assert.match(result.chatGroupId, /^[0-9a-f-]{36}$/);
+  assert.equal(supabase.getRows("chat_groups").length, 1);
+  assert.deepEqual(
+    supabase.getRows("chat_group_members").map((row) => row.user_id).sort(),
+    [TARGET_USER_ID, VIEWER_USER_ID].sort(),
+  );
+});
+
+test("startProfileDirectChat rejects profiles without a linked user", async () => {
+  const supabase = createSupabaseStub();
+  supabase.seed("user_organization_roles", [
+    {
+      organization_id: ORG_ID,
+      user_id: VIEWER_USER_ID,
+      role: "active_member",
+      status: "active",
+    },
+  ]);
+  supabase.seed("members", [
+    {
+      id: TARGET_MEMBER_ID,
+      organization_id: ORG_ID,
+      user_id: null,
+      status: "active",
+      deleted_at: null,
+      first_name: "Manual",
+      last_name: "Member",
+      email: "manual@example.com",
+    },
+  ]);
+
+  const result = await startProfileDirectChat(supabase as ProfileDirectChatSupabase, {
+    organizationId: ORG_ID,
+    viewerUserId: VIEWER_USER_ID,
+    profileType: "member",
+    profileId: TARGET_MEMBER_ID,
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    status: 409,
+    code: "profile_unlinked",
+    error: "This profile is not linked to an in-app user account.",
+  });
+  assert.equal(supabase.getRows("chat_groups").length, 0);
+  assert.equal(supabase.getRows("chat_group_members").length, 0);
+});
+
+test("startProfileDirectChat rejects viewers without a chat-eligible org role", async () => {
+  const supabase = createSupabaseStub();
+  supabase.seed("user_organization_roles", [
+    {
+      organization_id: ORG_ID,
+      user_id: VIEWER_USER_ID,
+      role: "coach",
+      status: "active",
+    },
+  ]);
+
+  const result = await startProfileDirectChat(supabase as ProfileDirectChatSupabase, {
+    organizationId: ORG_ID,
+    viewerUserId: VIEWER_USER_ID,
+    profileType: "member",
+    profileId: TARGET_MEMBER_ID,
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    status: 403,
+    code: "forbidden",
+    error: "You must be an active member of this organization to start a chat.",
+  });
+});
+
+test("startProfileDirectChat reports profile lookup failures separately from missing profiles", async () => {
+  const supabase = createSupabaseStub();
+  supabase.seed("user_organization_roles", [
+    {
+      organization_id: ORG_ID,
+      user_id: VIEWER_USER_ID,
+      role: "active_member",
+      status: "active",
+    },
+  ]);
+  supabase.simulateError("members", { message: "database unavailable" });
+
+  const result = await startProfileDirectChat(supabase as ProfileDirectChatSupabase, {
+    organizationId: ORG_ID,
+    viewerUserId: VIEWER_USER_ID,
+    profileType: "member",
+    profileId: TARGET_MEMBER_ID,
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    status: 500,
+    code: "profile_lookup_failed",
+    error: "Failed to load this profile for chat.",
+  });
+});
+
+test("startProfileDirectChat lets an active org member open a linked alumni profile chat", async () => {
+  const supabase = createSupabaseStub();
+  supabase.seed("user_organization_roles", [
+    {
+      organization_id: ORG_ID,
+      user_id: VIEWER_USER_ID,
+      role: "active_member",
+      status: "active",
+    },
+    {
+      organization_id: ORG_ID,
+      user_id: TARGET_USER_ID,
+      role: "alumni",
+      status: "active",
+    },
+  ]);
+  supabase.seed("users", [
+    {
+      id: TARGET_USER_ID,
+      name: "Taylor Alum",
+      email: "taylor@example.com",
+    },
+  ]);
+  supabase.seed("alumni", [
+    {
+      id: TARGET_ALUMNI_ID,
+      organization_id: ORG_ID,
+      user_id: TARGET_USER_ID,
+      deleted_at: null,
+      first_name: "Taylor",
+      last_name: "Alum",
+      email: "taylor@example.com",
+    },
+  ]);
+
+  const result = await startProfileDirectChat(supabase as ProfileDirectChatSupabase, {
+    organizationId: ORG_ID,
+    viewerUserId: VIEWER_USER_ID,
+    profileType: "alumni",
+    profileId: TARGET_ALUMNI_ID,
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.reused, false);
+  assert.deepEqual(
+    supabase.getRows("chat_group_members").map((row) => row.user_id).sort(),
+    [TARGET_USER_ID, VIEWER_USER_ID].sort(),
+  );
+});

--- a/apps/web/tests/routes/ai/tool-executor.test.ts
+++ b/apps/web/tests/routes/ai/tool-executor.test.ts
@@ -1668,6 +1668,7 @@ test("prepare_discussion_reply creates a pending confirmation action when comple
 
 test("prepare_chat_message returns missing_fields when the body is missing", async () => {
   const recipientMemberId = "11111111-1111-4111-8111-111111111111";
+  const recipientUserId = "22222222-2222-4222-8222-222222222222";
   const chatStub = createToolSupabaseStub({
     members: {
       select: {
@@ -1675,12 +1676,26 @@ test("prepare_chat_message returns missing_fields when the body is missing", asy
           {
             id: recipientMemberId,
             organization_id: ORG_ID,
-            user_id: "22222222-2222-4222-8222-222222222222",
+            user_id: recipientUserId,
             status: "active",
             deleted_at: null,
             first_name: "Jason",
             last_name: "Leonard",
             email: "jason@example.com",
+          },
+        ],
+        error: null,
+      },
+    },
+    user_organization_roles: {
+      select: {
+        data: [
+          { organization_id: ORG_ID, user_id: USER_ID, role: "admin", status: "active" },
+          {
+            organization_id: ORG_ID,
+            user_id: recipientUserId,
+            role: "alumni",
+            status: "active",
           },
         ],
         error: null,
@@ -1728,6 +1743,20 @@ test("prepare_chat_message creates a pending confirmation action when complete",
             first_name: "Jason",
             last_name: "Leonard",
             email: "jason@example.com",
+          },
+        ],
+        error: null,
+      },
+    },
+    user_organization_roles: {
+      select: {
+        data: [
+          { organization_id: ORG_ID, user_id: USER_ID, role: "admin", status: "active" },
+          {
+            organization_id: ORG_ID,
+            user_id: recipientUserId,
+            role: "alumni",
+            status: "active",
           },
         ],
         error: null,

--- a/apps/web/tests/routes/chat/members.test.ts
+++ b/apps/web/tests/routes/chat/members.test.ts
@@ -9,6 +9,10 @@ import {
   AuthPresets,
 } from "../../utils/authMock.ts";
 import { createSupabaseStub } from "../../utils/supabaseStub.ts";
+import {
+  mergeChatProfileCandidates,
+  uniqueChatEligibleUserIds,
+} from "../../../src/lib/chat/recipient-eligibility.ts";
 
 /**
  * Tests for /api/chat/[groupId]/members
@@ -66,8 +70,13 @@ interface SimulationContext {
   groupId: string;
   /** Chat group members pre-seeded in the context */
   groupMembers: ChatGroupMemberRow[];
-  /** User IDs of active org members */
-  activeOrgMemberUserIds: string[];
+  /** Org role rows used to validate add-member targets */
+  orgRoles: Array<{
+    user_id: string;
+    organization_id: string;
+    role: "admin" | "active_member" | "alumni" | "parent";
+    status: "active" | "revoked" | "pending";
+  }>;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -149,10 +158,17 @@ function simulateAddMembers(
     return { status: 403, error: "Forbidden" };
   }
 
-  // Validate each user_id is an active org member
-  const invalidIds = request.user_ids.filter(
-    (uid) => !ctx.activeOrgMemberUserIds.includes(uid)
+  // Validate each user_id is an active org member, including active alumni.
+  const activeChatEligibleUserIds = new Set(
+    ctx.orgRoles
+      .filter((role) => role.organization_id === ctx.organizationId)
+      .filter((role) => role.status === "active")
+      .filter((role) =>
+        ["admin", "active_member", "alumni", "parent"].includes(role.role)
+      )
+      .map((role) => role.user_id)
   );
+  const invalidIds = request.user_ids.filter((uid) => !activeChatEligibleUserIds.has(uid));
   if (invalidIds.length > 0) {
     return { status: 400, error: "Some users are not active org members" };
   }
@@ -265,7 +281,11 @@ const PARENT_USER_ID = "00000000-0000-4000-8000-000000000301";
 const OUTSIDER_USER_ID = "00000000-0000-4000-8000-000000000400";
 const NEW_USER_1_ID = "00000000-0000-4000-8000-000000000500";
 const NEW_USER_2_ID = "00000000-0000-4000-8000-000000000600";
+const ALUMNI_USER_ID = "00000000-0000-4000-8000-000000000601";
+const REVOKED_ALUMNI_USER_ID = "00000000-0000-4000-8000-000000000602";
+const OTHER_ORG_ALUMNI_USER_ID = "00000000-0000-4000-8000-000000000603";
 const ORG_ADMIN_USER_ID = "00000000-0000-4000-8000-000000000700";
+const OTHER_ORG_ID = "00000000-0000-4000-8000-000000000999";
 
 function createTestContext(
   overrides?: Partial<SimulationContext>
@@ -309,14 +329,17 @@ function createTestContext(
         removed_at: null,
       },
     ],
-    activeOrgMemberUserIds: [
-      ADMIN_USER_ID,
-      MOD_USER_ID,
-      MEMBER_USER_ID,
-      PARENT_USER_ID,
-      OUTSIDER_USER_ID,
-      NEW_USER_1_ID,
-      NEW_USER_2_ID,
+    orgRoles: [
+      { organization_id: ORG_ID, user_id: ADMIN_USER_ID, role: "active_member", status: "active" },
+      { organization_id: ORG_ID, user_id: MOD_USER_ID, role: "active_member", status: "active" },
+      { organization_id: ORG_ID, user_id: MEMBER_USER_ID, role: "active_member", status: "active" },
+      { organization_id: ORG_ID, user_id: PARENT_USER_ID, role: "parent", status: "active" },
+      { organization_id: ORG_ID, user_id: OUTSIDER_USER_ID, role: "active_member", status: "active" },
+      { organization_id: ORG_ID, user_id: NEW_USER_1_ID, role: "active_member", status: "active" },
+      { organization_id: ORG_ID, user_id: NEW_USER_2_ID, role: "active_member", status: "active" },
+      { organization_id: ORG_ID, user_id: ALUMNI_USER_ID, role: "alumni", status: "active" },
+      { organization_id: ORG_ID, user_id: REVOKED_ALUMNI_USER_ID, role: "alumni", status: "revoked" },
+      { organization_id: OTHER_ORG_ID, user_id: OTHER_ORG_ALUMNI_USER_ID, role: "alumni", status: "active" },
     ],
     ...overrides,
   };
@@ -495,6 +518,36 @@ test("POST: org admin can add members", () => {
   assert.strictEqual(result.skipped, 0);
 });
 
+test("POST: group moderator can add active alumni", () => {
+  const ctx = createTestContext();
+  const result = simulateAddMembers(
+    { auth: groupModeratorAuth, groupId: GROUP_ID, user_ids: [ALUMNI_USER_ID] },
+    ctx
+  );
+  assert.strictEqual(result.status, 200);
+  assert.strictEqual(result.added, 1);
+});
+
+test("POST: revoked alumni cannot be added", () => {
+  const ctx = createTestContext();
+  const result = simulateAddMembers(
+    { auth: groupModeratorAuth, groupId: GROUP_ID, user_ids: [REVOKED_ALUMNI_USER_ID] },
+    ctx
+  );
+  assert.strictEqual(result.status, 400);
+  assert.ok(result.error?.includes("not active org members"));
+});
+
+test("POST: alumni from another org cannot be added", () => {
+  const ctx = createTestContext();
+  const result = simulateAddMembers(
+    { auth: groupModeratorAuth, groupId: GROUP_ID, user_ids: [OTHER_ORG_ALUMNI_USER_ID] },
+    ctx
+  );
+  assert.strictEqual(result.status, 400);
+  assert.ok(result.error?.includes("not active org members"));
+});
+
 test("POST: empty user_ids returns 400", () => {
   const ctx = createTestContext();
   const result = simulateAddMembers(
@@ -550,6 +603,86 @@ test("POST: re-adding a soft-deleted member reactivates them", () => {
     (m) => m.user_id === MEMBER_USER_ID && m.removed_at === null
   );
   assert.ok(restored);
+});
+
+test("chat candidate helpers dedupe active org-role users", () => {
+  assert.deepStrictEqual(
+    uniqueChatEligibleUserIds([
+      { user_id: NEW_USER_1_ID },
+      { user_id: NEW_USER_1_ID },
+      { user_id: null },
+      {},
+      { user_id: ALUMNI_USER_ID },
+    ]),
+    [NEW_USER_1_ID, ALUMNI_USER_ID]
+  );
+});
+
+test("channel member candidates include alumni-only users and prefer member profiles for duplicates", () => {
+  const candidates = mergeChatProfileCandidates({
+    members: [
+      {
+        id: "member-profile",
+        user_id: NEW_USER_1_ID,
+        first_name: "Jordan",
+        last_name: "Member",
+        email: "jordan@example.com",
+        photo_url: "member.jpg",
+        role: "Captain",
+      },
+      {
+        id: "manual-member",
+        user_id: null,
+        first_name: "Manual",
+        last_name: "Only",
+        email: "manual@example.com",
+        photo_url: null,
+      },
+    ],
+    alumni: [
+      {
+        id: "duplicate-alumni-profile",
+        user_id: NEW_USER_1_ID,
+        first_name: "Jordan",
+        last_name: "Alum",
+        email: "alum-duplicate@example.com",
+        photo_url: "alum.jpg",
+        position_title: "Founder",
+      },
+      {
+        id: "alumni-profile",
+        user_id: ALUMNI_USER_ID,
+        first_name: "Taylor",
+        last_name: "Alum",
+        email: "taylor@example.com",
+        photo_url: null,
+        job_title: "Advisor",
+      },
+    ],
+  });
+
+  assert.deepStrictEqual(candidates, [
+    {
+      id: "member-profile",
+      user_id: NEW_USER_1_ID,
+      first_name: "Jordan",
+      last_name: "Member",
+      email: "jordan@example.com",
+      photo_url: "member.jpg",
+      role: "Captain",
+      profileType: "member",
+    },
+    {
+      id: "alumni-profile",
+      user_id: ALUMNI_USER_ID,
+      first_name: "Taylor",
+      last_name: "Alum",
+      email: "taylor@example.com",
+      photo_url: null,
+      role: "Advisor",
+      profileType: "alumni",
+    },
+  ]);
 });
 
 // ─── DELETE Tests ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds a **Message** button to member and alumni profile pages that opens a 1:1 direct chat with that person. The button renders only when **both** the viewer and the target hold an active chat-eligible org role.

## Why

There was no way to start a 1:1 chat from a profile — you had to go to the chat area and search. This makes person-to-person networking a one-click action from the profile you're already looking at.

## Changes

- **New route** `POST /api/organizations/[organizationId]/direct-chat/profile` + `startProfileDirectChat()` — authorizes the viewer, resolves the target (member or alumni), and reuses-or-creates the 1:1 group.
- **Alumni support** — linked, active alumni are now valid chat recipients across direct chat, the new-chat picker, and the manage-members panel (previously members-only).
- **Shared eligibility module** (`recipient-eligibility.ts`) — `CHAT_ELIGIBLE_ORG_ROLES`, `mergeChatProfileCandidates` (member-wins dedupe), `uniqueChatEligibleUserIds`; both client pickers now consume it instead of duplicating the logic.
- **RLS-correct chat creation** — the privileged `chat_groups` insert runs on the service-role client after app-layer authorization, matching mentorship auto-pairing and the AI direct-chat path. (Without this, non-admins got a 500.)
- **Better failure handling** — DB/RLS errors surface as `profile_lookup_failed` (500) instead of a misleading "profile not found" (404); structured server-side logging added at the chat-creation failure points.
- **Dead code removed** — an unreachable `recipient_lookup_failed → 409` branch in `ensureDirectChatForUser` (the self-message guard makes it unreachable).
- **Tests** — behavior tests for active-user dedupe, member/alumni precedence, and the profile direct-chat flow.

## Verification

- `typecheck` ✅ · `lint` ✅ · chat suites **117/117** ✅
- **Browser-tested as a non-admin active member** (not an admin): clicking Message creates a 1:1 group (creator = viewer:`admin`, target:`member`) and redirects to the chat window. A second click **reuses** the same group — confirmed exactly one group between the pair, no duplicates.

## Follow-ups (not in this PR)

- **Latency:** opening a chat is ~4s — the path does ~13 sequential DB round-trips and uses a full form-POST navigation (two document loads). Worth a dedicated perf PR (collapse the query chain into one RPC, client-side navigation, server-render first message page).
- **Server-side dedupe:** `direct-chat.ts`'s `loadActiveLinkedChatPeople` still duplicates the new shared client helper's logic (different row shape). Cleanup, non-blocking.