### PR TITLE
feat(assistant): grant parent role a read-only AI tool allowlist

### DIFF
--- a/apps/web/src/lib/ai/access-policy.ts
+++ b/apps/web/src/lib/ai/access-policy.ts
@@ -15,7 +15,6 @@ export interface AiToolAccessInput extends AiAccessDecisionInput {
 
 export type AiAccessDenialReason =
   | "member_access_kill_switch"
-  | "parent_role_disabled"
   | "role_not_allowed_for_tool"
   | "enterprise_tool_requires_admin";
 
@@ -46,7 +45,14 @@ const ALUMNI_ALLOWED_TOOLS: readonly ToolName[] = Object.freeze([
   "search_org_content",
 ]);
 
-const PARENT_ALLOWED_TOOLS: readonly ToolName[] = Object.freeze([]);
+// Parents see the same read-only subset as alumni: org-wide announcements and
+// events, plus navigation/search helpers. No member-directory or finance tools.
+const PARENT_ALLOWED_TOOLS: readonly ToolName[] = Object.freeze([
+  "list_announcements",
+  "list_events",
+  "find_navigation_targets",
+  "search_org_content",
+]);
 
 const ENTERPRISE_TOOL_NAMES: ReadonlySet<ToolName> = new Set<ToolName>([
   "list_enterprise_alumni",
@@ -92,9 +98,6 @@ function gateNonAdmin(input: AiAccessDecisionInput): AiAccessDecision | null {
   if (input.role === "admin") return null;
   if (isMemberAccessKilled()) {
     return { allowed: false, reason: "member_access_kill_switch" };
-  }
-  if (input.role === "parent") {
-    return { allowed: false, reason: "parent_role_disabled" };
   }
   return null;
 }

--- a/apps/web/tests/ai-access-policy.test.ts
+++ b/apps/web/tests/ai-access-policy.test.ts
@@ -176,8 +176,37 @@ describe("ai access policy — alumni", () => {
 describe("ai access policy — parent", () => {
   afterEach(restoreKillSwitch);
 
-  it("is disabled even when kill switch is lifted", () => {
+  it("gets the alumni-equivalent read-only subset when kill switch is lifted", () => {
     liftKillSwitch();
+    const allowed = getAllowedTools({ role: "parent" });
+    assert.deepEqual(new Set(allowed), new Set([
+      "list_announcements",
+      "list_events",
+      "find_navigation_targets",
+      "search_org_content",
+    ]));
+
+    const decision = isToolAllowed({
+      role: "parent",
+      toolName: "list_announcements",
+    });
+    assert.equal(decision.allowed, true);
+  });
+
+  it("denies member-only tools such as list_job_postings", () => {
+    liftKillSwitch();
+    const decision = isToolAllowed({
+      role: "parent",
+      toolName: "list_job_postings",
+    });
+    assert.equal(decision.allowed, false);
+    if (!decision.allowed) {
+      assert.equal(decision.reason, "role_not_allowed_for_tool");
+    }
+  });
+
+  it("is blocked entirely while the kill switch is active", () => {
+    process.env.AI_MEMBER_ACCESS_KILL = "1";
     const allowed = getAllowedTools({ role: "parent" });
     assert.deepEqual(allowed, []);
 
@@ -187,7 +216,7 @@ describe("ai access policy — parent", () => {
     });
     assert.equal(decision.allowed, false);
     if (!decision.allowed) {
-      assert.equal(decision.reason, "parent_role_disabled");
+      assert.equal(decision.reason, "member_access_kill_switch");
     }
   });
 });

--- a/apps/web/tests/routes/ai/tool-executor-access-policy.test.ts
+++ b/apps/web/tests/routes/ai/tool-executor-access-policy.test.ts
@@ -136,14 +136,34 @@ test("executor rejects enterprise tools for active_member even with enterprise r
   assert.equal(result.kind, "forbidden");
 });
 
-test("executor rejects everything for parent role", async () => {
+test("executor allows parent read-only tools when policy is green", async () => {
   const result = await executeToolCall(
-    makeCtx({
-      kind: "preverified_role",
-      source: "ai_org_context",
-      role: "parent",
-    }),
+    makeCtx(
+      {
+        kind: "preverified_role",
+        source: "ai_org_context",
+        role: "parent",
+      },
+      { supabase: createSupabaseStub() as any },
+    ),
     { name: "list_announcements", args: {} },
+  );
+
+  assert.notEqual(result.kind, "forbidden");
+  assert.notEqual(result.kind, "auth_error");
+});
+
+test("executor rejects member-only tools for parent role", async () => {
+  const result = await executeToolCall(
+    makeCtx(
+      {
+        kind: "preverified_role",
+        source: "ai_org_context",
+        role: "parent",
+      },
+      { supabase: createSupabaseStub() as any },
+    ),
+    { name: "list_job_postings", args: {} },
   );
 
   assert.equal(result.kind, "forbidden");


### PR DESCRIPTION
## What

Completes the parent → AI assistant feature. The assistant **API** and **UI** already admit the parent role on \`main\` (commits \`ff63e4ea\`, \`428c227f\`), but parents were still hard-blocked at the **tool layer** — so the assistant could open for a parent yet answer nothing. This PR closes that gap.

- Give parents the alumni-equivalent **read-only** tool subset: \`list_announcements\`, \`list_events\`, \`find_navigation_targets\`, \`search_org_content\`.
- Remove the now-dead \`parent_role_disabled\` gate and denial reason from the access policy.
- Parents remain denied member-only tools (e.g. \`list_job_postings\`) and all enterprise tools.

## Why

Without this, a parent who reaches the assistant (nav + page already open to them) gets an empty tool allowlist — every request is refused at \`isToolAllowed\`. This makes the feature actually functional for the parent role.

## Safety / rollout

- The global **kill switch** \`AI_MEMBER_ACCESS_KILL\` is unchanged and still defaults **ON** — all non-admin roles (including parent) are blocked until an operator sets \`AI_MEMBER_ACCESS_KILL=0\`. This PR does not flip it.
- No schema/migration changes. No new env. Pure access-policy logic.
- Parent reads go through the auth-bound (RLS) client, same path as \`active_member\`/\`alumni\`.

## Tests

- \`ai-access-policy.test.ts\` — parent gets the read-only subset when kill is lifted; denied member-only tools; blocked entirely while kill is active.
- \`tool-executor-access-policy.test.ts\` — executor allows parent read-only tools, rejects member-only tools.
- Full web suite (6119 tests) green on the source branch; 40 targeted tests + typecheck green on this isolated branch.

## Not manually smoke-tested

Static gates only (typecheck, lint, unit). The live RLS data-return path for a parent (do \`list_announcements\`/\`list_events\` actually return rows under parent RLS?) has **not** been exercised in a running app. Recommend a manual pass with a parent account + \`AI_MEMBER_ACCESS_KILL=0\` before enabling in prod.