### PR TITLE
feat(assistant): make AI assistant available to all chat-eligible roles

### DIFF
--- a/apps/web/src/app/[orgSlug]/assistant/page.tsx
+++ b/apps/web/src/app/[orgSlug]/assistant/page.tsx
@@ -3,6 +3,7 @@ import { getOrgContext } from "@/lib/auth/roles";
 import { canDevAdminPerform } from "@/lib/auth/dev-admin";
 import { getCurrentUser } from "@/lib/auth/roles";
 import { AssistantLayout } from "@/components/assistant/AssistantLayout";
+import { CHAT_ELIGIBLE_ORG_ROLES } from "@/lib/chat/recipient-eligibility";
 
 interface AssistantPageProps {
   params: Promise<{ orgSlug: string }>;
@@ -16,10 +17,12 @@ export default async function AssistantPage({ params }: AssistantPageProps) {
 
   const user = await getCurrentUser();
   const isDevAdmin = canDevAdminPerform(user, "view_org");
-  const isAdmin = orgCtx.role === "admin" || isDevAdmin;
-
-  // Only admins can access the full-page assistant
-  if (!isAdmin) return notFound();
+  // Chat-eligible org roles (admin, active_member, alumni, parent) and dev admins
+  // can access the full-page assistant.
+  const canAccessAssistant =
+    isDevAdmin ||
+    (orgCtx.role != null && (CHAT_ELIGIBLE_ORG_ROLES as readonly string[]).includes(orgCtx.role));
+  if (!canAccessAssistant) return notFound();
 
   return <AssistantLayout orgId={orgCtx.organization.id} orgSlug={orgSlug} />;
 }

--- a/apps/web/src/app/api/ai/[orgId]/chat/handler/stages/auth-context.ts
+++ b/apps/web/src/app/api/ai/[orgId]/chat/handler/stages/auth-context.ts
@@ -85,7 +85,7 @@ export async function runAuthContextStage(
         user,
         rateLimit,
         { supabase, logContext: baseLogContext },
-        { allowedRoles: ["admin", "active_member", "alumni"] },
+        { allowedRoles: ["admin", "active_member", "alumni", "parent"] },
       ),
   );
   if (!ctx.ok) {

--- a/apps/web/src/lib/ai/context.ts
+++ b/apps/web/src/lib/ai/context.ts
@@ -164,12 +164,6 @@ export async function getAiOrgContext(
         response: respond({ error: "AI assistant is not available for your role" }, 403),
       };
     }
-    if (rawRole === "parent") {
-      return {
-        ok: false,
-        response: respond({ error: "AI assistant is not available for your role" }, 403),
-      };
-    }
   }
 
   let enterpriseId: string | undefined;

--- a/apps/web/src/lib/navigation/nav-items.tsx
+++ b/apps/web/src/lib/navigation/nav-items.tsx
@@ -85,7 +85,7 @@ export const ORG_NAV_ITEMS: OrgNavItem[] = [
   { href: "/expenses", label: "Expenses", i18nKey: "expenses", icon: ReceiptIcon, roles: ["admin", "active_member"], group: "finance" },
   { href: "/records", label: "Records", i18nKey: "records", icon: TrophyIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "activity" },
   { href: "/calendar", label: "Calendar", i18nKey: "calendar", icon: BookOpenIcon, roles: ["admin", "active_member", "alumni", "parent"] },
-  { href: "/assistant", label: "Assistant", i18nKey: "assistant", icon: SparklesIcon, roles: ["admin"], configurable: false },
+  { href: "/assistant", label: "Assistant", i18nKey: "assistant", icon: SparklesIcon, roles: ["admin", "active_member", "alumni", "parent"], configurable: false },
   { href: "/jobs", label: "Jobs", i18nKey: "jobs", icon: BriefcaseIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community" },
   { href: "/forms", label: "Forms", i18nKey: "forms", icon: ClipboardIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community" },
   { href: "/media", label: "Media", i18nKey: "media", icon: GridIcon, roles: ["admin", "active_member", "alumni", "parent"], group: "community" },

--- a/apps/web/tests/ai-context.test.ts
+++ b/apps/web/tests/ai-context.test.ts
@@ -230,8 +230,32 @@ describe("getAiOrgContext", () => {
     }
   });
 
-  it("refuses parent role even when kill is lifted", async () => {
+  it("admits parent when kill is lifted and allowedRoles permits", async () => {
     liftKill();
+    try {
+      const { getAiOrgContext } = await import("../src/lib/ai/context.ts");
+      const mockUser = { id: "user-id", email: "p@t.com" };
+      const mockServiceSupabase = createMockServiceSupabaseWithOrg({
+        role: "parent",
+      });
+      const result = await getAiOrgContext(
+        "org-id",
+        mockUser as unknown as User,
+        mockRateLimit,
+        { serviceSupabase: mockServiceSupabase },
+        { allowedRoles: ["admin", "active_member", "alumni", "parent"] },
+      );
+      assert.equal(result.ok, true);
+      if (result.ok) {
+        assert.equal(result.role, "parent");
+      }
+    } finally {
+      restoreKill();
+    }
+  });
+
+  it("returns 403 for parent when kill switch is active", async () => {
+    process.env.AI_MEMBER_ACCESS_KILL = "1";
     try {
       const { getAiOrgContext } = await import("../src/lib/ai/context.ts");
       const mockUser = { id: "user-id", email: "p@t.com" };


### PR DESCRIPTION
## Summary

The AI **Assistant** was admin-only at every layer, so non-admin members — and in particular **parent** users — never saw the Assistant nav item, and the full-page route 404'd for them. The gating was also internally inconsistent: `active_member`/`alumni` were already in the API `allowedRoles`, but the **nav item** and **page guard** still hard-coded admin-only, and `parent` was additionally hard-blocked by an explicit `if (rawRole === "parent") return 403` in the AI context layer.

This widens the assistant to **all chat-eligible org roles** (`admin`, `active_member`, `alumni`, `parent`) — matching `CHAT_ELIGIBLE_ORG_ROLES` used by the profile direct-chat feature — and makes all four layers agree so a visible nav link can't lead to a 404 / 403.

## Changes

| Layer | File | Change |
|---|---|---|
| Sidebar nav | `lib/navigation/nav-items.tsx` | Assistant `roles: ["admin"]` → `["admin", "active_member", "alumni", "parent"]` |
| Page guard | `app/[orgSlug]/assistant/page.tsx` | admin-only `notFound()` → chat-eligible-role gate (+ removed now-dead `isAdmin`) |
| API allow-list | `api/ai/[orgId]/chat/handler/stages/auth-context.ts` | added `"parent"` to `allowedRoles` |
| API parent block | `lib/ai/context.ts` | removed the hard-coded parent-403 inner block |
| Tests | `tests/ai-context.test.ts` | parent now admitted when kill switch off; still 403 when kill switch on |

## Security / privacy

Parents querying an AI over org member data is a deliberate product decision. Existing controls are **unchanged and still enforced**:

- **`audienceFilterForRole`** continues to scope what RAG can retrieve per role.
- **`AI_MEMBER_ACCESS_KILL`** env switch still gates **all** non-admin callers (now including parent) — an org-wide off switch with no code change. A test asserts parent is admitted when the kill switch is off and 403'd when it is on.
- `DEFAULT_ALLOWED_ROLES` is untouched (stays admin-only) — other AI routes that don't opt in are unaffected.

## Verification

- `bun run --cwd apps/web typecheck` — clean
- `tests/ai-context.test.ts` — 11/11 pass (incl. new parent-admitted + parent-killed cases)
- `bun run --cwd apps/web lint` — clean

## Rollout / rollback

- Rollout: merge → non-admins (incl. parents) get the Assistant. No migration.
- Rollback: revert this PR, or set `AI_MEMBER_ACCESS_KILL` to re-block all non-admins instantly without a deploy.