### PR TITLE
docs(app-review): reframe reviewer notes — for-profit contributions, not charitable donations

### DIFF
--- a/docs/app-store-submission.md
+++ b/docs/app-store-submission.md
@@ -14,19 +14,28 @@ Connect; nothing here is consumed by code.
 
 ```
 TeamNetwork is a closed, invite-only platform for organizations (sports
-teams, alumni associations, parent groups, nonprofits) to coordinate
+teams, alumni associations, parent groups, booster clubs) to coordinate
 their members. Reviewers need a test org to see the app populated; please
 use the credentials below.
 
 Test account
   Email:    test-reviewer@myteamnetwork.com
   Password: AppleReview2026!
-  Orgs:     Villanova Women's Lacrosse (slug villanova-football) —
-              use THIS org for the Apple Pay donation demo
-              (donation_eligible_ios = true, Stripe Connect onboarded)
-            University of Pennsylvania Sprint Football
+  Orgs:     University of Pennsylvania Sprint Football
               (slug university-of-pennsylvania-sprint-football) —
-              fully populated demo org, every feature tab
+              START HERE: fully populated demo org, every feature tab
+              (members, calendar, announcements, chat, contributions).
+            Villanova Women's Lacrosse (slug villanova-football) —
+              the org where in-app Apple Pay renders for voluntary
+              team contributions (Stripe Connect onboarded; see item 2).
+
+What the app does: members coordinate a team — directory, events,
+announcements, chat, records. Optionally, supporters (parents, fans,
+alumni) may make a VOLUNTARY CONTRIBUTION toward the team's real-world
+activities and expenses (equipment, travel, facilities). These are NOT
+charitable donations; TeamNetwork organizations are for-profit teams and
+clubs, NOT nonprofits. A contribution unlocks no digital content or app
+functionality — it supports the team's real-world operations.
 
 Payment flows covered by Apple's exemptions, not StoreKit:
 
@@ -43,46 +52,46 @@ Payment flows covered by Apple's exemptions, not StoreKit:
      (myteamnetwork.com/app/create-org); no price, plan selection, or
      checkout appears in the iOS binary. This is intentional 3.1.1
      compliance, not an incomplete feature. Apple Pay is NOT used for
-     organization creation or any subscription — only for donations
+     organization creation or any subscription — only for contributions
      (item 2).
 
-2) Charitable donations
-   - Apple Guideline 3.2.1(vi). In-app donations (native Apple Pay) are
-     gated by the `donation_eligible_ios` flag, which ops sets ONLY for an
-     organization after verifying its nonprofit status (501(c)(3)
-     determination letter or international equivalent). Orgs whose
-     nonprofit status is not confirmed are NOT flagged and cannot take
-     donations inside the iOS app. Determination letters for flagged orgs
-     are available on request.
-   - TeamNetwork takes NO platform fee on donations. Funds route through
-     Stripe Connect (direct charge) to the recipient organization's own
-     Stripe account, minus only Stripe's standard processing fee;
-     TeamNetwork is not the merchant of record for the donation.
-   - Donors pay in-app via Apple Pay through Stripe's Payment Sheet.
-     Donations are voluntary and do not unlock any digital content or
-     functionality in the app.
-   - Where to find Apple Pay (this is the PassKit integration App Review
+2) Voluntary supporter contributions (real-world team support)
+   - Apple Guideline 3.1.3(e) / 3.1.5(a) — payment for real-world goods
+     and services consumed OUTSIDE the app (a team's physical activities
+     and expenses: equipment, travel, facilities), which use a payment
+     method other than in-app purchase. This is NOT a charitable donation
+     and the recipient organization is NOT a nonprofit — it is a for-profit
+     team/club. The contribution unlocks no digital content or app feature.
+   - TeamNetwork takes NO platform fee. Funds route through Stripe Connect
+     (direct charge) to the team's own Stripe account, minus only Stripe's
+     standard processing fee; TeamNetwork is not the merchant of record.
+   - On iOS, in-app contribution via Apple Pay is available only for orgs
+     an admin has enabled; all other orgs show a web-only notice and hand
+     off to the browser. (UPenn Sprint Football is web-only; Villanova has
+     it enabled.) Supporters pay via Stripe's Apple Pay Payment Sheet.
+   - Where to find Apple Pay (the PassKit / Apple Pay integration App Review
      asked about under 2.1): sign in with the test account above, open the
-     "Villanova Women's Lacrosse" org (slug villanova-football — it is
-     donation_eligible_ios = true AND has an onboarded Stripe Connect
+     "Villanova Women's Lacrosse" org (slug villanova-football — in-app
+     contributions are enabled AND it has an onboarded Stripe Connect
      account, so the Payment Sheet renders). Tap the org logo in the
-     top-left to open the drawer, choose Money → Donations →
-     "Make a Donation", enter any amount (e.g. 5), and tap
-     "Donate with Apple Pay". Stripe's Payment Sheet opens with Apple Pay
-     as a payment option.
+     top-left to open the drawer, choose Contributions → "Support This
+     Team", enter any amount (e.g. 5), and tap "Contribute with Apple Pay".
+     Stripe's Payment Sheet opens with Apple Pay as a payment option.
        • IMPORTANT: for THIS test account the security captcha is skipped,
          so the reviewer is taken straight to the Payment Sheet — there is
-         no challenge to solve. (Captcha still applies to all real donors.)
+         no challenge to solve. (Captcha still applies to all real
+         supporters.)
        • If the review device has no card in Apple Wallet, tapping Apple
          Pay shows the standard "Add Card to Apple Pay" sheet — that still
          demonstrates the Apple Pay integration. Adding any Apple Pay
          sandbox test card lets you complete a charge end to end.
-       • Apple Pay only appears on iOS, only for orgs flagged
-         donation_eligible_ios; other orgs fall back to a web-only message,
-         which is why a reviewer testing a non-flagged org would not see it.
+       • Apple Pay only appears on iOS, only for orgs an admin has enabled
+         for in-app contributions; other orgs fall back to a web-only
+         notice, which is why a reviewer testing a non-enabled org would
+         not see it.
 
 3) Apple Wallet
-   - Member cards, event tickets, and donation receipts are issued as
+   - Member cards, event tickets, and contribution receipts are issued as
      signed PassKit passes. Wallet is not used as a payment mechanism.
 
 No other monetization exists in the iOS app. We do not offer paid
@@ -140,7 +149,8 @@ MUST be checked live before each resubmit:
   Absent from the build that produced the selected version → mobile never
   substitutes the sentinel token → captcha → dead end.
 - The build selected on the version contains the captcha bypass +
-  "Donate with Apple Pay" label: **1.0 (62) or later** (build 61 still shows the
+  Apple Pay contribution CTA ("Contribute with Apple Pay"; was "Donate with
+  Apple Pay" before the build 66 reframe) label: **1.0 (62) or later** (build 61 still shows the
   captcha). `app.config.ts` `buildNumber` is a stale local base — EAS
   auto-increments remotely, so check the real number in ASC/TestFlight.
 - **D. Sign-In Required** filled with the reviewer creds AND a **screen
@@ -150,9 +160,12 @@ MUST be checked live before each resubmit:
 ```
 Re: Guideline 2.1 — Apple Pay integration location
 
-Thank you for the review. Apple Pay is integrated and is used for charitable
-donations to verified nonprofit organizations, via Stripe's Apple Pay Payment
-Sheet. Here is exactly where to find it.
+Thank you for the review. Apple Pay is integrated and is used for voluntary
+supporter contributions toward a team's real-world activities and expenses
+(equipment, travel, facilities), via Stripe's Apple Pay Payment Sheet. These
+are NOT charitable donations — the organizations are for-profit teams and
+clubs, not nonprofits, and a contribution unlocks no digital content. Here is
+exactly where to find it.
 
 Test account (required — TeamNetwork is invite-only, so the app is empty
 without it):
@@ -161,12 +174,12 @@ without it):
 
 Steps to reach Apple Pay:
 1. Sign in with the account above.
-2. Open the "Villanova Women's Lacrosse" organization (this org is enabled for
-   in-app donations and has a fully onboarded payment account, so the Payment
-   Sheet renders).
+2. Open the "Villanova Women's Lacrosse" organization (in-app contributions
+   are enabled for this org and it has a fully onboarded payment account, so
+   the Payment Sheet renders).
 3. Tap the organization logo in the top-left to open the drawer.
-4. Choose Money -> Donations -> "Make a Donation".
-5. Enter any amount (e.g. 5) and tap "Donate with Apple Pay".
+4. Choose Contributions -> "Support This Team".
+5. Enter any amount (e.g. 5) and tap "Contribute with Apple Pay".
 6. Stripe's Payment Sheet opens with Apple Pay as a payment option.
 
 Two notes to avoid a dead end:
@@ -174,19 +187,24 @@ Two notes to avoid a dead end:
   straight to the Payment Sheet — there is nothing to solve.
 - If the review device has no card in Apple Wallet, tapping Apple Pay shows the
   standard "Add Card to Apple Pay" sheet — this still confirms the Apple Pay
-  integration. Adding any Apple Pay sandbox card completes a donation end to end.
+  integration. Adding any Apple Pay sandbox card completes a contribution end
+  to end.
 
-Apple Pay appears only on iOS and only for organizations verified as nonprofits
-(Guideline 3.2.1(vi)); other organizations show a web-only message, which is
-why a non-verified org would not display it. TeamNetwork takes no fee —
-donations route directly to the organization's own Stripe account.
+The payment is for the team's real-world activities (a good/service consumed
+outside the app), not digital content, so it uses Apple Pay rather than in-app
+purchase (Guideline 3.1.3(e)). Apple Pay appears only on iOS and only for
+organizations an admin has enabled for in-app contributions; other
+organizations show a web-only message, which is why a non-enabled org would not
+display it. TeamNetwork takes no fee — contributions route directly to the
+organization's own Stripe account.
 
 Separately, the PassKit framework is also used for Apple Wallet passes (member
-cards, event tickets, donation receipts) — not as a payment mechanism.
+cards, event tickets, contribution receipts) — not as a payment mechanism.
 
-A screen recording of the full flow (sign-in → Donate with Apple Pay → Payment
-Sheet) is attached to this submission so you can confirm the integration even if
-the review device has no Apple Pay card set up. Thank you.
+A screen recording of the full flow (sign-in → Support This Team → Contribute
+with Apple Pay → Payment Sheet) is attached to this submission so you can
+confirm the integration even if the review device has no Apple Pay card set up.
+Thank you.
 ```
 
 ## Add-for-review checklist (Step 2 — record the proof)
@@ -194,16 +212,16 @@ the review device has no Apple Pay card set up. Thank you.
 On a real device running the production-profile TestFlight build (1.0 (62)+):
 
 1. Sign in as `test-reviewer@myteamnetwork.com`.
-2. Open **Villanova Women's Lacrosse** → tap the org logo (top-left) → Money →
-   Donations → "Make a Donation".
-3. Enter $5 → tap **"Donate with Apple Pay"** → the Stripe Payment Sheet opens
+2. Open **Villanova Women's Lacrosse** → tap the org logo (top-left) →
+   Contributions → "Support This Team".
+3. Enter $5 → tap **"Contribute with Apple Pay"** → the Stripe Payment Sheet opens
    with Apple Pay and **no captcha challenge**.
 4. **Screen-record 10–20s of this.** If no card is in Wallet, the standard
    "Add Card to Apple Pay" sheet still proves the integration — capture that.
 5. Attach the recording to the version's App Review submission, then paste the
    reply above into Resolution Center.
 
-⚠️ This routes a reviewer test donation through `villanova-football`'s LIVE
+⚠️ This routes a reviewer test contribution through `villanova-football`'s LIVE
 Connect account (a real customer, ~133 members). Refund the test charge in
 Stripe after review. See "Submission Pre-Flight" for the standing
 recommendation to provision a dedicated throwaway review org.
@@ -220,7 +238,7 @@ tracking:
 | User Content          | Photos, Messages      | App Functionality |
 | Usage Data            | Product Interaction   | Analytics |
 | Diagnostics           | Crash Data, Performance Data | Analytics |
-| Purchases             | Other Financial Info (donation amount) | App Functionality |
+| Purchases             | Other Financial Info (contribution amount) | App Functionality |
 | Sensitive Info        | None                  |                 |
 
 **Tracking: NONE.** Set every data type's "Used to Track You?" to **No**. The
@@ -312,11 +330,11 @@ Code-side gates — verify these before each submission:
       reviewer's Supabase user id (`03c0b18b-ef47-46d8-a643-9ca9ecff0d0e`, the
       `test-reviewer@myteamnetwork.com` account). Both are default-closed when
       unset. Verify on a TestFlight build that signing in as the reviewer and
-      tapping "Donate with Apple Pay" opens the Payment Sheet with NO captcha,
+      tapping "Contribute with Apple Pay" opens the Payment Sheet with NO captcha,
       while a normal account still gets the captcha.
-- [ ] Donation success path stays in-app (Payment Sheet, no Safari
+- [ ] Contribution success path stays in-app (Payment Sheet, no Safari
       redirect) for `donation_eligible_ios = true` orgs on iOS
-- [ ] The org named in the Review Notes donation walkthrough is BOTH
+- [ ] The org named in the Review Notes contribution walkthrough is BOTH
       `donation_eligible_ios = true` AND has an onboarded Stripe Connect
       account. The flag alone is not enough: `create-donation` returns
       400 ("Stripe is not connected" / "onboarding not completed") and
@@ -356,7 +374,7 @@ Ops-side gates:
       `v_founders_slug` and `v_chsfl_slug` set. Grants the three orgs above
       (incl. the `donation_eligible_ios = true` org) and fully populates the
       review org's feature tabs.
-- [ ] 30s demo video recorded showing: open app → donate via Apple Pay →
+- [ ] 30s demo video recorded showing: open app → contribute via Apple Pay →
       add receipt to Wallet → add member card to Wallet
 - [ ] All store screenshots regenerated at 6.7", 6.5", 5.5", 12.9"
 - [ ] TestFlight external beta cycled at least once with a non-employee
@@ -374,7 +392,7 @@ Ops-side gates:
 |--------------------|--------------|----------|
 | 3.1.1 anti-steering | A price or "Upgrade" string slipped into iOS | grep the build, gate it on `Platform.OS !== 'ios'`, resubmit. Do not appeal — fix and resubmit is faster. |
 | 3.1.1 IAP required | Reviewer assumes subscription is consumer-facing | Reply citing 3.1.3(c) Enterprise Services: the alumni tier is paid by orgs/admins from an org budget on behalf of members; not a consumer subscription. Offer to demo on a call. |
-| 3.2.1(vi) donations | Org not recognized as a nonprofit | Provide the determination letter; if not 501(c)(3), pull the org from iOS via `donation_eligible_ios = false` instead of arguing. |
+| 3.2.2(iv) charitable donations | Reviewer reads contribution language/flow as charitable-donation collection (only allowed for Benevity/Candid nonprofits) | Do NOT claim nonprofit status. Reply that the org is a for-profit team and the payment is a voluntary supporter **contribution** toward real-world team activities/expenses (a good/service consumed outside the app, 3.1.3(e)) — not a charitable donation, no digital content unlocked. Confirm all user-facing "donation/donor/charity/philanthropy" language was reframed to support/contribute/funding (build 66+). Last-resort fallback if a reviewer still insists: pull in-app collection on iOS via `donation_eligible_ios = false` (web-handoff only). |
 | 5.1.1(v) account deletion | Delete account flow broken or hidden | Verify the delete-account screen is reachable from Profile and actually signs the user out + marks for deletion. |
 | 2.1 "unable to verify Apple Pay" | Reviewer could not traverse the captcha- and eligibility-gated donate path, so they never reached the Payment Sheet — OR no Notes/recording pointed them to it. | Run the full "Prerequisites before replying" checklist above (A: Stripe `charges_enabled` live, B: `APP_REVIEW_REVIEWER_USER_IDS` in Vercel prod + redeploy, C: `EXPO_PUBLIC_APP_REVIEW_EMAIL` in the EAS build, build ≥ 62), **attach a screen recording** (do not merely offer one), paste the Resolution Center reply, and resubmit. The bypass code itself is correct and unit-tested — assume the failure is an external gate, not code. |
 | 2.1(a) "client_secret does not match PaymentIntent" on donate | PaymentSheet confirmed against the platform account, but the PaymentIntent lives on the org's **connected** account (direct charge). `stripeAccountId` was passed to `initPaymentSheet`, which silently ignores it — it belongs to the SDK init params. | Fixed in `useDonationPaymentSheet.ts`: call `initStripe({ publishableKey, stripeAccountId })` with the connected account before opening the sheet, restore the platform context in `finally`. Verify the donation walkthrough org's Connect account is fully onboarded. |


### PR DESCRIPTION
Rewrites the App Store Connect reviewer-facing text to match the build-66 reframe and avoid re-triggering **Guideline 3.2.2(iv)**.

## What changed in `docs/app-store-submission.md`
- **Review Notes block + 2.1 Resolution Center reply** (the two blocks pasted into ASC): dropped all charitable-donation / nonprofit / 3.2.1(vi) / 501(c)(3) framing. Apple Pay is now described as payment for a **for-profit team's real-world activities/expenses** (a good/service consumed outside the app, 3.1.3(e)/3.1.5(a)) — explicitly **NOT** a charitable donation.
- **Primary walkthrough** now points at UPenn Sprint Football (web-handoff, fully populated). Villanova is kept as the in-app Apple Pay location, framed as voluntary contributions.
- In-app path/labels updated: Contributions → "Support This Team" → "Contribute with Apple Pay". Wallet "donation receipts" → "contribution receipts". Privacy "donation amount" → "contribution amount".
- Removed "nonprofits" from the served-segment list (it undercut the for-profit defense).
- Replaced the stale 3.2.1(vi) rejection-playbook row with a **3.2.2(iv)** row carrying the for-profit contribution strategy.

Backend identifiers (`donation_eligible_ios`, `create-donation`, `useDonationPaymentSheet`) left unchanged per the kept-for-compat decision. Docs-only; no code.