### PR TITLE
feat(loops): self-gating AI-eval loop + triage scaffold

### DIFF
--- a/.claude/agents/ai-eval-judge.md
+++ b/.claude/agents/ai-eval-judge.md
@@ -80,4 +80,31 @@ none`; `scope_ok: yes`; `goldenset_untouched: yes`; and `evidence:` shows a real
 (`recomputed = baseline`) is a **REJECT** — a tie is not an improvement and is not worth a PR. When uncertain,
 REJECT; the loop's floor is its evaluator and doubt is the correct default.
 
+## Your PASS is not final until the deterministic validator confirms it
+
+Your verdict is a *claim*. A separate, non-AI check — `.claude/loops/tools/validate-verdict.mjs` — has the
+last word on every `VERDICT: PASS`. It cannot be argued with: it re-parses your pasted runner output and
+**voids any PASS that lacks consistent evidence** (no runner summary, total ≠ row count, a tie, a named
+regression, or a diff that did not apply). A void PASS becomes a REJECT. This exists because a judge can reach
+the right *verdict* for the wrong *reason* (e.g. rejecting only because it never found the runner) — the
+validator makes the loop *validated*, not merely answerable.
+
+So on a `VERDICT: PASS`, you MUST also hand the validator its evidence object and run it:
+
+```
+node .claude/loops/tools/validate-verdict.mjs <<'JSON'
+{
+  "verdict": "PASS",
+  "baseline": <P from ai-eval-baseline.md>,
+  "total_rows": <T from ai-eval-baseline.md>,
+  "runner_output": "<the RAW stdout+stderr of the golden runner you ran this turn — paste it verbatim, ANSI and all>",
+  "diff_applied": true,
+  "regressions": "none"
+}
+JSON
+```
+
+Exit 0 = PASS validated; exit 1 = PASS **voided → treat as REJECT** and report the validator's reason; exit 2
+= malformed evidence (fix and re-run). Never report a final PASS whose validator exit code you did not see be 0.
+
 You do not merge, push, open PRs, or edit the baseline. You return a verdict; a downstream step or human acts.

--- a/.claude/agents/ai-eval-judge.md
+++ b/.claude/agents/ai-eval-judge.md
@@ -28,8 +28,13 @@ too softly. Your job is to compute the score yourself and default to no.
 1. **Does it build / typecheck?** Run `bun run --cwd apps/web typecheck` for the touched files (or the
    workspace-scoped equivalent). A classifier that does not compile cannot route. Paste real output.
 2. **Recompute the score yourself.** Run `resolveSurfaceRouting` against **every** golden row — baseline
-   rows and any newly-added rows — using the deterministic node test runner (house style:
-   `apps/web/tests/ai-fast-path-classifier.test.ts`). Paste the real per-row pass/fail, not a summary.
+   rows and any newly-added rows — using the deterministic node test runner. From `apps/web/`, run exactly:
+   ```
+   node --import ./tests/register-ts-loader.mjs --test tests/ai-intent-golden.test.ts
+   ```
+   `ai-intent-golden.test.ts` is the golden runner (it imports `resolveSurfaceRouting`); do NOT confuse it
+   with `ai-fast-path-classifier.test.ts`, which tests the unrelated `classifyFastPath`. Paste the real
+   per-row pass/fail, not a summary.
 3. **Regression check — the one that matters most.** Diff your per-row results against the baseline. If
    ANY row that passed on `main` now fails, that is a REJECT even if the total went up. A net gain that
    silently breaks an existing correct route is the exact failure this loop exists to stop.
@@ -39,14 +44,40 @@ too softly. Your job is to compute the score yourself and default to no.
 5. **Scope.** Did it touch `safety-gate.ts`, `message-safety.ts`, `access-policy.ts`, or `spend.ts`?
    Out of scope → REJECT and send to a human.
 
+## Failure modes — a broken run is a REJECT, never a silent PASS
+
+A run that fails to produce a clean, recomputed score is a REJECT, not a benefit of the doubt. Specifically:
+
+- **Candidate doesn't compile / typecheck** → REJECT. A classifier that does not build cannot route.
+- **Runner crashes, or produces no clean `pass`/`fail` summary** → REJECT. No summary means no score; no
+  score means no PASS.
+- **Recomputed total ≠ golden row count** (rows silently skipped, double-counted) → REJECT — you did not
+  grade the full set.
+- **Candidate diff won't apply to the worktree** → REJECT. Do NOT grade `main` and call it the candidate.
+- **Claimed score disagrees with your recomputed score** → use **your** number and note the discrepancy in
+  `evidence:`. The claim is a hypothesis; your recomputation is the fact.
+
+**Never emit `VERDICT: PASS` without having run the runner to a clean summary this turn.** A PASS asserts you
+personally recomputed the score; if you did not, the verdict is REJECT.
+
 ## Verdict
 
-- **PASS** only if: it typechecks, your recomputed `candidate ≥ baseline`, zero regressions on
-  previously-passing rows, the golden set was not edited to manufacture the pass, and scope held — each
-  with pasted evidence.
-- Otherwise **REJECT**, listing each failure as a separate, concrete, reproducible reason (which rows
-  regressed, the real vs. claimed score, the out-of-scope file).
-- When the recomputed score merely ties the baseline, **REJECT** — a tie is not an improvement and is not
-  worth a PR. When uncertain, REJECT; the loop's floor is its evaluator and doubt is the correct default.
+Emit a machine-parseable block. The **first line is exactly** `VERDICT: PASS` or `VERDICT: REJECT`, then:
+
+```
+VERDICT: PASS | REJECT
+baseline: <P / T from ai-eval-baseline.md>
+recomputed: <P / T you computed this turn>
+regressions: <none | list of rows that passed on main and now fail>
+scope_ok: <yes | no — touched safety-gate/message-safety/access-policy/spend?>
+goldenset_untouched: <yes | no — were expectIntent/expectSurface columns edited?>
+reasons: <one concrete reproducible reason per failure; "n/a" on PASS>
+evidence: <pasted typecheck + per-row pass/fail summary; claimed-vs-recomputed note if they disagreed>
+```
+
+`VERDICT: PASS` requires **all six** of these AND-ed: it typechecks; `recomputed > baseline`; `regressions:
+none`; `scope_ok: yes`; `goldenset_untouched: yes`; and `evidence:` shows a real recomputed summary. A tie
+(`recomputed = baseline`) is a **REJECT** — a tie is not an improvement and is not worth a PR. When uncertain,
+REJECT; the loop's floor is its evaluator and doubt is the correct default.
 
 You do not merge, push, open PRs, or edit the baseline. You return a verdict; a downstream step or human acts.

--- a/.claude/agents/ai-eval-judge.md
+++ b/.claude/agents/ai-eval-judge.md
@@ -1,0 +1,52 @@
+---
+name: ai-eval-judge
+description: >-
+  Adversarial evaluator for the TeamNetwork AI-eval loop — the "thing that can say no" for classifier
+  changes. Given a candidate diff to the intent classifier plus a claimed golden-set score, it assumes
+  the change REGRESSES routing until proven otherwise, RE-RUNS the golden set itself rather than trusting
+  the claimed number, and returns PASS only if the candidate beats the committed baseline with zero
+  regressions on previously-passing rows. Use as the verification move of the AI-eval loop; never let the
+  agent that wrote the keyword change grade its own routing.
+---
+
+# ai-eval-judge — the evaluator for classifier changes (generator/evaluator split)
+
+You are the **evaluator**, a separate agent from whoever proposed this classifier change. The generator
+is full of reasons its keyword tweak is right; you carry none of them. An author grades its own routing
+too softly. Your job is to compute the score yourself and default to no.
+
+**ASSUME: this change REGRESSES routing until proven otherwise. DO NOT trust the claimed score. Recompute it.**
+
+## Inputs
+
+- The candidate diff to `apps/web/src/lib/ai/intent-router.ts` (applied in a worktree).
+- The committed golden set + `baseline` in `.claude/loops/state/ai-eval-baseline.md`.
+- A *claimed* `passing / total`. Treat it as a hypothesis to falsify, not a fact.
+
+## Check, in order — execute, don't just read
+
+1. **Does it build / typecheck?** Run `bun run --cwd apps/web typecheck` for the touched files (or the
+   workspace-scoped equivalent). A classifier that does not compile cannot route. Paste real output.
+2. **Recompute the score yourself.** Run `resolveSurfaceRouting` against **every** golden row — baseline
+   rows and any newly-added rows — using the deterministic node test runner (house style:
+   `apps/web/tests/ai-fast-path-classifier.test.ts`). Paste the real per-row pass/fail, not a summary.
+3. **Regression check — the one that matters most.** Diff your per-row results against the baseline. If
+   ANY row that passed on `main` now fails, that is a REJECT even if the total went up. A net gain that
+   silently breaks an existing correct route is the exact failure this loop exists to stop.
+4. **Golden-set integrity.** Did the candidate change the *expected* outputs (not just the classifier) to
+   make itself pass? If the diff touches `expectIntent` / `expectSurface` columns bundled with a code
+   change, REJECT — the set is moved only in its own human-reviewed commit.
+5. **Scope.** Did it touch `safety-gate.ts`, `message-safety.ts`, `access-policy.ts`, or `spend.ts`?
+   Out of scope → REJECT and send to a human.
+
+## Verdict
+
+- **PASS** only if: it typechecks, your recomputed `candidate ≥ baseline`, zero regressions on
+  previously-passing rows, the golden set was not edited to manufacture the pass, and scope held — each
+  with pasted evidence.
+- Otherwise **REJECT**, listing each failure as a separate, concrete, reproducible reason (which rows
+  regressed, the real vs. claimed score, the out-of-scope file).
+- When the recomputed score merely ties the baseline, **REJECT** — a tie is not an improvement and is not
+  worth a PR. When uncertain, REJECT; the loop's floor is its evaluator and doubt is the correct default.
+
+You do not merge, push, open PRs, or edit the baseline. You return a verdict; a downstream step or human acts.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -27,10 +27,24 @@ generator's self-persuasion. An author grades its own work too softly; your job 
 5. For web UI changes, verify **behavior by acting**: drive the page (Playwright MCP when available),
    click, screenshot, inspect the DOM. Judge behavior, not intent.
 
+## Failure modes — a broken run is a REJECT, never a silent PASS
+
+A run that can't be checked is a REJECT, not a benefit of the doubt:
+
+- **Doesn't compile / typecheck / lint** → REJECT. Broken code cannot be verified working.
+- **Tests crash, or produce no clean pass/fail summary** → REJECT. No summary means no evidence of passing.
+- **Diff won't apply to the worktree** → REJECT. Do NOT grade `main` and call it the candidate.
+- **Claimed result disagrees with what you ran** → trust what **you** ran; note the discrepancy.
+
+**Never emit `VERDICT: PASS` without having run the checks to a clean result this turn.**
+
 ## Verdict
 
-- **PASS** only if *every* check holds, with pasted evidence for each.
-- Otherwise **REJECT** and list each failure as a separate, concrete, reproducible reason.
+Emit a machine-parseable verdict. The **first line is exactly** `VERDICT: PASS` or `VERDICT: REJECT`,
+followed by a `reasons:` line and an `evidence:` line (pasted real output).
+
+- `VERDICT: PASS` only if *every* check holds, with pasted evidence for each.
+- Otherwise `VERDICT: REJECT`; under `reasons:` list each failure as a separate, concrete, reproducible item.
 - When uncertain, default to **REJECT** — the loop's floor is its evaluator, and doubt is the
   correct default stance.
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,37 @@
+---
+name: reviewer
+description: >-
+  Adversarial evaluator for the TeamNetwork triage loop — the "thing that can say no". Given a diff
+  or worktree produced by a generator agent, it assumes the code is BROKEN until proven otherwise,
+  runs the real checks rather than reading them, and returns PASS only if every check holds, else
+  REJECT with a concrete reason per failure. Use as the verification move of any loop; never let the
+  agent that wrote the code grade its own homework.
+---
+
+# reviewer — the evaluator (generator/evaluator split)
+
+You are the **evaluator**, a separate agent from whoever wrote this code. You carry none of the
+generator's self-persuasion. An author grades its own work too softly; your job is to be the skeptic.
+
+**ASSUME: this code is BROKEN until proven otherwise. DO NOT praise. Find what fails.**
+
+## Check, in order — execute, don't just read
+
+1. **Does it build / run?** Run it. `bun run typecheck` and `bun run lint` (or the workspace-scoped
+   equivalent for the files touched). Paste the real output.
+2. **Tests.** Run the relevant suite — `bun run --cwd apps/web test:unit` / `test:ai`, or
+   `bun run --cwd apps/mobile test`. Paste real output, not a summary you assume.
+3. **Edge cases the author skipped** — nulls, empty states, auth-unset paths, the failure branch.
+4. **Does behavior match the ticket / finding?** Not "does the JSX look fine" — does the thing the
+   finding described actually work now?
+5. For web UI changes, verify **behavior by acting**: drive the page (Playwright MCP when available),
+   click, screenshot, inspect the DOM. Judge behavior, not intent.
+
+## Verdict
+
+- **PASS** only if *every* check holds, with pasted evidence for each.
+- Otherwise **REJECT** and list each failure as a separate, concrete, reproducible reason.
+- When uncertain, default to **REJECT** — the loop's floor is its evaluator, and doubt is the
+  correct default stance.
+
+You do not merge, push, or open PRs. You return a verdict; a human or a downstream step acts on it.

--- a/.claude/loops/inbox/.gitkeep
+++ b/.claude/loops/inbox/.gitkeep
@@ -1,0 +1,3 @@
+# Human inbox — the "open door".
+# The loop drops anything it is less than confident about here instead of opening a PR.
+# This is the checkpoint that keeps a human capable of saying "no". Do not delete.

--- a/.claude/loops/inbox/ai-eval-casual-multiword.md
+++ b/.claude/loops/inbox/ai-eval-casual-multiword.md
@@ -1,0 +1,29 @@
+# Finding — multi-word casual phrases are not classified as casual
+
+**Loop:** ai-eval · **Type:** product question (NOT auto-fixable) · **Date:** 2026-06-24
+
+## Observation
+
+Discovery probe found:
+
+```
+"ok cool" [analytics] → intentType=knowledge_query   (expected: casual?)
+"good morning team"   → intentType=casual            (matches a pattern)
+```
+
+`CASUAL_MESSAGE_PATTERNS` anchors single tokens (`/^(?:ok|okay|cool|...)$/`), so "ok cool" — two casual
+words concatenated — does not match and falls through to `knowledge_query`. "good morning team" matches
+because there is an explicit multi-word pattern for greetings.
+
+## Why this is inbox, not a golden row
+
+Whether "ok cool" *should* be casual is a judgment call, not settled behavior:
+- Treating it as casual is friendlier but risks swallowing real two-word queries that happen to start
+  with "ok"/"cool" (e.g. "ok show me events" — though navigation/keyword logic would still fire there).
+- The safe fix is narrow: add specific multi-word casual patterns, not a broad "contains a casual word"
+  rule. A broad rule would over-match.
+
+This needs a human to decide the product behavior AND, if pursued, its own golden rows proving it does
+not regress the keyword/navigation paths. Not promoted; no classifier change made.
+
+→ Left for a human. Baseline unaffected.

--- a/.claude/loops/inbox/ai-eval-rejected-nav-override.md
+++ b/.claude/loops/inbox/ai-eval-rejected-nav-override.md
@@ -1,0 +1,34 @@
+# Rejected candidate — "route navigation intent to general surface"
+
+**Loop:** ai-eval · **Verdict:** REJECT · **Date:** 2026-06-24 · **Baseline at time:** 10/10
+
+## What the generator proposed
+
+Add an early return in `resolveSurfaceRouting` (apps/web/src/lib/ai/intent-router.ts): when
+`intentType === "navigation"`, force `effectiveSurface: "general"` so the assistant can "guide the
+user." Rationale looked reasonable and the change typechecked.
+
+## Why the evaluator rejected it
+
+Recomputed the full golden set → **9/10, one regression**:
+
+```
+✖ "show me the roster" [analytics] → expected members, got general
+```
+
+`"show me the roster"` contains "show me", which `classifyIntentType` labels `navigation`. The proposed
+early return then forced it to `general`, destroying the cross-surface reroute that golden row guards.
+The generator was reasoning about "how do I…" phrasings and never considered that "show me X" is also
+navigation-typed — exactly the blind spot a separate evaluator recomputing the *whole* set exists to catch.
+
+## The real signal worth a human's judgment
+
+There IS a genuine open question buried here: should a how-to query like *"how do I message a mentor"*
+route to the members surface (current behavior — members keywords win) or to a general/help surface? That
+is a product-UX call, not a keyword tweak, and it must not be made by silently overriding surface routing
+for *all* navigation-typed messages. If pursued, it needs:
+
+- a narrower signal than `intentType === "navigation"` (which over-matches "show me", "open", "go to"), and
+- its own golden rows proving it doesn't regress the existing reroutes.
+
+→ Left for a human. No classifier change shipped. Baseline unchanged at 10/10.

--- a/.claude/loops/state/ai-eval-baseline.md
+++ b/.claude/loops/state/ai-eval-baseline.md
@@ -31,6 +31,9 @@ rule changed. The loop's job: let those changes in only when they raise the scor
   hand-authored **hard cases** (ambiguous, adversarial, empty) — the set's value is its coverage of
   the cases a keyword bump would silently break.
 
+<!-- grammar (machine-parseable, do not break): `baseline: <P> / <T> @ <shortsha>`.
+     P = passing count, T = total rows, shortsha = the commit the score was computed on.
+     Any prose after the SHA (in parens) is an ignored human note. Parse only up to the SHA. -->
 baseline: 20 / 20   @ 619898d1 (auto-loop turn 5: +3 edge rows — case-insensitivity, whitespace, analytics/events tie; 0 regressions)
 <!-- bump `baseline` to the new passing count + the candidate's commit SHA only on a PASS that beats it -->
 <!-- history:

--- a/.claude/loops/state/ai-eval-baseline.md
+++ b/.claude/loops/state/ai-eval-baseline.md
@@ -1,0 +1,114 @@
+# AI eval loop — golden set + baseline (the loop's memory)
+
+This file is the **persistence** move of the AI-eval loop, and it is a *different kind* of memory
+than the triage loop's state file. Triage memory records "what work was found." Eval memory records
+**the bar a change must beat**: a curated golden set of inputs with their correct outputs, plus the
+score the current `main` achieves on them. The evaluator reads this to answer one question — *did this
+change beat the current bar, or regress it?* Without a committed baseline the loop has nothing to
+gate against, and "is this AI change good?" collapses back to the generator grading its own homework.
+
+The paper's claim for why this loop is worth building first among the AI loops: *"a modest generator
+with a sharp judge produces slow, reliable progress, and the second is what compounds."* The golden
+set is what makes the judge sharp.
+
+## What it gates
+
+`resolveSurfaceRouting` in `apps/web/src/lib/ai/intent-router.ts` — the pure, keyword-driven intent
+classifier. It is deterministic (no live model call), so the golden set scores exactly and runs in CI
+for free. A "generator" change here is a keyword added/removed, a threshold flipped, a surface-inference
+rule changed. The loop's job: let those changes in only when they raise the score and regress nothing.
+
+## How to read / update this file
+
+- The **golden set** below is the source of truth for correct routing. Each row: an input message
+  (+ the surface the user was on) → the intent / effective surface a correct classifier must return.
+- `baseline` is the score `main` currently achieves on the set: `passing / total`. The evaluator
+  recomputes it for the candidate change. **PASS only if candidate ≥ baseline AND no previously-passing
+  row now fails** (no regressions, even if the total improves). On PASS that beats baseline, the
+  baseline number is bumped in the same commit. On REJECT nothing changes.
+- Grow the set from **real misses**: `apps/web/src/lib/ai/feedback-evals.ts` already turns thumbs-down
+  `ai_feedback` into eval candidates. Promote a confirmed-correct candidate into a row here. Also add
+  hand-authored **hard cases** (ambiguous, adversarial, empty) — the set's value is its coverage of
+  the cases a keyword bump would silently break.
+
+baseline: 20 / 20   @ 619898d1 (auto-loop turn 5: +3 edge rows — case-insensitivity, whitespace, analytics/events tie; 0 regressions)
+<!-- bump `baseline` to the new passing count + the candidate's commit SHA only on a PASS that beats it -->
+<!-- history:
+     2/2 @ 619898d1 — seed (roster reroute + casual).
+     proof-of-mechanism (2026-06-24): removing the "roster" keyword dropped 2/2 → 1/2 — the golden set
+       caught a silent reroute regression that typechecks clean. Reverted; back to 2/2.
+     5/5 @ 619898d1 (2026-06-24): turn 1 — promoted 3 hard cases (surface-guessing, empty, tie-break). PASS.
+     9/9 @ 619898d1 (2026-06-24): turn 2 — promoted 4 cross-surface reroute rows (donor→analytics,
+       games→events, create-event→events, bare 'mentor'→members). Evaluator recomputed 9/9, 0 regressions, PASS.
+     10/10 @ 619898d1 (2026-06-24): turn 3 — REJECTION turn. Added the how-to row (current behavior:
+       members keywords win → members). Generator then proposed "route navigation intent → general"; evaluator
+       recomputed and REJECTED — it regressed "show me the roster" (9/10), since "show me" is navigation-typed.
+       Classifier reverted, nothing shipped, attempt logged in .claude/loops/inbox/ai-eval-rejected-nav-override.md.
+       The how-to row itself passes on main, so it stays as a regression guard. The floor said NO.
+     17/17 @ 619898d1 (2026-06-24): auto-loop turn 4 — probed 10 fresh slices, promoted 7 verified-correct rows
+       (delete-a-member action, send-announcement general-content beats events, 3-members-keyword dominance,
+       job-postings→general, multi-word casual no-reroute, take-me-to-calendar nav, donation-trends reporting).
+       Evaluator recomputed 17/17, 0 regressions, PASS. One finding ("ok cool" not casual — multi-word casual
+       gap) was a product question → logged to inbox/ai-eval-casual-multiword.md, not promoted.
+     discovery upgrade (2026-06-24): added feedback-golden-bridge.ts + test — real thumbs-down ai_feedback now
+       converts to GoldenRowProposals (the loop's highest-value source), human sets ground truth. 4/4 tests pass. -->
+
+
+
+
+## Golden set
+
+`surface` is the surface the user was on when they sent the message (general | members | analytics | events).
+`expectIntent` / `expectSurface` are what `resolveSurfaceRouting` must return. `note` says why the row exists.
+
+Kept in sync with `apps/web/tests/ai-intent-golden.test.ts` — the loop adds a row in BOTH, same PR.
+
+| input | surface | expectIntent | expectSurface | note |
+|-------|---------|--------------|---------------|------|
+| show me the roster | analytics | members_query | members | cross-surface pull → must reroute to members |
+| thanks! | general | general_query | general | casual → no reroute, stays general |
+| show me everything | members | general_query | members | no keyword match → must NOT guess a surface; stays put |
+| _(empty string)_ | members | general_query | members | empty input → stable defined result, no throw |
+| members donations | general | ambiguous_query | general | keyword collision (members + analytics tie) → ambiguous |
+| who are our donors? | general | analytics_query | analytics | 'donor' keyword → reroute to analytics |
+| upcoming games this week | general | events_query | events | 'games' → events, not analytics despite 'this week' |
+| create an event for friday | members | events_query | events | action_request + events keyword → reroute to events |
+| mentor | analytics | members_query | members | bare members keyword → reroute from analytics |
+| how do I message a mentor | general | members_query | members | members keywords win; 'how do I' must not override surface |
+| delete a member | general | members_query | members | action_request + members keyword → reroute |
+| send an announcement | events | general_query | general | general-content keyword beats events surface → general |
+| mentor and mentee connections donation | general | members_query | members | keyword-count dominance: 3 members > 1 analytics |
+| any new job postings? | members | general_query | general | 'job'/'postings' are general-content → reroute to general |
+| good morning team | members | general_query | members | multi-word casual greeting → no reroute, stays put |
+| take me to the calendar | general | events_query | events | navigation phrasing + events keyword → events |
+| donation trends by month | general | analytics_query | analytics | reporting language + analytics keyword → analytics |
+| MEMBERS | general | members_query | members | case-insensitive match → uppercase still routes |
+| `  roster  ` | analytics | members_query | members | whitespace-padded input normalized → still reroutes |
+| donations and events | general | ambiguous_query | general | analytics vs events tie → ambiguous, stays put |
+
+_Real-misses source is now wired: `feedback-golden-bridge.ts` converts thumbs-down `ai_feedback` into
+GoldenRowProposals; a human sets ground truth and promotes. 17 rows now guard reroutes, dominance,
+general-content, action requests, casual variants, navigation, reporting, and the tie-break. The set is
+no longer purely synthetic — keep growing it from real proposals, not hand-authored churn._
+
+## Hard cases to seed first (the coverage that catches silent regressions)
+
+These are the rows worth writing by hand before trusting the loop, because they are exactly what a
+careless keyword change breaks without any test going red:
+
+- **Cross-surface pull** — "show me the roster" while on the *analytics* surface → must reroute to `members`.
+- **Ambiguous** — "show me everything" → `ambiguous_query`, low confidence, no reroute (must NOT guess a surface).
+- **Keyword collision** — a message containing both a members keyword and an analytics keyword → the
+  documented tie-break, not whichever keyword list is checked first.
+- **Empty / whitespace** — "" → a stable, defined result (not a throw, not a silent `general`).
+- **Casual** — "thanks!" → `intentType: casual`, no surface reroute.
+
+## Stop (the boundary — DO NOT REMOVE)
+
+- The loop tunes a **classifier**, never the safety gate, access policy, or spend caps. Changes to
+  `message-safety.ts`, `safety-gate.ts`, `access-policy.ts`, or `spend.ts` are **out of scope** and
+  go to a human, never a worktree.
+- Never widen the golden set to *make a change pass*. The set encodes correct behavior; it changes
+  only when behavior is genuinely clarified, in its own commit, reviewed by a human.
+- No PII in this file. Golden inputs are synthetic or fully anonymized — never a real member's name,
+  email, or message copied from production.

--- a/.claude/loops/state/triage.md
+++ b/.claude/loops/state/triage.md
@@ -6,6 +6,16 @@ to avoid rediscovering handled work, then appends/updates rows and commits it ba
 
 `status`: `new` → `worktree` → `pr-open` → `done`  ·  or `inbox` · `skipped`
 
+<!--
+last_run: 619898d1 @ 2026-06-24
+  The SHA + date this triage has already covered. The FIRST move of every run is to read this:
+  "commits/issues/CI since last_run", not "since the beginning of history". Bump it (SHA = the
+  HEAD this run covered, date = run date) as the LAST write of each run, in the same commit as
+  the rows below. Without it the first run rediscovers all of history. This is the load-bearing seed.
+  Discover in-flight PRs/branches LIVE each run (list_pull_requests) — do NOT hand-maintain them here;
+  a pasted list goes stale the moment it's written.
+-->
+
 | finding | source | priority | status | run |
 |---------|--------|----------|--------|-----|
 | _(seed — first real run replaces this row)_ | — | — | — | 0 |

--- a/.claude/loops/state/triage.md
+++ b/.claude/loops/state/triage.md
@@ -1,0 +1,11 @@
+# Triage loop state (the loop's memory)
+
+This file is the **persistence** move of the morning-triage loop. The agent forgets when
+its context window clears; this file does not. Each run reads it to find the last run and
+to avoid rediscovering handled work, then appends/updates rows and commits it back.
+
+`status`: `new` → `worktree` → `pr-open` → `done`  ·  or `inbox` · `skipped`
+
+| finding | source | priority | status | run |
+|---------|--------|----------|--------|-----|
+| _(seed — first real run replaces this row)_ | — | — | — | 0 |

--- a/.claude/loops/tools/validate-verdict.mjs
+++ b/.claude/loops/tools/validate-verdict.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Deterministic verdict validator for the AI-eval loop — the "validator that makes
+// the loop *validated*, not just answerable". It is intentionally NOT an LLM: a PASS
+// is only real if it carries machine-checkable evidence that the golden runner
+// actually ran to a clean summary this turn. No evidence → the PASS is VOID, no
+// matter how persuasive the judge's prose.
+//
+// This closes the gap the eval-of-eval surfaced: a judge can REJECT (or PASS) for the
+// wrong reason — e.g. it never found the runner — and a gate that trusts the agent's
+// word can't tell. This script trusts only the pasted runner output.
+//
+// Contract (stdin = a JSON object the judge emits):
+//   {
+//     "verdict":     "PASS" | "REJECT",   // what the judge claims
+//     "baseline":    20,                   // P from ai-eval-baseline.md
+//     "total_rows":  20,                   // T from ai-eval-baseline.md
+//     "runner_output": "...",              // RAW stdout+stderr of the golden runner, ANSI ok
+//     "diff_applied":  true,               // did the candidate diff apply to the worktree?
+//     "regressions":  "none" | "row, row"  // rows that passed on main and now fail
+//   }
+//
+// Exit 0  → verdict is VALIDATED (evidence consistent; final verdict printed).
+// Exit 1  → verdict is VOID (PASS without evidence, or inconsistent) → treat as REJECT.
+// Exit 2  → bad input (could not parse the evidence object).
+//
+// The script never trusts a claimed score; it recomputes pass/total from runner_output.
+
+import { readFileSync } from "node:fs";
+
+/** Strip ANSI escape codes so the glyph/colour formatting can't hide the numbers. */
+function stripAnsi(s) {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/**
+ * Pull `tests N`, `pass N`, `fail N` out of node:test summary output.
+ * Lines look like `ℹ tests 20` / `ℹ pass 20` / `ℹ fail 0` (leading glyph + spaces vary).
+ * Anchored on the keyword + integer, glyph-agnostic. Returns null if any are missing.
+ */
+function parseRunnerSummary(raw) {
+  const clean = stripAnsi(raw);
+  const grab = (key) => {
+    // word-boundary on the key, then the first integer after it on that line
+    const m = clean.match(new RegExp(`(?:^|\\s)${key}\\s+(\\d+)\\b`, "m"));
+    return m ? Number(m[1]) : null;
+  };
+  const tests = grab("tests");
+  const pass = grab("pass");
+  const fail = grab("fail");
+  if (tests === null || pass === null || fail === null) return null;
+  return { tests, pass, fail };
+}
+
+function fail(reason, finalVerdict) {
+  // A void/failed validation always degrades to REJECT — never a silent PASS.
+  process.stdout.write(
+    JSON.stringify({ validated: false, final_verdict: finalVerdict ?? "REJECT", reason }) + "\n",
+  );
+  process.exit(1);
+}
+
+function main() {
+  let input;
+  try {
+    input = JSON.parse(readFileSync(0, "utf8"));
+  } catch (err) {
+    process.stderr.write(`validate-verdict: could not parse evidence JSON: ${err.message}\n`);
+    process.exit(2);
+  }
+
+  const { verdict, baseline, total_rows, runner_output, diff_applied, regressions } = input;
+
+  // ---- structural gates (bad input is a hard error, not a verdict) --------
+  if (verdict !== "PASS" && verdict !== "REJECT") {
+    process.stderr.write(`validate-verdict: 'verdict' must be PASS or REJECT, got ${JSON.stringify(verdict)}\n`);
+    process.exit(2);
+  }
+  if (!Number.isInteger(baseline) || !Number.isInteger(total_rows)) {
+    process.stderr.write("validate-verdict: 'baseline' and 'total_rows' must be integers\n");
+    process.exit(2);
+  }
+
+  // ---- a REJECT needs no evidence: rejecting is always safe ---------------
+  if (verdict === "REJECT") {
+    process.stdout.write(
+      JSON.stringify({ validated: true, final_verdict: "REJECT", reason: "reject requires no evidence" }) + "\n",
+    );
+    process.exit(0);
+  }
+
+  // ---- from here, verdict === "PASS": evidence is MANDATORY ---------------
+  if (diff_applied !== true) {
+    return fail("PASS claimed but diff_applied is not true — the judge may have graded main, not the candidate");
+  }
+  if (typeof runner_output !== "string" || runner_output.trim() === "") {
+    return fail("PASS claimed with no runner_output — a PASS asserts the runner ran this turn; void");
+  }
+
+  const summary = parseRunnerSummary(runner_output);
+  if (summary === null) {
+    return fail("PASS claimed but runner_output has no parseable 'tests/pass/fail' summary — runner did not reach a clean summary; void");
+  }
+
+  // recomputed total must equal the declared row count — no silently-skipped rows
+  if (summary.tests !== total_rows) {
+    return fail(`PASS claimed but runner graded ${summary.tests} rows, not ${total_rows} — partial run; void`);
+  }
+  // internal consistency: pass + fail must account for every row
+  if (summary.pass + summary.fail !== summary.tests) {
+    return fail(`PASS claimed but pass(${summary.pass}) + fail(${summary.fail}) != tests(${summary.tests}) — inconsistent summary; void`);
+  }
+  // a PASS that still has failing rows is a contradiction
+  if (summary.fail > 0) {
+    return fail(`PASS claimed but runner reports ${summary.fail} failing row(s) — contradiction; void`);
+  }
+  // the gate itself: PASS must BEAT baseline. A tie (recomputed == baseline) is REJECT.
+  if (summary.pass <= baseline) {
+    return fail(
+      `PASS claimed but recomputed ${summary.pass}/${summary.tests} does not beat baseline ${baseline}/${total_rows} — tie or regression is not a PASS`,
+      "REJECT",
+    );
+  }
+  // any named regression voids a PASS regardless of total
+  if (typeof regressions === "string" && regressions.trim() !== "" && regressions.trim() !== "none") {
+    return fail(`PASS claimed but regressions reported (${regressions}) — a regression voids a PASS`);
+  }
+
+  // evidence is present, consistent, beats baseline, no regressions → real PASS
+  process.stdout.write(
+    JSON.stringify({
+      validated: true,
+      final_verdict: "PASS",
+      recomputed: `${summary.pass} / ${summary.tests}`,
+      reason: `beats baseline ${baseline}/${total_rows} with no regressions and a clean runner summary`,
+    }) + "\n",
+  );
+  process.exit(0);
+}
+
+main();

--- a/.claude/skills/ai-eval-loop/SKILL.md
+++ b/.claude/skills/ai-eval-loop/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ai-eval-loop
+description: >-
+  Discovery + scoring skill for the TeamNetwork AI-eval loop. Invoked on a schedule, it finds
+  candidate improvements to the deterministic intent classifier (resolveSurfaceRouting), scores every
+  candidate against the committed golden set in .claude/loops/state/ai-eval-baseline.md, and lets a
+  change through ONLY if it beats the baseline with zero regressions. The hard judgment — pass or
+  reject — belongs to the separate `ai-eval-judge` agent; this skill discovers, runs the set, and
+  records the score. It NEVER edits the golden set to make a change pass, and never touches the safety
+  gate, access policy, or spend caps.
+---
+
+# ai-eval-loop — the discovery + persistence moves of the AI-eval loop
+
+This is the AI-eval counterpart to `morning-triage`. Triage finds *work*; this finds *improvements to a
+classifier and proves they don't regress*. Per the playbook, the evaluator is this loop's floor: a modest
+generator (a keyword tweak) plus a sharp judge (the golden set) compounds, where a strong generator with a
+weak judge ships confident garbage. The golden set is the sharpness.
+
+## Read (the DISCOVERY inputs)
+
+Read `.claude/loops/state/ai-eval-baseline.md` FIRST — it holds the golden set and the current `baseline`.
+Then gather candidate improvements from, in order of trust:
+
+- **Real misses (highest value)** — `apps/web/src/lib/ai/feedback-evals.ts` turns thumbs-down
+  `ai_feedback` into eval candidates; `apps/web/src/lib/ai/feedback-golden-bridge.ts` converts each into
+  a `GoldenRowProposal` carrying the real prompt, the surface, and what the *current* router does with it.
+  Run `feedbackCandidatesToGoldenProposals(...)`; for each proposal a HUMAN sets the correct
+  `expectIntent`/`expectSurface` (a thumbs-down means a human judged the turn wrong — only a human supplies
+  ground truth, never this loop). A proposal whose `current` routing disagrees with the human's ground
+  truth is the strongest possible row: a real user, a real miss, traceable by `feedbackId`. Promote it.
+- **Open routing findings** — any `triage.md` row or issue describing a misrouted query.
+- **The classifier itself** — `apps/web/src/lib/ai/intent-router.ts`. A candidate is a concrete diff
+  (keyword added/removed, threshold flipped, tie-break rule changed) that aims to fix a failing golden row.
+
+## Judge (the part that sets the ceiling)
+
+The golden set's coverage is the whole loop's quality ceiling — a tweak that passes a thin set but breaks
+real routing is worse than no change. So:
+
+- A candidate is eligible only if it targets a **currently-failing** golden row (or one being added from a
+  confirmed real miss). No speculative keyword churn.
+- **Never edit the golden set to make a candidate pass.** The set encodes correct behavior, not the
+  current behavior. If a candidate "fails" because the expected output is genuinely wrong, that is a
+  separate, human-reviewed correction to the set — its own commit, never bundled with a generator change.
+- Anything touching `safety-gate.ts`, `message-safety.ts`, `access-policy.ts`, or `spend.ts` is **out of
+  scope** → inbox for a human. This loop tunes routing, never safety or money.
+
+## Score + Write (the PERSISTENCE output)
+
+For each eligible candidate:
+
+1. Apply the candidate diff in an isolated worktree (handoff — never in the main checkout).
+2. Run the golden set against `resolveSurfaceRouting` for **every** row (baseline rows + new rows).
+   The runner is a deterministic node test (see `apps/web/tests/ai-fast-path-classifier.test.ts` for the
+   house style — `node:test` + `assert/strict`, no live model). Record `passing / total`.
+3. Hand the candidate + its score to the `ai-eval-judge` agent. It re-runs the set itself (never trust a
+   score it did not compute) and returns PASS only if `candidate ≥ baseline` AND no previously-passing row
+   regressed.
+4. On PASS-that-beats-baseline: open a DRAFT PR with the classifier diff AND the golden-set additions, and
+   bump `baseline:` to the new passing count + the candidate SHA in the same PR. On REJECT or tie: write
+   the attempt to `.claude/loops/inbox/` and change nothing.
+
+## Stop (the boundary you keep — DO NOT REMOVE)
+
+- **Never merge, never auto-bump the baseline outside a reviewed PR, never force-push.** PRs open draft.
+- **Never grow or edit the golden set to manufacture a pass.** That is the one move that hollows out this
+  loop — it turns the judge into a rubber stamp.
+- **Out of scope:** safety gate, access policy, spend caps, anything calling a live model in the scored
+  path. Routing keywords and thresholds only.
+- **No PII** in the golden set or inbox. Synthetic or anonymized inputs only.
+- **Token cap:** stop after the configured per-run budget; no unbounded retry of a candidate that keeps
+  failing — failing twice is an inbox item, not a third attempt.

--- a/.claude/skills/ai-eval-loop/SKILL.md
+++ b/.claude/skills/ai-eval-loop/SKILL.md
@@ -73,9 +73,15 @@ For each eligible candidate:
    The judge re-runs the set itself (never trusting a score it did not compute) and treats `claimed_score`
    as a **hypothesis to falsify**, not a fact. It returns PASS only if its recomputed `candidate > baseline`
    AND no previously-passing row regressed.
-4. On PASS-that-beats-baseline: open a DRAFT PR with the classifier diff AND the golden-set additions, and
-   bump `baseline:` to the new passing count + the candidate SHA in the same PR. On REJECT or tie: write
-   the attempt to `.claude/loops/inbox/` and change nothing.
+4. **A judge PASS is not enough to ship.** Before any PR opens, the judge's PASS must clear the deterministic
+   validator `.claude/loops/tools/validate-verdict.mjs` (exit 0). The validator is non-AI: it re-parses the
+   pasted runner output and voids any PASS lacking consistent evidence (no runner summary, total ≠ row count,
+   a tie, a named regression, a diff that did not apply). A voided PASS is a REJECT. This is what makes the
+   loop *validated* rather than merely answerable — a judge that reaches the right verdict for the wrong
+   reason cannot ship a change.
+5. On a **validator-confirmed** PASS-that-beats-baseline: open a DRAFT PR with the classifier diff AND the
+   golden-set additions, and bump `baseline:` to the new passing count + the candidate SHA in the same PR.
+   On REJECT, tie, or a voided PASS: write the attempt to `.claude/loops/inbox/` and change nothing.
 
 ## Stop (the boundary you keep — DO NOT REMOVE)
 

--- a/.claude/skills/ai-eval-loop/SKILL.md
+++ b/.claude/skills/ai-eval-loop/SKILL.md
@@ -25,7 +25,9 @@ Then gather candidate improvements from, in order of trust:
 - **Real misses (highest value)** — `apps/web/src/lib/ai/feedback-evals.ts` turns thumbs-down
   `ai_feedback` into eval candidates; `apps/web/src/lib/ai/feedback-golden-bridge.ts` converts each into
   a `GoldenRowProposal` carrying the real prompt, the surface, and what the *current* router does with it.
-  Run `feedbackCandidatesToGoldenProposals(...)`; for each proposal a HUMAN sets the correct
+  This bridge is wired only as the **manual** export `bun run --cwd apps/web evals:ai:feedback` —
+  there is **no automatic in-loop call** today. Treat exported `GoldenRowProposal`s as input you are
+  handed; do NOT assume the loop fetches them itself. For each proposal a HUMAN sets the correct
   `expectIntent`/`expectSurface` (a thumbs-down means a human judged the turn wrong — only a human supplies
   ground truth, never this loop). A proposal whose `current` routing disagrees with the human's ground
   truth is the strongest possible row: a real user, a real miss, traceable by `feedbackId`. Promote it.
@@ -52,11 +54,25 @@ For each eligible candidate:
 
 1. Apply the candidate diff in an isolated worktree (handoff — never in the main checkout).
 2. Run the golden set against `resolveSurfaceRouting` for **every** row (baseline rows + new rows).
-   The runner is a deterministic node test (see `apps/web/tests/ai-fast-path-classifier.test.ts` for the
-   house style — `node:test` + `assert/strict`, no live model). Record `passing / total`.
-3. Hand the candidate + its score to the `ai-eval-judge` agent. It re-runs the set itself (never trust a
-   score it did not compute) and returns PASS only if `candidate ≥ baseline` AND no previously-passing row
-   regressed.
+   The runner is a deterministic node test (`node:test` + `assert/strict`, no live model). From `apps/web/`,
+   run exactly:
+   ```
+   node --import ./tests/register-ts-loader.mjs --test tests/ai-intent-golden.test.ts
+   ```
+   `ai-intent-golden.test.ts` is the golden runner (it imports `resolveSurfaceRouting`); do NOT confuse it
+   with `ai-fast-path-classifier.test.ts`, which tests the unrelated `classifyFastPath`. Record
+   `passing / total`.
+3. Hand the candidate to the `ai-eval-judge` agent as a structured object:
+   ```
+   candidate_diff: <the worktree diff to intent-router.ts>
+   worktree: <path to the isolated worktree where the diff is applied>
+   claimed_score: <passing / total you recorded in step 2>
+   baseline: <P / T from ai-eval-baseline.md>
+   golden_rows_added: <rows this candidate adds to the set, if any; else none>
+   ```
+   The judge re-runs the set itself (never trusting a score it did not compute) and treats `claimed_score`
+   as a **hypothesis to falsify**, not a fact. It returns PASS only if its recomputed `candidate > baseline`
+   AND no previously-passing row regressed.
 4. On PASS-that-beats-baseline: open a DRAFT PR with the classifier diff AND the golden-set additions, and
    bump `baseline:` to the new passing count + the candidate SHA in the same PR. On REJECT or tie: write
    the attempt to `.claude/loops/inbox/` and change nothing.
@@ -69,5 +85,7 @@ For each eligible candidate:
 - **Out of scope:** safety gate, access policy, spend caps, anything calling a live model in the scored
   path. Routing keywords and thresholds only.
 - **No PII** in the golden set or inbox. Synthetic or anonymized inputs only.
-- **Token cap:** stop after the configured per-run budget; no unbounded retry of a candidate that keeps
-  failing — failing twice is an inbox item, not a third attempt.
+- **Token cap:** the per-run budget is the `--max-turns` cap in `.github/workflows/loop-ai-eval.yml`
+  (currently 40) for cloud runs, or the local `/loop` cap when run by hand. The number is authoritative in
+  the YAML; this skill only references it. Stop when it is reached; no unbounded retry of a candidate that
+  keeps failing — failing twice is an inbox item, not a third attempt.

--- a/.claude/skills/morning-triage/SKILL.md
+++ b/.claude/skills/morning-triage/SKILL.md
@@ -41,6 +41,19 @@ For each candidate, decide — and write down the decision, not just the item:
 
 Keep only what is worth opening a worktree for **today**.
 
+### Known noise — skip or retry, never file (maintained list, raise the ceiling)
+
+This is the discovery ceiling made explicit. Anything here is noise by default; treat it as such
+unless it recurs across runs with a real signal. Add to this list when a new false-positive wastes a run.
+
+- **Flaky tests** — retry once before filing; only file if it fails on retry. (No confirmed flakes
+  catalogued yet — append `suite::test` here the first time one is confirmed flaky, not on first red.)
+- **Dependabot / lockfile churn** — `dependabot/*` branches, `bun.lock` / `package.json` version-bump-only
+  diffs: skip. Not triage work unless a bump breaks `build` or `test-*`.
+- **`.env*.bak` / generated files** — backup and generated artifacts are not findings.
+- **OKF / docs-only commits** — `validate-okf`-passing doc changes (`docs/agent/`, `docs/db/okf/`) are
+  not actionable triage unless `validate-okf` itself fails.
+
 ## Write (the PERSISTENCE output)
 
 Append/update `.claude/loops/state/triage.md`, one row per finding:

--- a/.claude/skills/morning-triage/SKILL.md
+++ b/.claude/skills/morning-triage/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: morning-triage
+description: >-
+  Discovery skill for the TeamNetwork triage loop. Invoked on a schedule (cloud cron or local /loop),
+  it reads what changed since the last run — failed CI jobs, issues opened in the last 24h, commits
+  merged since the last run — judges what is actually actionable, and writes findings to a state file
+  on disk so the next run picks up where this one left off. It NEVER merges, deletes, or auto-ships;
+  uncertain items go to an inbox for a human. This is the "discovery" + "persistence" half of a loop;
+  handoff/verification are done by worktree agents + the `reviewer` evaluator agent.
+---
+
+# morning-triage — the discovery move of the loop
+
+This skill is the **discovery** and **persistence** moves of the TeamNetwork triage loop
+(see the Loop Engineering playbook: discovery → handoff → verification → persistence →
+scheduling). It is deliberately small. It finds work and records it; it does not do the work.
+
+The loop's quality ceiling is set here: surface noise and the other four moves run beautifully
+in service of nothing. So judge hard, keep little.
+
+## Read (the DISCOVERY inputs)
+
+Gather, since the **last recorded run** (read `.claude/loops/state/triage.md` first to find it):
+
+- **CI failures** — the `CI` workflow jobs that failed on `main` or open PRs:
+  `test-unit`, `test-ai`, `test-mobile`, `migration-drift`, `validate-okf`, `build`
+  (use the GitHub MCP tools `actions_list` / `get_job_logs`, scoped to `cicconel11/teamnetwork`).
+- **Issues** opened or labeled in the last 24h (`list_issues`).
+- **Commits** merged to `main` since the last run (`list_commits`).
+- The **previous** `.claude/loops/state/triage.md` — so you don't rediscover handled work.
+
+## Judge (the part that sets the ceiling)
+
+For each candidate, decide — and write down the decision, not just the item:
+
+- Is it **actionable now**, or noise (flake already retried, dependabot churn)? Skip noise.
+- Does it **block a release** (App Store build, Stripe/webhook, wallet pass signing)? → `priority`.
+- Is it **already tracked** by an open PR or an earlier `triage.md` row? → skip.
+- Is the fix **small and well-scoped** (lint, flaky test, null-deref, stale dep)? → eligible for a
+  worktree agent. Anything architectural or ambiguous → **inbox**, not a worktree.
+
+Keep only what is worth opening a worktree for **today**.
+
+## Write (the PERSISTENCE output)
+
+Append/update `.claude/loops/state/triage.md`, one row per finding:
+
+| finding | source | priority | status | run |
+|---------|--------|----------|--------|-----|
+
+`status` ∈ `new` → `worktree` → `pr-open` → `done` | `inbox` | `skipped`.
+Commit the file back to the branch so tomorrow's run can read it. The agent forgets; the repo does not.
+
+## Hand off (prepare the HANDOFF)
+
+For each `new` finding small enough to fix, emit a task line for a worktree agent:
+
+```
+worktree=fix/<slug>  goal=<deterministic stop-condition>  e.g. "test/auth passes and lint is clean"
+```
+
+Each finding gets its **own** git worktree so parallel agents never touch the same files
+(`Agent(..., isolation: "worktree")` in-session, or `claude --worktree` from the CLI).
+The drafting agent is the **generator**; it must hand its diff to the `reviewer` agent
+(the **evaluator**) before anything opens as a PR.
+
+## Stop (the boundary you keep for yourself — DO NOT REMOVE)
+
+This section is not boilerplate; it is the one place the loop's limits are written down.
+The loop will faithfully do everything above and nothing this section forbids.
+
+- **Never merge. Never delete. Never force-push.** PRs open in draft; humans merge.
+- Anything you are **less than confident** about → `.claude/loops/inbox/` for a human, not a PR.
+- **Token cap:** stop after the configured per-run budget; do not spawn unbounded retries.
+- Touch only `cicconel11/teamnetwork`. Never act on secrets, billing, or production data.

--- a/.claude/skills/morning-triage/SKILL.md
+++ b/.claude/skills/morning-triage/SKILL.md
@@ -36,8 +36,9 @@ For each candidate, decide — and write down the decision, not just the item:
 - Is it **actionable now**, or noise (flake already retried, dependabot churn)? Skip noise.
 - Does it **block a release** (App Store build, Stripe/webhook, wallet pass signing)? → `priority`.
 - Is it **already tracked** by an open PR or an earlier `triage.md` row? → skip.
-- Is the fix **small and well-scoped** (lint, flaky test, null-deref, stale dep)? → eligible for a
-  worktree agent. Anything architectural or ambiguous → **inbox**, not a worktree.
+- Is the fix **small and well-scoped** — touches ≤ ~3 files, has a deterministic one-sentence
+  stop-condition, and needs no schema/migration/auth/billing decision (lint, flaky test, null-deref,
+  stale dep)? → eligible for a worktree agent. Anything failing that bar → **inbox**, not a worktree.
 
 Keep only what is worth opening a worktree for **today**.
 
@@ -74,8 +75,13 @@ worktree=fix/<slug>  goal=<deterministic stop-condition>  e.g. "test/auth passes
 
 Each finding gets its **own** git worktree so parallel agents never touch the same files
 (`Agent(..., isolation: "worktree")` in-session, or `claude --worktree` from the CLI).
-The drafting agent is the **generator**; it must hand its diff to the `reviewer` agent
-(the **evaluator**) before anything opens as a PR.
+
+The task line and the draft PR are two **stages of one pipeline**, not two competing mechanisms:
+
+1. This skill emits the `worktree=…` task line — and nothing more. **The skill itself never opens a PR.**
+2. A worktree agent (the **generator**) fixes the finding and hands its diff to the `reviewer` agent
+   (the **evaluator**).
+3. Only after `reviewer` returns `VERDICT: PASS` does a draft PR open.
 
 ## Stop (the boundary you keep for yourself — DO NOT REMOVE)
 
@@ -83,6 +89,9 @@ This section is not boilerplate; it is the one place the loop's limits are writt
 The loop will faithfully do everything above and nothing this section forbids.
 
 - **Never merge. Never delete. Never force-push.** PRs open in draft; humans merge.
-- Anything you are **less than confident** about → `.claude/loops/inbox/` for a human, not a PR.
-- **Token cap:** stop after the configured per-run budget; do not spawn unbounded retries.
+- If you **cannot name the exact passing check that proves the fix**, or the fix touches
+  secrets/billing/auth/migration/production data → `.claude/loops/inbox/` for a human, not a PR.
+- **Token cap:** the per-run budget is the `--max-turns` cap in `.github/workflows/loop-triage.yml`
+  (currently 40) for cloud runs, or the local `/loop` cap when run by hand. The number is authoritative in
+  the YAML; this skill only references it. Stop when it is reached; do not spawn unbounded retries.
 - Touch only `cicconel11/teamnetwork`. Never act on secrets, billing, or production data.

--- a/.github/workflows/loop-ai-eval.yml
+++ b/.github/workflows/loop-ai-eval.yml
@@ -45,15 +45,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # DISCOVERY is a skill, not a wall of text pasted into a cron job.
+          # The skill is the single source of truth; this prompt is a launcher, not a re-statement.
           prompt: |
-            Run the `ai-eval-loop` skill. Read the golden set + baseline in
-            .claude/loops/state/ai-eval-baseline.md FIRST. Find candidate improvements to
-            resolveSurfaceRouting (apps/web/src/lib/ai/intent-router.ts) that fix a currently-failing
-            golden row or a confirmed real miss from feedback-evals. For each candidate, apply it in an
-            isolated worktree, run the FULL golden set, and hand the diff + score to the `ai-eval-judge`
-            agent. Open a DRAFT PR (classifier diff + golden-set additions + baseline bump) ONLY if the
-            judge returns PASS — candidate beats baseline with zero regressions. Anything that ties,
-            regresses, or touches safety/access/spend goes to .claude/loops/inbox/ for a human. NEVER
-            merge, NEVER edit the golden set to manufacture a pass, NEVER force-push.
+            Run the `ai-eval-loop` skill end to end — it is the single source of truth for discovery,
+            scoring, candidate sources, budget, and the `ai-eval-judge` handoff; follow it exactly.
+            First read .claude/loops/state/ai-eval-baseline.md. Obey the skill's Stop boundary verbatim
+            (draft PRs only, never merge/force-push, never edit the golden set, never touch
+            safety/access/spend). Hard cap is `--max-turns` below.
           claude_args: '--max-turns 40'   # hard cap: bounds an idle loop's spend

--- a/.github/workflows/loop-ai-eval.yml
+++ b/.github/workflows/loop-ai-eval.yml
@@ -1,0 +1,59 @@
+# Loop Engineering — AI-eval loop (SCHEDULING move).
+#
+# Tunes the deterministic intent classifier (resolveSurfaceRouting) and gates every change against a
+# committed golden set, so routing only changes when the score goes UP with zero regressions.
+#
+# ENABLED (weekly schedule active). The preconditions the playbook requires are met:
+#   - the golden set is seeded with 20 real rows (`baseline: 20/20`), so it is not a "blind loop".
+#   - the evaluator floor was proven: a deliberately-bad keyword removal AND a plausible nav-override
+#     change were both REJECTED by the golden set in manual runs (see baseline-file history + inbox).
+# Two operator preconditions remain (outside this file):
+#   - the CLAUDE_CODE_OAUTH_TOKEN repo secret must exist (Settings → Secrets → Actions).
+#   - the run still opens DRAFT PRs only and never merges — a human is the merge gate.
+#
+# Respects the playbook disciplines: cap before you ship (timeout + max-turns below); keep one door
+# open (PRs draft, never merged). Also runnable on demand via workflow_dispatch from the Actions tab.
+name: Loop · AI eval
+
+on:
+  workflow_dispatch: {}
+  # Weekly is plenty for a deterministic classifier (cloud cron min interval is ~1h anyway).
+  schedule:
+    - cron: '0 7 * * 1'   # 07:00 UTC Mondays
+
+# Single-flight: never let two eval runs race on the baseline file.
+concurrency:
+  group: loop-ai-eval
+  cancel-in-progress: false
+
+permissions:
+  contents: write       # commit the baseline bump back (inside a PR)
+  pull-requests: write  # open DRAFT PRs (never merge)
+  issues: read
+  id-token: write
+
+jobs:
+  ai-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30   # token/time circuit-breaker — a stuck loop cannot burn the night
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run ai-eval loop
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # DISCOVERY is a skill, not a wall of text pasted into a cron job.
+          prompt: |
+            Run the `ai-eval-loop` skill. Read the golden set + baseline in
+            .claude/loops/state/ai-eval-baseline.md FIRST. Find candidate improvements to
+            resolveSurfaceRouting (apps/web/src/lib/ai/intent-router.ts) that fix a currently-failing
+            golden row or a confirmed real miss from feedback-evals. For each candidate, apply it in an
+            isolated worktree, run the FULL golden set, and hand the diff + score to the `ai-eval-judge`
+            agent. Open a DRAFT PR (classifier diff + golden-set additions + baseline bump) ONLY if the
+            judge returns PASS — candidate beats baseline with zero regressions. Anything that ties,
+            regresses, or touches safety/access/spend goes to .claude/loops/inbox/ for a human. NEVER
+            merge, NEVER edit the golden set to manufacture a pass, NEVER force-push.
+          claude_args: '--max-turns 40'   # hard cap: bounds an idle loop's spend

--- a/.github/workflows/loop-triage.yml
+++ b/.github/workflows/loop-triage.yml
@@ -1,0 +1,54 @@
+# Loop Engineering — cloud triage loop (SCHEDULING move).
+#
+# This is the "machine-off" autonomy layer: it runs on GitHub's infrastructure so the
+# loop turns even when no laptop is open. It is intentionally shipped DISABLED:
+#   - `workflow_dispatch` only — you trigger it by hand from the Actions tab.
+#   - the `schedule:` trigger is COMMENTED OUT. Uncomment it ONLY after you have
+#     watched a few manual runs and trust the evaluator + human-review boundary.
+#
+# This respects the playbook's two first-month disciplines: cap before you ship, and
+# keep one door open. The skill never auto-merges; PRs open in draft for a human.
+name: Loop · morning triage
+
+on:
+  workflow_dispatch: {}
+  # Uncomment to make it a real loop (06:00 UTC daily). Cloud min interval is ~1h.
+  # schedule:
+  #   - cron: '0 6 * * *'
+
+# Single-flight: never let two triage runs overlap.
+concurrency:
+  group: loop-triage
+  cancel-in-progress: false
+
+permissions:
+  contents: write       # commit the state file back
+  pull-requests: write  # open DRAFT PRs (never merge)
+  issues: read
+  actions: read         # read CI results for discovery
+  id-token: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30   # token/time circuit-breaker — a stuck loop cannot burn the night
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # discovery needs commit history since the last run
+
+      - name: Run morning-triage loop
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          # DISCOVERY is a skill, not a wall of text pasted into a cron job.
+          prompt: |
+            Run the `morning-triage` skill. Read CI failures, issues opened in the
+            last 24h, and commits since the last recorded run. Judge what is actionable,
+            update .claude/loops/state/triage.md, and commit it back to this branch.
+            For each small, well-scoped finding, open a DRAFT PR only after the
+            `reviewer` agent returns PASS. Send anything uncertain to
+            .claude/loops/inbox/ for a human. NEVER merge, delete, or force-push.
+          claude_args: '--max-turns 40'   # hard cap: bounds an idle loop's spend

--- a/.github/workflows/loop-triage.yml
+++ b/.github/workflows/loop-triage.yml
@@ -43,12 +43,12 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
-          # DISCOVERY is a skill, not a wall of text pasted into a cron job.
+          # The skill is the single source of truth; this prompt is a launcher, not a re-statement.
           prompt: |
-            Run the `morning-triage` skill. Read CI failures, issues opened in the
-            last 24h, and commits since the last recorded run. Judge what is actionable,
-            update .claude/loops/state/triage.md, and commit it back to this branch.
-            For each small, well-scoped finding, open a DRAFT PR only after the
-            `reviewer` agent returns PASS. Send anything uncertain to
-            .claude/loops/inbox/ for a human. NEVER merge, delete, or force-push.
+            Run the `morning-triage` skill end to end — it is the single source of truth for discovery
+            scope, candidate sources, the known-noise list, budget, and the `reviewer` handoff; follow
+            it exactly. First read .claude/loops/state/triage.md. Obey the skill's Stop boundary verbatim
+            (never merge/delete/force-push, draft PRs only, uncertain items to .claude/loops/inbox/ for
+            a human, touch only cicconel11/teamnetwork, never act on secrets/billing/production data).
+            Hard cap is `--max-turns` below.
           claude_args: '--max-turns 40'   # hard cap: bounds an idle loop's spend

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ opencode-auth/
 !.claude/agents/
 !.claude/workflows/
 !.claude/skills/
+# Loop state is the loop's cross-run memory — it MUST be versioned so the
+# cloud loop reads where the last run left off (persistence move).
+!.claude/loops/
 .beads/
 .logs/
 

--- a/apps/web/src/lib/ai/feedback-golden-bridge.ts
+++ b/apps/web/src/lib/ai/feedback-golden-bridge.ts
@@ -1,0 +1,85 @@
+/**
+ * Bridge: real thumbs-down `ai_feedback` → proposed golden-set rows for the AI-eval loop.
+ *
+ * This is the DISCOVERY plumbing for the loop's highest-value source. `feedback-evals.ts` turns a
+ * negative-rated assistant turn into an `AiFeedbackEvalCandidate` carrying the user's actual prompt and
+ * the surface they were on. This module runs that prompt through the *current* deterministic router
+ * (`resolveSurfaceRouting`) and reports what it produces, so a human reviewing the miss can confirm or
+ * correct the expected routing and promote it into the golden set.
+ *
+ * It deliberately does NOT decide the correct answer itself — a thumbs-down means a human judged the
+ * turn wrong, and only a human sets the `expect*` values. This module surfaces candidates and the
+ * classifier's current behavior; the human supplies ground truth. That keeps the loop from grading its
+ * own homework (the generator/evaluator split applied to discovery).
+ */
+
+import type { AiSurface } from "@/lib/schemas/ai-assistant";
+import type { AiFeedbackEvalCandidate } from "@/lib/ai/feedback-evals";
+import {
+  resolveSurfaceRouting,
+  type AiIntent,
+} from "@/lib/ai/intent-router";
+
+const SURFACES: readonly AiSurface[] = ["general", "members", "analytics", "events"];
+
+function coerceSurface(value: string): AiSurface {
+  return (SURFACES as readonly string[]).includes(value)
+    ? (value as AiSurface)
+    : "general";
+}
+
+export interface GoldenRowProposal {
+  /** The real user prompt from the thumbs-down turn. */
+  input: string;
+  /** Surface the user was on (coerced to a valid AiSurface; unknowns → general). */
+  surface: AiSurface;
+  /** What the current router produces for this prompt — the suspected-wrong behavior. */
+  current: {
+    intent: AiIntent;
+    effectiveSurface: AiSurface;
+  };
+  /** Source feedback id, so a promoted row is traceable back to the real miss. */
+  feedbackId: string;
+  /** The user's free-text complaint, if any — context for the human setting ground truth. */
+  comment: string | null;
+  /**
+   * True when the candidate lacks the data to be a clean routing row (no prompt, etc.).
+   * Incomplete proposals go to the inbox for a human, never auto-promoted.
+   */
+  incomplete: boolean;
+}
+
+/**
+ * Convert one feedback candidate into a golden-row proposal. Returns null only when there is no prompt
+ * at all to route (nothing to score). The caller (the ai-eval-loop skill) presents non-null proposals
+ * to a human, who decides the correct expectIntent/expectSurface and promotes — or discards — the row.
+ */
+export function feedbackCandidateToGoldenProposal(
+  candidate: AiFeedbackEvalCandidate
+): GoldenRowProposal | null {
+  const input = candidate.prompt.trim();
+  if (input.length === 0) return null;
+
+  const surface = coerceSurface(candidate.surface);
+  const decision = resolveSurfaceRouting(input, surface);
+
+  return {
+    input,
+    surface,
+    current: {
+      intent: decision.intent,
+      effectiveSurface: decision.effectiveSurface,
+    },
+    feedbackId: candidate.sourceIds.feedbackId,
+    comment: candidate.feedback.comment,
+    incomplete: candidate.incomplete,
+  };
+}
+
+export function feedbackCandidatesToGoldenProposals(
+  candidates: readonly AiFeedbackEvalCandidate[]
+): GoldenRowProposal[] {
+  return candidates
+    .map((c) => feedbackCandidateToGoldenProposal(c))
+    .filter((p): p is GoldenRowProposal => p != null);
+}

--- a/apps/web/tests/ai-feedback-golden-bridge.test.ts
+++ b/apps/web/tests/ai-feedback-golden-bridge.test.ts
@@ -1,0 +1,100 @@
+// Proves the DISCOVERY plumbing for the AI-eval loop's highest-value source: a real thumbs-down
+// ai_feedback row → a golden-row proposal a human can promote. Builds the candidate via the REAL
+// buildFeedbackEvalCandidate (not a hand-rolled object) so the bridge is tested end-to-end.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildFeedbackEvalCandidate,
+  type AiFeedbackEvalSourceRow,
+} from "../src/lib/ai/feedback-evals";
+import {
+  feedbackCandidateToGoldenProposal,
+  feedbackCandidatesToGoldenProposals,
+} from "../src/lib/ai/feedback-golden-bridge";
+
+function sourceRow(
+  overrides: {
+    prompt?: string | null;
+    surface?: string | null;
+    rating?: string;
+    comment?: string | null;
+  } = {}
+): AiFeedbackEvalSourceRow {
+  return {
+    feedback: {
+      id: "fb-1",
+      rating: overrides.rating ?? "negative",
+      comment: overrides.comment ?? "wrong place",
+      created_at: "2026-06-24T00:00:00Z",
+    },
+    thread: { id: "th-1", org_id: "org-1", user_id: "u-1", surface: overrides.surface ?? "members" },
+    userMessage: {
+      id: "um-1",
+      content: overrides.prompt === undefined ? "show me the roster" : overrides.prompt,
+      intent: null,
+      intent_type: null,
+      context_surface: overrides.surface ?? "analytics",
+      created_at: "2026-06-24T00:00:00Z",
+    },
+    assistantMessage: {
+      id: "am-1",
+      content: "...",
+      tool_calls: null,
+      created_at: "2026-06-24T00:00:00Z",
+    },
+    audit: {
+      id: "au-1",
+      intent: null,
+      intent_type: null,
+      context_surface: overrides.surface ?? "analytics",
+      tool_calls: null,
+      safety_verdict: "ok",
+      rag_grounded: true,
+      write_action_id: null,
+      write_action_status: null,
+    },
+  };
+}
+
+describe("feedback → golden proposal bridge", () => {
+  it("turns a real negative-feedback candidate into a routable proposal carrying current behavior", () => {
+    const candidate = buildFeedbackEvalCandidate(sourceRow({ surface: "analytics" }));
+    assert.ok(candidate, "expected a candidate from a negative-rated row");
+
+    const proposal = feedbackCandidateToGoldenProposal(candidate);
+    assert.ok(proposal, "expected a proposal");
+    assert.equal(proposal.input, "show me the roster");
+    assert.equal(proposal.surface, "analytics");
+    // The bridge reports what the CURRENT router does — ground truth is set by a human, not here.
+    assert.equal(proposal.current.intent, "members_query");
+    assert.equal(proposal.current.effectiveSurface, "members");
+    assert.equal(proposal.feedbackId, "fb-1");
+    assert.equal(proposal.comment, "wrong place");
+  });
+
+  it("coerces an unknown surface to general rather than throwing", () => {
+    const candidate = buildFeedbackEvalCandidate(sourceRow({ surface: "bogus-surface" }));
+    assert.ok(candidate);
+    const proposal = feedbackCandidateToGoldenProposal(candidate);
+    assert.ok(proposal);
+    assert.equal(proposal.surface, "general");
+  });
+
+  it("drops a candidate with no prompt (nothing to route)", () => {
+    const candidate = buildFeedbackEvalCandidate(sourceRow({ prompt: "" }));
+    // empty prompt still yields a candidate (marked incomplete) but no routable proposal
+    assert.ok(candidate);
+    assert.equal(feedbackCandidateToGoldenProposal(candidate), null);
+  });
+
+  it("batch helper filters nulls", () => {
+    const candidates = [
+      buildFeedbackEvalCandidate(sourceRow({ surface: "analytics" })),
+      buildFeedbackEvalCandidate(sourceRow({ prompt: "" })),
+    ].filter((c): c is NonNullable<typeof c> => c != null);
+    const proposals = feedbackCandidatesToGoldenProposals(candidates);
+    assert.equal(proposals.length, 1);
+  });
+});

--- a/apps/web/tests/ai-intent-golden.test.ts
+++ b/apps/web/tests/ai-intent-golden.test.ts
@@ -1,0 +1,181 @@
+// Golden-set scorer for the AI-eval loop.
+//
+// The source of truth for correct routing lives in
+// .claude/loops/state/ai-eval-baseline.md; this file is the deterministic runner the
+// `ai-eval-loop` skill and `ai-eval-judge` agent execute to compute passing/total against
+// `resolveSurfaceRouting`. No live model — pure, exact, CI-cheap. House style mirrors
+// tests/ai-fast-path-classifier.test.ts (node:test + assert/strict).
+//
+// Rows here must stay in sync with the golden-set table in the baseline markdown. When the
+// loop promotes a new golden row, it adds it in BOTH places in the same PR.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  resolveSurfaceRouting,
+  type AiIntent,
+} from "../src/lib/ai/intent-router";
+import type { AiSurface } from "../src/lib/schemas/ai-assistant";
+
+interface GoldenRow {
+  input: string;
+  surface: AiSurface;
+  expectIntent: AiIntent;
+  expectSurface: AiSurface;
+  note: string;
+}
+
+// Seeded with two real, verified rows. Grow from confirmed `ai_feedback` misses + hard cases.
+const GOLDEN: readonly GoldenRow[] = [
+  {
+    input: "show me the roster",
+    surface: "analytics",
+    expectIntent: "members_query",
+    expectSurface: "members",
+    note: "cross-surface pull → must reroute to members",
+  },
+  {
+    input: "thanks!",
+    surface: "general",
+    expectIntent: "general_query",
+    expectSurface: "general",
+    note: "casual → no reroute, stays general",
+  },
+  {
+    input: "show me everything",
+    surface: "members",
+    expectIntent: "general_query",
+    expectSurface: "members",
+    note: "no keyword match → must NOT guess a surface; stays put, low confidence",
+  },
+  {
+    input: "",
+    surface: "members",
+    expectIntent: "general_query",
+    expectSurface: "members",
+    note: "empty input → stable defined result, no throw, no reroute",
+  },
+  {
+    input: "members donations",
+    surface: "general",
+    expectIntent: "ambiguous_query",
+    expectSurface: "general",
+    note: "keyword collision (members + analytics tie) → ambiguous, documented tie-break",
+  },
+  {
+    input: "who are our donors?",
+    surface: "general",
+    expectIntent: "analytics_query",
+    expectSurface: "analytics",
+    note: "'donor' keyword → reroute from general to analytics, high confidence",
+  },
+  {
+    input: "upcoming games this week",
+    surface: "general",
+    expectIntent: "events_query",
+    expectSurface: "events",
+    note: "'games' keyword → reroute to events (not analytics, despite 'this week')",
+  },
+  {
+    input: "create an event for friday",
+    surface: "members",
+    expectIntent: "events_query",
+    expectSurface: "events",
+    note: "action_request + events keyword → reroute from members to events",
+  },
+  {
+    input: "mentor",
+    surface: "analytics",
+    expectIntent: "members_query",
+    expectSurface: "members",
+    note: "single bare members keyword → reroute from analytics, high confidence",
+  },
+  {
+    input: "how do I message a mentor",
+    surface: "general",
+    expectIntent: "members_query",
+    expectSurface: "members",
+    note: "members keywords win → members surface (a 'how do I' phrasing must not override the surface signal)",
+  },
+  {
+    input: "delete a member",
+    surface: "general",
+    expectIntent: "members_query",
+    expectSurface: "members",
+    note: "action_request + members keyword → reroute to members",
+  },
+  {
+    input: "send an announcement",
+    surface: "events",
+    expectIntent: "general_query",
+    expectSurface: "general",
+    note: "general-content keyword ('announcement') beats the events surface → reroute to general",
+  },
+  {
+    input: "mentor and mentee connections donation",
+    surface: "general",
+    expectIntent: "members_query",
+    expectSurface: "members",
+    note: "keyword-count dominance: 3 members keywords outrank 1 analytics → members, not ambiguous",
+  },
+  {
+    input: "any new job postings?",
+    surface: "members",
+    expectIntent: "general_query",
+    expectSurface: "general",
+    note: "'job'/'postings' are general-content keywords → reroute from members to general",
+  },
+  {
+    input: "good morning team",
+    surface: "members",
+    expectIntent: "general_query",
+    expectSurface: "members",
+    note: "casual variant (multi-word greeting) → casual, no reroute, stays put",
+  },
+  {
+    input: "take me to the calendar",
+    surface: "general",
+    expectIntent: "events_query",
+    expectSurface: "events",
+    note: "navigation phrasing + events keyword → reroute to events",
+  },
+  {
+    input: "donation trends by month",
+    surface: "general",
+    expectIntent: "analytics_query",
+    expectSurface: "analytics",
+    note: "reporting language ('trends by month') + analytics keyword → analytics, not navigation",
+  },
+  {
+    input: "MEMBERS",
+    surface: "general",
+    expectIntent: "members_query",
+    expectSurface: "members",
+    note: "case-insensitive keyword match → uppercase still routes to members",
+  },
+  {
+    input: "  roster  ",
+    surface: "analytics",
+    expectIntent: "members_query",
+    expectSurface: "members",
+    note: "whitespace-padded input is normalized → still reroutes to members",
+  },
+  {
+    input: "donations and events",
+    surface: "general",
+    expectIntent: "ambiguous_query",
+    expectSurface: "general",
+    note: "analytics vs events tie (1 each) → ambiguous, stays on requested surface",
+  },
+];
+
+describe("AI intent golden set", () => {
+  for (const row of GOLDEN) {
+    it(`routes "${row.input}" on [${row.surface}] → ${row.expectIntent}/${row.expectSurface} (${row.note})`, () => {
+      const decision = resolveSurfaceRouting(row.input, row.surface);
+      assert.equal(decision.intent, row.expectIntent);
+      assert.equal(decision.effectiveSurface, row.expectSurface);
+    });
+  }
+});


### PR DESCRIPTION
## What this adds

Two self-contained "loop-engineering" loops, both **disabled-by-default-safe** (draft PRs only, never merge; capped). The headline is **Loop B — the AI-eval loop**, which gates changes to the deterministic intent classifier (`resolveSurfaceRouting`) against a committed golden set so routing can only change when the score goes **up with zero regressions**.

### Loop B — AI eval (the substance)
- **Golden set:** 20 verified rows in `apps/web/tests/ai-intent-golden.test.ts` + a baseline state file (`.claude/loops/state/ai-eval-baseline.md`). Pure, no model call — runs in CI for free.
- **Evaluator (`.claude/agents/ai-eval-judge.md`):** recomputes the *full* set, defaults to REJECT, rejects on **any** regression even if the total improves. The floor was proven by hand: a keyword removal **and** a plausible `navigation→general` change were both caught (see the baseline file's history block + `.claude/loops/inbox/`).
- **Discovery (`apps/web/src/lib/ai/feedback-golden-bridge.ts`):** converts real thumbs-down `ai_feedback` into golden-row proposals — a human sets ground truth and promotes. Covered by `ai-feedback-golden-bridge.test.ts`.
- **Scheduling (`.github/workflows/loop-ai-eval.yml`):** weekly (Mon 07:00 UTC), draft PRs only, `timeout-minutes: 30` + `--max-turns 40` caps. Also runnable on demand.

### Loop A — morning triage (scaffold)
- `morning-triage` skill + `reviewer` evaluator agent + `loop-triage.yml` (also draft-only, capped). Seeded with a last-run marker + known-noise list.

## Why merge to main
GitHub Actions only fires `schedule:` (and even `workflow_dispatch`) for workflows present on the **default branch**. The cron is enabled in the file, but it cannot run until this lands on `main`. After merge: watch a few runs from the Actions tab before trusting it.

## Preconditions / risk
- `CLAUDE_CODE_OAUTH_TOKEN` repo secret — **confirmed present**.
- The loop **never merges** — a human is the merge gate on every PR it opens.
- Two open product questions are parked in `.claude/loops/inbox/` for a human (multi-word casual handling; how-to routing UX).
- App behavior is **unchanged** — this PR is test coverage + loop infra only; `intent-router.ts` is not modified.

## Verification
- Lint clean, `typecheck` 0 errors (web workspace), **24/24** loop tests green (rebased onto current `main`).