### PR TITLE
feat(alumni): reachability health card + unclaimed-cohort re-invite console

### DIFF
--- a/apps/web/src/app/[orgSlug]/alumni/cohorts/CohortConsoleClient.tsx
+++ b/apps/web/src/app/[orgSlug]/alumni/cohorts/CohortConsoleClient.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Card, Button, Badge, Spinner, EmptyState } from "@/components/ui";
+
+type Segment =
+  | "linkedEligible"
+  | "linkedNotEligible"
+  | "unclaimedWithEmail"
+  | "unclaimedNoEmail";
+
+interface CohortEntry {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  segment: Segment | "softDeleted";
+  last_invite_sent_at: string | null;
+  invite_count: number;
+}
+
+interface ReInviteResult {
+  alumniId: string;
+  status: "sent" | "skipped" | "failed";
+  reason?: string;
+}
+
+interface ReInviteResponse {
+  sent: number;
+  skipped: number;
+  failed: number;
+  results: ReInviteResult[];
+}
+
+// Display order + copy for the four live segments. Soft-deleted rows never
+// reach the console (the API excludes them), so they aren't listed here.
+const SEGMENT_META: { key: Segment; title: string; description: string }[] = [
+  {
+    key: "unclaimedWithEmail",
+    title: "Unclaimed — has email",
+    description: "Never claimed an account, but we have an email. Re-invitable.",
+  },
+  {
+    key: "unclaimedNoEmail",
+    title: "Unclaimed — no email",
+    description: "Never claimed and no email on file. Structurally unreachable.",
+  },
+  {
+    key: "linkedNotEligible",
+    title: "Linked — can't chat",
+    description: "Linked to a user, but without an active chat-eligible role.",
+  },
+  {
+    key: "linkedEligible",
+    title: "Reachable",
+    description: "Linked and chat-eligible — fully reachable.",
+  },
+];
+
+const COOLDOWN_MS = 14 * 24 * 60 * 60 * 1000;
+
+function fullName(entry: CohortEntry): string {
+  const name = [entry.first_name, entry.last_name].filter(Boolean).join(" ").trim();
+  return name || "(no name)";
+}
+
+function isOnCooldown(entry: CohortEntry, nowMs: number): boolean {
+  if (!entry.last_invite_sent_at) return false;
+  return nowMs - Date.parse(entry.last_invite_sent_at) < COOLDOWN_MS;
+}
+
+export function CohortConsoleClient({ organizationId }: { organizationId: string }) {
+  const [entries, setEntries] = useState<CohortEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [isSending, setIsSending] = useState(false);
+  const [lastResult, setLastResult] = useState<ReInviteResponse | null>(null);
+  // Set once on mount to keep cooldown checks stable across renders.
+  const [nowMs] = useState(() => Date.now());
+
+  const loadCohorts = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const res = await fetch(`/api/organizations/${organizationId}/alumni/cohorts`);
+      if (!res.ok) {
+        setLoadError("Unable to load alumni cohorts.");
+        return;
+      }
+      const data = (await res.json()) as { entries: CohortEntry[] };
+      setEntries(data.entries ?? []);
+    } catch {
+      setLoadError("Unable to load alumni cohorts.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [organizationId]);
+
+  useEffect(() => {
+    void loadCohorts();
+  }, [loadCohorts]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<Segment, CohortEntry[]>();
+    for (const meta of SEGMENT_META) map.set(meta.key, []);
+    for (const entry of entries) {
+      const bucket = map.get(entry.segment as Segment);
+      if (bucket) bucket.push(entry);
+    }
+    return map;
+  }, [entries]);
+
+  // Only unclaimed-with-email rows that are off cooldown can actually be sent.
+  const selectableIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const entry of entries) {
+      if (entry.segment === "unclaimedWithEmail" && !isOnCooldown(entry, nowMs)) {
+        ids.add(entry.id);
+      }
+    }
+    return ids;
+  }, [entries, nowMs]);
+
+  const toggle = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const sendReInvites = async () => {
+    if (selectedIds.size === 0) return;
+    setIsSending(true);
+    setLastResult(null);
+    try {
+      const res = await fetch(`/api/organizations/${organizationId}/alumni/re-invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ alumniIds: [...selectedIds] }),
+      });
+      if (!res.ok) {
+        setLastResult({ sent: 0, skipped: 0, failed: selectedIds.size, results: [] });
+        return;
+      }
+      const data = (await res.json()) as ReInviteResponse;
+      setLastResult(data);
+      setSelectedIds(new Set());
+      // Refresh so cooldown stamps + counters reflect the send.
+      await loadCohorts();
+    } catch {
+      setLastResult({ sent: 0, skipped: 0, failed: selectedIds.size, results: [] });
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Card className="p-8">
+        <div className="flex items-center justify-center">
+          <Spinner />
+        </div>
+      </Card>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <Card className="p-6">
+        <p className="text-sm text-red-600">{loadError}</p>
+        <Button className="mt-3" variant="secondary" onClick={() => void loadCohorts()}>
+          Retry
+        </Button>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {lastResult && (
+        <div className="rounded-lg bg-green-50 p-3 text-sm text-green-800">
+          Sent {lastResult.sent} · skipped {lastResult.skipped} · failed {lastResult.failed}
+        </div>
+      )}
+
+      {SEGMENT_META.map((meta) => {
+        const rows = grouped.get(meta.key) ?? [];
+        const isReInvitable = meta.key === "unclaimedWithEmail";
+        return (
+          <Card key={meta.key} className="p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <div>
+                <h2 className="text-sm font-semibold text-gray-900">{meta.title}</h2>
+                <p className="text-xs text-gray-500">{meta.description}</p>
+              </div>
+              <Badge>{rows.length}</Badge>
+            </div>
+
+            {rows.length === 0 ? (
+              <EmptyState title="No alumni in this segment" />
+            ) : (
+              <ul className="divide-y divide-gray-100">
+                {rows.map((entry) => {
+                  const cooled = isReInvitable && isOnCooldown(entry, nowMs);
+                  const selectable = selectableIds.has(entry.id);
+                  return (
+                    <li
+                      key={entry.id}
+                      className="flex items-center justify-between gap-3 py-2 text-sm"
+                    >
+                      <div className="flex items-center gap-3">
+                        {isReInvitable && (
+                          <input
+                            type="checkbox"
+                            className="h-4 w-4"
+                            disabled={!selectable}
+                            checked={selectedIds.has(entry.id)}
+                            onChange={() => toggle(entry.id)}
+                            aria-label={`Select ${fullName(entry)}`}
+                          />
+                        )}
+                        <div>
+                          <span className="font-medium text-gray-900">{fullName(entry)}</span>
+                          {entry.email && (
+                            <span className="ml-2 text-gray-500">{entry.email}</span>
+                          )}
+                        </div>
+                      </div>
+                      {isReInvitable && (
+                        <span className="text-xs text-gray-400">
+                          {cooled
+                            ? "On cooldown"
+                            : entry.invite_count > 0
+                              ? `Invited ${entry.invite_count}×`
+                              : "Not yet invited"}
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </Card>
+        );
+      })}
+
+      {selectedIds.size > 0 && (
+        <div className="fixed bottom-6 left-1/2 flex -translate-x-1/2 items-center gap-4 rounded-xl border border-gray-200 bg-white p-4 shadow-xl">
+          <span className="text-sm font-medium text-gray-900">
+            {selectedIds.size} selected
+          </span>
+          <div className="h-4 w-px bg-gray-200" />
+          <Button onClick={() => void sendReInvites()} isLoading={isSending}>
+            Re-invite selected ({selectedIds.size})
+          </Button>
+          <button
+            onClick={() => setSelectedIds(new Set())}
+            className="text-sm text-gray-500 hover:text-gray-900"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/[orgSlug]/alumni/cohorts/page.tsx
+++ b/apps/web/src/app/[orgSlug]/alumni/cohorts/page.tsx
@@ -1,0 +1,28 @@
+import { redirect } from "next/navigation";
+import { getOrgContext } from "@/lib/auth/roles";
+import { PageHeader } from "@/components/layout";
+import { CohortConsoleClient } from "./CohortConsoleClient";
+
+interface CohortsPageProps {
+  params: Promise<{ orgSlug: string }>;
+}
+
+// Admin-only console that segments the org's alumni by reachability state and
+// re-invites the unclaimed-with-email cohort. Mirrors the data-health page gate.
+export default async function CohortsPage({ params }: CohortsPageProps) {
+  const { orgSlug } = await params;
+  const orgCtx = await getOrgContext(orgSlug);
+
+  if (!orgCtx.organization) return null;
+  if (!orgCtx.isAdmin) redirect(`/${orgSlug}`);
+
+  return (
+    <div className="space-y-6 animate-fade-in">
+      <PageHeader
+        title="Alumni reachability"
+        description="Segment alumni by whether they can be reached, and re-invite the unclaimed cohort. Re-invites are limited to one every 14 days per alumnus."
+      />
+      <CohortConsoleClient organizationId={orgCtx.organization.id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/[orgSlug]/alumni/page.tsx
+++ b/apps/web/src/app/[orgSlug]/alumni/page.tsx
@@ -194,10 +194,15 @@ export default async function AlumniPage({ params, searchParams }: AlumniPagePro
         description={`${total} ${pageLabel.toLowerCase()}${hasActiveFilters ? ` ${tActions("filtered")}` : ` ${tActions("inOurNetwork")}`}`}
         actions={
           canEdit && (
-            <AlumniActionsMenu
-              orgSlug={orgSlug}
-              actionLabel={actionLabel}
-            />
+            <div className="flex items-center gap-2">
+              <Link
+                href={`/${orgSlug}/alumni/cohorts`}
+                className="inline-flex items-center rounded-lg border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                Reachability
+              </Link>
+              <AlumniActionsMenu orgSlug={orgSlug} actionLabel={actionLabel} />
+            </div>
           )
         }
       />

--- a/apps/web/src/app/[orgSlug]/data-health/page.tsx
+++ b/apps/web/src/app/[orgSlug]/data-health/page.tsx
@@ -80,6 +80,12 @@ export default async function DataHealthPage({ params }: DataHealthPageProps) {
       : report.enrichment.state === "degraded"
         ? "bad"
         : "warn";
+  const reachTone: Tone =
+    report.reachability.state === "ok"
+      ? "good"
+      : report.reachability.state === "degraded"
+        ? "bad"
+        : "warn";
 
   return (
     <div className="space-y-6 animate-fade-in">
@@ -88,7 +94,7 @@ export default async function DataHealthPage({ params }: DataHealthPageProps) {
         description="Read-only correctness checks across the assistant's RAG index and LinkedIn enrichment. Counts show divergence between live data and each pipeline."
       />
 
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="grid gap-4 lg:grid-cols-3">
         <Card title="RAG index" tone={ragTone} state={report.rag.state}>
           <MetricRow label="Missing coverage" value={report.rag.counts.missingCoverage} />
           <MetricRow label="Orphan chunks" value={report.rag.counts.orphanChunks} />
@@ -104,6 +110,19 @@ export default async function DataHealthPage({ params }: DataHealthPageProps) {
           />
           <MetricRow label="Stalled runs" value={report.enrichment.counts.stalledRuns} />
           <MetricRow label="Pre-provenance rows" value={report.enrichment.counts.preProvenance} />
+        </Card>
+
+        <Card title="Reachability" tone={reachTone} state={report.reachability.state}>
+          <MetricRow label="Total alumni" value={report.reachability.counts.totalAlumni} />
+          <MetricRow label="Linked alumni" value={report.reachability.counts.linkedAlumni} />
+          <MetricRow
+            label="Chat-eligible %"
+            value={`${report.reachability.counts.chatEligiblePercent}%`}
+          />
+          <MetricRow
+            label="Unclaimed with email"
+            value={report.reachability.counts.unclaimedWithEmail}
+          />
         </Card>
       </div>
     </div>

--- a/apps/web/src/app/api/organizations/[organizationId]/alumni/cohorts/route.ts
+++ b/apps/web/src/app/api/organizations/[organizationId]/alumni/cohorts/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { getOrgMembership } from "@/lib/auth/api-helpers";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+import { baseSchemas } from "@/lib/security/validation";
+import {
+  classifyAlumniReachability,
+  fetchAllPaged,
+  linkedUserIdsOf,
+  resolveEligibleUserIds,
+  type ReachabilitySegment,
+} from "@/lib/alumni/reachability-segments";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface RouteParams {
+  params: Promise<{ organizationId: string }>;
+}
+
+interface CohortAlumniRow {
+  id: string;
+  user_id: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  last_invite_sent_at: string | null;
+  invite_count: number | null;
+}
+
+interface CohortEntry {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  segment: ReachabilitySegment;
+  last_invite_sent_at: string | null;
+  invite_count: number;
+}
+
+// GET /api/organizations/:organizationId/alumni/cohorts
+//
+// Admin-only: list this org's non-deleted alumni tagged with their reachability
+// segment (the same predicate the data-health card counts, so the two surfaces
+// agree). Returns alumni PII — every entry point here is admin-gated.
+export async function GET(req: Request, { params }: RouteParams) {
+  const { organizationId } = await params;
+  if (!baseSchemas.uuid.safeParse(organizationId).success) {
+    return NextResponse.json({ error: "Invalid identifier" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const rateLimit = checkRateLimit(req, {
+    userId: user?.id ?? null,
+    feature: "alumni cohorts list",
+    limitPerIp: 60,
+    limitPerUser: 60,
+  });
+  if (!rateLimit.ok) {
+    return buildRateLimitResponse(rateLimit);
+  }
+
+  const respond = (payload: unknown, status = 200) =>
+    NextResponse.json(payload, { status, headers: rateLimit.headers });
+
+  if (!user) {
+    return respond({ error: "Unauthorized" }, 401);
+  }
+
+  const serviceSupabase = createServiceClient();
+
+  let membership;
+  try {
+    membership = await getOrgMembership(serviceSupabase, user.id, organizationId);
+  } catch (error) {
+    console.error("[alumni/cohorts GET] Failed to verify membership:", error);
+    return respond({ error: "Unable to verify permissions" }, 500);
+  }
+
+  if (membership?.role !== "admin") {
+    return respond({ error: "Forbidden" }, 403);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = serviceSupabase as any;
+
+  let rows: CohortAlumniRow[];
+  let truncated: boolean;
+  try {
+    const result = await fetchAllPaged<CohortAlumniRow>((from, to) =>
+      sb
+        .from("alumni")
+        .select("id, user_id, first_name, last_name, email, last_invite_sent_at, invite_count")
+        .eq("organization_id", organizationId)
+        .is("deleted_at", null)
+        .order("last_name", { ascending: true })
+        .range(from, to)
+    );
+    rows = result.rows;
+    truncated = result.truncated;
+  } catch (error) {
+    console.error("[alumni/cohorts GET] Failed to load alumni:", error);
+    return respond({ error: "Failed to load alumni" }, 500);
+  }
+
+  let eligibleUserIds: Set<string>;
+  try {
+    const resolved = await resolveEligibleUserIds(sb, organizationId, linkedUserIdsOf(rows));
+    eligibleUserIds = resolved.eligibleUserIds;
+    truncated = truncated || resolved.truncated;
+  } catch (error) {
+    console.error("[alumni/cohorts GET] Failed to resolve eligibility:", error);
+    return respond({ error: "Failed to resolve reachability" }, 500);
+  }
+
+  const entries: CohortEntry[] = rows.map((row) => ({
+    id: row.id,
+    first_name: row.first_name,
+    last_name: row.last_name,
+    email: row.email,
+    segment: classifyAlumniReachability(
+      { user_id: row.user_id, email: row.email, deleted_at: null },
+      eligibleUserIds
+    ),
+    last_invite_sent_at: row.last_invite_sent_at,
+    invite_count: typeof row.invite_count === "number" ? row.invite_count : 0,
+  }));
+
+  return respond({ entries, truncated });
+}

--- a/apps/web/src/app/api/organizations/[organizationId]/alumni/re-invite/route.ts
+++ b/apps/web/src/app/api/organizations/[organizationId]/alumni/re-invite/route.ts
@@ -1,0 +1,344 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { getOrgMembership } from "@/lib/auth/api-helpers";
+import { checkRateLimit, buildRateLimitResponse } from "@/lib/security/rate-limit";
+import { baseSchemas, validateJson, ValidationError } from "@/lib/security/validation";
+import { sendEmail } from "@/lib/notifications";
+import { buildInviteLink } from "@/lib/invites/buildInviteLink";
+import { getAppUrl } from "@/lib/url";
+
+// Durable per-alumnus cooldown. The DB column `last_invite_sent_at` is the real
+// gate (the in-memory rate limiter is only per-instance burst protection), so a
+// re-invite is refused if the alumnus was invited within this window.
+const REINVITE_COOLDOWN_MS = 14 * 24 * 60 * 60 * 1000;
+
+// Send fan-out matches the CSV-import re-invite path.
+const CONCURRENCY = 10;
+
+const reInviteSchema = z.object({
+  alumniIds: z.array(baseSchemas.uuid).min(1).max(200),
+});
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface RouteParams {
+  params: Promise<{ organizationId: string }>;
+}
+
+type SkipReason = "cooldown" | "linked" | "no_email" | "not_found";
+
+interface ReInviteResult {
+  alumniId: string;
+  // `sent_unstamped`: the email went out but the durable cooldown stamp failed,
+  // so the 14-day gate is NOT recorded for this recipient. Surfaced distinctly
+  // (not as a clean `sent`) so an immediate re-send can't silently bypass the
+  // cooldown unnoticed.
+  status: "sent" | "sent_unstamped" | "skipped" | "failed";
+  reason?: SkipReason | "send_failed" | "stamp_failed";
+}
+
+interface AlumniReInviteRow {
+  id: string;
+  user_id: string | null;
+  email: string | null;
+  first_name: string | null;
+  last_invite_sent_at: string | null;
+  invite_count: number | null;
+}
+
+interface OrgInviteRpc {
+  rpc: (
+    fn: "create_org_invite",
+    params: {
+      p_organization_id: string;
+      p_role: string;
+      p_uses: number | null;
+      p_expires_at: string | null;
+    }
+  ) => Promise<{
+    data: { code?: string | null; token?: string | null } | null;
+    error: { message: string } | null;
+  }>;
+}
+
+// POST /api/organizations/:organizationId/alumni/re-invite
+//
+// Admin-only: re-invite a selected cohort of unclaimed alumni (user_id IS NULL,
+// email present, non-deleted). Each target is gated by a durable 14-day
+// cooldown. Shaped so a future cron could reuse it; no background send ships.
+export async function POST(req: Request, { params }: RouteParams) {
+  const { organizationId } = await params;
+  if (!baseSchemas.uuid.safeParse(organizationId).success) {
+    return NextResponse.json({ error: "Invalid identifier" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const rateLimit = checkRateLimit(req, {
+    userId: user?.id ?? null,
+    feature: "alumni re-invite",
+    limitPerIp: 20,
+    limitPerUser: 15,
+  });
+  if (!rateLimit.ok) {
+    return buildRateLimitResponse(rateLimit);
+  }
+
+  const respond = (payload: unknown, status = 200) =>
+    NextResponse.json(payload, { status, headers: rateLimit.headers });
+
+  if (!user) {
+    return respond({ error: "Unauthorized" }, 401);
+  }
+
+  let body: z.infer<typeof reInviteSchema>;
+  try {
+    body = await validateJson(req, reInviteSchema, { maxBodyBytes: 20_000 });
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return respond({ error: error.message, details: error.details }, 400);
+    }
+    return respond({ error: "Invalid request" }, 400);
+  }
+
+  const serviceSupabase = createServiceClient();
+
+  let membership;
+  try {
+    membership = await getOrgMembership(serviceSupabase, user.id, organizationId);
+  } catch (error) {
+    console.error("[alumni/re-invite POST] Failed to verify membership:", error);
+    return respond({ error: "Unable to verify permissions" }, 500);
+  }
+
+  if (membership?.role !== "admin") {
+    return respond({ error: "Forbidden" }, 403);
+  }
+
+  const alumniIds = [...new Set(body.alumniIds)];
+
+  // Load every requested alumnus, org-scoped + non-deleted. Rows that aren't
+  // returned (wrong org, soft-deleted, bad id) become per-id "not_found" skips.
+  // The invite-tracking columns are new (generated DB types lag the migration),
+  // so this query runs through an any-typed client, mirroring import-csv.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: alumniData, error: alumniError } = await (serviceSupabase as any)
+    .from("alumni")
+    .select("id, user_id, email, first_name, last_invite_sent_at, invite_count")
+    .eq("organization_id", organizationId)
+    .is("deleted_at", null)
+    .in("id", alumniIds);
+
+  if (alumniError) {
+    console.error("[alumni/re-invite POST] Failed to load alumni:", alumniError);
+    return respond({ error: "Failed to load alumni" }, 500);
+  }
+
+  const byId = new Map<string, AlumniReInviteRow>();
+  for (const row of (alumniData ?? []) as AlumniReInviteRow[]) {
+    byId.set(row.id, row);
+  }
+
+  const nowMs = Date.now();
+  const results: ReInviteResult[] = [];
+  const sendable: AlumniReInviteRow[] = [];
+
+  // Partition requested ids into immediate skips vs. sendable targets. A row is
+  // sendable only if unclaimed, has an email, and is past its cooldown.
+  for (const id of alumniIds) {
+    const row = byId.get(id);
+    if (!row) {
+      results.push({ alumniId: id, status: "skipped", reason: "not_found" });
+      continue;
+    }
+    if (row.user_id) {
+      results.push({ alumniId: id, status: "skipped", reason: "linked" });
+      continue;
+    }
+    if (!row.email) {
+      results.push({ alumniId: id, status: "skipped", reason: "no_email" });
+      continue;
+    }
+    if (
+      row.last_invite_sent_at &&
+      nowMs - Date.parse(row.last_invite_sent_at) < REINVITE_COOLDOWN_MS
+    ) {
+      results.push({ alumniId: id, status: "skipped", reason: "cooldown" });
+      continue;
+    }
+    sendable.push(row);
+  }
+
+  if (sendable.length > 0) {
+    const sendResults = await sendCohortInvites({
+      serviceSupabase,
+      userSupabase: supabase,
+      organizationId,
+      actorUserId: user.id,
+      sendable,
+      nowMs,
+    });
+    results.push(...sendResults);
+  }
+
+  // `sent_unstamped` emails reached the recipient, so they count toward `sent`;
+  // `sentUnstamped` surfaces the cooldown-bookkeeping miss separately.
+  const sentUnstamped = results.filter((r) => r.status === "sent_unstamped").length;
+  const sent = results.filter((r) => r.status === "sent").length + sentUnstamped;
+  const skipped = results.filter((r) => r.status === "skipped").length;
+  const failed = results.filter((r) => r.status === "failed").length;
+
+  return respond({ sent, sentUnstamped, skipped, failed, results });
+}
+
+interface SendCohortInput {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  serviceSupabase: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userSupabase: any;
+  organizationId: string;
+  actorUserId: string;
+  sendable: AlumniReInviteRow[];
+  nowMs: number;
+}
+
+/**
+ * Create one alumni invite for the cohort, then email each target and stamp its
+ * cooldown on success. Mirrors the CSV-import re-invite path: create_org_invite
+ * runs through the *user* client (it is SECURITY DEFINER and checks the caller's
+ * admin role via auth.uid()), then sendEmail fans out at CONCURRENCY.
+ */
+async function sendCohortInvites(input: SendCohortInput): Promise<ReInviteResult[]> {
+  const { serviceSupabase, userSupabase, organizationId, actorUserId, sendable, nowMs } = input;
+
+  const { data: invite, error: inviteError } = await (userSupabase as OrgInviteRpc).rpc(
+    "create_org_invite",
+    {
+      p_organization_id: organizationId,
+      p_role: "alumni",
+      p_uses: sendable.length,
+      p_expires_at: null,
+    }
+  );
+
+  if (inviteError || !invite) {
+    console.error("[alumni/re-invite POST] Failed to create invite:", inviteError);
+    // The whole cohort fails to send — no cooldown stamped, so a retry is clean.
+    return sendable.map((row) => ({
+      alumniId: row.id,
+      status: "failed" as const,
+      reason: "send_failed" as const,
+    }));
+  }
+
+  const { data: orgData } = await serviceSupabase
+    .from("organizations")
+    .select("name")
+    .eq("id", organizationId)
+    .maybeSingle();
+
+  const orgName = orgData?.name ?? "your alumni network";
+  const joinLink = buildInviteLink({
+    kind: "org",
+    baseUrl: getAppUrl(),
+    orgId: organizationId,
+    code: invite.code ?? null,
+    token: invite.token ?? null,
+  });
+
+  const sentAt = new Date(nowMs).toISOString();
+
+  const tasks = sendable.map((row) => async (): Promise<ReInviteResult> => {
+    const emailResult = await sendEmail({
+      to: row.email as string,
+      subject: `You've been added to ${orgName}'s alumni network`,
+      body: [
+        `Hi ${row.first_name ?? "there"},`,
+        "",
+        `You've been added to ${orgName}'s alumni network on TeamNetwork.`,
+        "",
+        `Click the link below to join and access your alumni profile:`,
+        joinLink,
+        "",
+        "If you have any questions, reply to this email.",
+        "",
+        "Best regards,",
+        `The ${orgName} Team`,
+      ].join("\n"),
+    });
+
+    // sendEmail never throws; a non-success result is a per-recipient failure.
+    // Do NOT bump the cooldown on failure — that would falsely block a retry.
+    if (!emailResult.success) {
+      return { alumniId: row.id, status: "failed", reason: "send_failed" };
+    }
+
+    // Stamp the durable cooldown + bump the counter. supabase-js can't do an
+    // atomic `col + 1` in .update(), so increment from the row we loaded; the
+    // ids are deduped and an admin sends once, so there's no concurrent writer.
+    const { error: updateError } = await serviceSupabase
+      .from("alumni")
+      .update({
+        last_invite_sent_at: sentAt,
+        invite_count: (row.invite_count ?? 0) + 1,
+      })
+      .eq("id", row.id)
+      .eq("organization_id", organizationId)
+      .is("deleted_at", null)
+      .is("user_id", null);
+
+    // The email already went out, so we always audit (below). But if the
+    // cooldown stamp failed, the durable 14-day gate is NOT recorded — report
+    // `sent_unstamped` rather than a clean `sent` so an immediate re-send can't
+    // silently slip past the cooldown.
+    const stamped = !updateError;
+    if (updateError) {
+      console.error("[alumni/re-invite POST] Failed to stamp cooldown:", updateError);
+    }
+
+    // Audit trail — mirror the link-user route's direct insert into the
+    // org-scoped admin audit table (TEXT resource_type, service-role-only RLS).
+    // Written whether or not the stamp succeeded: it records that this alumnus
+    // was actually emailed, which is exactly the fact a missed cooldown needs.
+    const { error: auditError } = await serviceSupabase.from("data_access_log").insert({
+      actor_user_id: actorUserId,
+      resource_type: "alumni_reinvite",
+      resource_id: row.id,
+      organization_id: organizationId,
+    });
+    if (auditError) {
+      console.error("[alumni/re-invite POST] Failed to write audit log:", auditError);
+    }
+
+    return stamped
+      ? { alumniId: row.id, status: "sent" }
+      : { alumniId: row.id, status: "sent_unstamped", reason: "stamp_failed" };
+  });
+
+  const results: ReInviteResult[] = [];
+  for (let i = 0; i < tasks.length; i += CONCURRENCY) {
+    const batch = tasks.slice(i, i + CONCURRENCY).map((task) => task());
+    const settled = await Promise.allSettled(batch);
+    for (let j = 0; j < settled.length; j++) {
+      const res = settled[j];
+      if (res.status === "fulfilled") {
+        results.push(res.value);
+      } else {
+        console.error("[alumni/re-invite POST] Send task rejected:", res.reason);
+        results.push({
+          alumniId: sendable[i + j].id,
+          status: "failed",
+          reason: "send_failed",
+        });
+      }
+    }
+  }
+
+  return results;
+}

--- a/apps/web/src/lib/alumni/reachability-segments.ts
+++ b/apps/web/src/lib/alumni/reachability-segments.ts
@@ -1,0 +1,136 @@
+import { CHAT_ELIGIBLE_ORG_ROLES } from "@/lib/chat/recipient-eligibility";
+
+/**
+ * Shared reachability predicate for an org's `alumni` roster.
+ *
+ * A network is only worth its *reachable* nodes. An alumnus is reachable when
+ * they are linked to a user that carries an active chat-eligible org role — the
+ * same predicate `loadActiveLinkedAlumni` (chat/direct-chat.ts) applies to
+ * decide who can be messaged. Unclaimed alumni (`user_id` null) are dead nodes.
+ *
+ * Two surfaces consume this module:
+ *   - the data-health card (counts only), via {@link reachability-health.ts}
+ *   - the cohort console (per-row list), via the cohorts API route
+ * Both classify with {@link classifyAlumniReachability}, so they can never
+ * disagree about who is reachable.
+ */
+
+/** The five mutually-exclusive reachability states an alumnus can be in. */
+export type ReachabilitySegment =
+  /** Linked AND active chat-eligible role — the truly reachable. */
+  | "linkedEligible"
+  /** Linked but no active chat-eligible role — linked, can't chat. */
+  | "linkedNotEligible"
+  /** Unclaimed with an email on file — the re-invite target. */
+  | "unclaimedWithEmail"
+  /** Unclaimed with no email — structurally unreachable. */
+  | "unclaimedNoEmail"
+  /** Soft-deleted alumni — excluded from totals. */
+  | "softDeleted";
+
+/**
+ * The minimal alumnus shape the classifier reads. Any richer alumni row (the
+ * console pulls names + invite tracking too) structurally satisfies this.
+ */
+export interface ReachabilityClassifiable {
+  user_id: string | null;
+  email: string | null;
+  deleted_at: string | null;
+}
+
+/**
+ * Classify a single alumnus into its reachability segment.
+ *
+ * `eligibleUserIds` is the set of linked user_ids that carry an active
+ * chat-eligible org role (resolved once per scan, mirroring
+ * loadActiveLinkedAlumni). Soft-deleted rows short-circuit first so they never
+ * land in a live segment.
+ */
+export function classifyAlumniReachability(
+  row: ReachabilityClassifiable,
+  eligibleUserIds: ReadonlySet<string>
+): ReachabilitySegment {
+  if (row.deleted_at) return "softDeleted";
+  if (row.user_id) {
+    return eligibleUserIds.has(row.user_id) ? "linkedEligible" : "linkedNotEligible";
+  }
+  if (row.email) return "unclaimedWithEmail";
+  return "unclaimedNoEmail";
+}
+
+/** Roles re-exported so callers resolving eligibility never re-list them. */
+export { CHAT_ELIGIBLE_ORG_ROLES };
+
+/** Page size + hard cap shared by every reachability scan. */
+export const REACHABILITY_PAGE_SIZE = 1000;
+export const REACHABILITY_MAX_ROWS = REACHABILITY_PAGE_SIZE * 20;
+
+function toMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message: unknown }).message;
+    if (typeof message === "string" && message.length > 0) return message;
+  }
+  return "unknown_error";
+}
+
+/**
+ * Page a `.range()`-driven query to the shared cap. Throws on the first query
+ * error (callers wrap in try/catch); returns `truncated` when the cap is hit.
+ */
+export async function fetchAllPaged<T>(
+  build: (from: number, to: number) => Promise<{ data: unknown; error: unknown }>
+): Promise<{ rows: T[]; truncated: boolean }> {
+  const rows: T[] = [];
+  let from = 0;
+  while (from < REACHABILITY_MAX_ROWS) {
+    const { data, error } = await build(from, from + REACHABILITY_PAGE_SIZE - 1);
+    if (error) throw new Error(toMessage(error));
+    const page = (data ?? []) as T[];
+    rows.push(...page);
+    if (page.length < REACHABILITY_PAGE_SIZE) return { rows, truncated: false };
+    from += REACHABILITY_PAGE_SIZE;
+  }
+  return { rows, truncated: true };
+}
+
+/**
+ * Resolve the subset of `linkedUserIds` that carry an active chat-eligible org
+ * role — the eligibility half of the reachability predicate, mirroring
+ * loadActiveLinkedAlumni (chat/direct-chat.ts). Returns the set plus whether
+ * the role scan was truncated. Both reachability surfaces call this, so they
+ * resolve eligibility identically.
+ */
+export async function resolveEligibleUserIds(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sb: any,
+  orgId: string,
+  linkedUserIds: string[]
+): Promise<{ eligibleUserIds: Set<string>; truncated: boolean }> {
+  if (linkedUserIds.length === 0) {
+    return { eligibleUserIds: new Set<string>(), truncated: false };
+  }
+  const { rows, truncated } = await fetchAllPaged<{ user_id: string | null }>((from, to) =>
+    sb
+      .from("user_organization_roles")
+      .select("user_id")
+      .eq("organization_id", orgId)
+      .eq("status", "active")
+      .in("role", CHAT_ELIGIBLE_ORG_ROLES)
+      .in("user_id", linkedUserIds)
+      .range(from, to)
+  );
+  const eligibleUserIds = new Set(
+    rows.map((row) => row.user_id).filter((value): value is string => Boolean(value))
+  );
+  return { eligibleUserIds, truncated };
+}
+
+/** Distinct non-null user_ids across a set of alumni rows. */
+export function linkedUserIdsOf(rows: { user_id: string | null }[]): string[] {
+  return [
+    ...new Set(
+      rows.map((row) => row.user_id).filter((value): value is string => Boolean(value))
+    ),
+  ];
+}

--- a/apps/web/src/lib/audit/data-access-log.ts
+++ b/apps/web/src/lib/audit/data-access-log.ts
@@ -1,7 +1,13 @@
 import { createServiceClient } from "@/lib/supabase/service";
 import { hashIp, getClientIp } from "@/lib/compliance/audit-log";
 
-type ResourceType = "member_profile" | "form_submission" | "data_export" | "roster_download";
+type ResourceType =
+  | "member_profile"
+  | "form_submission"
+  | "data_export"
+  | "roster_download"
+  | "alumni_user_link"
+  | "alumni_reinvite";
 
 /**
  * Log an access event to the data_access_log table.

--- a/apps/web/src/lib/health/org-data-health.ts
+++ b/apps/web/src/lib/health/org-data-health.ts
@@ -4,6 +4,10 @@ import {
   checkEnrichmentHealth,
   type EnrichmentHealthReport,
 } from "@/lib/linkedin/enrichment-health";
+import {
+  checkReachabilityHealth,
+  type ReachabilityHealthReport,
+} from "@/lib/health/reachability-health";
 
 /**
  * Consolidated read-only data-health report for one org, spanning the two
@@ -14,6 +18,9 @@ import {
  * The people-graph is served directly from Postgres (`mentorship_pairs` +
  * member/alumni projections), so there is no separate store to drift against.
  *
+ *  - reachability: which alumni are linked + chat-eligible vs. unclaimed dead
+ *    nodes — diagnoses how much of the network is actually reachable.
+ *
  * Each section degrades independently — a section that cannot be computed
  * reports `degraded` rather than failing the whole report.
  */
@@ -21,6 +28,7 @@ export interface OrgDataHealthReport {
   orgId: string;
   rag: RagHealthReport;
   enrichment: EnrichmentHealthReport;
+  reachability: ReachabilityHealthReport;
 }
 
 interface GetOrgDataHealthOptions {
@@ -33,14 +41,16 @@ export async function getOrgDataHealth(
   orgId: string,
   options: GetOrgDataHealthOptions = {}
 ): Promise<OrgDataHealthReport> {
-  const [rag, enrichment] = await Promise.all([
+  const [rag, enrichment, reachability] = await Promise.all([
     checkRagHealth(serviceSupabase, orgId),
     checkEnrichmentHealth(serviceSupabase, orgId, { now: options.now }),
+    checkReachabilityHealth(serviceSupabase, orgId),
   ]);
 
   return {
     orgId,
     rag,
     enrichment,
+    reachability,
   };
 }

--- a/apps/web/src/lib/health/reachability-health.ts
+++ b/apps/web/src/lib/health/reachability-health.ts
@@ -1,0 +1,189 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  classifyAlumniReachability,
+  fetchAllPaged,
+  linkedUserIdsOf,
+  resolveEligibleUserIds,
+  type ReachabilitySegment,
+} from "@/lib/alumni/reachability-segments";
+
+/**
+ * Read-only reachability checker for an org's `alumni` roster.
+ *
+ * A network is only worth its *reachable* nodes. An alumnus is reachable when
+ * they are linked to a user that carries an active chat-eligible org role —
+ * the same predicate `loadActiveLinkedAlumni` (chat/direct-chat.ts) applies to
+ * decide who can be messaged. Unclaimed alumni (`user_id` null) are dead nodes:
+ * they can't be messaged and can't be surfaced into warm paths.
+ *
+ * This module computes all five mutually-exclusive reachability segments. The
+ * data-health card renders four counts derived from them; the segment counts
+ * are the seam a future cohort console reuses, so the two surfaces can never
+ * disagree about who is reachable.
+ *
+ * Runs on the service-role client (RLS-bypassing, admin-gated upstream) and
+ * emits counts only — no emails or PII leave the module.
+ */
+
+/**
+ * Mutually-exclusive reachability segments over an org's alumni rows.
+ * The first four partition the non-deleted alumni; `softDeleted` is disjoint
+ * and excluded from every total.
+ */
+export interface ReachabilitySegmentCounts {
+  /** Linked AND active chat-eligible role — the truly reachable. */
+  linkedEligible: number;
+  /** Linked but no active chat-eligible role — linked, can't chat. */
+  linkedNotEligible: number;
+  /** Unclaimed with an email on file — the re-invite target. */
+  unclaimedWithEmail: number;
+  /** Unclaimed with no email — structurally unreachable. */
+  unclaimedNoEmail: number;
+  /** Soft-deleted alumni — excluded from totals. */
+  softDeleted: number;
+}
+
+export interface ReachabilityHealthReport {
+  orgId: string;
+  state: "ok" | "gaps" | "degraded";
+  reason: string | null;
+  segments: ReachabilitySegmentCounts;
+  /** Card-facing counts, all derived from {@link ReachabilitySegmentCounts}. */
+  counts: {
+    /** Non-deleted alumni (the partition the card totals over). */
+    totalAlumni: number;
+    /** Non-deleted alumni with a linked user_id. */
+    linkedAlumni: number;
+    /** linkedEligible / linkedAlumni as a 0–100 integer percent (0 when none linked). */
+    chatEligiblePercent: number;
+    /** Re-invitable stragglers. */
+    unclaimedWithEmail: number;
+  };
+  truncated: boolean;
+}
+
+interface AlumniRow {
+  id: string;
+  user_id: string | null;
+  email: string | null;
+}
+
+function toMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message: unknown }).message;
+    if (typeof message === "string" && message.length > 0) return message;
+  }
+  return "unknown_error";
+}
+
+const ZERO_SEGMENTS: ReachabilitySegmentCounts = {
+  linkedEligible: 0,
+  linkedNotEligible: 0,
+  unclaimedWithEmail: 0,
+  unclaimedNoEmail: 0,
+  softDeleted: 0,
+};
+
+function degraded(orgId: string, reason: string): ReachabilityHealthReport {
+  return {
+    orgId,
+    state: "degraded",
+    reason,
+    segments: { ...ZERO_SEGMENTS },
+    counts: {
+      totalAlumni: 0,
+      linkedAlumni: 0,
+      chatEligiblePercent: 0,
+      unclaimedWithEmail: 0,
+    },
+    truncated: false,
+  };
+}
+
+export async function checkReachabilityHealth(
+  serviceSupabase: SupabaseClient,
+  orgId: string
+): Promise<ReachabilityHealthReport> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = serviceSupabase as any;
+
+  let nonDeleted: AlumniRow[];
+  let softDeletedCount: number;
+  let truncated = false;
+
+  try {
+    // Soft-deleted alumni: counted (head only — they never enter a segment scan).
+    const { count: deletedCount, error: deletedError } = await sb
+      .from("alumni")
+      .select("id", { count: "exact", head: true })
+      .eq("organization_id", orgId)
+      .not("deleted_at", "is", null);
+    if (deletedError) return degraded(orgId, toMessage(deletedError));
+    softDeletedCount = typeof deletedCount === "number" ? deletedCount : 0;
+
+    // Non-deleted alumni rows: the partition the four live segments cover.
+    // We need user_id + email per row to bucket them, so we page the rows
+    // (bounded by the shared cap) rather than issuing four separate count
+    // queries that could drift from one another.
+    const alumniResult = await fetchAllPaged<AlumniRow>((from, to) =>
+      sb
+        .from("alumni")
+        .select("id, user_id, email")
+        .eq("organization_id", orgId)
+        .is("deleted_at", null)
+        .range(from, to)
+    );
+    nonDeleted = alumniResult.rows;
+    truncated = alumniResult.truncated;
+  } catch (error) {
+    return degraded(orgId, toMessage(error));
+  }
+
+  // Resolve which linked user_ids carry an active chat-eligible org role —
+  // shared with the cohort console's list path, so both resolve eligibility
+  // identically (and the roles are never re-listed here).
+  let eligibleUserIds: Set<string>;
+  try {
+    const resolved = await resolveEligibleUserIds(sb, orgId, linkedUserIdsOf(nonDeleted));
+    eligibleUserIds = resolved.eligibleUserIds;
+    truncated = truncated || resolved.truncated;
+  } catch (error) {
+    return degraded(orgId, toMessage(error));
+  }
+
+  // Bucket every non-deleted row through the shared classifier — the same
+  // predicate the cohort console's list path uses, so counts can't drift from
+  // the per-row segmentation. softDeleted is counted separately (head query);
+  // these rows are pre-filtered to deleted_at IS NULL, so the classifier never
+  // returns "softDeleted" here.
+  const segments: ReachabilitySegmentCounts = { ...ZERO_SEGMENTS, softDeleted: softDeletedCount };
+  for (const row of nonDeleted) {
+    const segment: ReachabilitySegment = classifyAlumniReachability(
+      { user_id: row.user_id, email: row.email, deleted_at: null },
+      eligibleUserIds
+    );
+    segments[segment] += 1;
+  }
+
+  const totalAlumni = nonDeleted.length;
+  const linkedAlumni = segments.linkedEligible + segments.linkedNotEligible;
+  const chatEligiblePercent =
+    linkedAlumni > 0 ? Math.round((segments.linkedEligible / linkedAlumni) * 100) : 0;
+
+  return {
+    orgId,
+    // Re-invitable stragglers are a remediable gap, mirroring the sibling
+    // checkers that report `gaps` when there is actionable divergence.
+    state: segments.unclaimedWithEmail > 0 ? "gaps" : "ok",
+    reason: truncated ? "partial_scan" : null,
+    segments,
+    counts: {
+      totalAlumni,
+      linkedAlumni,
+      chatEligiblePercent,
+      unclaimedWithEmail: segments.unclaimedWithEmail,
+    },
+    truncated,
+  };
+}

--- a/apps/web/tests/routes/organizations/alumni-reinvite.test.ts
+++ b/apps/web/tests/routes/organizations/alumni-reinvite.test.ts
@@ -1,0 +1,436 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { createSupabaseStub } from "../../utils/supabaseStub.ts";
+import { checkReachabilityHealth } from "../../../src/lib/health/reachability-health.ts";
+import { classifyAlumniReachability } from "../../../src/lib/alumni/reachability-segments.ts";
+
+const ORG_ID = "11111111-1111-1111-1111-111111111111";
+
+const reInviteSource = await readFile(
+  new URL(
+    "../../../src/app/api/organizations/[organizationId]/alumni/re-invite/route.ts",
+    import.meta.url
+  ),
+  "utf8"
+);
+
+const cohortsSource = await readFile(
+  new URL(
+    "../../../src/app/api/organizations/[organizationId]/alumni/cohorts/route.ts",
+    import.meta.url
+  ),
+  "utf8"
+);
+
+// ── Source assertions: the route's authorization + safety invariants ─────────
+
+test("re-invite route exports POST and is admin-only", () => {
+  assert.match(reInviteSource, /export async function POST/);
+  assert.match(reInviteSource, /membership\?\.role !== "admin"/);
+  assert.match(reInviteSource, /Forbidden/);
+});
+
+test("re-invite route validates a bounded alumniIds uuid array", () => {
+  assert.match(reInviteSource, /alumniIds: z\.array\(baseSchemas\.uuid\)/);
+  assert.match(reInviteSource, /\.max\(200\)/);
+  assert.match(reInviteSource, /validateJson\(req, reInviteSchema/);
+});
+
+test("re-invite route enforces a 14-day durable cooldown", () => {
+  assert.match(reInviteSource, /14 \* 24 \* 60 \* 60 \* 1000/);
+  assert.match(reInviteSource, /reason: "cooldown"/);
+  assert.match(reInviteSource, /last_invite_sent_at/);
+});
+
+test("re-invite route only targets unclaimed, emailed, non-deleted alumni", () => {
+  // user_id IS NULL guard on both the partition and the update
+  assert.match(reInviteSource, /reason: "linked"/);
+  assert.match(reInviteSource, /reason: "no_email"/);
+  assert.match(reInviteSource, /\.is\("deleted_at", null\)/);
+  assert.match(reInviteSource, /\.is\("user_id", null\)/);
+});
+
+test("re-invite route creates the invite through the user client (SECURITY DEFINER admin check)", () => {
+  // create_org_invite checks auth.uid()'s admin role, so it must run on the
+  // user client, not the service client.
+  assert.match(reInviteSource, /userSupabase as OrgInviteRpc\)\.rpc\(\s*"create_org_invite"/);
+  assert.match(reInviteSource, /buildInviteLink/);
+});
+
+test("re-invite route does NOT stamp a cooldown on send failure", () => {
+  // The cooldown update must be gated behind a successful send.
+  assert.match(reInviteSource, /if \(!emailResult\.success\)/);
+  // failure path returns before the alumni update
+  const failIdx = reInviteSource.indexOf('status: "failed", reason: "send_failed"');
+  const updateIdx = reInviteSource.indexOf("last_invite_sent_at: sentAt");
+  assert.ok(failIdx !== -1 && updateIdx !== -1 && failIdx < updateIdx);
+});
+
+test("re-invite route reports sent_unstamped when the cooldown stamp fails after send", () => {
+  // The email went out but the durable gate wasn't recorded — must be surfaced
+  // distinctly so an immediate re-send can't silently bypass the cooldown.
+  assert.match(reInviteSource, /sent_unstamped/);
+  assert.match(reInviteSource, /reason: "stamp_failed"/);
+  assert.match(reInviteSource, /const stamped = !updateError/);
+});
+
+test("re-invite route audits each send into data_access_log", () => {
+  assert.match(reInviteSource, /data_access_log/);
+  assert.match(reInviteSource, /resource_type: "alumni_reinvite"/);
+  assert.match(reInviteSource, /actor_user_id: actorUserId/);
+});
+
+test("cohorts route is admin-only and returns segmented entries", () => {
+  assert.match(cohortsSource, /export async function GET/);
+  assert.match(cohortsSource, /membership\?\.role !== "admin"/);
+  assert.match(cohortsSource, /classifyAlumniReachability/);
+});
+
+// ── Classifier parity: the list path and the count path must agree ───────────
+// Both surfaces classify with classifyAlumniReachability. This test runs the
+// real count path (checkReachabilityHealth) over a stub, then independently
+// classifies the same rows the way the cohorts route does, and asserts the
+// per-segment tallies match exactly. Guards against drift between the two.
+
+interface Fixture {
+  id: string;
+  user_id: string | null;
+  email: string | null;
+  deleted_at: string | null;
+}
+
+function seedFixtures(stub: ReturnType<typeof createSupabaseStub>, rows: Fixture[]) {
+  stub.seed(
+    "alumni",
+    rows.map((r) => ({ organization_id: ORG_ID, ...r }))
+  );
+}
+
+test("count path and list path produce identical segment tallies", async () => {
+  const stub = createSupabaseStub();
+  const rows: Fixture[] = [
+    { id: "a-elig", user_id: "u-elig", email: "e@x.com", deleted_at: null },
+    { id: "a-elig2", user_id: "u-elig2", email: "e2@x.com", deleted_at: null },
+    { id: "a-noelig", user_id: "u-noelig", email: "n@x.com", deleted_at: null },
+    { id: "a-unclaimed", user_id: null, email: "u@x.com", deleted_at: null },
+    { id: "a-noemail", user_id: null, email: null, deleted_at: null },
+    { id: "a-deleted", user_id: "u-del", email: "d@x.com", deleted_at: "2026-01-01T00:00:00.000Z" },
+  ];
+  seedFixtures(stub, rows);
+  // u-elig + u-elig2 carry an active chat-eligible role; u-noelig does not.
+  stub.seed("user_organization_roles", [
+    { organization_id: ORG_ID, user_id: "u-elig", status: "active", role: "alumni" },
+    { organization_id: ORG_ID, user_id: "u-elig2", status: "active", role: "admin" },
+  ]);
+
+  // Count path (data-health card).
+  const report = await checkReachabilityHealth(stub as any, ORG_ID);
+
+  // List path (cohorts route): resolve the same eligible set, classify each
+  // non-deleted row, then tally.
+  const eligibleUserIds = new Set(["u-elig", "u-elig2"]);
+  const listTally = {
+    linkedEligible: 0,
+    linkedNotEligible: 0,
+    unclaimedWithEmail: 0,
+    unclaimedNoEmail: 0,
+    softDeleted: 0,
+  };
+  for (const row of rows) {
+    const segment = classifyAlumniReachability(row, eligibleUserIds);
+    listTally[segment] += 1;
+  }
+
+  // The count path counts soft-deleted via a separate head query, so compare
+  // the four live segments plus the (independently counted) soft-deleted total.
+  assert.equal(report.segments.linkedEligible, listTally.linkedEligible);
+  assert.equal(report.segments.linkedNotEligible, listTally.linkedNotEligible);
+  assert.equal(report.segments.unclaimedWithEmail, listTally.unclaimedWithEmail);
+  assert.equal(report.segments.unclaimedNoEmail, listTally.unclaimedNoEmail);
+  assert.equal(report.segments.softDeleted, listTally.softDeleted);
+
+  // Sanity: the expected split.
+  assert.deepEqual(listTally, {
+    linkedEligible: 2,
+    linkedNotEligible: 1,
+    unclaimedWithEmail: 1,
+    unclaimedNoEmail: 1,
+    softDeleted: 1,
+  });
+});
+
+// ── Re-invite logic simulator ────────────────────────────────────────────────
+// Mirrors the route's partition + send semantics (the route handler itself
+// needs mocked Supabase/Resend clients, so — like the link-user route test —
+// the decision tree is re-implemented and exercised directly).
+
+const COOLDOWN_MS = 14 * 24 * 60 * 60 * 1000;
+
+interface SimAlumnus {
+  id: string;
+  user_id: string | null;
+  email: string | null;
+  last_invite_sent_at: string | null;
+  invite_count: number;
+  deleted_at?: string | null;
+}
+
+interface SimResult {
+  alumniId: string;
+  status: "sent" | "sent_unstamped" | "skipped" | "failed";
+  reason?: string;
+}
+
+interface SimOutcome {
+  results: SimResult[];
+  sent: number;
+  skipped: number;
+  failed: number;
+  // Post-send state keyed by id (mutated copies).
+  rows: Map<string, SimAlumnus>;
+  audits: { actorUserId: string; resourceType: string; resourceId: string }[];
+}
+
+/**
+ * Re-implements the re-invite route's per-id decision tree. `sendOk` controls
+ * whether the (single) cohort email send succeeds — modelling sendEmail's
+ * success flag. `stampOk` (default true) controls whether the post-send cooldown
+ * UPDATE succeeds; when false the email still went out but the durable gate is
+ * not recorded, so the result is `sent_unstamped`. `now` is the reference time
+ * for cooldown checks.
+ */
+function simulateReInvite(opts: {
+  requestedIds: string[];
+  roster: SimAlumnus[];
+  actorUserId: string;
+  now: number;
+  sendOk: boolean;
+  stampOk?: boolean;
+}): SimOutcome {
+  const { requestedIds, roster, actorUserId, now, sendOk, stampOk = true } = opts;
+  const rows = new Map<string, SimAlumnus>();
+  for (const r of roster) {
+    if (!r.deleted_at) rows.set(r.id, { ...r });
+  }
+
+  const ids = [...new Set(requestedIds)];
+  const results: SimResult[] = [];
+  const sendable: SimAlumnus[] = [];
+  const audits: SimOutcome["audits"] = [];
+
+  for (const id of ids) {
+    const row = rows.get(id);
+    if (!row) {
+      results.push({ alumniId: id, status: "skipped", reason: "not_found" });
+      continue;
+    }
+    if (row.user_id) {
+      results.push({ alumniId: id, status: "skipped", reason: "linked" });
+      continue;
+    }
+    if (!row.email) {
+      results.push({ alumniId: id, status: "skipped", reason: "no_email" });
+      continue;
+    }
+    if (row.last_invite_sent_at && now - Date.parse(row.last_invite_sent_at) < COOLDOWN_MS) {
+      results.push({ alumniId: id, status: "skipped", reason: "cooldown" });
+      continue;
+    }
+    sendable.push(row);
+  }
+
+  for (const row of sendable) {
+    if (!sendOk) {
+      // No cooldown stamp, no counter bump, no audit on failure.
+      results.push({ alumniId: row.id, status: "failed", reason: "send_failed" });
+      continue;
+    }
+    // The email went out — always audit, whether or not the stamp lands.
+    if (stampOk) {
+      row.last_invite_sent_at = new Date(now).toISOString();
+      row.invite_count += 1;
+    }
+    audits.push({
+      actorUserId,
+      resourceType: "alumni_reinvite",
+      resourceId: row.id,
+    });
+    results.push(
+      stampOk
+        ? { alumniId: row.id, status: "sent" }
+        : { alumniId: row.id, status: "sent_unstamped", reason: "stamp_failed" }
+    );
+  }
+
+  // sent_unstamped emails reached the recipient, so count toward `sent`.
+  const sent = results.filter(
+    (r) => r.status === "sent" || r.status === "sent_unstamped"
+  ).length;
+  return {
+    results,
+    sent,
+    skipped: results.filter((r) => r.status === "skipped").length,
+    failed: results.filter((r) => r.status === "failed").length,
+    rows,
+    audits,
+  };
+}
+
+function unclaimed(overrides: Partial<SimAlumnus> = {}): SimAlumnus {
+  return {
+    id: randomUUID(),
+    user_id: null,
+    email: "a@x.com",
+    last_invite_sent_at: null,
+    invite_count: 0,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+const NOW = Date.parse("2026-06-24T00:00:00.000Z");
+
+test("unclaimed-with-email alum is sent, stamped, counted, and audited", () => {
+  const actor = randomUUID();
+  const alum = unclaimed();
+  const out = simulateReInvite({
+    requestedIds: [alum.id],
+    roster: [alum],
+    actorUserId: actor,
+    now: NOW,
+    sendOk: true,
+  });
+
+  assert.equal(out.sent, 1);
+  assert.equal(out.results[0].status, "sent");
+  const after = out.rows.get(alum.id)!;
+  assert.equal(after.last_invite_sent_at, new Date(NOW).toISOString());
+  assert.equal(after.invite_count, 1);
+  assert.deepEqual(out.audits, [
+    { actorUserId: actor, resourceType: "alumni_reinvite", resourceId: alum.id },
+  ]);
+});
+
+test("an alum invited 5 days ago is skipped for cooldown — no new invite, counters unchanged", () => {
+  const recent = new Date(NOW - 5 * 24 * 60 * 60 * 1000).toISOString();
+  const alum = unclaimed({ last_invite_sent_at: recent, invite_count: 1 });
+  const out = simulateReInvite({
+    requestedIds: [alum.id],
+    roster: [alum],
+    actorUserId: randomUUID(),
+    now: NOW,
+    sendOk: true,
+  });
+
+  assert.equal(out.sent, 0);
+  assert.equal(out.skipped, 1);
+  assert.equal(out.results[0].reason, "cooldown");
+  const after = out.rows.get(alum.id)!;
+  assert.equal(after.last_invite_sent_at, recent);
+  assert.equal(after.invite_count, 1);
+  assert.equal(out.audits.length, 0);
+});
+
+test("an alum invited 20 days ago is past cooldown and sends", () => {
+  const old = new Date(NOW - 20 * 24 * 60 * 60 * 1000).toISOString();
+  const alum = unclaimed({ last_invite_sent_at: old, invite_count: 2 });
+  const out = simulateReInvite({
+    requestedIds: [alum.id],
+    roster: [alum],
+    actorUserId: randomUUID(),
+    now: NOW,
+    sendOk: true,
+  });
+
+  assert.equal(out.sent, 1);
+  assert.equal(out.rows.get(alum.id)!.invite_count, 3);
+});
+
+test("ineligible targets are skipped, never invited", () => {
+  const linked = unclaimed({ user_id: randomUUID() });
+  const noEmail = unclaimed({ email: null });
+  const deleted = unclaimed({ deleted_at: "2026-01-01T00:00:00.000Z" });
+  const out = simulateReInvite({
+    requestedIds: [linked.id, noEmail.id, deleted.id],
+    roster: [linked, noEmail, deleted],
+    actorUserId: randomUUID(),
+    now: NOW,
+    sendOk: true,
+  });
+
+  assert.equal(out.sent, 0);
+  assert.equal(out.skipped, 3);
+  const reasons = out.results.map((r) => r.reason).sort();
+  assert.deepEqual(reasons, ["linked", "no_email", "not_found"]);
+  assert.equal(out.audits.length, 0);
+});
+
+test("send failure counts as failed, leaves counters untouched (no false cooldown)", () => {
+  const alum = unclaimed();
+  const out = simulateReInvite({
+    requestedIds: [alum.id],
+    roster: [alum],
+    actorUserId: randomUUID(),
+    now: NOW,
+    sendOk: false,
+  });
+
+  assert.equal(out.failed, 1);
+  assert.equal(out.sent, 0);
+  const after = out.rows.get(alum.id)!;
+  assert.equal(after.last_invite_sent_at, null);
+  assert.equal(after.invite_count, 0);
+  assert.equal(out.audits.length, 0);
+});
+
+test("email sent but cooldown stamp failed is reported as sent_unstamped (not a clean sent)", () => {
+  // Guards the cooldown-bypass window: if the email went out but the durable
+  // stamp failed, the result must NOT masquerade as a clean `sent` (which would
+  // let an immediate re-send slip past the 14-day gate unnoticed). The audit row
+  // is still written because the alumnus was in fact emailed.
+  const actor = randomUUID();
+  const alum = unclaimed();
+  const out = simulateReInvite({
+    requestedIds: [alum.id],
+    roster: [alum],
+    actorUserId: actor,
+    now: NOW,
+    sendOk: true,
+    stampOk: false,
+  });
+
+  assert.equal(out.results[0].status, "sent_unstamped");
+  assert.equal(out.results[0].reason, "stamp_failed");
+  // The recipient was reached, so it counts toward sent…
+  assert.equal(out.sent, 1);
+  // …but the durable cooldown was NOT recorded — the next send isn't blocked.
+  const after = out.rows.get(alum.id)!;
+  assert.equal(after.last_invite_sent_at, null);
+  assert.equal(after.invite_count, 0);
+  // The email-went-out fact is audited regardless.
+  assert.deepEqual(out.audits, [
+    { actorUserId: actor, resourceType: "alumni_reinvite", resourceId: alum.id },
+  ]);
+});
+
+test("a mixed cohort reports sent/skipped/failed independently", () => {
+  const fresh = unclaimed();
+  const cooled = unclaimed({
+    last_invite_sent_at: new Date(NOW - 24 * 60 * 60 * 1000).toISOString(),
+  });
+  const linked = unclaimed({ user_id: randomUUID() });
+  const out = simulateReInvite({
+    requestedIds: [fresh.id, cooled.id, linked.id],
+    roster: [fresh, cooled, linked],
+    actorUserId: randomUUID(),
+    now: NOW,
+    sendOk: true,
+  });
+
+  assert.equal(out.sent, 1);
+  assert.equal(out.skipped, 2);
+  assert.equal(out.failed, 0);
+});

--- a/apps/web/tests/routes/organizations/data-health.test.ts
+++ b/apps/web/tests/routes/organizations/data-health.test.ts
@@ -3,10 +3,18 @@ import test, { beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { createSupabaseStub } from "../../utils/supabaseStub.ts";
 import { getOrgDataHealth } from "../../../src/lib/health/org-data-health.ts";
+import { checkReachabilityHealth } from "../../../src/lib/health/reachability-health.ts";
 import { normalizeRole } from "../../../src/lib/auth/role-utils.ts";
 import { resetSuggestionTelemetryForTests } from "../../../src/lib/people-graph/telemetry.ts";
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111";
+
+/** Seed an active chat-eligible role row for a linked user. */
+function seedEligibleRole(stub: ReturnType<typeof createSupabaseStub>, userId: string) {
+  stub.seed("user_organization_roles", [
+    { organization_id: ORG_ID, user_id: userId, status: "active", role: "alumni" },
+  ]);
+}
 
 beforeEach(() => {
   resetSuggestionTelemetryForTests();
@@ -79,4 +87,165 @@ test("getOrgDataHealth is org-scoped and surfaces another org's data nowhere", a
   // The other org's userless member must not appear in this org's report.
   assert.deepEqual(report.enrichment.userlessRows, []);
   assert.equal(JSON.stringify(report).includes("m-other"), false);
+});
+
+test("getOrgDataHealth returns the reachability section alongside rag + enrichment", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("alumni", [
+    { id: "al-linked", organization_id: ORG_ID, user_id: "u1", email: "l@x.com", deleted_at: null },
+  ]);
+  seedEligibleRole(stub, "u1");
+
+  const report = await getOrgDataHealth(stub as any, ORG_ID, {
+    now: Date.parse("2026-06-15T12:00:00.000Z"),
+  });
+
+  assert.ok(report.reachability, "report carries a reachability section");
+  assert.equal(report.reachability.orgId, ORG_ID);
+  assert.equal(report.reachability.counts.totalAlumni, 1);
+  assert.equal(report.reachability.counts.linkedAlumni, 1);
+});
+
+// --- reachability segmentation ---
+
+test("checkReachabilityHealth segments alumni across all five reachability states", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("alumni", [
+    // linkedEligible: linked + active chat-eligible role
+    { id: "a-eligible", organization_id: ORG_ID, user_id: "u-elig", email: "e@x.com", deleted_at: null },
+    // linkedNotEligible: linked, but no active chat-eligible role
+    { id: "a-noteligible", organization_id: ORG_ID, user_id: "u-noelig", email: "n@x.com", deleted_at: null },
+    // unclaimedWithEmail
+    { id: "a-unclaimed-email", organization_id: ORG_ID, user_id: null, email: "u@x.com", deleted_at: null },
+    // unclaimedNoEmail
+    { id: "a-unclaimed-noemail", organization_id: ORG_ID, user_id: null, email: null, deleted_at: null },
+    // softDeleted (excluded from totals)
+    { id: "a-deleted", organization_id: ORG_ID, user_id: "u-del", email: "d@x.com", deleted_at: "2026-01-01T00:00:00.000Z" },
+  ]);
+  seedEligibleRole(stub, "u-elig");
+  // u-noelig has an *inactive* role → not eligible
+  stub.seed("user_organization_roles", [
+    { organization_id: ORG_ID, user_id: "u-noelig", status: "inactive", role: "alumni" },
+  ]);
+
+  const report = await checkReachabilityHealth(stub as any, ORG_ID);
+
+  assert.deepEqual(report.segments, {
+    linkedEligible: 1,
+    linkedNotEligible: 1,
+    unclaimedWithEmail: 1,
+    unclaimedNoEmail: 1,
+    softDeleted: 1,
+  });
+  // Total/linked exclude the soft-deleted row.
+  assert.equal(report.counts.totalAlumni, 4);
+  assert.equal(report.counts.linkedAlumni, 2);
+  assert.equal(report.counts.unclaimedWithEmail, 1);
+  // unclaimedWithEmail > 0 → gaps
+  assert.equal(report.state, "gaps");
+});
+
+test("checkReachabilityHealth counts a linked-but-not-chat-eligible alum as linkedNotEligible", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("alumni", [
+    { id: "a", organization_id: ORG_ID, user_id: "u", email: "e@x.com", deleted_at: null },
+  ]);
+  // A role that is active but NOT in CHAT_ELIGIBLE_ORG_ROLES.
+  stub.seed("user_organization_roles", [
+    { organization_id: ORG_ID, user_id: "u", status: "active", role: "viewer" },
+  ]);
+
+  const report = await checkReachabilityHealth(stub as any, ORG_ID);
+
+  assert.equal(report.segments.linkedEligible, 0);
+  assert.equal(report.segments.linkedNotEligible, 1);
+});
+
+test("checkReachabilityHealth excludes soft-deleted alumni from total/linked/unclaimed", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("alumni", [
+    { id: "live", organization_id: ORG_ID, user_id: null, email: "x@x.com", deleted_at: null },
+    { id: "dead-linked", organization_id: ORG_ID, user_id: "u", email: "y@x.com", deleted_at: "2026-01-01T00:00:00.000Z" },
+    { id: "dead-unclaimed", organization_id: ORG_ID, user_id: null, email: "z@x.com", deleted_at: "2026-01-01T00:00:00.000Z" },
+  ]);
+  seedEligibleRole(stub, "u");
+
+  const report = await checkReachabilityHealth(stub as any, ORG_ID);
+
+  assert.equal(report.counts.totalAlumni, 1);
+  assert.equal(report.counts.linkedAlumni, 0);
+  assert.equal(report.segments.unclaimedWithEmail, 1);
+  assert.equal(report.segments.softDeleted, 2);
+});
+
+// --- chat-eligible % edge cases ---
+
+test("checkReachabilityHealth reports 0% chat-eligible when no alumni are linked", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("alumni", [
+    { id: "a", organization_id: ORG_ID, user_id: null, email: "x@x.com", deleted_at: null },
+  ]);
+
+  const report = await checkReachabilityHealth(stub as any, ORG_ID);
+
+  assert.equal(report.counts.linkedAlumni, 0);
+  assert.equal(report.counts.chatEligiblePercent, 0);
+});
+
+test("checkReachabilityHealth reports 100% when the only linked alum is chat-eligible", async () => {
+  const stub = createSupabaseStub();
+  stub.seed("alumni", [
+    { id: "a", organization_id: ORG_ID, user_id: "u", email: "x@x.com", deleted_at: null },
+  ]);
+  seedEligibleRole(stub, "u");
+
+  const report = await checkReachabilityHealth(stub as any, ORG_ID);
+
+  assert.equal(report.counts.chatEligiblePercent, 100);
+});
+
+test("checkReachabilityHealth reports 60% when 3 of 5 linked alumni are chat-eligible", async () => {
+  const stub = createSupabaseStub();
+  const linked = [];
+  for (let i = 0; i < 5; i++) {
+    linked.push({
+      id: `a${i}`,
+      organization_id: ORG_ID,
+      user_id: `u${i}`,
+      email: `e${i}@x.com`,
+      deleted_at: null,
+    });
+  }
+  stub.seed("alumni", linked);
+  // Only u0, u1, u2 carry an active chat-eligible role.
+  for (const userId of ["u0", "u1", "u2"]) seedEligibleRole(stub, userId);
+
+  const report = await checkReachabilityHealth(stub as any, ORG_ID);
+
+  assert.equal(report.counts.linkedAlumni, 5);
+  assert.equal(report.segments.linkedEligible, 3);
+  assert.equal(report.counts.chatEligiblePercent, 60);
+});
+
+test("checkReachabilityHealth degrades to zeroed counts when the alumni query fails", async () => {
+  const stub = createSupabaseStub();
+  stub.simulateError("alumni", { message: "db down" });
+
+  const report = await checkReachabilityHealth(stub as any, ORG_ID);
+
+  assert.equal(report.state, "degraded");
+  assert.equal(report.reason, "db down");
+  assert.deepEqual(report.segments, {
+    linkedEligible: 0,
+    linkedNotEligible: 0,
+    unclaimedWithEmail: 0,
+    unclaimedNoEmail: 0,
+    softDeleted: 0,
+  });
+  assert.deepEqual(report.counts, {
+    totalAlumni: 0,
+    linkedAlumni: 0,
+    chatEligiblePercent: 0,
+    unclaimedWithEmail: 0,
+  });
 });

--- a/apps/web/tests/utils/supabaseStub.ts
+++ b/apps/web/tests/utils/supabaseStub.ts
@@ -52,7 +52,8 @@ type TableName =
   | "ai_document_chunks"
   | "ai_indexing_exclusions"
   | "announcements"
-  | "organization_email_domains";
+  | "organization_email_domains"
+  | "data_access_log";
 
 type Row = Record<string, unknown>;
 
@@ -120,6 +121,7 @@ const uniqueKeys: Record<TableName, UniqueConstraint[]> = {
   ai_indexing_exclusions: [],
   announcements: [],
   organization_email_domains: ["organization_id", "domain"],
+  data_access_log: [],
 };
 
 function nowIso() {
@@ -180,6 +182,7 @@ export function createSupabaseStub() {
     ai_indexing_exclusions: [],
     announcements: [],
     organization_email_domains: [],
+    data_access_log: [],
   };
 
   // RPC handler registry

--- a/supabase/migrations/20261226000000_alumni_reinvite_tracking.sql
+++ b/supabase/migrations/20261226000000_alumni_reinvite_tracking.sql
@@ -1,0 +1,23 @@
+-- Alumni re-invite tracking (Phase 2: Unclaimed-Alumni Cohort Console).
+--
+-- The cohort console lets an admin re-invite unclaimed alumni (user_id IS NULL
+-- with an email on file). Invite cadence is bounded by a durable per-alumnus
+-- cooldown — the DB column below is the real gate; the in-memory checkRateLimit
+-- is only per-instance burst protection.
+--
+-- No backfill: organization_invites carries no per-recipient email, so there is
+-- no way to reconstruct a true last-invite timestamp for existing rows. Leaving
+-- last_invite_sent_at NULL lets the first re-invite proceed immediately rather
+-- than inventing a false cooldown.
+
+ALTER TABLE public.alumni
+  ADD COLUMN IF NOT EXISTS last_invite_sent_at timestamptz NULL;
+
+ALTER TABLE public.alumni
+  ADD COLUMN IF NOT EXISTS invite_count integer NOT NULL DEFAULT 0;
+
+-- The console scans the unclaimed cohort (the re-invite target) per org; this
+-- partial index keeps that scan off the full alumni table.
+CREATE INDEX IF NOT EXISTS alumni_unclaimed_idx
+  ON public.alumni (organization_id)
+  WHERE deleted_at IS NULL AND user_id IS NULL;


### PR DESCRIPTION
## What

Phase 2 of alumni reachability: a **reachability health card** on the alumni/data-health pages plus an **unclaimed-cohort console** that lets an admin re-invite alumni who have an email on file but never claimed their account (\`user_id IS NULL\`).

- **Reachability segments** (\`reachability-segments.ts\`, \`reachability-health.ts\`) — classifies the alumni roster into reachable / unclaimed / no-email segments and surfaces it as a health card.
- **Cohort console** (\`CohortConsoleClient.tsx\`, \`alumni/cohorts\` page + \`GET .../alumni/cohorts\` route) — admin view of the unclaimed cohort.
- **Re-invite route** (\`POST .../alumni/re-invite\`) — sends an alumni invite to a selected cohort, gated by a durable 14-day per-alumnus cooldown.

## Database

New migration \`20261226000000_alumni_reinvite_tracking.sql\` — **additive only, idempotent**:
- \`alumni.last_invite_sent_at timestamptz NULL\` — the durable cooldown gate.
- \`alumni.invite_count integer NOT NULL DEFAULT 0\`.
- Partial index \`alumni_unclaimed_idx (organization_id) WHERE deleted_at IS NULL AND user_id IS NULL\` to keep the cohort scan off the full table.

No backfill: \`organization_invites\` has no per-recipient email, so a true last-invite timestamp can't be reconstructed; NULL lets the first re-invite proceed immediately rather than inventing a false cooldown.

## Security / correctness notes

- **Admin-only**: \`getOrgMembership\` → 403 unless \`role === "admin"\`. Invite creation runs through the *user* client (\`create_org_invite\` is SECURITY DEFINER and re-checks \`auth.uid()\`), so it's defense-in-depth, not service-role bypass.
- **Org-scoped + unclaimed-only**: every query filters \`organization_id\`, \`deleted_at IS NULL\`, and the cooldown stamp also requires \`user_id IS NULL\`.
- **Input validation**: Zod, UUID array \`min(1).max(200)\`, 20 KB body cap. Per-IP/per-user rate limit.
- **Durable cooldown**: the DB column is the real gate; the in-memory limiter is only per-instance burst protection. A \`sent_unstamped\` status is surfaced distinctly when the email went out but the cooldown stamp failed — so an immediate re-send can't silently bypass the 14-day window.
- **No cooldown bump on send failure** (clean retry). **Audit**: every actual send writes \`data_access_log\` with \`resource_type: "alumni_reinvite"\`.

## Tests

- \`alumni-reinvite.test.ts\` (436 LOC) — authz, org-scoping, cooldown skip, no-email/linked/not-found skips, send-failure handling, \`sent_unstamped\` path.
- \`data-health.test.ts\` (169 LOC) — reachability segmentation.
- Migration timestamp-uniqueness guard passes. Typecheck + lint clean; 28 new tests green.

## Rollout

- Migration is additive/idempotent — safe to apply ahead of code. No rollback complications (drop two columns + index if ever needed).
- No background/cron send ships — re-invite is admin-initiated only. The route is shaped so a future cron *could* reuse it, but none is wired here.